### PR TITLE
Fix unknown module ext.jquery.atwho

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -305,8 +305,7 @@ return [
 			'jquery/jquery.atwho.css'
 		],
 		'dependencies' => [
-			'ext.smw',
-			'ext.jquery.atwho'
+			'ext.smw'
 		],
 		'targets' => [
 			'mobile',


### PR DESCRIPTION
Follow up to #5777
It was still listed as a dependency for ext.smw.suggester

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified the dependency management for the `ext.smw.suggester` module by removing an unnecessary dependency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->