### PR TITLE
Disable premature optimisation of preloading data

### DIFF
--- a/src/MediaWiki/Hooks/ArticleViewHeader.php
+++ b/src/MediaWiki/Hooks/ArticleViewHeader.php
@@ -76,11 +76,6 @@ class ArticleViewHeader implements HookListener {
 
 		$subject = DIWikiPage::newFromTitle( $title );
 
-		// Preload data most likely to be used during a request hereby providing
-		// a possibility to bundle relevant data objects early given that this
-		// hook runs before any other GET request
-		$this->store->getObjectIds()->preload( [ $subject ] );
-
 		$changePropagationWatchlist = array_flip(
 			$this->getOption( 'smwgChangePropagationWatchlist', [] )
 		);


### PR DESCRIPTION
It causes excessive DB calls on all page load, even if the parser cache is used. Cherry-picked from WeirdGloop's fork.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed preloading of object IDs in the Article View Header, optimizing data loading during requests.
- **Refactor**
	- Streamlined the data fetching strategy without affecting existing functionality related to category updates and message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->