### PR TITLE
Hooks: Convert $user UserIdentityValue to User in onRevisionFromEditComplete

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -569,6 +569,7 @@ class Hooks {
 		$applicationFactory = ApplicationFactory::getInstance();
 		$mwCollaboratorFactory = $applicationFactory->newMwCollaboratorFactory();
 
+		$user = User::newFromIdentity( $user );
 		$editInfo = $mwCollaboratorFactory->newEditInfo(
 			$wikiPage,
 			$revision,


### PR DESCRIPTION
> SMW\MediaWiki\MwCollaboratorFactory::newEditInfo(): Argument #3 ($user) must be of type ?User, MediaWiki\User\UserIdentityValue given, called in /srv/mediawiki/1.42/extensions/SemanticMediaWiki/src/MediaWiki/Hooks.php on line 572

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of user identity in the editing process, ensuring user data is processed accurately.

- **Refactor**
	- Enhanced the logic related to user identity management for better encapsulation within the User class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->