### PR TITLE
Load ext.smw.style in Special:SemanticMediaWiki

### DIFF
--- a/src/MediaWiki/Specials/SpecialAdmin.php
+++ b/src/MediaWiki/Specials/SpecialAdmin.php
@@ -64,6 +64,7 @@ class SpecialAdmin extends SpecialPage {
 		$output->setPageTitle( $this->msg_text( 'smw-title' ) );
 		$output->addHelpLink( $this->msg_text( 'smw-admin-helplink' ), true );
 
+		$output->addModuleStyles( 'ext.smw.style' );
 		$output->addModuleStyles( 'ext.smw.special.style' );
 		$output->addModules( 'ext.smw.admin' );
 


### PR DESCRIPTION
Follow up to #5752

It seems that the styles are needed on that page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced styling capabilities for the administrative interface by integrating new module styles.
  
- **Bug Fixes**
	- Improved consistency of styles applied during page execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->