### PR TITLE
Use setExtensionData instead of setPageProperty for `smw-semanticdata-status`

### DIFF
--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -351,7 +351,7 @@ class ParserData {
 
 		$this->parserOutput->setExtensionData(
 			'smw-semanticdata-status',
-			$this->semanticData->getProperties() !== [] ?? false
+			$this->semanticData->getProperties() !== []
 		);
 	}
 
@@ -370,7 +370,7 @@ class ParserData {
 	 * @return boolean
 	 */
 	public static function hasSemanticData( ParserOutput $parserOutput ) {
-		return $parserOutput->getExtensionData( 'smw-semanticdata-status' );
+		return $parserOutput->getExtensionData( 'smw-semanticdata-status' ) ?? false;
 	}
 
 	/**

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -371,7 +371,7 @@ class ParserData {
 	 * @return boolean
 	 */
 	public static function hasSemanticData( ParserOutput $parserOutput ) {
-		return (bool)( $parserOutput->getExtensionData( 'smw-semanticdata-status' ) ?? false );
+		return (bool)$parserOutput->getExtensionData( 'smw-semanticdata-status' );
 	}
 
 	/**

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -349,18 +349,10 @@ class ParserData {
 	public function markParserOutput() {
 		$this->parserOutput->setTimestamp( wfTimestampNow() );
 
-		if ( method_exists( $this->parserOutput, 'setPageProperty' ) ) {
-			$this->parserOutput->setPageProperty(
-				'smw-semanticdata-status',
-				$this->semanticData->getProperties() !== []
-			);
-		} else {
-			// MW < 1.38
-			$this->parserOutput->setProperty(
-				'smw-semanticdata-status',
-				$this->semanticData->getProperties() !== []
-			);
-		}
+		$this->parserOutput->setPageProperty(
+			'smw-semanticdata-status',
+			$this->semanticData->getProperties() !== []
+		);
 	}
 
 	/**

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -349,10 +349,9 @@ class ParserData {
 	public function markParserOutput() {
 		$this->parserOutput->setTimestamp( wfTimestampNow() );
 
-		// ParserOutput::setExtensionData can only take scalar values
 		$this->parserOutput->setExtensionData(
 			'smw-semanticdata-status',
-			$this->semanticData->getProperties() !== [] ? 'true' : 'false'
+			$this->semanticData->getProperties() !== []
 		);
 	}
 
@@ -371,7 +370,7 @@ class ParserData {
 	 * @return boolean
 	 */
 	public static function hasSemanticData( ParserOutput $parserOutput ) {
-		return $parserOutput->getExtensionData( 'smw-semanticdata-status' ) === 'true';
+		return $parserOutput->getExtensionData( 'smw-semanticdata-status' );
 	}
 
 	/**

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -371,7 +371,7 @@ class ParserData {
 	 * @return boolean
 	 */
 	public static function hasSemanticData( ParserOutput $parserOutput ) {
-		return (bool)$parserOutput->getExtensionData( 'smw-semanticdata-status' );
+		return $parserOutput->getExtensionData( 'smw-semanticdata-status' ) === 'true';
 	}
 
 	/**

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -349,9 +349,10 @@ class ParserData {
 	public function markParserOutput() {
 		$this->parserOutput->setTimestamp( wfTimestampNow() );
 
-		$this->parserOutput->setPageProperty(
+		// ParserOutput::setExtensionData can only take scalar values
+		$this->parserOutput->setExtensionData(
 			'smw-semanticdata-status',
-			$this->semanticData->getProperties() !== []
+			$this->semanticData->getProperties() !== [] ? 'true' : 'false'
 		);
 	}
 
@@ -370,14 +371,7 @@ class ParserData {
 	 * @return boolean
 	 */
 	public static function hasSemanticData( ParserOutput $parserOutput ) {
-		if ( method_exists( $parserOutput, 'getPageProperty' ) ) {
-			// T301915
-			return (bool)( $parserOutput->getPageProperty( 'smw-semanticdata-status' ) ?? false );
-		} else {
-			// MW < 1.38
-			return (bool)$parserOutput->getProperty( 'smw-semanticdata-status' );
-		}
-
+		return (bool)( $parserOutput->getExtensionData( 'smw-semanticdata-status' ) ?? false );
 	}
 
 	/**

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -351,7 +351,7 @@ class ParserData {
 
 		$this->parserOutput->setExtensionData(
 			'smw-semanticdata-status',
-			$this->semanticData->getProperties() !== []
+			$this->semanticData->getProperties() !== [] ?? false
 		);
 	}
 

--- a/tests/phpunit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -216,14 +216,8 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 
 		$displayTitle = isset( $parameters['displaytitle'] ) ? $parameters['displaytitle'] : false;
 
-		if ( method_exists( $parserOutput, 'setPageProperty' ) ) {
-			$parserOutput->setPageProperty( 'smw-semanticdata-status', $parameters['data-status'] );
-			$parserOutput->setPageProperty( 'displaytitle', $displayTitle );
-		} else {
-			// MW < 1.38
-			$parserOutput->setProperty( 'smw-semanticdata-status', $parameters['data-status'] );
-			$parserOutput->setProperty( 'displaytitle', $displayTitle );
-		}
+		$parserOutput->setPageProperty( 'smw-semanticdata-status', $parameters['data-status'] );
+		$parserOutput->setPageProperty( 'displaytitle', $displayTitle );
 
 		$text   = '';
 
@@ -322,13 +316,7 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 
 		$parserOutput->addCategory( 'Foo', 'Foo' );
 		$parserOutput->addCategory( 'Bar', 'Bar' );
-		if ( method_exists( $parserOutput, 'setPageProperty' ) ) {
-			$parserOutput->setPageProperty( 'smw-semanticdata-status', true );
-		} else {
-			// MW < 1.38
-			$parserOutput->setProperty( 'smw-semanticdata-status', true );
-		}
-
+		$parserOutput->setPageProperty( 'smw-semanticdata-status', true );
 
 		$instance = new ParserAfterTidy(
 			$parser,

--- a/tests/phpunit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -216,7 +216,7 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 
 		$displayTitle = isset( $parameters['displaytitle'] ) ? $parameters['displaytitle'] : false;
 
-		$parserOutput->setExtensionData( 'smw-semanticdata-status', $parameters['data-status'] ? 'true' : 'false' );
+		$parserOutput->setExtensionData( 'smw-semanticdata-status', $parameters['data-status'] );
 		$parserOutput->setPageProperty( 'displaytitle', $displayTitle );
 
 		$text   = '';
@@ -316,8 +316,7 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 
 		$parserOutput->addCategory( 'Foo', 'Foo' );
 		$parserOutput->addCategory( 'Bar', 'Bar' );
-		// ParserOutput::setExtensionData can only take scalar values
-		$parserOutput->setExtensionData( 'smw-semanticdata-status', 'true' );
+		$parserOutput->setExtensionData( 'smw-semanticdata-status', true );
 
 		$instance = new ParserAfterTidy(
 			$parser,

--- a/tests/phpunit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -216,7 +216,7 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 
 		$displayTitle = isset( $parameters['displaytitle'] ) ? $parameters['displaytitle'] : false;
 
-		$parserOutput->setPageProperty( 'smw-semanticdata-status', $parameters['data-status'] );
+		$parserOutput->setExtensionData( 'smw-semanticdata-status', $parameters['data-status'] ? 'true' : 'false' );
 		$parserOutput->setPageProperty( 'displaytitle', $displayTitle );
 
 		$text   = '';
@@ -316,7 +316,8 @@ class ParserAfterTidyTest extends \PHPUnit_Framework_TestCase {
 
 		$parserOutput->addCategory( 'Foo', 'Foo' );
 		$parserOutput->addCategory( 'Bar', 'Bar' );
-		$parserOutput->setPageProperty( 'smw-semanticdata-status', true );
+		// ParserOutput::setExtensionData can only take scalar values
+		$parserOutput->setExtensionData( 'smw-semanticdata-status', 'true' );
 
 		$instance = new ParserAfterTidy(
 			$parser,


### PR DESCRIPTION
We don't need `smw-semanticdata-status` in the database. And this will also fix the non-string value deprecation issue with `setPageProperty`.

Fixes: #5751 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Improved handling of semantic data within the application, ensuring a more consistent approach to status management.

- **Bug Fixes**
	- Streamlined logic for setting and retrieving semantic data, eliminating unnecessary complexity and version checks.

- **Refactor**
	- Deprecated older methods in favor of new, clearer methods for managing semantic data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->