### PR TITLE
Remove call to LoadBalancer::reuseConnection()

### DIFF
--- a/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
+++ b/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
@@ -108,9 +108,6 @@ class LoadBalancerConnectionProvider implements IConnectionProvider {
 	 * @since 1.9
 	 */
 	public function releaseConnection() {
-		if ( $this->loadBalancer !== null && $this->connection !== null ) {
-			$this->loadBalancer->reuseConnection( $this->connection );
-		}
 	}
 
 	/**


### PR DESCRIPTION
Deprecated since MW 1.39
https://phabricator.wikimedia.org/T326274

Fixes: #5735

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the connection handling logic to improve resource management by simplifying the `releaseConnection` method.
  
- **Refactor**
	- Removed conditional checks in the `releaseConnection` method, streamlining the connection release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->