### PR TITLE
Allow RDF link in the head element to be disabled

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -2510,7 +2510,16 @@ return ( function () {
 		 *
 		 * @since 3.2
 		 */
-		'smwgDetectOutdatedData' => false
+		'smwgDetectOutdatedData' => false,
+
+		/**
+		 * Whether Special:ExportRDF <link> element is added to the <head> element
+		 * Used to avoid bots scraping ExportRDF by not advertising on every page
+		 * Because the page is not a cheap call
+		 *
+		 * @since 5.0
+		 */
+		'smwgEnableExportRDFLink' => true
 
 	];
 } )();

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -467,7 +467,8 @@ class Hooks {
 		$beforePageDisplay->setOptions(
 			[
 				'incomplete_tasks' => $setupFile->findIncompleteTasks(),
-				'is_upgrade' => $setupFile->get( SetupFile::PREVIOUS_VERSION )
+				'is_upgrade' => $setupFile->get( SetupFile::PREVIOUS_VERSION ),
+				'smwgEnableExportRDFLink' => $GLOBALS['smwgEnableExportRDFLink'],
 			]
 		);
 

--- a/src/MediaWiki/Hooks/BeforePageDisplay.php
+++ b/src/MediaWiki/Hooks/BeforePageDisplay.php
@@ -63,7 +63,6 @@ class BeforePageDisplay implements HookListener {
 	public function process( OutputPage $outputPage, Skin $skin ) {
 		$title = $outputPage->getTitle();
 		$user = $outputPage->getUser();
-
 		// #2726
 		$userOptionsLookup = ServicesFactory::getInstance()->singleton( 'UserOptionsLookup' );
 		if ( $userOptionsLookup->getOption( $user, 'smw-prefs-general-options-suggester-textinput' ) ) {
@@ -75,7 +74,11 @@ class BeforePageDisplay implements HookListener {
 		}
 
 		// Add export link to the head
-		if ( $title instanceof Title && !$title->isSpecialPage() ) {
+		if (
+			$this->getOption( 'smwgEnableExportRDFLink' ) &&
+			$title instanceof Title &&
+			!$title->isSpecialPage()
+		) {
 			$link['rel']   = 'alternate';
 			$link['type']  = 'application/rdf+xml';
 			$link['title'] = $title->getPrefixedText();

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -209,7 +209,8 @@ class Settings extends Options {
 			'smwgCheckForConstraintErrors' => $GLOBALS['smwgCheckForConstraintErrors'],
 			'smwgPlainList' => $GLOBALS['smwgPlainList'],
 			'smwgDetectOutdatedData' => $GLOBALS['smwgDetectOutdatedData'],
-			'smwgIgnoreUpgradeKeyCheck' => $GLOBALS['smwgIgnoreUpgradeKeyCheck']
+			'smwgIgnoreUpgradeKeyCheck' => $GLOBALS['smwgIgnoreUpgradeKeyCheck'],
+			'smwgEnableExportRDFLink' => $GLOBALS['smwgEnableExportRDFLink']
  		];
 
 		$this->isLoaded = true;

--- a/tests/phpunit/MediaWiki/Hooks/BeforePageDisplayTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/BeforePageDisplayTest.php
@@ -216,6 +216,12 @@ class BeforePageDisplayTest extends \PHPUnit_Framework_TestCase {
 
 		$instance = new BeforePageDisplay();
 
+		$instance->setOptions(
+			[
+				'smwgEnableExportRDFLink' => true
+			]
+		);
+
 		$this->assertTrue(
 			$instance->process( $this->outputPage, $this->skin )
 		);


### PR DESCRIPTION
Used to avoid bots scraping ExportRDF by not advertising on every page because the page is not a cheap call.

The idea is based on the implementation from the WeirdGloop: https://github.com/SemanticMediaWiki/SemanticMediaWiki/commit/c7ea14bb20f5d5cfe8dc9134f4f5336e6d2109c3

TODO: When this is merged, update https://www.semantic-mediawiki.org/wiki/Help:Configuration#Export_settings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration setting to control the visibility of the RDF export link in page headers.
  
- **Bug Fixes**
	- Enhanced logic to ensure the export link is only added when the new setting is enabled.

- **Chores**
	- Minor formatting adjustments for improved readability in the code.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->