### PR TITLE
Clean up unused code that are MW < 1.39 and PHP < 7.4

### DIFF
--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -157,24 +157,16 @@ class ContentParser {
 		// Avoid "The content model 'xyz' is not registered on this wiki."
 		try {
 			$services = MediaWikiServices::getInstance();
-			// MW 1.38+
-			if ( method_exists( $services, 'getContentRenderer' ) ) {
-				// MW 1.42+
-				if ( version_compare( MW_VERSION, '1.42', '<' ) ) {
-					$revision = $revision->getId();
-				}
-				$contentRenderer = $services->getContentRenderer();
-				$this->parserOutput = $contentRenderer->getParserOutput(
-					$content,
-					$this->getTitle(),
-					$revision
-				);
-			} else {
-				$this->parserOutput = $content->getParserOutput(
-					$this->getTitle(),
-					$revision->getId()
-				);
+			// MW 1.42+
+			if ( version_compare( MW_VERSION, '1.42', '<' ) ) {
+				$revision = $revision->getId();
 			}
+			$contentRenderer = $services->getContentRenderer();
+			$this->parserOutput = $contentRenderer->getParserOutput(
+				$content,
+				$this->getTitle(),
+				$revision
+			);
 		} catch( \MWUnknownContentModelException $e ) {
 			$this->parserOutput = null;
 		}

--- a/includes/SMW_PageSchemas.php
+++ b/includes/SMW_PageSchemas.php
@@ -297,12 +297,7 @@ class SMWPageSchemas extends PSExtensionHandler {
 			$jobs[] = new PSCreatePageJob( $propTitle, $jobParams );
 		}
 
-		if ( method_exists( MediaWikiServices::class, 'getJobQueueGroup' ) ) {
-			// MW 1.37+
-			MediaWikiServices::getInstance()->getJobQueueGroup()->push( $jobs );
-		} else {
-			JobQueueGroup::singleton()->push( $jobs );
-		}
+		MediaWikiServices::getInstance()->getJobQueueGroup()->push( $jobs );
 	}
 
 	/**

--- a/includes/specials/SMW_SpecialTypes.php
+++ b/includes/specials/SMW_SpecialTypes.php
@@ -102,11 +102,6 @@ class SMWSpecialTypes extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/properties-concepts-types';
 	}
 

--- a/includes/specials/SpecialConcepts.php
+++ b/includes/specials/SpecialConcepts.php
@@ -175,11 +175,6 @@ class SpecialConcepts extends \SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/properties-concepts-types';
 	}
 

--- a/includes/specials/SpecialProperties.php
+++ b/includes/specials/SpecialProperties.php
@@ -56,22 +56,12 @@ class SpecialProperties extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/properties-concepts-types';
 	}
 
 	private function getLimitOffset() {
 		$request = $this->getRequest();
-		if ( method_exists( $request, 'getLimitOffsetForUser' ) ) {
-			// MW 1.35+
-			return $request->getLimitOffsetForUser( $this->getUser() );
-		} else {
-			return $request->getLimitOffset();
-		}
+		return $request->getLimitOffsetForUser( $this->getUser() );
 	}
 
 }

--- a/includes/specials/SpecialUnusedProperties.php
+++ b/includes/specials/SpecialUnusedProperties.php
@@ -57,22 +57,12 @@ class SpecialUnusedProperties extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/properties-concepts-types';
 	}
 
 	private function getLimitOffset() {
 		$request = $this->getRequest();
-		if ( method_exists( $request, 'getLimitOffsetForUser' ) ) {
-			// MW 1.35+
-			return $request->getLimitOffsetForUser( $this->getUser() );
-		} else {
-			return $request->getLimitOffset();
-		}
+		return $request->getLimitOffsetForUser( $this->getUser() );
 	}
 
 }

--- a/includes/specials/SpecialWantedProperties.php
+++ b/includes/specials/SpecialWantedProperties.php
@@ -63,22 +63,12 @@ class SpecialWantedProperties extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/properties-concepts-types';
 	}
 
 	private function getLimitOffset() {
 		$request = $this->getRequest();
-		if ( method_exists( $request, 'getLimitOffsetForUser' ) ) {
-			// MW 1.35+
-			return $request->getLimitOffsetForUser( $this->getUser() );
-		} else {
-			return $request->getLimitOffset();
-		}
+		return $request->getLimitOffsetForUser( $this->getUser() );
 	}
 
 }

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -117,8 +117,7 @@ return [
 	// Avoid "Warning: Use of the json module is deprecated since MediaWiki 1.29"
 	// jStorage was added in MW 1.20
 	'ext.jquery.jStorage' => $moduleTemplate + [
-		'scripts' => 'jquery/jquery.jstorage.js',
-		'dependencies' => version_compare( MW_VERSION, '1.29', '<' ) ? 'json' : [],
+		'scripts' => 'jquery/jquery.jstorage.js'
 	],
 
 	// md5 hash key generator

--- a/res/smw/special.search/search.input.js
+++ b/res/smw/special.search/search.input.js
@@ -23,13 +23,7 @@
 			// expected on a [[ ... ]] input
 			context.on( 'keyup keypres mouseenter', function( e ) {
 
-				// MW 1.27 - MW 1.31
-				var highlighter = context.parent().find( '.oo-ui-widget' );
-
-				// MW 1.32+
-				if ( highlighter.length == 0 ) {
-					highlighter = $( '.oo-ui-defaultOverlay > .oo-ui-widget' );
-				};
+				var highlighter = $( '.oo-ui-defaultOverlay > .oo-ui-widget' );
 
 				// Disable (hide) the MW's search input highlighter
 				if ( context.val().search( /\[|\[\[|in:|not:|has:|phrase:|::/gi ) > -1 ) {

--- a/res/smw/suggester/ext.smw.suggester.textInput.js
+++ b/res/smw/suggester/ext.smw.suggester.textInput.js
@@ -49,13 +49,7 @@
 				// input help will be shown
 				context.on( 'keyup keypres mouseenter', function( e ) {
 
-					// MW 1.27 - MW 1.31
-					var highlighter = context.parent().find( '.oo-ui-widget' );
-
-					// MW 1.32+
-					if ( highlighter.length == 0 ) {
-						highlighter = $( '.oo-ui-defaultOverlay > .oo-ui-widget' );
-					};
+					var highlighter = $( '.oo-ui-defaultOverlay > .oo-ui-widget' );
 
 					// Disable (hide) the MW's search input highlighter
 					if ( context.val().search( /\[|\[\[|in:|not:|has:|phrase:|::/gi ) > -1 ) {

--- a/src/Factbox/Factbox.php
+++ b/src/Factbox/Factbox.php
@@ -341,8 +341,6 @@ class Factbox {
 		$this->displayTitleFinder->prefetchFromSemanticData( $semanticData );
 
 		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
-		// Hook deprecated with SMW 1.9 and will vanish with SMW 1.11
-		$hookContainer->run( 'smwShowFactbox', [ &$html, $semanticData ] );
 
 		// Hook since 1.9
 		if ( $hookContainer->run( 'SMW::Factbox::BeforeContentGeneration', [ &$html, $semanticData ] ) ) {

--- a/src/Importer/ContentCreators/TextContentCreator.php
+++ b/src/Importer/ContentCreators/TextContentCreator.php
@@ -154,26 +154,14 @@ class TextContentCreator implements ContentCreator {
 			$user = User::newSystemUser( $importContents->getImportPerformer(), [ 'steal' => true ] );
 		}
 
-		if ( method_exists( $page, 'doUserEditContent' ) ) {
-			// MW 1.36+
-			// Use the global user if necessary (same as doEditContent())
-			$user = $user ?? RequestContext::getMain()->getUser();
-			$status = $page->doUserEditContent(
-				$content,
-				$user,
-				$importContents->getDescription(),
-				EDIT_FORCE_BOT
-			);
-		} else {
-			// <= MW 1.35
-			$status = $page->doEditContent(
-				$content,
-				$importContents->getDescription(),
-				EDIT_FORCE_BOT,
-				false,
-				$user
-			);
-		}
+		// Use the global user if necessary (same as doEditContent())
+		$user = $user ?? RequestContext::getMain()->getUser();
+		$status = $page->doUserEditContent(
+			$content,
+			$user,
+			$importContents->getDescription(),
+			EDIT_FORCE_BOT
+		);
 
 
 

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -314,12 +314,6 @@ class Hooks {
 			'AdminLinks' => [ $this, 'onAdminLinks' ],
 			'PageSchemasRegisterHandlers' => [ $this, 'onPageSchemasRegisterHandlers' ]
 		];
-
-		if ( version_compare( MW_VERSION, '1.37', '<' ) ) {
-			$this->handlers += [
-				'PersonalUrls' => [ $this, 'onPersonalUrls' ]
-			];
-		}
 	}
 
 	/**

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -1235,12 +1235,7 @@ class Hooks {
 		);
 
 		$userChange->setOrigin( 'BlockIpComplete' );
-		if ( method_exists( $block, 'getTargetUserIdentity' ) ) {
-			// MW 1.37+
-			$userChange->process( $block->getTargetUserIdentity() );
-		} else {
-			$userChange->process( $block->getTarget() );
-		}
+		$userChange->process( $block->getTargetUserIdentity() );
 
 		return true;
 	}
@@ -1258,12 +1253,7 @@ class Hooks {
 		);
 
 		$userChange->setOrigin( 'UnblockUserComplete' );
-		if ( method_exists( $block, 'getTargetUserIdentity' ) ) {
-			// MW 1.37+
-			$userChange->process( $block->getTargetUserIdentity() );
-		} else {
-			$userChange->process( $block->getTarget() );
-		}
+		$userChange->process( $block->getTargetUserIdentity() );
 
 		return true;
 	}

--- a/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
+++ b/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
@@ -146,15 +146,8 @@ class InternalParseBeforeLinks implements HookListener {
 		return true;
 	}
 
-	/**
-	 * #656 / MW 1.24+
-	 */
 	private function getRedirectTarget() {
-		if ( method_exists( $this->parser->getOptions(), 'getRedirectTarget' ) ) {
-			return $this->parser->getOptions()->getRedirectTarget();
-		}
-
-		return null;
+		return $this->parser->getOptions()->getRedirectTarget();
 	}
 
 }

