### PR TITLE
PropertiesQueryPage : Fix "contains 1 abstract method and must therefore be declared abstract or implement the remaining methods "

### DIFF
--- a/includes/querypages/PropertiesQueryPage.php
+++ b/includes/querypages/PropertiesQueryPage.php
@@ -272,4 +272,11 @@ class PropertiesQueryPage extends QueryPage {
 		return $this->listLookup->fetchList();
 	}
 
+	/**
+	 * @return array|bool
+	 */
+	public function getQueryInfo() {
+		return false;
+	}
+
 }


### PR DESCRIPTION
> PHP Fatal Error: Class SMW\PropertiesQueryPage contains 1 abstract method and must therefore be declared abstract or implement the remaining methods (MediaWiki\SpecialPage\QueryPage::getQueryInfo)