### PR TITLE
Replace smw-callout with MW core message boxes in PHP

### DIFF
--- a/res/smw/special/ext.smw.special.ask.js
+++ b/res/smw/special/ext.smw.special.ask.js
@@ -45,7 +45,7 @@
 
 		this.hideList = '#ask-embed, #inlinequeryembed, #ask-showhide,' +
 		'#ask-debug, #ask-clipboard, #ask-navinfo, #ask-cache, #result,' +
-		'#result-error, #ask-pagination, #ask-export-links, #tab-label-smw-askt-compact,' +
+		'.smw-error-result-error, #ask-pagination, #ask-export-links, #tab-label-smw-askt-compact,' +
 		'#tab-label-smw-askt-code, #tab-label-smw-askt-debug, #tab-label-smw-askt-extra,' +
 		'#tab-label-smw-askt-result, #tab-label-smw-askt-clipboard, #search';
 

--- a/src/MediaWiki/Content/HtmlBuilder.php
+++ b/src/MediaWiki/Content/HtmlBuilder.php
@@ -346,13 +346,7 @@ class HtmlBuilder {
 	}
 
 	private function schema_unknown_type( $params ) {
-		return Html::rawElement(
-			'p',
-			[
-				'class' => 'smw-callout smw-callout-error plainlinks'
-			],
-			$params['msg']
-		);
+		return Html::errorBox( $params['msg'] );
 	}
 
 	private function schema_help_link( $params ) {

--- a/src/MediaWiki/Hooks/ArticleViewHeader.php
+++ b/src/MediaWiki/Hooks/ArticleViewHeader.php
@@ -140,14 +140,14 @@ class ArticleViewHeader implements HookListener {
 	}
 
 	private function message( $type, array $message ) {
-		return Html::rawElement(
-			'div',
-			[
-				'id' => $message[0],
-				'class' => 'plainlinks ' . ( $type !== '' ? 'smw-callout smw-callout-' . $type : '' )
-			],
-			Message::get( $message, Message::PARSE, Message::USER_LANGUAGE )
-		);
+		$content = Message::get( $message, Message::PARSE, Message::USER_LANGUAGE );
+		switch ( $type ) {
+			case 'error':
+				return Html::errorBox( $content );
+			case 'warning':
+				return Html::warningBox( $content );
+			default:
+				return Html::noticeBox( $content, '' );
+		}
 	}
-
 }

--- a/src/MediaWiki/Hooks/BeforePageDisplay.php
+++ b/src/MediaWiki/Hooks/BeforePageDisplay.php
@@ -45,12 +45,11 @@ class BeforePageDisplay implements HookListener {
 			return;
 		}
 
