### PR TITLE
Remove unused mediawiki.api.parse dependency

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -617,7 +617,6 @@ return [
 		'scripts'  => [ 'smw/deferred/ext.smw.deferred.js' ],
 		'dependencies'  => [
 			'mediawiki.api',
-			'mediawiki.api.parse',
 			'onoi.rangeslider'
 		],
 		'messages' => [
@@ -646,7 +645,6 @@ return [
 		'scripts'  => [ 'smw/util/smw.property.page.js' ],
 		'dependencies'  => [
 			'mediawiki.api',
-			'mediawiki.api.parse',
 			'ext.smw.tooltip',
 			'smw.jsonview'
 		],


### PR DESCRIPTION
The module no longer exists (#5743)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined dependencies for the `ext.smw.deferred` and `smw.property.page` modules by removing the reliance on `mediawiki.api.parse`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->