### PR TITLE
Clean up single-use ResourceLoader modules

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -46,9 +46,16 @@ return [
 		'targets' => [ 'mobile', 'desktop' ]
 	],
 
+	// https://github.com/TerryZ/SelectMenu
 	'smw.ui' => $moduleTemplate + [
-		'scripts' => 'smw/smw.ui.js',
-		'dependencies' => [ 'ext.smw', 'jquery.selectmenu' ],
+		'scripts' => [
+			'jquery/jquery.selectmenu.js',
+			'smw/smw.ui.js'
+		],
+		'dependencies' => [
+			'ext.smw',
+			'smw.ui.styles'
+		],
 		'targets' => [ 'mobile', 'desktop' ]
 	],
 
@@ -73,29 +80,6 @@ return [
 			'smw/special/ext.smw.special.preferences.css'
 		],
 		'targets' => [ 'mobile', 'desktop' ]
-	],
-
-	// https://github.com/TerryZ/SelectMenu
-	'jquery.selectmenu' => $moduleTemplate + [
-		'scripts' => 'jquery/jquery.selectmenu.js',
-		'dependencies' => [
-			'jquery.selectmenu.styles'
-		],
-		'targets' => [
-			'mobile',
-			'desktop'
-		]
-	],
-
-	'jquery.selectmenu.styles' => $moduleTemplate + [
-		'styles' => [
-			'jquery/jquery.selectmenu.css',
-			'smw/smw.selectmenu.css'
-		],
-		'targets' => [
-			'mobile',
-			'desktop'
-		]
 	],
 
 	// Load the module explicitly, otherwise mobile will complain with

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -119,7 +119,6 @@ return [
 			'mediawiki.storage',
 			'mediawiki.util',
 			'ext.smw',
-			'ext.smw.data',
 			'ext.smw.query'
 		]
 	],

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -691,16 +691,6 @@ return [
 		]
 	],
 
