### PR TITLE
Completely replace smw-callout with message boxes

### DIFF
--- a/res/smw/deferred/ext.smw.deferred.js
+++ b/res/smw/deferred/ext.smw.deferred.js
@@ -124,7 +124,7 @@
 
 			self.container.find( '#deferred-control' ).replaceWith( "<div id='deferred-control'></div>" );
 			self.container.find( '.irs' ).hide();
-			self.replaceOutput( error, "smw-callout smw-callout-error" );
+			self.replaceOutput( error, "error" );
 		} );
 	};
 

--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -80,6 +80,15 @@
 	line-height: 1.42857143;
 }
 
+/**
+ * Use to hide server-rendered message boxes
+ * For example, an error box is rendered in DuplicateLookupTaskHandler.php server-side,
+ * then being enabled in ext.smw.special.admin.js client-side.
+ */
+ .smw-message--hidden {
+	display: none !important;
+}
+
 .client-nojs .smw-placeholder::after {
 	content: "JavaScript is disabled or could not be detected!";
 	top: 80%;
@@ -471,103 +480,6 @@ label.smw-form-checkbox {
 	font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
 	font-size: 14px;
 	line-height: 1.42857143;
-}
-
-/* Thanks to the bootstrap css*/
-.smw-callout {
-	padding: 10px;
-	margin: 0.5em 0;
-	/*border: 1px solid #eee;*/
-	border-left-width: 5px;
-	border-radius: 1px;
-}
-
-.smw-callout p {
-	margin: 5px 0 5px 0;
-}
-
-.smw-callout-info {
-	/*border: 1px solid #d9edf7;
-	background-color: #d9edf7;
-	border-left-width: 5px;
-	border-left-color: #1b809e;*/
-
-	padding: .8em 1em;
-	background: #d9edf7;
-	margin: 0.5rem 0;
-	border-left: 5px solid #1b809e;
-}
-
-.smw-callout-info .title {
-	color: #1b809e;
-}
-
-.smw-callout-info-light {
-	/*border: 1px solid #f9f9f9;
-	background-color: #f9f9f9;
-	border-left-width: 5px;
-	border-left-color: #ddd;*/
-
-	padding: .8em 1em;
-	background: #f9f9f9;
-	margin: 0.5rem 0;
-	border-left: 5px solid #ddd;
-}
-
-.smw-callout-info-light .title {
-	color: #1b809e;
-}
-
-.smw-callout-warning {
-	/*border: 1px solid #fcf8e3;
-	background-color: #fcf8e3;
-	border-left-width: 5px;
-	border-left-color: #aa6708;*/
-
-	padding: .8em 1em;
-	background: #fcf8e3;
-	margin: 0.5rem 0;
-	border-left: 5px solid #aa6708;
-}
-
-.smw-callout-warning .title {
-	color: #aa6708;
-}
-
-.smw-callout-success {
-	/*border: 1px solid #dff0d8;
-	background-color: #dff0d8;
-	border-left-width: 5px;
-	border-left-color: #3c763d;*/
-
-	padding: .8em 1em;
-	background: #dff0d8;
-	margin: 0.5rem 0;
-	border-left: 5px solid #3c763d;
-}
-
-.smw-callout-success .title {
-	color: #3c763d;
-}
-
-.smw-callout-error {
-	/*border: 1px solid #f2dede;
-	background-color: #f2dede;
-	border-left-width: 5px;
-	border-left-color: #ce4844;*/
-
-	padding: .8em 1em;
-	background: #f2dede;
-	margin: 0.5rem 0;
-	border-left: 5px solid #ce4844;
-}
-
-.smw-callout .title {
-	margin-top: 0;
-	margin-bottom: 5px;
-	font-size: 16px;
-	font-family: inherit;
-	font-weight: 500;
 }
 
 .smw-svg-icon {

--- a/res/smw/ext.smw.skin-chameleon.css
+++ b/res/smw/ext.smw.skin-chameleon.css
@@ -69,11 +69,6 @@ input#smw-property-input.autocomplete-suggestions {
 	padding: .20em .25em .35em .25em;
 }
 
-.smw-callout ul,
-.smw-callout ol {
-	margin-bottom: 0;
-}
-
 .ns-112.action-submit .error ul {
     margin: 0;
     font-size: 1rem;

--- a/res/smw/special/ext.smw.special.admin.js
+++ b/res/smw/special/ext.smw.special.admin.js
@@ -196,7 +196,10 @@
 		this.context.css( 'opacity', 1 );
 		this.context.find( '.smw-jsonview-menu' ).hide();
 		this.context.find( '.' + this.contentClass ).hide();
-		this.context.find( '.' + this.errorClass ).append( error ).addClass( 'smw-callout smw-callout-error' );
+
+		var errorBox = this.context.find( '.' + this.errorClass );
+		errorBox.removeClass( 'smw-message--hidden' );
+		errorBox.find( '.smw-message-content' ).append( error );
 	};
 
 	/**

--- a/res/smw/special/ext.smw.special.ask.css
+++ b/res/smw/special/ext.smw.special.ask.css
@@ -56,10 +56,6 @@ div#query legend {
 	font-weight:bold;
 }
 
-#ask-change-info {
-	margin-top: 15px;
-}
-
 .smw-ask-toplinks {
 	padding: 0px 5px 5px 0px;
 	padding: 8px 15px;

--- a/res/smw/special/ext.smw.special.ask.js
+++ b/res/smw/special/ext.smw.special.ask.js
@@ -118,11 +118,15 @@
 		var msg = this.messages[key];
 		var msgType = msg[1];
 		var messageBox = this.messageBox;
-		var className = messageBox.attr( 'class' ).replace( '-' + this.messageBoxType, '-' + msgType );
-		messageBox.attr( 'class', className );
-		messageBox.removeClass( 'smw-message--hidden' );
+		// Remove old type class and add new one
+		messageBox.removeClass( 'smw-message-' + this.messageBoxType )
+			.addClass( 'smw-message-' + msgType );
 		messageBox.id = 'status-format-change';
-		messageBox.find( '.smw-message-content' ).append( mw.msg( msg[0], this.name ) );
+		// Clear existing content before adding new message
+		messageBox.find( '.smw-message-content' )
+			.empty()
+			.append( mw.msg( msg[0], this.name ) );
+		messageBox.removeClass( 'smw-message--hidden' );
 		this.messageBoxType = msgType;
 	};
 
@@ -139,10 +143,11 @@
 		// Reset message box to inital state
 		var msgType = 'notice';
 		var messageBox = this.messageBox;
-		var className = messageBox.attr( 'class' ).replace( '-' + this.messageBoxType, '-' + msgType );
-		messageBox.attr( 'class', className );
 		messageBox.addClass( 'smw-message--hidden' );
-		messageBox.find( '.smw-message-content' ).empty( '' );
+		// Remove old type class and add new one
+		messageBox.removeClass( 'smw-message-' + this.messageBoxType )
+			.addClass( 'smw-message-' + msgType );
+		messageBox.find( '.smw-message-content' ).empty();
 		this.messageBoxType = msgType;
 	};
 

--- a/res/smw/special/ext.smw.special.ask.js
+++ b/res/smw/special/ext.smw.special.ask.js
@@ -42,6 +42,10 @@
 		this.messages = {};
 
 		this.html = mw.html;
+		// Message box is server-rendered in LinksWidget.php
+		this.messageBox = $( '.smw-ask-change-info' );
+		// Default state is "notice"
+		this.messageBoxType = 'notice';
 
 		this.hideList = '#ask-embed, #inlinequeryembed, #ask-showhide,' +
 		'#ask-debug, #ask-clipboard, #ask-navinfo, #ask-cache, #result,' +
@@ -109,21 +113,17 @@
 	 */
 	change.prototype.show = function( key ) {
 
-		var msg = this.messages[key];
-
-		var html = this.html.element(
-			'div',
-			{
-				id: 'status-format-change',
-				class: 'smw-callout smw-callout-' + msg[1]
-			},
-			mw.msg( msg[0], this.name )
-		);
-
 		$( this.hideList ).hide();
 
-		$( '#status-format-change' ).remove();
-		$( '#ask-change-info' ).append( html );
+		var msg = this.messages[key];
+		var msgType = msg[1];
+		var messageBox = this.messageBox;
+		var className = messageBox.attr( 'class' ).replace( '-' + this.messageBoxType, '-' + msgType );
+		messageBox.attr( 'class', className );
+		messageBox.removeClass( 'smw-message--hidden' );
+		messageBox.id = 'status-format-change';
+		messageBox.find( '.smw-message-content' ).append( mw.msg( msg[0], this.name ) );
+		this.messageBoxType = msgType;
 	};
 
 	/**
@@ -133,10 +133,17 @@
 	change.prototype.hide = function() {
 
 		$( this.hideList ).show();
-		$( '#status-format-change' ).remove();
-
 		$( '#inlinequeryembed, #embed_hide' ).hide();
 		$( '#embed_show' ).show();
+
+		// Reset message box to inital state
+		var msgType = 'notice';
+		var messageBox = this.messageBox;
+		var className = messageBox.attr( 'class' ).replace( '-' + this.messageBoxType, '-' + msgType );
+		messageBox.attr( 'class', className );
+		messageBox.addClass( 'smw-message--hidden' );
+		messageBox.find( '.smw-message-content' ).empty( '' );
+		this.messageBoxType = msgType;
 	};
 
 	/**

--- a/res/smw/special/ext.smw.special.ask.js
+++ b/res/smw/special/ext.smw.special.ask.js
@@ -121,7 +121,7 @@
 		// Remove old type class and add new one
 		messageBox.removeClass( 'smw-message-' + this.messageBoxType )
 			.addClass( 'smw-message-' + msgType );
-		messageBox.id = 'status-format-change';
+		messageBox.attr( 'id', 'status-format-change' );
 		// Clear existing content before adding new message
 		messageBox.find( '.smw-message-content' )
 			.empty()
@@ -147,6 +147,7 @@
 		// Remove old type class and add new one
 		messageBox.removeClass( 'smw-message-' + this.messageBoxType )
 			.addClass( 'smw-message-' + msgType );
+		messageBox.removeAttr( 'id' );
 		messageBox.find( '.smw-message-content' ).empty();
 		this.messageBoxType = msgType;
 	};

--- a/res/smw/special/ext.smw.special.browse.js
+++ b/res/smw/special/ext.smw.special.browse.js
@@ -135,7 +135,7 @@
 			text = '<b>' + status.error.code + '</b><br\>' + status.error.info.replace(/#/g, "<br\>#" );
 		}
 
-		this.context.find( '.smwb-status' ).append( text ).addClass( 'smw-callout smw-callout-error' );
+		this.context.find( '.smwb-status' ).append( text ).addClass( 'error' );
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Supplement/DuplicateLookupTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/DuplicateLookupTaskHandler.php
@@ -130,28 +130,31 @@ class DuplicateLookupTaskHandler extends TaskHandler implements ActionableTask {
 
 		// Ajax is doing the query and result display to avoid a timeout issue
 		$html = Html::rawElement(
-				'div',
-				[
-					'class' => 'smw-admin-supplementary-duplicate-lookup',
-					'style' => 'opacity:0.5;position: relative;',
-					'data-config' => json_encode(
-						[
-							'contentClass' => 'smw-admin-supplementary-duplookup-content',
-							'errorClass'   => 'smw-admin-supplementary-duplookup-error'
-						]
-					)
-				],
-				Html::rawElement(
-				'div',
-				[
-					'class' => 'smw-admin-supplementary-duplookup-error'
-				]
-			) . Html::rawElement(
+			'div',
+			[
+				'class' => 'smw-admin-supplementary-duplicate-lookup',
+				'style' => 'opacity:0.5;position: relative;',
+				'data-config' => json_encode(
+					[
+						'contentClass' => 'smw-admin-supplementary-duplookup-content',
+						'errorClass'   => 'smw-admin-supplementary-duplookup-error'
+					]
+				)
+			],
+			Html::errorBox(
+				// Since message boxes can be rendered differently in different MW version,
+				// insert a div wrapper so JS can target that
+				Html::rawElement( 'div', [ 'class' => 'smw-message-content' ] ),
+				'',
+				'smw-message--hidden smw-admin-supplementary-duplookup-error'
+			) .
+			Html::rawElement(
 				'div',
 				[
 					'class' => 'smw-jsonview-menu',
 				]
-			) . Html::rawElement(
+			) .
+			Html::rawElement(
 				'pre',
 				[
 					'class' => 'smw-admin-supplementary-duplookup-content'

--- a/src/MediaWiki/Specials/Ask/LinksWidget.php
+++ b/src/MediaWiki/Specials/Ask/LinksWidget.php
@@ -203,31 +203,34 @@ class LinksWidget {
 			return '';
 		}
 
-		return  Html::rawElement(
-			'div',
+		return Html::noticeBox(
+				// Since message boxes can be rendered differently in different MW version,
+				// insert a div wrapper so JS can target that
+				Html::rawElement( 'div', [ 'class' => 'smw-message-content' ] ),
+				'smw-ask-change-info smw-message--hidden'
+			) .
+			Html::rawElement(
+				'div',
 				[
-					'id' => 'ask-change-info'
-				]
-			) . Html::rawElement(
-			'div',
-			[
-				'class' => 'smw-ask-button-submit'
-			], Html::element(
-				'input',
-				[
-					'id' => 'search-action',
-					'type'  => 'submit',
-					'value' => wfMessage( 'smw_ask_submit' )->escaped()
-				]
-			) . Html::element(
-				'input',
-				[
-					'type'  => 'hidden',
-					'name'  => 'eq',
-					'value' => 'yes'
-				]
-			)
-		);
+					'class' => 'smw-ask-button-submit'
+				],
+				Html::element(
+					'input',
+					[
+						'id' => 'search-action',
+						'type'  => 'submit',
+						'value' => wfMessage( 'smw_ask_submit' )->escaped()
+					]
+				) .
+				Html::element(
+					'input',
+					[
+						'type'  => 'hidden',
+						'name'  => 'eq',
+						'value' => 'yes'
+					]
+				)
+			);
 	}
 
 	/**

--- a/src/MediaWiki/Specials/PendingTasks/IncompleteSetupTasks.php
+++ b/src/MediaWiki/Specials/PendingTasks/IncompleteSetupTasks.php
@@ -56,8 +56,7 @@ class IncompleteSetupTasks {
 			$html = Html::rawElement(
 				'p',
 				[
-					'style' => 'margin-top:10px;color:#888',
-					//'class' => 'smw-callout smw-callout-error'
+					'style' => 'margin-top:10px;color:#888'
 				],
 				Message::get( [ 'smw-pendingtasks-setup-intro', $count ], Message::PARSE, Message::USER_LANGUAGE )
 			) . $this->buildList( $incompleteTasks );


### PR DESCRIPTION
Follow up to #5758

- Add `smw-message--hidden` class to hide server-rendered message boxes
- Add `smw-message-content` class to target message content in server-rendered boxes
- Drop all usage of smw-callout in JS. They are either replaced by message boxes or the built-in `error` class

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced a new CSS class `.smw-message--hidden` for better control of message visibility.

- **Bug Fixes**
  - Simplified error message styling across various components by standardizing error class usage.
  
- **Style**
  - Removed outdated callout styles and adjusted button hover states for improved user interface consistency.
  - Enhanced layout responsiveness for mobile devices.

- **Chores**
  - Minor adjustments to the HTML structure for better error message presentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->