### PR TITLE
Add ext.smw.tooltip.styles to avoid FOUC of tooltip content

### DIFF
--- a/includes/Highlighter.php
+++ b/includes/Highlighter.php
@@ -156,6 +156,7 @@ class Highlighter {
 	 * @return string
 	 */
 	public function getHtml() {
+		SMWOutputs::requireStyle( 'ext.smw.tooltip.styles' );
 		SMWOutputs::requireResource( 'ext.smw.tooltips' );
 		return $this->getContainer();
 	}


### PR DESCRIPTION
Follow up to #5752

`smw-highlighter` requires the styles in `ext.smw.tooltip.styles` (more specifically [just this](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/139d9d3e0d3029b4feea1f391f3e0c4c79bab776/res/smw/util/ext.smw.util.tooltip.css#L71))  to hide the tooltip content to avoid Flash of Unstyled Content. Compared to the previous approach, `ext.smw.tooltip.styles` will only be added when highlighter is used on the page.