-		$outputPage->prependHTML(
-			'<div class="errorbox" style="display:block;">Semantic MediaWiki ' .
-			'was installed but not enabled on this wiki. Please consult the ' .
-			'<a href="https://www.semantic-mediawiki.org/wiki/Extension_registration">help page</a> for ' .
-			'instructions and further assistances.</div>'
-		);
+		$outputPage->prependHTML( Html::errorBox(
+			'Semantic MediaWiki was installed but not enabled on this wiki. ' .
+			'Please consult the <a href="https://www.semantic-mediawiki.org/wiki/Extension_registration">help page</a> ' .
+			'for instructions and further assistances.'
+		) );
 	}
 
 	/**
@@ -111,26 +110,25 @@ class BeforePageDisplay implements HookListener {
 		$is_upgrade = $this->getOption( 'is_upgrade' ) !== null ? 2 : 1;
 		$count = count( $this->getOption( 'incomplete_tasks' ) );
 
-		return Html::rawElement(
-			'div',
+		// TODO: Refactor message content HTML generation into Mustache or another class
+		$title = Html::rawElement( 'strong', [], Message::get( 'smw-title' ) );
+		$note = Html::rawElement( 'span',
 			[
-				'class' => 'smw-callout smw-callout-error plainlinks'
+				'style' => 'color: var( --color-subtle, #54595d ); font-size: 0.75rem;'
 			],
-			Html::rawElement(
-				'div',
-				[
-					'style' => 'font-size: 10px;text-align: right;margin-top: 5px;margin-bottom: -5px; float:right;'
-				],
-				Message::get( [ 'smw-install-incomplete-intro-note' ], Message::PARSE, Message::USER_LANGUAGE )
-			) . Html::rawElement(
-				'div',
-				[
-					'class' => 'title'
-				],
-				Message::get( 'smw-title' )
-			) .
-			Message::get( [ 'smw-install-incomplete-intro', $is_upgrade, $count ], Message::PARSE, Message::USER_LANGUAGE )
+			Message::get( [ 'smw-install-incomplete-intro-note' ], Message::PARSE, Message::USER_LANGUAGE )
+		);
+		$header = Html::rawElement( 'div',
+			[
+				'style' => 'display: flex; flex-wrap: wrap; align-items: baseline; justify-content: space-between; gap: 0.25rem 0.5rem;'
+			],
+			$title . $note
+		);
+		$content = Message::get( [ 'smw-install-incomplete-intro', $is_upgrade, $count ], Message::PARSE, Message::USER_LANGUAGE );
+
+		return Html::errorBox(
+			$header .
+			Html::rawElement( 'p', [], $content )
 		);
 	}
-
 }

--- a/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
@@ -297,11 +297,7 @@ class EntityLookupTaskHandler extends TaskHandler implements ActionableTask {
 			);
 			$output .= '<pre>' . $this->outputFormatter->encodeAsJson( $references ) . '</pre>';
 		} else {
-			$error .= Html::element(
-				'div',
-				[
-					'class' => 'smw-callout smw-callout-warning'
-				],
+			$error .= Html::warningBox(
 				$this->msg( [ 'smw-admin-iddispose-no-references', $id ] )
 			);
 

--- a/src/MediaWiki/Specials/Ask/ErrorWidget.php
+++ b/src/MediaWiki/Specials/Ask/ErrorWidget.php
@@ -21,12 +21,10 @@ class ErrorWidget {
 	 * @return string
 	 */
 	public static function disabled() {
-		return Html::element(
-			'div',
-			[
-				'class' => 'smw-callout smw-callout-error'
-			],
-			Message::get( 'smw_iq_disabled', Message::TEXT, Message::USER_LANGUAGE )
+		return Html::errorBox(
+			Message::get( 'smw_iq_disabled', Message::TEXT, Message::USER_LANGUAGE ),
+			'',
+			'smw-error-disabled'
 		);
 	}
 
@@ -36,13 +34,9 @@ class ErrorWidget {
 	 * @return string
 	 */
 	public static function noResult() {
-		return Html::element(
-			'div',
-			[
-				'id'    => 'no-result',
-				'class' => 'smw-callout smw-callout-info'
-			],
-			Message::get( 'smw_result_noresults', Message::TEXT, Message::USER_LANGUAGE )
+		return Html::noticeBox(
+			Message::get( 'smw_result_noresults', Message::TEXT, Message::USER_LANGUAGE ),
+			'smw-notice-result-noresults'
 		);
 	}
 
@@ -61,12 +55,10 @@ class ErrorWidget {
 			Html::rawElement(
 				'noscript',
 				[],
-				Html::rawElement(
-					'div',
-					[
-						'class' => 'smw-callout smw-callout-error',
-					],
-					Message::get( 'smw-noscript', Message::PARSE, Message::USER_LANGUAGE )
+				Html::errorBox(
+					Message::get( 'smw-noscript', Message::PARSE, Message::USER_LANGUAGE ),
+					'',
+					'smw-error-noscript'
 				)
 			)
 		);
@@ -78,12 +70,10 @@ class ErrorWidget {
 	 * @return string
 	 */
 	public static function sessionFailure() {
-		return Html::rawElement(
-			'div',
-			[
-				'class' => 'smw-callout smw-callout-error'
-			],
-			Message::get( 'sessionfailure', Message::TEXT, Message::USER_LANGUAGE )
+		return Html::errorBox(
+			Message::get( 'sessionfailure', Message::TEXT, Message::USER_LANGUAGE ),
+			'',
+			'smw-error-session-failure'
 		);
 	}
 
@@ -120,14 +110,7 @@ class ErrorWidget {
 			$error =  implode( ' ', $errors );
 		}
 
-		return Html::rawElement(
-			'div',
-			[
-				'id'    => 'result-error',
-				'class' => 'smw-callout smw-callout-error'
-			],
-			$error
-		);
+		return Html::errorBox( $error, '', 'smw-error-result-error' );
 	}
 
 }

--- a/src/MediaWiki/Specials/Browse/HtmlBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlBuilder.php
@@ -200,11 +200,7 @@ class HtmlBuilder {
 				Html::rawElement(
 					'noscript',
 					[],
-					Html::rawElement(
-						'div',
-						[
-							'class' => 'smw-callout smw-callout-error',
-						],
+					Html::errorBox(
 						Message::get( 'smw-noscript', Message::PARSE, $this->language )
 					)
 				)

--- a/src/MediaWiki/Specials/FacetedSearch/ResultFetcher.php
+++ b/src/MediaWiki/Specials/FacetedSearch/ResultFetcher.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Specials\FacetedSearch;
 
+use Html;
 use SMW\Store;
 use SMW\Localizer\Message;
 use SMWQueryProcessor as QueryProcessor;
@@ -192,7 +193,7 @@ class ResultFetcher {
 				$msg .= Message::decode( $error );
 			}
 
-			return '<div class="smw-callout smw-callout-error">' . $msg . '</div>';
+			return Html::errorBox( $msg );
 		}
 
 		if ( $this->queryResult === null ) {
@@ -208,7 +209,9 @@ class ResultFetcher {
 		$html = $printer->getResult( $this->queryResult, $this->params, SMW_OUTPUT_HTML );
 
 		if ( $html === '' ) {
-			$html = '<div class="smw-callout smw-callout-warning">' . Message::get( [ 'smw-facetedsearch-no-output', $this->format ] ) . '</div>';
+			$html = Html::warningBox(
+				Message::get( [ 'smw-facetedsearch-no-output', $this->format ] )
+			);
 		}
 
 		return $html;

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -104,12 +104,10 @@ class SpecialBrowse extends SpecialPage {
 				$error .= Message::decode( $error, Message::TEXT, Message::USER_LANGUAGE );
 			}
 
-			$html = Html::rawElement(
-				'div',
-				[
-					'class' => 'smw-callout smw-callout-error'
-				],
-				Message::get( [ 'smw-browse-invalid-subject', $error ], Message::TEXT, Message::USER_LANGUAGE )
+			$html = Html::errorBox(
+				Message::get( [ 'smw-browse-invalid-subject', $error ], Message::TEXT, Message::USER_LANGUAGE ),
+				'',
+				'smw-error-browse'
 			);
 
 			if ( !$this->including() ) {

--- a/src/ParserFunctions/ConceptParserFunction.php
+++ b/src/ParserFunctions/ConceptParserFunction.php
@@ -132,12 +132,9 @@ class ConceptParserFunction {
 		$message = '';
 
 		if ( wfMessage( 'smw-concept-introductory-message' )->exists() ) {
-			$message = Html::rawElement(
-				'div',
-				[
-					'class' => 'plainlinks smw-callout smw-callout-info'
-				],
-				wfMessage( 'smw-concept-introductory-message', $title->getText() )->text()
+			$message = Html::noticeBox(
+				wfMessage( 'smw-concept-introductory-message', $title->getText() )->text(),
+				'plainlinks'
 			);
 		}
 

--- a/src/Property/DeclarationExaminerMsgBuilder.php
+++ b/src/Property/DeclarationExaminerMsgBuilder.php
@@ -87,7 +87,7 @@ class DeclarationExaminerMsgBuilder {
 		}
 
 		$class = "plainlinks $msgKey";
-		switch( $type ) {
+		switch ( $type ) {
 			case 'plain':
 				return Html::rawElement( 'div', [ 'class' => $class ], $msg );
 			case 'error':

--- a/src/Property/DeclarationExaminerMsgBuilder.php
+++ b/src/Property/DeclarationExaminerMsgBuilder.php
@@ -86,18 +86,19 @@ class DeclarationExaminerMsgBuilder {
 			return;
 		}
 
-		if ( $type !== 'plain' ) {
-			$class = "smw-callout smw-callout-$type";
+		$class = "plainlinks $msgKey";
+		switch( $type ) {
+			case 'plain':
+				return Html::rawElement( 'div', [ 'class' => $class ], $msg );
+			case 'error':
+				return Html::errorBox( $msg, '', $class );
+			case 'info':
+				return Html::noticeBox( $msg, $class );
+			case 'warning':
+				return Html::warningBox( $msg, $class );
+			default:
+				return '';
 		}
-
-		return Html::rawElement(
-			'div',
-			[
-				'id' => "$msgKey",
-				'class' => "plainlinks $msgKey $class"
-			],
-			$msg
-		);
 	}
 
 	private function msg( $msg, $type = Message::PARSE, $lang = Message::USER_LANGUAGE ) {

--- a/src/Query/RemoteRequest.php
+++ b/src/Query/RemoteRequest.php
@@ -98,11 +98,11 @@ class RemoteRequest implements QueryEngine {
 			return $this->further_link( $query );
 		}
 
+		$source = $query->getQuerySource();
 		if ( !isset( $this->parameters['url'] ) ) {
 			throw new RuntimeException( "Missing a remote URL for $source" );
 		}
 
-		$source = $query->getQuerySource();
 		$this->init();
 
 		if ( !$this->canConnect( $this->parameters['url'] ) ) {

--- a/src/Query/RemoteRequest.php
+++ b/src/Query/RemoteRequest.php
@@ -269,12 +269,7 @@ class RemoteRequest implements QueryEngine {
 	private function error() {
 		$params = func_get_args();
 
-		return Html::rawElement(
-			'div',
-			[
-				'id' => $params[0],
-				'class' => 'smw-callout smw-callout-error'
-			],
+		return Html::errorBox(
 			Message::get( $params, Message::PARSE, Message::USER_LANGUAGE )
 		);
 	}

--- a/src/Query/RemoteRequest.php
+++ b/src/Query/RemoteRequest.php
@@ -270,7 +270,9 @@ class RemoteRequest implements QueryEngine {
 		$params = func_get_args();
 
 		return Html::errorBox(
-			Message::get( $params, Message::PARSE, Message::USER_LANGUAGE )
+			Message::get( $params, Message::PARSE, Message::USER_LANGUAGE ),
+			'',
+			$params[0]
 		);
 	}
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0111.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0111.json
@@ -16,7 +16,7 @@
 			"assert-output": {
 				"onPageView": {},
 				"to-contain": [
-					"<div id=\"smw-property-name-reserved\" class=\"plainlinks smw-property-name-reserved smw-callout smw-callout-error\">"
+					"plainlinks smw-property-name-reserved"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1008.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1008.json
@@ -28,7 +28,7 @@
 					"parameters": {}
 				},
 				"to-contain": [
-					"<div id=\"smw-property-req-violation-forced-removal-annotated-type\" class=\"plainlinks smw-property-req-violation-forced-removal-annotated-type smw-callout smw-callout-error\">"
+					"plainlinks smw-property-req-violation-forced-removal-annotated-type"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0018.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0018.json
@@ -23,7 +23,7 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<div id=\"ask-status\" class=\"smw-ask-status plainlinks\"><noscript><div class=\"smw-callout smw-callout-error\">"
+					"smw-error-noscript"
 				]
 			}
 		},

--- a/tests/phpunit/MediaWiki/Specials/Ask/ErrorWidgetTest.php
+++ b/tests/phpunit/MediaWiki/Specials/Ask/ErrorWidgetTest.php
@@ -64,6 +64,7 @@ class ErrorWidgetTest extends \PHPUnit_Framework_TestCase {
 	 *
 	 * @param string $message
 	 * @return $string HTML of the error message box
+	 * @since 5.0.0
 	 */
 	private function getErrorMessageHTML( $message ) {
 		return Html::errorBox( $message, '', 'smw-error-result-error' );

--- a/tests/phpunit/MediaWiki/Specials/Ask/ErrorWidgetTest.php
+++ b/tests/phpunit/MediaWiki/Specials/Ask/ErrorWidgetTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\MediaWiki\Specials\Ask;
 
+use Html;
 use SMW\MediaWiki\Specials\Ask\ErrorWidget;
 use SMW\Tests\PHPUnitCompat;
 
@@ -57,6 +58,17 @@ class ErrorWidgetTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
+	/**
+	 * Return an error box using core MW method
+	 * This is required because the output is different depending on the MW version
+	 *
+	 * @param string $message
+	 * @return $string HTML of the error message box
+	 */
+	private function getErrorMessageHTML( $message ) {
+		return Html::errorBox( $message, '', 'smw-error-result-error' );
+	}
+
 	public function queryErrorProvider() {
 		$provider[] = [
 			'',
@@ -65,23 +77,23 @@ class ErrorWidgetTest extends \PHPUnit_Framework_TestCase {
 
 		$provider[] = [
 			[ 'Foo' ],
-			'<div id="result-error" class="smw-callout smw-callout-error">Foo</div>'
+			$this->getErrorMessageHTML( 'Foo' )
 		];
 
 		$provider[] = [
 			[ 'Foo', 'Bar' ],
-			'<div id="result-error" class="smw-callout smw-callout-error"><ul><li>Foo</li><li>Bar</li></ul></div>'
+			$this->getErrorMessageHTML( '<ul><li>Foo</li><li>Bar</li></ul>' )
 		];
 
 		$provider[] = [
 			[ 'Foo', [ 'Bar' ] ],
-			'<div id="result-error" class="smw-callout smw-callout-error"><ul><li>Foo</li><li>Bar</li></ul></div>'
+			$this->getErrorMessageHTML( '<ul><li>Foo</li><li>Bar</li></ul>' )
 		];
 
 		// Filter duplicate
 		$provider[] = [
 			[ 'Foo', [ 'Bar' ], 'Bar' ],
-			'<div id="result-error" class="smw-callout smw-callout-error"><ul><li>Foo</li><li>Bar</li></ul></div>'
+			$this->getErrorMessageHTML( '<ul><li>Foo</li><li>Bar</li></ul>' )
 		];
 
 		return $provider;

--- a/tests/phpunit/MediaWiki/Specials/SpecialBrowseTest.php
+++ b/tests/phpunit/MediaWiki/Specials/SpecialBrowseTest.php
@@ -72,13 +72,13 @@ class SpecialBrowseTest extends \PHPUnit_Framework_TestCase {
 		#0
 		$provider[] = [
 			'',
-			[ 'smw-callout smw-callout-error' ]
+			[ 'smw-error-browse' ]
 		];
 
 		#1
 		$provider[] = [
 			':Has-20foo/http:-2F-2Fexample.org-2Fid-2FCurly-2520Brackets-257B-257D',
-			[ 'smw-callout smw-callout-error' ]
+			[ 'smw-error-browse' ]
 		];
 
 		#2

--- a/tests/phpunit/Property/DeclarationExaminerMsgBuilderTest.php
+++ b/tests/phpunit/Property/DeclarationExaminerMsgBuilderTest.php
@@ -62,7 +62,7 @@ class DeclarationExaminerMsgBuilderTest extends \PHPUnit_Framework_TestCase {
 	 */
 	private function getMessageBoxHTML( $type, $key, $content ) {
 		$class = "plainlinks $key";
-		switch( $type ) {
+		switch ( $type ) {
 			case 'plain':
 				return Html::rawElement( 'div', [ 'class' => $class ], $content );
 			case 'error':
@@ -82,25 +82,25 @@ class DeclarationExaminerMsgBuilderTest extends \PHPUnit_Framework_TestCase {
 			$this->getMessageBoxHTML( 'plain', 'foo', '⧼foo⧽' )
 		];
 
-		// ranking
+		// Test message ranking: error messages should appear before plain messages
 		yield [
 			[ [ 'plain', 'bar' ], [ 'error', 'foo' ] ],
 			$this->getMessageBoxHTML( 'error', 'foo', '⧼foo⧽' ) . $this->getMessageBoxHTML( 'plain', 'bar', '⧼bar⧽' )
 		];
 
-		//_list
+		// Test list rendering: messages with _list should generate HTML unordered lists
 		yield [
 			[ [ 'error', '_msgkey' => 'foo', '_list' => [ 'a', 'b' ] ] ],
 			$this->getMessageBoxHTML( 'error', 'foo', '⧼foo⧽<ul><li>a</li><li>b</li></ul>' )
 		];
 
-		// _merge
+		// Test message merging: multiple messages should be combined with proper spacing
 		yield [
 			[ [ 'error', '_merge' => [ 'a', 'b' ] ] ],
 			$this->getMessageBoxHTML( 'error', 'a-b', '⧼a⧽&nbsp;⧼b⧽' )
 		];
 
-		// Unknown type
+		// Test unknown type
 		yield [
 			[ [ '__foobar__', 'foo' ] ],
 			''

--- a/tests/phpunit/Property/DeclarationExaminerMsgBuilderTest.php
+++ b/tests/phpunit/Property/DeclarationExaminerMsgBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\Property;
 
+use Html;
 use SMW\Property\DeclarationExaminerMsgBuilder;
 use SMW\DataItemFactory;
 use SMW\Tests\TestEnvironment;
@@ -50,66 +51,60 @@ class DeclarationExaminerMsgBuilderTest extends \PHPUnit_Framework_TestCase {
 		);
 	}
 
-	public function messageProvider() {
-		if ( version_compare( MW_VERSION, '1.28', '<' ) ) {
-			yield [
-				[ [ 'plain', 'foo' ] ],
-				'<div id="foo" class="plainlinks foo">&lt;foo&gt;</div>'
-			];
-
-			// ranking
-			yield [
-				[ [ 'plain', 'bar' ], [ 'error', 'foo' ] ],
-				'<div id="foo" class="plainlinks foo smw-callout smw-callout-error">&lt;foo&gt;</div><div id="bar" class="plainlinks bar">&lt;bar&gt;</div>'
-			];
-
-			//_list
-			yield [
-				[ [ 'error', '_msgkey' => 'foo', '_list' => [ 'a', 'b' ] ] ],
-				'<div id="foo" class="plainlinks foo smw-callout smw-callout-error">&lt;foo&gt;<ul><li>a</li><li>b</li></ul></div>'
-			];
-
-			// _merge
-			yield [
-				[ [ 'error', '_merge' => [ 'a', 'b' ] ] ],
-				'<div id="a-b" class="plainlinks a-b smw-callout smw-callout-error">&lt;a&gt;&nbsp;&lt;b&gt;</div>'
-			];
-
-			// Unknown type
-			yield [
-				[ [ '__foobar__', 'foo' ] ],
-				''
-			];
-		} else {
-			yield [
-				[ [ 'plain', 'foo' ] ],
-				'<div id="foo" class="plainlinks foo">⧼foo⧽</div>'
-			];
-
-			// ranking
-			yield [
-				[ [ 'plain', 'bar' ], [ 'error', 'foo' ] ],
-				'<div id="foo" class="plainlinks foo smw-callout smw-callout-error">⧼foo⧽</div><div id="bar" class="plainlinks bar">⧼bar⧽</div>'
-			];
-
-			//_list
-			yield [
-				[ [ 'error', '_msgkey' => 'foo', '_list' => [ 'a', 'b' ] ] ],
-				'<div id="foo" class="plainlinks foo smw-callout smw-callout-error">⧼foo⧽<ul><li>a</li><li>b</li></ul></div>'
-			];
-
-			// _merge
-			yield [
-				[ [ 'error', '_merge' => [ 'a', 'b' ] ] ],
-				'<div id="a-b" class="plainlinks a-b smw-callout smw-callout-error">⧼a⧽&nbsp;⧼b⧽</div>'
-			];
-
-			// Unknown type
-			yield [
-				[ [ '__foobar__', 'foo' ] ],
-				''
-			];
+	/**
+	 * Return a message box using core MW method
+	 * This is required because the output is different depending on the MW version
+	 *
+	 * @param string $type
+	 * @param string $key
+	 * @param string $content
+	 * @return $string HTML of the message box
+	 */
+	private function getMessageBoxHTML( $type, $key, $content ) {
+		$class = "plainlinks $key";
+		switch( $type ) {
+			case 'plain':
+				return Html::rawElement( 'div', [ 'class' => $class ], $content );
+			case 'error':
+				return Html::errorBox( $content, '', $class );
+			case 'info':
+				return Html::noticeBox( $content, $class );
+			case 'warning':
+				return Html::warningBox( $content, $class );
+			default:
+				return '';
 		}
+	}
+
+	public function messageProvider() {
+		yield [
+			[ [ 'plain', 'foo' ] ],
+			$this->getMessageBoxHTML( 'plain', 'foo', '⧼foo⧽' )
+		];
+
+		// ranking
+		yield [
+			[ [ 'plain', 'bar' ], [ 'error', 'foo' ] ],
+			$this->getMessageBoxHTML( 'error', 'foo', '⧼foo⧽' ) . $this->getMessageBoxHTML( 'plain', 'bar', '⧼bar⧽' )
+		];
+
+		//_list
+		yield [
+			[ [ 'error', '_msgkey' => 'foo', '_list' => [ 'a', 'b' ] ] ],
+			$this->getMessageBoxHTML( 'error', 'foo', '⧼foo⧽<ul><li>a</li><li>b</li></ul>' )
+		];
+
+		// _merge
+		yield [
+			[ [ 'error', '_merge' => [ 'a', 'b' ] ] ],
+			$this->getMessageBoxHTML( 'error', 'a-b', '⧼a⧽&nbsp;⧼b⧽' )
+		];
+
+		// Unknown type
+		yield [
+			[ [ '__foobar__', 'foo' ] ],
+			''
+		];
 	}
 
 }


### PR DESCRIPTION
MW core already comes with a message box system that is simliar to SMW callout. Switching to the core implementation will reduce the maintenance needed, keep the styles aligned with core, and reduce unnessecary code.

The JS usage of smw-callout will be replaced in a follow up PR.

Related: #5743, #5546

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced error message presentation across various components using standardized HTML output methods.
  
- **Bug Fixes**
  - Corrected parameter type annotations for methods to improve clarity and documentation.

- **Tests**
  - Introduced new methods to standardize error message generation in test cases, improving consistency and maintainability.
  - Updated expected output in multiple test cases to reflect changes in error message formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->