### PR TITLE
Load ext.smw.style only when needed

### DIFF
--- a/includes/specials/SMW_SpecialTypes.php
+++ b/includes/specials/SMW_SpecialTypes.php
@@ -44,7 +44,10 @@ class SMWSpecialTypes extends SpecialPage {
 		$this->setHeaders();
 		$out = $this->getOutput();
 
-		$out->addModuleStyles( 'ext.smw.page.styles' );
+		$out->addModuleStyles( [
+			'ext.smw.style',
+			'ext.smw.page.styles'
+		] );
 		$out->addModules( 'smw.property.page' );
 
 		$params = Infolink::decodeParameters( $param ?? '', false );

--- a/includes/specials/SpecialConcepts.php
+++ b/includes/specials/SpecialConcepts.php
@@ -38,7 +38,10 @@ class SpecialConcepts extends \SpecialPage {
 	public function execute( $param ) {
 		$this->setHeaders();
 		$out = $this->getOutput();
-		$out->addModuleStyles( 'ext.smw.page.styles' );
+		$out->addModuleStyles( [
+			'ext.smw.style',
+			'ext.smw.page.styles'
+		] );
 
 		$limit = $this->getRequest()->getVal( 'limit', 50 );
 		$offset = $this->getRequest()->getVal( 'offset', 0 );

--- a/src/MediaWiki/Hooks/BeforePageDisplay.php
+++ b/src/MediaWiki/Hooks/BeforePageDisplay.php
@@ -65,22 +65,6 @@ class BeforePageDisplay implements HookListener {
 		$title = $outputPage->getTitle();
 		$user = $outputPage->getUser();
 
-		// MW 1.26 / T107399 / Async RL causes style delay
-		$outputPage->addModuleStyles(
-			[
-				'ext.smw.style',
-				'ext.smw.tooltip.styles'
-			]
-		);
-
-		if ( $title->getNamespace() === NS_SPECIAL ) {
-			$outputPage->addModuleStyles(
-				[
-					'ext.smw.special.styles'
-				]
-			);
-		}
-
 		// #2726
 		$userOptionsLookup = ServicesFactory::getInstance()->singleton( 'UserOptionsLookup' );
 		if ( $userOptionsLookup->getOption( $user, 'smw-prefs-general-options-suggester-textinput' ) ) {

--- a/src/MediaWiki/Page/ConceptPage.php
+++ b/src/MediaWiki/Page/ConceptPage.php
@@ -53,7 +53,10 @@ class ConceptPage extends Page {
 	 */
 	protected function getHtml() {
 		$context = $this->getContext();
-		$context->getOutput()->addModuleStyles( 'ext.smw.page.styles' );
+		$context->getOutput()->addModuleStyles( [
+			'ext.smw.style',
+			'ext.smw.page.styles'
+		] );
 
 		$request = $context->getRequest();
 		$store = ApplicationFactory::getInstance()->getStore();

--- a/src/MediaWiki/Page/Page.php
+++ b/src/MediaWiki/Page/Page.php
@@ -62,7 +62,10 @@ abstract class Page extends Article {
 	 */
 	public function view() {
 		$outputPage = $this->getContext()->getOutput();
-		$outputPage->addModuleStyles( 'ext.smw.page.styles' );
+		$outputPage->addModuleStyles( [
+			'ext.smw.style',
+			'ext.smw.page.styles'
+		] );
 
 		if ( !$this->getOption( 'SMW_EXTENSION_LOADED' ) ) {
 			$outputPage->setPageTitle( $this->getTitle()->getPrefixedText() );

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -197,10 +197,12 @@ class SpecialAsk extends SpecialPage {
 		$out = $this->getOutput();
 		$request = $this->getRequest();
 
-		$out->addModuleStyles( 'ext.smw.style' );
-		$out->addModuleStyles( 'ext.smw.ask.styles' );
-		$out->addModuleStyles( 'ext.smw.table.styles' );
-		$out->addModuleStyles( 'ext.smw.page.styles' );
+		$out->addModuleStyles( [
+			'ext.smw.style',
+			'ext.smw.ask.styles',
+			'ext.smw.page.styles',
+			'ext.smw.table.styles'
+		] );
 
 		$out->addModuleStyles(
 			HtmlModal::getModuleStyles()

--- a/src/MediaWiki/Specials/SpecialMissingRedirectAnnotations.php
+++ b/src/MediaWiki/Specials/SpecialMissingRedirectAnnotations.php
@@ -32,6 +32,8 @@ class SpecialMissingRedirectAnnotations extends SpecialPage {
 		$this->setHeaders();
 		$output = $this->getOutput();
 
+		$output->addModuleStyles( [ 'ext.smw.style' ] );
+
 		$applicationFactory = ApplicationFactory::getInstance();
 		$dataValueFactory = DataValueFactory::getInstance();
 

--- a/src/MediaWiki/Specials/SpecialPropertyLabelSimilarity.php
+++ b/src/MediaWiki/Specials/SpecialPropertyLabelSimilarity.php
@@ -32,6 +32,8 @@ class SpecialPropertyLabelSimilarity extends SpecialPage {
 		$output = $this->getOutput();
 		$webRequest = $this->getRequest();
 
+		$output->addModuleStyles( [ 'ext.smw.style' ] );
+
 		$applicationFactory = ApplicationFactory::getInstance();
 		$store = $applicationFactory->getStore( '\SMW\SQLStore\SQLStore' );
 


### PR DESCRIPTION
Issue: #5743

This should shave off ~16.0 KB gzipped to the initial RL stylesheet on most pages, which helps significantly in page load time.
I am not sure if this catch all instances of `ext.smw.style` usage since there are many components in SMW and the dependency tree wasn't easy to figure out.

I also took out `ext.smw.tooltip.styles` because it should be loaded with other tooltip modules already, there should be no need to load it.

Probably a lot more work needed for #5743, but it should be a great first step to start with.