--- a/src/MediaWiki/Page/Page.php
+++ b/src/MediaWiki/Page/Page.php
@@ -88,11 +88,7 @@ abstract class Page extends Article {
 		$diffOnly = $request->getBool( 'diffonly', $userOptionsLookup->getOption( $user, 'diffonly' ) );
 
 		if ( !isset( $diff ) || !$diffOnly ) {
-			// MW 1.25+
-			if ( method_exists( $outputPage, 'setIndicators' ) && ( $indicators = $this->getTopIndicators() ) !== '' ) {
-				$outputPage->setIndicators( $indicators );
-			}
-
+			$outputPage->setIndicators( $indicators );
 			$outputPage->addHTML( $this->initHtml() );
 			$outputPage->addHTML( $this->beforeView() );
 		}

--- a/src/MediaWiki/Page/Page.php
+++ b/src/MediaWiki/Page/Page.php
@@ -88,7 +88,6 @@ abstract class Page extends Article {
 		$diffOnly = $request->getBool( 'diffonly', $userOptionsLookup->getOption( $user, 'diffonly' ) );
 
 		if ( !isset( $diff ) || !$diffOnly ) {
-			$outputPage->setIndicators( $indicators );
 			$outputPage->addHTML( $this->initHtml() );
 			$outputPage->addHTML( $this->beforeView() );
 		}
@@ -140,15 +139,6 @@ abstract class Page extends Article {
 	 */
 	protected function getRedirectTargetURL() {
 		return false;
-	}
-
-	/**
-	 * @since 2.4
-	 *
-	 * @return string
-	 */
-	protected function getTopIndicators() {
-		return '';
 	}
 
 	/**

--- a/src/MediaWiki/Search/SearchEngineFactory.php
+++ b/src/MediaWiki/Search/SearchEngineFactory.php
@@ -38,10 +38,7 @@ class SearchEngineFactory {
 		$type = $settings->get( 'smwgFallbackSearchType' );
 		$defaultSearchEngine = $applicationFactory->create( 'DefaultSearchEngineTypeForDB', $connection );
 
-		// https://github.com/wikimedia/mediawiki/commit/f92a1a6db3b659d9943ca66eacff99b5e4133c7b
-		if ( version_compare( MW_VERSION, '1.34', '>=' ) ) {
-			$connection = $applicationFactory->create( 'DBLoadBalancer' );
-		}
+		$connection = $applicationFactory->create( 'DBLoadBalancer' );
 
 		if ( is_callable( $type ) ) {
 			// #3939

--- a/src/MediaWiki/Search/SearchEngineFactory.php
+++ b/src/MediaWiki/Search/SearchEngineFactory.php
@@ -38,8 +38,6 @@ class SearchEngineFactory {
 		$type = $settings->get( 'smwgFallbackSearchType' );
 		$defaultSearchEngine = $applicationFactory->create( 'DefaultSearchEngineTypeForDB', $connection );
 
-		$connection = $applicationFactory->create( 'DBLoadBalancer' );
-
 		if ( is_callable( $type ) ) {
 			// #3939
 			$fallbackSearchEngine = $type( $connection );

--- a/src/MediaWiki/Search/SearchEngineFactory.php
+++ b/src/MediaWiki/Search/SearchEngineFactory.php
@@ -38,13 +38,15 @@ class SearchEngineFactory {
 		$type = $settings->get( 'smwgFallbackSearchType' );
 		$defaultSearchEngine = $applicationFactory->create( 'DefaultSearchEngineTypeForDB', $connection );
 
+		$dbLoadBalancer = $applicationFactory->create( 'DBLoadBalancer' );
+
 		if ( is_callable( $type ) ) {
 			// #3939
-			$fallbackSearchEngine = $type( $connection );
+			$fallbackSearchEngine = $type( $dbLoadBalancer );
 		} elseif ( $type !== null && $this->isValidSearchDatabaseType( $type ) ) {
-			$fallbackSearchEngine = new $type( $connection );
+			$fallbackSearchEngine = new $type( $dbLoadBalancer );
 		} else {
-			$fallbackSearchEngine = new $defaultSearchEngine( $connection );
+			$fallbackSearchEngine = new $defaultSearchEngine( $dbLoadBalancer );
 		}
 
 		if ( !$fallbackSearchEngine instanceof SearchEngine ) {

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -185,11 +185,6 @@ class SpecialAsk extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/search';
 	}
 

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -221,11 +221,6 @@ class SpecialBrowse extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/search';
 	}
 

--- a/src/MediaWiki/Specials/SpecialConstraintErrorList.php
+++ b/src/MediaWiki/Specials/SpecialConstraintErrorList.php
@@ -63,11 +63,6 @@ class SpecialConstraintErrorList extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/maintenance';
 	}
 

--- a/src/MediaWiki/Specials/SpecialFacetedSearch.php
+++ b/src/MediaWiki/Specials/SpecialFacetedSearch.php
@@ -210,11 +210,6 @@ class SpecialFacetedSearch extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/search';
 	}
 

--- a/src/MediaWiki/Specials/SpecialMissingRedirectAnnotations.php
+++ b/src/MediaWiki/Specials/SpecialMissingRedirectAnnotations.php
@@ -85,11 +85,6 @@ class SpecialMissingRedirectAnnotations extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/maintenance';
 	}
 

--- a/src/MediaWiki/Specials/SpecialPageProperty.php
+++ b/src/MediaWiki/Specials/SpecialPageProperty.php
@@ -85,11 +85,6 @@ class SpecialPageProperty extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/search';
 	}
 

--- a/src/MediaWiki/Specials/SpecialPendingTaskList.php
+++ b/src/MediaWiki/Specials/SpecialPendingTaskList.php
@@ -49,11 +49,6 @@ class SpecialPendingTaskList extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/maintenance';
 	}
 

--- a/src/MediaWiki/Specials/SpecialProcessingErrorList.php
+++ b/src/MediaWiki/Specials/SpecialProcessingErrorList.php
@@ -62,11 +62,6 @@ class SpecialProcessingErrorList extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/maintenance';
 	}
 

--- a/src/MediaWiki/Specials/SpecialPropertyLabelSimilarity.php
+++ b/src/MediaWiki/Specials/SpecialPropertyLabelSimilarity.php
@@ -87,11 +87,6 @@ class SpecialPropertyLabelSimilarity extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/properties-concepts-types';
 	}
 

--- a/src/MediaWiki/Specials/SpecialSearchByProperty.php
+++ b/src/MediaWiki/Specials/SpecialSearchByProperty.php
@@ -82,12 +82,7 @@ class SpecialSearchByProperty extends SpecialPage {
 
 	private function getLimitOffset() {
 		$request = $this->getRequest();
-		if ( method_exists( $request, 'getLimitOffsetForUser' ) ) {
-			// MW 1.35+
-			return $request->getLimitOffsetForUser( $this->getUser() );
-		} else {
-			return $request->getLimitOffset();
-		}
+		return $request->getLimitOffsetForUser( $this->getUser() );
 	}
 
 	/**

--- a/src/MediaWiki/Specials/SpecialSearchByProperty.php
+++ b/src/MediaWiki/Specials/SpecialSearchByProperty.php
@@ -94,11 +94,6 @@ class SpecialSearchByProperty extends SpecialPage {
 	 * @see SpecialPage::getGroupName
 	 */
 	protected function getGroupName() {
-		if ( version_compare( MW_VERSION, '1.33', '<' ) ) {
-			return 'smw_group';
-		}
-
-		// #3711, MW 1.33+
 		return 'smw_group/search';
 	}
 

--- a/src/MediaWiki/TitleFactory.php
+++ b/src/MediaWiki/TitleFactory.php
@@ -60,27 +60,7 @@ class TitleFactory {
 			->getDBLoadBalancer()
 			->getMaintenanceConnectionRef( DB_REPLICA );
 
-		// Since PageStore is only available starting from 1.36
-		if ( version_compare( MW_VERSION, '1.36', '>=' ) ) {
-			$fields = $container->getPageStore()->getSelectFields();
-		} else {
-			$fields = [
-				'page_id',
-				'page_namespace',
-				'page_title',
-				'page_is_redirect',
-				'page_is_new',
-				'page_touched',
-				'page_links_updated',
-				'page_latest',
-				'page_len',
-				'page_content_model'
-			];
-
-			if ( $container->getMainConfig()->get( 'PageLanguageUseDB' ) ) {
-				$fields[] = 'page_lang';
-			}
-		}
+		$fields = $container->getPageStore()->getSelectFields();
 
 		$res = $dbr->select(
 			'page',

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -55,24 +55,20 @@ return [
 	 */
 	'WikiImporter' => function ( $containerBuilder, \ImportSource $importSource ) {
 		$containerBuilder->registerExpectedReturnType( 'WikiImporter', '\WikiImporter' );
-		if ( version_compare( MW_VERSION, '1.37', '<' ) ) {
-			return new WikiImporter( $importSource, $containerBuilder->create( 'MainConfig' ) );
-		} else {
-			$services = MediaWikiServices::getInstance();
-			return new WikiImporter(
-				$importSource,
-				$containerBuilder->create( 'MainConfig' ),
-				$services->getHookContainer(),
-				$services->getContentLanguage(),
-				$services->getNamespaceInfo(),
-				$services->getTitleFactory(),
-				$services->getWikiPageFactory(),
-				$services->getWikiRevisionUploadImporter(),
-				$services->getPermissionManager(),
-				$services->getContentHandlerFactory(),
-				$services->getSlotRoleRegistry()
-			);
-		}
+		$services = MediaWikiServices::getInstance();
+		return new WikiImporter(
+			$importSource,
+			$containerBuilder->create( 'MainConfig' ),
+			$services->getHookContainer(),
+			$services->getContentLanguage(),
+			$services->getNamespaceInfo(),
+			$services->getTitleFactory(),
+			$services->getWikiPageFactory(),
+			$services->getWikiRevisionUploadImporter(),
+			$services->getPermissionManager(),
+			$services->getContentHandlerFactory(),
+			$services->getSlotRoleRegistry()
+		);
 	},
 
 	/**

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -188,12 +188,7 @@ return [
 	'JobQueueGroup' => function ( $containerBuilder ) {
 		$containerBuilder->registerExpectedReturnType( 'JobQueueGroup', '\JobQueueGroup' );
 
-		if ( method_exists( MediaWikiServices::class, 'getJobQueueGroup' ) ) {
-			// MW 1.37+
-			return MediaWikiServices::getInstance()->getJobQueueGroup();
-		} else {
-			return JobQueueGroup::singleton();
-		}
+		return MediaWikiServices::getInstance()->getJobQueueGroup();
 	},
 
 	/**

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -182,18 +182,6 @@ final class Setup {
 				$vars['wgResourceModules'] = array_merge( $vars['wgResourceModules'], include( $file ) );
 			}
 		}
-
-		// #3626
-		//
-		// Required due to support of LTS (1.31)
-		// Do replace `mediawiki.api.parse` (Resources.php) with `mediawiki.api`
-		// starting with the next supported LTS (likely MW 1.35)
-		if ( version_compare( MW_VERSION, '1.32', '>=' ) ) {
-			$vars['wgResourceModules']['mediawiki.api.parse'] = [
-				'dependencies' => 'mediawiki.api',
-				'targets' => [ 'desktop', 'mobile' ]
-			];
-		}
 	}
 
 	private function initConnectionProviders() {

--- a/src/Tesa/tests/phpunit/Unit/SanitizerTest.php
+++ b/src/Tesa/tests/phpunit/Unit/SanitizerTest.php
@@ -76,12 +76,6 @@ class SanitizerTest extends TestCase {
 	}
 
 	public function testReduceLengthToNearestWholeWordForNonLatinString() {
-		if ( version_compare( phpversion(), '5.4', '<' ) ) {
-			$this->markTestSkipped(
-				"Boo, PHP 5.3 returns with `Failed asserting that 9 matches expected 3`"
-			);
-		}
-
 		$instance = new Sanitizer( '一　二　三' );
 		$instance->reduceLengthTo( 3 );
 

--- a/src/Tesa/tests/phpunit/Unit/Tokenizer/JaCompoundGroupTokenizerTest.php
+++ b/src/Tesa/tests/phpunit/Unit/Tokenizer/JaCompoundGroupTokenizerTest.php
@@ -27,12 +27,6 @@ class JaCompoundGroupTokenizerTest extends TestCase {
 	 * @dataProvider stringProvider
 	 */
 	public function testTokenize( $string, $expected ) {
-		if ( version_compare( phpversion(), '5.4', '<' ) ) {
-			$this->markTestSkipped(
-				"Boo, PHP 5.3 returns with unexpected results"
-			);
-		}
-
 		$instance = new JaCompoundGroupTokenizer();
 
 		$this->assertEquals(
@@ -42,12 +36,6 @@ class JaCompoundGroupTokenizerTest extends TestCase {
 	}
 
 	public function testTokenizeWithOption() {
-		if ( version_compare( phpversion(), '5.4', '<' ) ) {
-			$this->markTestSkipped(
-				"Ehh, PHP 5.3 returns with unexpected results"
-			);
-		}
-
 		$string = 'と歓声を上げていました';
 
 		$tokenizer = $this->getMockBuilder( '\Onoi\Tesa\Tokenizer\Tokenizer' )

--- a/src/Tesa/tests/phpunit/Unit/Tokenizer/NGramTokenizerTest.php
+++ b/src/Tesa/tests/phpunit/Unit/Tokenizer/NGramTokenizerTest.php
@@ -27,12 +27,6 @@ class NGramTokenizerTest extends TestCase {
 	 * @dataProvider stringProvider
 	 */
 	public function testTokenize( $string, $ngram, $expected ) {
-		if ( version_compare( phpversion(), '5.4', '<' ) ) {
-			$this->markTestSkipped(
-				"Ehh, PHP 5.3 returns with unexpected results"
-			);
-		}
-
 		$instance = new NGramTokenizer( null, $ngram );
 
 		$this->assertEquals(

--- a/src/Utils/CliMsgFormatter.php
+++ b/src/Utils/CliMsgFormatter.php
@@ -206,7 +206,7 @@ class CliMsgFormatter {
 		// "...osx uses \r as carriage return and line feed ..." hence using
 		// `\033[0G` instead
 
-		return ( version_compare( PHP_VERSION, '7.3', '<' ) ? "\r" : "\033[0G" ) . ( sprintf( "%-{$len}s%s", "$firstCol" . sprintf( "%'{$placeHolder}{$placeholderLen}s", ' ' ), $secondCol ) );
+		return "\033[0G" . ( sprintf( "%-{$len}s%s", "$firstCol" . sprintf( "%'{$placeHolder}{$placeholderLen}s", ' ' ), $secondCol ) );
 	}
 
 	/**

--- a/tests/phpunit/Importer/ContentCreators/XmlContentCreatorTest.php
+++ b/tests/phpunit/Importer/ContentCreators/XmlContentCreatorTest.php
@@ -23,10 +23,6 @@ class XmlContentCreatorTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		if ( !interface_exists( '\ImportSource' ) ) {
-			$this->markTestSkipped( "ImportSource interface is unknown (MW 1.25-)" );
-		}
-
 		$importStreamSource = $this->getMockBuilder( '\ImportStreamSource' )
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0014.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0014.json
@@ -182,27 +182,6 @@
 		},
 		{
 			"type": "special",
-			"about": "#6 (MW 1.38-)",
-			"skip-on": {
-				"mediawiki": [ ">1.37.x", "MediaWiki changed the HTML Tidy" ]
-			},
-			"special-page": {
-				"page": "Browse",
-				"query-parameters": "Example/S0014/\"Some\"&*^-25-20-2D",
-				"request-parameters": {
-					"output": "legacy"
-				}
-			},
-			"assert-output": {
-				"to-contain": [
-					"Example/S0014/%22Some%22%26*%5E-25-20-2D",
-					"title=\"Example/S0014/&quot;Some&quot;&amp;*^-25-20-2D\">Example/S0014/\"Some\"&*^-25-20-2D</a>",
-					"Example-2FS0014-2F&quot;Some&quot;-26*^-2D25-2D20-2D2D"
-				]
-			}
-		},
-		{
-			"type": "special",
 			"about": "#6 (MW 1.38+)",
 			"skip-on": {
 				"mediawiki": [ "<1.37.x", "MediaWiki changed the HTML Tidy" ]
@@ -218,28 +197,6 @@
 				"to-contain": [
 					"Example/S0014/%22Some%22%26*%5E-25-20-2D",
 					"title=\"Example/S0014/&quot;Some&quot;&amp;*^-25-20-2D\">Example/S0014/\"Some\"&amp;*^-25-20-2D</a>",
-					"Example-2FS0014-2F&quot;Some&quot;-26*^-2D25-2D20-2D2D"
-				]
-			}
-		},
-		{
-			"type": "special",
-			"about": "#7 (MW 1.38-)",
-			"skip-on": {
-				"mediawiki": [ ">1.37.x", "MediaWiki changed the HTML Tidy" ]
-			},
-			"special-page": {
-				"page": "Browse",
-				"query-parameters": "",
-				"request-parameters": {
-					"output": "legacy",
-					"article": "Example/S0014/\"Some\"&*^-25-20-2D"
-				}
-			},
-			"assert-output": {
-				"to-contain": [
-					"Example/S0014/%22Some%22%26*%5E-25-20-2D",
-					"title=\"Example/S0014/&quot;Some&quot;&amp;*^-25-20-2D\">Example/S0014/\"Some\"&*^-25-20-2D</a>",
 					"Example-2FS0014-2F&quot;Some&quot;-26*^-2D25-2D20-2D2D"
 				]
 			}

--- a/tests/phpunit/Integration/MediaWiki/ApiBrowseBySubjectDBIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/ApiBrowseBySubjectDBIntegrationTest.php
@@ -135,15 +135,9 @@ class ApiBrowseBySubjectDBIntegrationTest extends DatabaseTestCase {
 			'browsebysubject'
 		);
 
-		// Went away with 1.26/1.27
-		if ( function_exists( 'setRawMode' ) && $asRawMode ) {
-			$instance->getMain()->getResult()->setRawMode();
-		}
-
 		$instance->execute();
 
-		// MW 1.25
-		return method_exists( $instance, 'getResult' ) ? $instance->getResult() : $instance;
+		return $instance->getResult();
 	}
 
 }

--- a/tests/phpunit/Integration/MediaWiki/Hooks/PageMoveCompleteIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/PageMoveCompleteIntegrationTest.php
@@ -179,12 +179,9 @@ class PageMoveCompleteIntegrationTest extends DatabaseTestCase {
 			$this->newRevisionFromTitle( $title )
 		);
 
-		// Required due to how MoveTo/Title uses the `TitleIsMovable` hook
-		if ( version_compare( MW_VERSION, '1.34', '>=' ) ) {
-			$this->assertNull(
-				$this->newRevisionFromTitle( $expectedNewTitle )
-			);
-		}
+		$this->assertNull(
+			$this->newRevisionFromTitle( $expectedNewTitle )
+		);
 
 		$this->toBeDeleted = [
 			$title,

--- a/tests/phpunit/MediaWiki/Api/AskArgsTest.php
+++ b/tests/phpunit/MediaWiki/Api/AskArgsTest.php
@@ -108,8 +108,7 @@ class AskArgsTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->execute();
 
-		// MW 1.25
-		$result = method_exists( $instance->getResult(), 'getResultData' ) ? $instance->getResult()->getResultData() : $instance->getResultData();
+		$result = $instance->getResult()->getResultData();
 
 		// This came with 1.25, no idea what this suppose to be
 		unset( $result['_type'] );

--- a/tests/phpunit/MediaWiki/Api/InfoTest.php
+++ b/tests/phpunit/MediaWiki/Api/InfoTest.php
@@ -93,8 +93,7 @@ class InfoTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->execute();
 
-		// MW 1.25
-		$result = method_exists( $instance->getResult(), 'getResultData' ) ? $instance->getResult()->getResultData() : $instance->getResultData();
+		$result = $instance->getResult()->getResultData();
 
 		// This came with 1.25, no idea what this suppose to be
 		unset( $result['_type'] );

--- a/tests/phpunit/MediaWiki/Api/QueryTest.php
+++ b/tests/phpunit/MediaWiki/Api/QueryTest.php
@@ -116,8 +116,7 @@ class QueryTest extends \PHPUnit_Framework_TestCase {
 
 		$method->invoke( $instance, $queryResult );
 
-		// MW 1.25
-		$result = method_exists( $apiResult, 'getResultData' ) ? $apiResult->getResultData() : $instance->getData();
+		$result = $apiResult->getResultData();
 
 		// This came with 1.25, no idea what this suppose to be
 		unset( $result['warnings'] );

--- a/tests/phpunit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/MediaWiki/HooksTest.php
@@ -245,7 +245,6 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			[ 'callMaintenanceUpdateAddParams' ],
 			[ 'callResourceLoaderGetConfigVars' ],
 			[ 'callGetPreferences' ],
-			[ 'callPersonalUrls' ],
 			[ 'callSkinTemplateNavigation' ],
 			[ 'callLoadExtensionSchemaUpdates' ],
 			[ 'callExtensionTypes' ],
@@ -1032,51 +1031,6 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			$instance->getHandlerFor( $handler ),
 			[ $user, &$preferences ]
 		);
-		return $handler;
-	}
-
-	public function callPersonalUrls( $instance ) {
-		$this->markTestSkipped( 'The PersonalUrls hook does not exist on MW 1.37 and newer.' );
-
-		$preferenceExaminer = $this->getMockBuilder( '\SMW\MediaWiki\Preference\PreferenceExaminer' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$preferenceExaminer->expects( $this->any() )
-			->method( 'hasPreferenceOf' )
-			->will( $this->returnValue( false ) );
-
-		$this->testEnvironment->registerObject( 'PreferenceExaminer', $preferenceExaminer );
-
-		$handler = 'PersonalUrls';
-
-		$user = $this->getMockBuilder( '\User' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$skinTemplate = $this->getMockBuilder( '\SkinTemplate' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$skinTemplate->expects( $this->any() )
-			->method( 'getUser' )
-			->will( $this->returnValue( $user ) );
-
-		$personal_urls = [];
-
-		$this->assertTrue(
-			$instance->isRegistered( $handler )
-		);
-
-		$this->assertThatHookIsExcutable(
-			$instance->getHandlerFor( $handler ),
-			[ &$personal_urls, $title, $skinTemplate ]
-		);
-
 		return $handler;
 	}
 

--- a/tests/phpunit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/MediaWiki/HooksTest.php
@@ -1036,9 +1036,7 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 	}
 
 	public function callPersonalUrls( $instance ) {
-		if ( version_compare( MW_VERSION, '1.37', '>=' ) ) {
-			$this->markTestSkipped( 'The PersonalUrls hook does not exist on MW 1.37 and newer.' );
-		}
+		$this->markTestSkipped( 'The PersonalUrls hook does not exist on MW 1.37 and newer.' );
 
 		$preferenceExaminer = $this->getMockBuilder( '\SMW\MediaWiki\Preference\PreferenceExaminer' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/MediaWiki/MessageBuilderTest.php
+++ b/tests/phpunit/MediaWiki/MessageBuilderTest.php
@@ -87,9 +87,7 @@ class MessageBuilderTest extends \PHPUnit_Framework_TestCase {
 		$this->assertContains( 'class="mw-nextlink"', $links[0] );
 		$this->assertContains( '>next 20<', $links[0] );
 
-		$nums= [ 20, 50, 100, 250, 500 ];
-		// On MW 1.39 and newer, the current limit selection is not a link any more.
-		$nums = version_compare( MW_VERSION, '1.39', '>=' ) ? [ 50, 100, 250, 500 ] : $nums;
+		$nums = [ 50, 100, 250, 500 ];
 		for ( $i = 1; $i < count( $links ); $i++ ) {
 			$a = $links[$i];
 			$this->assertContains( 'class="mw-numlink"', $a );

--- a/tests/phpunit/PostProcHandlerTest.php
+++ b/tests/phpunit/PostProcHandlerTest.php
@@ -260,11 +260,9 @@ class PostProcHandlerTest extends \PHPUnit_Framework_TestCase {
 			]
 		);
 
-		if ( version_compare( MW_VERSION, '1.39', '>=' ) ) {
-			$this->markTestSkipped(
-				"Check smwLikelyOutdatedDependencies set up for MW >= 1.39"
-			);
-		}
+		$this->markTestSkipped(
+			"Check smwLikelyOutdatedDependencies set up for MW >= 1.39"
+		);
 
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/PropertyAliasFinderTest.php
+++ b/tests/phpunit/PropertyAliasFinderTest.php
@@ -135,7 +135,7 @@ class PropertyAliasFinderTest extends \PHPUnit_Framework_TestCase {
 
 		$instance->registerAliasByMsgKey( '_Foo', 'smw-bar' );
 
-		$msgKey = version_compare( MW_VERSION, '1.28', '<' ) ? '<smw-bar>' : '⧼smw-bar⧽';
+		$msgKey = '⧼smw-bar⧽';
 
 		$this->assertEquals(
 			[ $msgKey => '_Foo' ],

--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -112,11 +112,6 @@ class TestEnvironment {
 	 * @param string $name
 	 */
 	public function resetMediaWikiService( $name ) {
-		// MW 1.27+ (yet 1.27.0.rc has no access to "resetServiceForTesting")
-		if ( !class_exists( '\MediaWiki\MediaWikiServices' ) || !method_exists( \MediaWiki\MediaWikiServices::getInstance(), 'resetServiceForTesting' ) ) {
-			return null;
-		}
-
 		try {
 			\MediaWiki\MediaWikiServices::getInstance()->resetServiceForTesting( $name );
 		} catch( \Exception $e ) {
@@ -162,12 +157,7 @@ class TestEnvironment {
 
 		$lbFactory = \MediaWiki\MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
 
-		// MW 1.33+
-		if ( method_exists( $lbFactory, 'setLocalDomainPrefix' ) ) {
-			$lbFactory->setLocalDomainPrefix( $prefix );
-		} else {
-			$lbFactory->setDomainPrefix( $prefix );
-		}
+		$lbFactory->setLocalDomainPrefix( $prefix );
 
 		$GLOBALS['wgDBprefix'] = $prefix;
 	}

--- a/tests/phpunit/UncaughtExceptionHandlerTest.php
+++ b/tests/phpunit/UncaughtExceptionHandlerTest.php
@@ -101,7 +101,7 @@ class UncaughtExceptionHandlerTest extends \PHPUnit_Framework_TestCase {
 
 		yield[
 			[ 'msg' => 'SemanticFoobar', 'type' => 'incompatible-php' ],
-			( version_compare( MW_VERSION, '1.32', '<' ) ? \SMW\SetupCheck::ERROR_EXTENSION_DEPENDENCY : \SMW\SetupCheck::ERROR_EXTENSION_INCOMPATIBLE )
+			\SMW\SetupCheck::ERROR_EXTENSION_INCOMPATIBLE
 		];
 
 		yield[

--- a/tests/phpunit/Utils/CliMsgFormatterTest.php
+++ b/tests/phpunit/Utils/CliMsgFormatterTest.php
@@ -66,7 +66,7 @@ class CliMsgFormatterTest extends \PHPUnit_Framework_TestCase {
 	public function testTwoColsOverride() {
 		$instance = new CliMsgFormatter();
 
-		$op = ( version_compare( PHP_VERSION, '7.3', '<' ) ? "\r" : "\033[0G" );
+		$op = "\033[0G";
 
 		$this->assertEquals(
 			"{$op}Foo                                                                     Bar",

--- a/tests/phpunit/Utils/Connection/TestDatabaseConnectionProvider.php
+++ b/tests/phpunit/Utils/Connection/TestDatabaseConnectionProvider.php
@@ -33,13 +33,7 @@ class TestDatabaseConnectionProvider implements ConnectionProvider {
 	 */
 	public function getConnection() {
 		$lb = $this->getLoadBalancer();
-
-		// MW 1.39+
-		if ( method_exists( $lb, 'getConnectionInternal' ) ) {
-			return $lb->getConnectionInternal( $this->id );
-		}
-
-		return $lb->getConnection( $this->id );
+		return $lb->getConnectionInternal( $this->id );
 	}
 
 	public function releaseConnection() {

--- a/tests/phpunit/Utils/MwApiFactory.php
+++ b/tests/phpunit/Utils/MwApiFactory.php
@@ -34,10 +34,6 @@ class MwApiFactory {
 	 * @return ApiResult
 	 */
 	public function newApiResult( array $params ) {
-		if ( version_compare( MW_VERSION, '1.25', '<' ) ) {
-			return new ApiResult( $this->newApiMain( $params ) );
-		}
-
 		$result = new ApiResult( 5 );
 
 		$errorFormatter = new \ApiErrorFormatter_BackCompat( $result );

--- a/tests/phpunit/Utils/Runners/JobQueueRunner.php
+++ b/tests/phpunit/Utils/Runners/JobQueueRunner.php
@@ -134,25 +134,14 @@ class JobQueueRunner {
 	 */
 	private function pop() {
 		$offset = 0;
-
-		if ( method_exists( MediaWikiServices::class, 'getJobQueueGroup' ) ) {
-			// MW 1.37+
-			return MediaWikiServices::getInstance()->getJobQueueGroup()->pop();
-		} else {
-			return JobQueueGroup::singleton()->pop();
-		}
+		return MediaWikiServices::getInstance()->getJobQueueGroup()->pop();
 	}
 
 	/**
 	 * @see https://gerrit.wikimedia.org/r/#/c/162009/
 	 */
 	public function pop_type( $type ) {
-		if ( method_exists( MediaWikiServices::class, 'getJobQueueGroup' ) ) {
-			// MW 1.37+
-			return MediaWikiServices::getInstance()->getJobQueueGroup()->get( $type )->pop();
-		} else {
-			return JobQueueGroup::singleton()->get( $type )->pop();
-		}
+		return MediaWikiServices::getInstance()->getJobQueueGroup()->get( $type )->pop();
 	}
 
 }

--- a/tests/phpunit/Utils/Runners/XmlImportRunner.php
+++ b/tests/phpunit/Utils/Runners/XmlImportRunner.php
@@ -84,24 +84,20 @@ class XmlImportRunner {
 			$config = \ConfigFactory::getDefaultInstance()->makeConfig( 'main' );
 		}
 
-		if ( version_compare( MW_VERSION, '1.37', '<' ) ) {
-			$importer = new WikiImporter( $source->value, $config );
-		} else {
-			$services = MediaWikiServices::getInstance();
-			$importer = new WikiImporter(
-				$source->value,
-				$config,
-				$services->getHookContainer(),
-				$services->getContentLanguage(),
-				$services->getNamespaceInfo(),
-				$services->getTitleFactory(),
-				$services->getWikiPageFactory(),
-				$services->getWikiRevisionUploadImporter(),
-				$services->getPermissionManager(),
-				$services->getContentHandlerFactory(),
-				$services->getSlotRoleRegistry()
-			);
-		}
+		$services = MediaWikiServices::getInstance();
+		$importer = new WikiImporter(
+			$source->value,
+			$config,
+			$services->getHookContainer(),
+			$services->getContentLanguage(),
+			$services->getNamespaceInfo(),
+			$services->getTitleFactory(),
+			$services->getWikiPageFactory(),
+			$services->getWikiRevisionUploadImporter(),
+			$services->getPermissionManager(),
+			$services->getContentHandlerFactory(),
+			$services->getSlotRoleRegistry()
+		);
 		$importer->setDebug( $this->verbose );
 
 		$reporter = new ImportReporter(

--- a/tests/phpunit/includes/ContentParserTest.php
+++ b/tests/phpunit/includes/ContentParserTest.php
@@ -53,9 +53,7 @@ class ContentParserTest extends \PHPUnit_Framework_TestCase {
 
 		$this->testEnvironment = new TestEnvironment();
 
-		if ( version_compare( MW_VERSION, '1.38', '>=' ) ) {
-			$this->contentRenderer = MediaWikiServices::getInstance()->getContentRenderer();
-		}
+		$this->contentRenderer = MediaWikiServices::getInstance()->getContentRenderer();
 	}
 
 	protected function tearDown(): void {
@@ -107,23 +105,17 @@ class ContentParserTest extends \PHPUnit_Framework_TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		if ( version_compare( MW_VERSION, '1.38', '<' ) ) {
-			$content->expects( $this->any() )
+		$this->testEnvironment->redefineMediaWikiService( 'ContentRenderer', function () {
+			$contentRenderer = $this->getMockBuilder( '\MediaWiki\Content\Renderer\ContentRenderer' )
+				->disableOriginalConstructor()
+				->getMock();
+
+			$contentRenderer->expects( $this->any() )
 				->method( 'getParserOutput' )
 				->will( $this->returnValue( $this->parserOutput ) );
-		} else {
-			$this->testEnvironment->redefineMediaWikiService( 'ContentRenderer', function () {
-				$contentRenderer = $this->getMockBuilder( '\MediaWiki\Content\Renderer\ContentRenderer' )
-					->disableOriginalConstructor()
-					->getMock();
 
-				$contentRenderer->expects( $this->any() )
-					->method( 'getParserOutput' )
-					->will( $this->returnValue( $this->parserOutput ) );
-
-				return $contentRenderer;
-			} );
-		}
+			return $contentRenderer;
+		} );
 
 		$revision = $this->getMockBuilder( '\MediaWiki\Revision\RevisionRecord' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/includes/formatters/MessageFormatterTest.php
+++ b/tests/phpunit/includes/formatters/MessageFormatterTest.php
@@ -110,11 +110,8 @@ class MessageFormatterTest extends SemanticMediaWikiTestCase {
 		foreach ( $messages as $msg ) {
 			$this->assertInstanceOf( '\Message', $msg );
 
-			// getParams() only got added in MW 1.21
-			if ( method_exists( $msg, 'getParams' ) ) {
-				foreach ( $msg->getParams() as $result ) {
-					$this->assertEquals( $param, $result );
-				}
+			foreach ( $msg->getParams() as $result ) {
+				$this->assertEquals( $param, $result );
 			}
 		}
 	}


### PR DESCRIPTION
They are unnecessary since the minimum requirement for SMW 5.0.0 is MW 1.39, which requires PHP >= 7.4
Also removed the `smwShowFactbox` hook that was supposed to be hard-deprecated in SMW 1.11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
	- Streamlined logic in various methods across multiple classes, enhancing performance and maintainability by removing unnecessary version checks.
	- Consistent return values for group names in special pages, ensuring uniform behavior regardless of MediaWiki version.

- **Bug Fixes**
	- Simplified error handling in tests and core functionalities, improving reliability and clarity.

- **Tests**
	- Updated test cases to reflect changes in logic, ensuring they run unconditionally and accurately assess functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->