### PR TITLE
Use skinStyles for ext.smw.style

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -31,13 +31,17 @@ return [
 	'ext.smw.style' => $moduleTemplate + [
 		'styles' => [
 			'smw/ext.smw.css',
-			'smw/ext.smw.skin.css',
 			'smw/ext.smw.dropdown.css',
 			'smw/ext.smw.table.css',
 			'smw/ext.smw.tabs.css',
 			'smw/factbox/smw.factbox.css',
 			'smw/smw.indicators.css',
 			'smw/smw.jsonview.css'
+		],
+		'skinStyles' => [
+			'chameleon' => [ 'smw/ext.smw.skin-chameleon.css' ],
+			'foreground' => [ 'smw/ext.smw.skin-foreground.css' ],
+			'vector' => [ 'smw/ext.smw.skin-vector.css' ]
 		],
 		'position' => 'top',
 		'targets' => [ 'mobile', 'desktop' ]

--- a/res/smw/ext.smw.skin-chameleon.css
+++ b/res/smw/ext.smw.skin-chameleon.css
@@ -26,92 +26,61 @@
  * @author mwjames
  */
 
-/**
- * .skin-vector specific styles
- */
-
-.skin-vector input#smw-property-input.autocomplete-suggestions {
-	height: 1.15em;
-	padding: 2px 2px;
-}
-
-.skin-chameleon .smw-page-indicator {
+.smw-page-indicator {
 	padding: 0.35rem 0.85rem;
 	line-height: 1.55;
 }
 
-/**
- * .skin-chameleon specific styles
- */
-.skin-chameleon input#smw-property-input.autocomplete-suggestions {
+input#smw-property-input.autocomplete-suggestions {
 	height: 30px;
 	padding: 2px 2px;
 }
 
-.skin-chameleon .autocomplete-suggestion {
+.autocomplete-suggestion {
 	padding: 2px 5px;
 	white-space: nowrap;
 	overflow: hidden;
 	font-size: 0.9em;
 }
 
-.skin-chameleon .smwfact td {
+.smwfact td {
 	padding: 5px;
 }
 
-.skin-chameleon .smw-modal-content {
+.smw-modal-content {
 	line-height: 1.8;
 }
 
-.skin-chameleon .smw-tabs section pre {
+.smw-tabs section pre {
 	margin-top: 0px;
 	width: 100%;
 }
 
-.skin-chameleon .smw-jsonview-menu {
+.smw-jsonview-menu {
 	height: 29px;
 	top: 50px;
 }
 
 .smw-ui-input-filter input {
-	padding: .25em .55em .25em .55em !important;
-}
-
-.skin-chameleon .smw-ui-input-filter input {
 	padding: .35em .55em .35em .55em !important;
 }
 
-.skin-chameleon .smw-ui-input-filter-tooltip {
+.smw-ui-input-filter-tooltip {
 	padding: .20em .25em .35em .25em;
 }
 
-.skin-chameleon .smw-callout ul,
-.skin-chameleon .smw-callout ol {
+.smw-callout ul,
+.smw-callout ol {
 	margin-bottom: 0;
 }
 
-.ns-112.skin-chameleon.action-submit .error ul {
+.ns-112.action-submit .error ul {
     margin: 0 0 0 0;
     font-size: 1rem;
 }
 
-.skin-chameleon fieldset legend {
+fieldset legend {
 	width:unset;
 	padding-left: 5px;
 	padding-right: 5px;
-}
-
-/**
- * .skin-foreground specific styles
- */
-.skin-foreground input#smw-property-input.autocomplete-suggestions {
-	height: 32px;
-	padding: 2px 0px 0px 8px;
-}
-
-.skin-foreground .autocomplete-suggestion {
-	padding: 2px 5px;
-	white-space: nowrap;
-	overflow: hidden;
-	font-size: 0.9em;
 }

--- a/res/smw/ext.smw.skin-chameleon.css
+++ b/res/smw/ext.smw.skin-chameleon.css
@@ -33,7 +33,7 @@
 
 input#smw-property-input.autocomplete-suggestions {
 	height: 30px;
-	padding: 2px 2px;
+	padding: 2px;
 }
 
 .autocomplete-suggestion {
@@ -62,7 +62,7 @@ input#smw-property-input.autocomplete-suggestions {
 }
 
 .smw-ui-input-filter input {
-	padding: .35em .55em .35em .55em !important;
+	padding: .35em .55em !important;
 }
 
 .smw-ui-input-filter-tooltip {
@@ -75,7 +75,7 @@ input#smw-property-input.autocomplete-suggestions {
 }
 
 .ns-112.action-submit .error ul {
-    margin: 0 0 0 0;
+    margin: 0;
     font-size: 1rem;
 }
 

--- a/res/smw/ext.smw.skin-foreground.css
+++ b/res/smw/ext.smw.skin-foreground.css
@@ -27,7 +27,7 @@
  */
 
 .smw-ui-input-filter input {
-	padding: .25em .55em .25em .55em !important;
+	padding: .25em .55em !important;
 }
 
 input#smw-property-input.autocomplete-suggestions {

--- a/res/smw/ext.smw.skin-foreground.css
+++ b/res/smw/ext.smw.skin-foreground.css
@@ -1,0 +1,43 @@
+/*!
+ * This file is part of the Semantic MediaWiki Extension
+ * @see https://www.semantic-mediawiki.org/
+ *
+ * @section LICENSE
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * @since 3.0
+ *
+ * @file
+ * @ingroup SMW
+ *
+ * @licence GNU GPL v2+
+ * @author mwjames
+ */
+
+.smw-ui-input-filter input {
+	padding: .25em .55em .25em .55em !important;
+}
+
+input#smw-property-input.autocomplete-suggestions {
+	height: 32px;
+	padding: 2px 0px 0px 8px;
+}
+
+.autocomplete-suggestion {
+	padding: 2px 5px;
+	white-space: nowrap;
+	overflow: hidden;
+	font-size: 0.9em;
+}

--- a/res/smw/ext.smw.skin-vector.css
+++ b/res/smw/ext.smw.skin-vector.css
@@ -1,0 +1,36 @@
+/*!
+ * This file is part of the Semantic MediaWiki Extension
+ * @see https://www.semantic-mediawiki.org/
+ *
+ * @section LICENSE
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * @since 3.0
+ *
+ * @file
+ * @ingroup SMW
+ *
+ * @licence GNU GPL v2+
+ * @author mwjames
+ */
+
+.smw-ui-input-filter input {
+	padding: .25em .55em .25em .55em !important;
+}
+
+input#smw-property-input.autocomplete-suggestions {
+	height: 1.15em;
+	padding: 2px 2px;
+}

--- a/res/smw/ext.smw.skin-vector.css
+++ b/res/smw/ext.smw.skin-vector.css
@@ -27,10 +27,10 @@
  */
 
 .smw-ui-input-filter input {
-	padding: .25em .55em .25em .55em !important;
+	padding: .25em .55em !important;
 }
 
 input#smw-property-input.autocomplete-suggestions {
 	height: 1.15em;
-	padding: 2px 2px;
+	padding: 2px;
 }


### PR DESCRIPTION
Issue: #5743

Skin-specific styles should only be loaded with the skin.
We can use `skinStyles` to load styles conditionally depends on the current skin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new CSS files for `skin-foreground` and `skin-vector`, enhancing styling for input elements and autocomplete suggestions.
	- Organized skin styles into a new structure for better management and application across different skins.

- **Bug Fixes**
	- Removed specific skin prefixes from various CSS selectors, allowing styles to apply universally, improving consistency across different interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->