-	'jquery.mark.js'  => $moduleTemplate + [
-		'scripts'  => [
-			'jquery/jquery.mark.js'
-		],
-		'targets' => [
-			'mobile',
-			'desktop'
-		]
-	],
-
 	'smw.jsonview.styles' => $moduleTemplate + [
 		'styles' => [
 			'smw/smw.jsonview.css'
@@ -713,6 +703,7 @@ return [
 
 	'smw.jsonview' => $moduleTemplate + [
 		'scripts' => [
+			'jquery/jquery.mark.js',
 			'smw/smw.jsonview.js'
 		],
 		'styles' => [
@@ -729,7 +720,6 @@ return [
 		],
 		'dependencies'  => [
 			'jquery.jsonview',
-			'jquery.mark.js',
 			'ext.smw'
 		],
 		'targets' => [

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -89,42 +89,6 @@ return [
 		'targets' => [ 'mobile', 'desktop' ]
 	],
 
-	// dataItem representation
-	'ext.smw.dataItem' => $moduleTemplate + [
-		'scripts' => [
-			'smw/data/ext.smw.dataItem.wikiPage.js',
-			'smw/data/ext.smw.dataItem.uri.js',
-			'smw/data/ext.smw.dataItem.time.js',
-			'smw/data/ext.smw.dataItem.property.js',
-			'smw/data/ext.smw.dataItem.unknown.js',
-			'smw/data/ext.smw.dataItem.number.js',
-			'smw/data/ext.smw.dataItem.text.js',
-			'smw/data/ext.smw.dataItem.geo.js',
-		],
-		'dependencies' => [
-			'ext.smw',
-			'mediawiki.Title',
-			'mediawiki.Uri'
-		]
-	],
-
-	// dataValue representation
-	'ext.smw.dataValue' => $moduleTemplate + [
-		'scripts' => [
-			'smw/data/ext.smw.dataValue.quantity.js',
-		],
-		'dependencies' => 'ext.smw.dataItem'
-	],
-
-	// dataItem representation
-	'ext.smw.data' => $moduleTemplate + [
-		'scripts' => 'smw/data/ext.smw.data.js',
-		'dependencies' => [
-			'ext.smw.dataItem',
-			'ext.smw.dataValue'
-		]
-	],
-
 	// Query
 	'ext.smw.query' => $moduleTemplate + [
 		'scripts' => 'smw/query/ext.smw.query.js',
@@ -137,10 +101,24 @@ return [
 
 	// API
 	'ext.smw.api' => $moduleTemplate + [
-		'scripts' => 'smw/api/ext.smw.api.js',
+		'scripts' => [
+			'smw/data/ext.smw.dataItem.wikiPage.js',
+			'smw/data/ext.smw.dataItem.uri.js',
+			'smw/data/ext.smw.dataItem.time.js',
+			'smw/data/ext.smw.dataItem.property.js',
+			'smw/data/ext.smw.dataItem.unknown.js',
+			'smw/data/ext.smw.dataItem.number.js',
+			'smw/data/ext.smw.dataItem.text.js',
+			'smw/data/ext.smw.dataItem.geo.js',
+			'smw/data/ext.smw.dataValue.quantity.js',
+			'smw/data/ext.smw.data.js',
+			'smw/api/ext.smw.api.js'
+		],
 		'dependencies' => [
+			'mediawiki.Title',
 			'mediawiki.storage',
 			'mediawiki.util',
+			'ext.smw',
 			'ext.smw.data',
 			'ext.smw.query'
 		]

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -98,15 +98,6 @@ return [
 		]
 	],
 
-	'jquery.jsonview' => $moduleTemplate + [
-		'scripts' => 'jquery/jquery.jsonview.js',
-		'styles' => 'jquery/jquery.jsonview.css',
-		'targets' => [
-			'mobile',
-			'desktop'
-		]
-	],
-
 	// Load the module explicitly, otherwise mobile will complain with
 	// "Uncaught Error: Unknown dependency: jquery.async"
 	'ext.jquery.async' => $moduleTemplate + [
@@ -703,10 +694,12 @@ return [
 
 	'smw.jsonview' => $moduleTemplate + [
 		'scripts' => [
+			'jquery/jquery.jsonview.js',
 			'jquery/jquery.mark.js',
 			'smw/smw.jsonview.js'
 		],
 		'styles' => [
+			'jquery/jquery.jsonview.css',
 			'smw/smw.jsonview.css'
 		],
 		'messages' => [
@@ -719,7 +712,6 @@ return [
 			'smw-jsonview-search-label'
 		],
 		'dependencies'  => [
-			'jquery.jsonview',
 			'ext.smw'
 		],
 		'targets' => [

--- a/res/Resources.php
+++ b/res/Resources.php
@@ -333,29 +333,16 @@ return [
 	],
 
 	// https://github.com/ichord/Caret.js
-	'ext.jquery.caret' => $moduleTemplate + [
-		'scripts' => 'jquery/jquery.caret.js',
-		'targets' => [
-			'mobile',
-			'desktop'
-		]
-	],
-
 	// https://github.com/ichord/At.js
-	'ext.jquery.atwho' => $moduleTemplate + [
-		'scripts' => 'jquery/jquery.atwho.js',
-		'styles' => 'jquery/jquery.atwho.css',
-		'dependencies' => [
-			'ext.jquery.caret'
-		],
-		'targets' => [
-			'mobile',
-			'desktop'
-		]
-	],
-
 	'ext.smw.suggester' => $moduleTemplate + [
-		'scripts' => 'smw/suggester/ext.smw.suggester.js',
+		'scripts' => [
+			'jquery/jquery.caret.js',
+			'jquery/jquery.atwho.js',
+			'smw/suggester/ext.smw.suggester.js'
+		],
+		'styles' => [
+			'jquery/jquery.atwho.css'
+		],
 		'dependencies' => [
 			'ext.smw',
 			'ext.jquery.atwho'


### PR DESCRIPTION
SMW has a lot of ResourceLoader modules that is only used by one other module. This PR aims to merge these modules to the parent module to reduce bloat on the ResourceLoader definition, and also make the dependency more clear as there are less modules.

| Old | New | Commit
| -------- | ------- | ------- |
| `jquery.mark` |  `smw.jsonview` | cd7d25f13c3ea2587552ae1db92381c4883a61fe
| `jquery.jsonview` |  `smw.jsonview` | 7dc7eaad1cafcc7140659f4d91664e356dd81b32
| `jquery.caret` |  `ext.smw.suggester` | cd7d25f13c3ea2587552ae1db92381c4883a61fe
| `jquery.atwho` |  `ext.smw.suggester` | cd7d25f13c3ea2587552ae1db92381c4883a61fe
| `jquery.selectmenu` |  `smw.ui` | 176fa149447ccb89cf4b7165bafa2aa9166eea8c
| `jquery.selectmenu.styles` |  `smw.ui.styles` | 176fa149447ccb89cf4b7165bafa2aa9166eea8c
| `ext.smw.dataItem` |  `ext.smw.api` | 586e04eb9161e71d90bd9472b7128af91b56eb6b
| `ext.smw.dataValue` |  `ext.smw.api` | 586e04eb9161e71d90bd9472b7128af91b56eb6b
| `ext.smw.data` |  `ext.smw.api` | 586e04eb9161e71d90bd9472b7128af91b56eb6b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced resource management with a modular approach to scripts and dependencies.
	- Improved suggestion functionality with additional scripts and styles.
- **Bug Fixes**
	- Consolidated select menu functionality for better integration.
- **Refactor**
	- Streamlined resource definitions for clarity and compatibility across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->