### PR TITLE
Remove MW_VERSION definition

### DIFF
--- a/includes/SemanticMediaWiki.php
+++ b/includes/SemanticMediaWiki.php
@@ -32,11 +32,6 @@ class SemanticMediaWiki {
 			require_once ( dirname( __DIR__ ) . "/includes/GlobalFunctions.php" );
 		}
 
-		// https://phabricator.wikimedia.org/T212738
-		if ( !defined( 'MW_VERSION' ) ) {
-			define( 'MW_VERSION', $GLOBALS['wgVersion'] );
-		}
-
 		// We're moving away from enableSemantics, so set this here.
 		if ( !defined( 'SMW_EXTENSION_LOADED' ) ) {
 			define( 'SMW_EXTENSION_LOADED', true );


### PR DESCRIPTION
It has been defined in MW core long time ago, the compatibility is no longer needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version handling within the Semantic MediaWiki extension.
  
- **Bug Fixes**
	- Improved stability by removing reliance on the MediaWiki version constant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->