### PR TITLE
Fix "Deprecated: Return type of x should either be compatible with Iterator::x"

### DIFF
--- a/src/Iterators/CsvFileIterator.php
+++ b/src/Iterators/CsvFileIterator.php
@@ -119,7 +119,7 @@ class CsvFileIterator implements Iterator, Countable {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function rewind() {
+	public function rewind(): rewind {
 		$this->key = 0;
 		$this->file->rewind();
 	}
@@ -131,7 +131,7 @@ class CsvFileIterator implements Iterator, Countable {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function current() {
+	public function current(): mixed {
 		// First iteration to match the header
 		if ( $this->parseHeader && $this->key == 0 ) {
 			$this->header = $this->file->fgetcsv( $this->delimiter );
@@ -150,7 +150,7 @@ class CsvFileIterator implements Iterator, Countable {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function key() {
+	public function key(): mixed {
 		return $this->key;
 	}
 
@@ -161,7 +161,7 @@ class CsvFileIterator implements Iterator, Countable {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function next() {
+	public function next(): void {
 		return !$this->file->eof();
 	}
 
@@ -172,7 +172,7 @@ class CsvFileIterator implements Iterator, Countable {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function valid() {
+	public function valid(): bool {
 		if ( $this->next() ) {
 			return true;
 		}

--- a/src/Iterators/CsvFileIterator.php
+++ b/src/Iterators/CsvFileIterator.php
@@ -132,7 +132,8 @@ class CsvFileIterator implements Iterator, Countable {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function current(): mixed {
+	#[\ReturnTypeWillChange]
+	public function current() {
 		// First iteration to match the header
 		if ( $this->parseHeader && $this->key == 0 ) {
 			$this->header = $this->file->fgetcsv( $this->delimiter );

--- a/src/Iterators/CsvFileIterator.php
+++ b/src/Iterators/CsvFileIterator.php
@@ -119,7 +119,7 @@ class CsvFileIterator implements Iterator, Countable {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function rewind(): rewind {
+	public function rewind(): void {
 		$this->key = 0;
 		$this->file->rewind();
 	}

--- a/src/Iterators/CsvFileIterator.php
+++ b/src/Iterators/CsvFileIterator.php
@@ -161,7 +161,8 @@ class CsvFileIterator implements Iterator, Countable {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function next(): void {
+	#[\ReturnTypeWillChange]
+	public function next() {
 		return !$this->file->eof();
 	}
 

--- a/src/Iterators/CsvFileIterator.php
+++ b/src/Iterators/CsvFileIterator.php
@@ -90,6 +90,7 @@ class CsvFileIterator implements Iterator, Countable {
 	 *
 	 * {@inheritDoc}
 	 */
+	#[\ReturnTypeWillChange]
 	public function count() {
 		if ( $this->count ) {
 			return $this->count;

--- a/src/Iterators/CsvFileIterator.php
+++ b/src/Iterators/CsvFileIterator.php
@@ -152,7 +152,8 @@ class CsvFileIterator implements Iterator, Countable {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function key(): mixed {
+	#[\ReturnTypeWillChange]
+	public function key() {
 		return $this->key;
 	}
 

--- a/src/SPARQLStore/QueryEngine/RepositoryResult.php
+++ b/src/SPARQLStore/QueryEngine/RepositoryResult.php
@@ -173,7 +173,7 @@ class RepositoryResult implements Iterator {
 	 *
 	 * @return array of (SMWExpElement or null), or false at end of data
 	 */
-	public function current() {
+	public function current(): mixed {
 		return current( $this->data );
 	}
 
@@ -183,7 +183,7 @@ class RepositoryResult implements Iterator {
 	 *
 	 * @return array of (SMWExpElement or null), or false at end of data
 	 */
-	public function next() {
+	public function next(): void {
 		return next( $this->data );
 	}
 
@@ -193,7 +193,7 @@ class RepositoryResult implements Iterator {
 	 *
 	 * @return array of (SMWExpElement or null), or false at end of data
 	 */
-	public function key() {
+	public function key(): mixed {
 		return key( $this->data );
 	}
 

--- a/src/SPARQLStore/QueryEngine/RepositoryResult.php
+++ b/src/SPARQLStore/QueryEngine/RepositoryResult.php
@@ -173,7 +173,8 @@ class RepositoryResult implements Iterator {
 	 *
 	 * @return array of (SMWExpElement or null), or false at end of data
 	 */
-	public function current(): mixed {
+	#[\ReturnTypeWillChange]
+	public function current() {
 		return current( $this->data );
 	}
 

--- a/src/SPARQLStore/QueryEngine/RepositoryResult.php
+++ b/src/SPARQLStore/QueryEngine/RepositoryResult.php
@@ -194,7 +194,8 @@ class RepositoryResult implements Iterator {
 	 *
 	 * @return array of (SMWExpElement or null), or false at end of data
 	 */
-	public function key(): mixed {
+	#[\ReturnTypeWillChange]
+	public function key() {
 		return key( $this->data );
 	}
 

--- a/src/SPARQLStore/QueryEngine/RepositoryResult.php
+++ b/src/SPARQLStore/QueryEngine/RepositoryResult.php
@@ -183,7 +183,8 @@ class RepositoryResult implements Iterator {
 	 *
 	 * @return array of (SMWExpElement or null), or false at end of data
 	 */
-	public function next(): void {
+	#[\ReturnTypeWillChange]
+	public function next() {
 		return next( $this->data );
 	}
 


### PR DESCRIPTION
I have made the types match https://www.php.net/manual/en/class.iterator.php

We require php 7.4+ so there is no incompatibility.