### PR TITLE
Fix failing HTML tests for MW > 1.40

### DIFF
--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -137,11 +137,15 @@ return [
 
 	/**
 	 * DBLoadBalancer
+	 * $dbProviderOrdbOrLb is:
+	 * - IConnectionProvider when MW >= 1.41
+	 * - IDatabase | ILoadBalancer when MW < 1.41
+	 * https://phabricator.wikimedia.org/T326274
 	 *
 	 * @return callable
 	 */
-	'DefaultSearchEngineTypeForDB' => function ( $containerBuilder, IDatabase $db ) {
-		return MediaWikiServices::getInstance()->getSearchEngineFactory()->getSearchEngineClass( $db );
+	'DefaultSearchEngineTypeForDB' => function ( $containerBuilder, $dbProviderOrdbOrLb ) {
+		return MediaWikiServices::getInstance()->getSearchEngineFactory()->getSearchEngineClass( $dbProviderOrdbOrLb );
 	},
 
 	/**

--- a/tests/phpunit/MediaWiki/Search/ProfileForm/Forms/CustomFormTest.php
+++ b/tests/phpunit/MediaWiki/Search/ProfileForm/Forms/CustomFormTest.php
@@ -48,12 +48,16 @@ class CustomFormTest extends \PHPUnit_Framework_TestCase {
 		$form = [
 			'<div class="smw-input-field" style="display:inline-block;">',
 			'<input class="smw-input" name="barproperty[]" value="1001" placeholder="Bar property ..." ',
-			'data-property="Bar property" title="Bar property"/></div>'
+			'data-property="Bar property" title="Bar property"></div>'
 		];
+
+		$actual = $instance->makeFields( [ 'Bar property' ] );
+		// MW 1.39-1.40 produces self-closing tag, which is invalid HTML
+		$actual = str_replace( '/>', '>', $actual );
 
 		$this->assertContains(
 			implode( '', $form ),
-			$instance->makeFields( [ 'Bar property' ] )
+			$actual
 		);
 
 		$this->assertEquals(

--- a/tests/phpunit/MediaWiki/Search/ProfileForm/Forms/FieldTest.php
+++ b/tests/phpunit/MediaWiki/Search/ProfileForm/Forms/FieldTest.php
@@ -76,21 +76,25 @@ class FieldTest extends \PHPUnit_Framework_TestCase {
 	public function testInput( $attr, $expected ) {
 		$instance = new Field();
 
+		$actual = $instance->input( $attr );
+		// MW 1.39-1.40 produces self-closing tag, which is invalid HTML
+		$actual = str_replace( '/>', '>', $actual );
+
 		$this->assertContains(
 			$expected,
-			$instance->input( $attr )
+			$actual
 		);
 	}
 
 	public function inputAttributeProvider() {
 		yield [
 			[ 'name' => 'Foobar' ],
-			'<div class="smw-input-field"><input name="Foobar" placeholder=""/></div>'
+			'<div class="smw-input-field"><input name="Foobar" placeholder=""></div>'
 		];
 
 		yield [
 			[ 'name' => 'Foobar', 'multifield' => true ],
-			'<div class="smw-input-field"><input name="Foobar[]" placeholder=""/></div>'
+			'<div class="smw-input-field"><input name="Foobar[]" placeholder=""></div>'
 		];
 	}
 

--- a/tests/phpunit/MediaWiki/Search/ProfileForm/FormsBuilderTest.php
+++ b/tests/phpunit/MediaWiki/Search/ProfileForm/FormsBuilderTest.php
@@ -98,12 +98,16 @@ class FormsBuilderTest extends \PHPUnit_Framework_TestCase {
 		$expected = [
 			'<button type="button" id="smw-search-forms" class="smw-selectmenu-button is-disabled".*',
 			'name="smw-form" value="".*',
-			'data-list="[{&quot;id&quot;:&quot;bar&quot;,&quot;name&quot;:&quot;Bar&quot;,&quot;desc&quot;:&quot;Bar&quot;},{&quot;id&quot;:&quot;foo&quot;,&quot;name&quot;:&quot;Foo&quot;,&quot;desc&quot;:&quot;Foo&quot;}]" data-nslist="[]">Form</button><input type="hidden" name="smw-form"/>'
+			'data-list="[{&quot;id&quot;:&quot;bar&quot;,&quot;name&quot;:&quot;Bar&quot;,&quot;desc&quot;:&quot;Bar&quot;},{&quot;id&quot;:&quot;foo&quot;,&quot;name&quot;:&quot;Foo&quot;,&quot;desc&quot;:&quot;Foo&quot;}]" data-nslist="[]">Form</button><input type="hidden" name="smw-form">'
 		];
+
+		$actual = $instance->buildFormList( $title );
+		// MW 1.39-1.40 produces self-closing tag, which is invalid HTML
+		$actual = str_replace( '/>', '>', $actual );
 
 		$this->stringValidator->assertThatStringContains(
 			$expected,
-			$instance->buildFormList( $title )
+			$actual
 		);
 	}
 

--- a/tests/phpunit/MediaWiki/Search/ProfileForm/ProfileFormTest.php
+++ b/tests/phpunit/MediaWiki/Search/ProfileForm/ProfileFormTest.php
@@ -132,14 +132,17 @@ class ProfileFormTest extends \PHPUnit_Framework_TestCase {
 
 		$expected = [
 			'<fieldset id="smw-searchoptions">',
-			'<input type="hidden" name="ns-list"/>',
+			'<input type="hidden" name="ns-list">',
 			'<div class="smw-search-options">',
 			'<div class="smw-search-sort"><button type="button" id="smw-search-sort" class="smw-selectmenu-button is-disabled" name="sort"',
 		];
 
+		// MW 1.39-1.40 produces self-closing tag, which is invalid HTML
+		$actual = str_replace( '/>', '>', $form );
+
 		$this->stringValidator->assertThatStringContains(
 			$expected,
-			$form
+			$actual
 		);
 	}
 

--- a/tests/phpunit/MediaWiki/Search/SearchEngineFactoryTest.php
+++ b/tests/phpunit/MediaWiki/Search/SearchEngineFactoryTest.php
@@ -26,7 +26,14 @@ class SearchEngineFactoryTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp(): void {
 		$this->testEnvironment = new TestEnvironment();
 
-		$this->connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
+		if ( version_compare( MW_VERSION, '1.40', '>' ) ) {
+			$this->connection = $this->getMockBuilder( '\Wikimedia\Rdbms\IConnectionProvider' )
+				->disableOriginalConstructor()
+				->getMockForAbstractClass();
+			return;
+		}
+
+		$this->connection = $this->getMockBuilder( '\Wikimedia\Rdbms\IDatabase' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 	}

--- a/tests/phpunit/MediaWiki/Search/SearchEngineFactoryTest.php
+++ b/tests/phpunit/MediaWiki/Search/SearchEngineFactoryTest.php
@@ -26,14 +26,7 @@ class SearchEngineFactoryTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp(): void {
 		$this->testEnvironment = new TestEnvironment();
 
-		if ( version_compare( MW_VERSION, '1.40', '>' ) ) {
-			$this->connection = $this->getMockBuilder( '\Wikimedia\Rdbms\IConnectionProvider' )
-				->disableOriginalConstructor()
-				->getMockForAbstractClass();
-			return;
-		}
-
-		$this->connection = $this->getMockBuilder( '\Wikimedia\Rdbms\IDatabase' )
+		$this->connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 	}

--- a/tests/phpunit/SetupCheckTest.php
+++ b/tests/phpunit/SetupCheckTest.php
@@ -24,6 +24,12 @@ class SetupCheckTest extends \PHPUnit_Framework_TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
+		// Don't know why this is undefined but it is required by
+		// testReadFromFile_InvalidJSON_ThrowsException()
+		if ( !defined( 'SMW_PHPUNIT_DIR' ) ) {
+			define( 'SMW_PHPUNIT_DIR', __DIR__ );
+		}
+
 		$this->setupFile = $this->getMockBuilder( '\SMW\SetupFile' )
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/phpunit/Utils/HtmlTabsTest.php
+++ b/tests/phpunit/Utils/HtmlTabsTest.php
@@ -58,8 +58,8 @@ class HtmlTabsTest extends \PHPUnit_Framework_TestCase {
 		$actual = $instance->buildHTML( [ 'class' => 'foo-bar' ] );
 		// MW 1.39-1.40 produces self-closing tag, which is invalid HTML
 		$actual = str_replace(
-			html_entity_encode( '/>' ),
-			html_entity_encode( '>' ),
+			htmlspecialchars( '/>' ),
+			htmlspecialchars( '>' ),
 			$actual
 		);
 

--- a/tests/phpunit/Utils/HtmlTabsTest.php
+++ b/tests/phpunit/Utils/HtmlTabsTest.php
@@ -55,11 +55,15 @@ class HtmlTabsTest extends \PHPUnit_Framework_TestCase {
 		$instance->tab( 'foo', 'FOO' );
 		$instance->content( 'foo', '< ... bar ... >' );
 
+		$actual = $instance->buildHTML( [ 'class' => 'foo-bar' ] );
+		// MW 1.39-1.40 produces self-closing tag, which is invalid HTML
+		$actual = str_replace( '/&gt;', '&gt;', $actual );
+
 		$this->assertContains(
 			'<div class="smw-tabs smw-subtab foo-bar" ' .
 			'data-subtab="&quot;&lt;input id=\&quot;tab-foo\&quot; ' .
 			'class=\&quot;nav-tab\&quot; type=\&quot;radio\&quot; ' .
-			'name=\&quot;tabs\&quot; checked=\&quot;\&quot;\/&gt;&lt;label ' .
+			'name=\&quot;tabs\&quot; checked=\&quot;\&quot;\&gt;&lt;label ' .
 			'id=\&quot;tab-label-foo\&quot; for=\&quot;tab-foo\&quot; ' .
 			'class=\&quot;nav-label\&quot;&gt;FOO&lt;\/label&gt;&quot;">' .
 			'<div id="tab-content-foo" class="subtab-content">< ... bar ... ></div></div>',

--- a/tests/phpunit/Utils/HtmlTabsTest.php
+++ b/tests/phpunit/Utils/HtmlTabsTest.php
@@ -67,7 +67,7 @@ class HtmlTabsTest extends \PHPUnit_Framework_TestCase {
 			'id=\&quot;tab-label-foo\&quot; for=\&quot;tab-foo\&quot; ' .
 			'class=\&quot;nav-label\&quot;&gt;FOO&lt;\/label&gt;&quot;">' .
 			'<div id="tab-content-foo" class="subtab-content">< ... bar ... ></div></div>',
-			$instance->buildHTML( [ 'class' => 'foo-bar' ] )
+			$actual
 		);
 	}
 

--- a/tests/phpunit/Utils/HtmlTabsTest.php
+++ b/tests/phpunit/Utils/HtmlTabsTest.php
@@ -57,7 +57,11 @@ class HtmlTabsTest extends \PHPUnit_Framework_TestCase {
 
 		$actual = $instance->buildHTML( [ 'class' => 'foo-bar' ] );
 		// MW 1.39-1.40 produces self-closing tag, which is invalid HTML
-		$actual = str_replace( '/&gt;', '&gt;', $actual );
+		$actual = str_replace(
+			html_entity_encode( '/>' ),
+			html_entity_encode( '>' ),
+			$actual
+		);
 
 		$this->assertContains(
 			'<div class="smw-tabs smw-subtab foo-bar" ' .

--- a/tests/phpunit/Utils/HtmlTabsTest.php
+++ b/tests/phpunit/Utils/HtmlTabsTest.php
@@ -33,13 +33,17 @@ class HtmlTabsTest extends \PHPUnit_Framework_TestCase {
 		$instance->tab( 'foo', 'FOO' );
 		$instance->content( 'foo', '< ... bar ... >' );
 
+		$actual = $instance->buildHTML( [ 'class' => 'foo-bar' ] );
+		// MW 1.39-1.40 produces self-closing tag, which is invalid HTML
+		$actual = str_replace( '/>', '>', $actual );
+
 		$this->assertContains(
 			'<div class="smw-tabs foo-bar">' .
-			'<input id="tab-foo" class="nav-tab" type="radio" name="tabs" checked=""/>' .
+			'<input id="tab-foo" class="nav-tab" type="radio" name="tabs" checked="">' .
 			'<label id="tab-label-foo" for="tab-foo" class="nav-label">FOO</label>' .
 			'<section id="tab-content-foo">< ... bar ... ></section>' .
 			'</div>',
-			$instance->buildHTML( [ 'class' => 'foo-bar' ] )
+			$actual
 		);
 	}
 
@@ -68,13 +72,17 @@ class HtmlTabsTest extends \PHPUnit_Framework_TestCase {
 		$instance->tab( 'foo', 'FOO' );
 		$instance->content( 'foo', '< ... bar ... >' );
 
+		$actual = $instance->buildHTML( [ 'class' => 'foo-bar' ] );
+		// MW 1.39-1.40 produces self-closing tag, which is invalid HTML
+		$actual = str_replace( '/>', '>', $actual );
+
 		$this->assertContains(
 			'<div class="smw-tabs foo-bar">' .
-			'<input id="tab-foo" class="nav-tab" type="radio" name="tabs" checked=""/>' .
+			'<input id="tab-foo" class="nav-tab" type="radio" name="tabs" checked="">' .
 			'<label id="tab-label-foo" for="tab-foo" class="nav-label">FOO</label>' .
 			'<section id="tab-content-foo">< ... bar ... ></section>' .
 			'</div>',
-			$instance->buildHTML( [ 'class' => 'foo-bar' ] )
+			$actual
 		);
 	}
 


### PR DESCRIPTION
For the HTML-related tests, the failure was caused by the self-closing tag in the `<input>` element.
I added a check to ensure that the `/` is taken out from the actual result before the comparison.

For `SetupCheckTest`, I am not sure why `SMW_PHPUNIT_DIR` is undefined, but I added a null check to define it just in case. (#5701)

For `SearchEngineFactoryTest`, I am not sure how to fix it properly. The param for `SearchEngineFactory::getSearchEngineClass()` was changed from `ILoadBalancer`/`IDatabase` to `IConnectionProvider` since MW 1.41. ([1.39](https://doc.wikimedia.org/mediawiki-core/REL1_39/php/classSearchEngineFactory.html#a6599d7cd10957b8e911d2438a8749fd2) vs [1.41](https://doc.wikimedia.org/mediawiki-core/REL1_41/php/classSearchEngineFactory.html#a6599d7cd10957b8e911d2438a8749fd2))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Enhanced flexibility of the database connection service to accommodate different MediaWiki versions.

- **Bug Fixes**
  - Corrected HTML output for input and button elements across various tests to ensure compliance with standards, particularly for MediaWiki versions 1.39-1.40.
  - Updated tests to handle self-closing tags appropriately, ensuring valid HTML generation.

- **Tests**
  - Improved test structure and assertions to validate HTML output effectively across different scenarios, including adjustments for self-closing tags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->