### PR TITLE
EditProtectedPropertyAnnotatorTest: Remove use of isProtected in testAddTopIndicatorToFromMatchableRestriction

### DIFF
--- a/tests/phpunit/Property/Annotators/EditProtectedPropertyAnnotatorTest.php
+++ b/tests/phpunit/Property/Annotators/EditProtectedPropertyAnnotatorTest.php
@@ -97,11 +97,6 @@ class EditProtectedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$title->expects( $this->once() )
-			->method( 'isProtected' )
-			->with( $this->equalTo( 'edit' ) )
-			->will( $this->returnValue( true ) );
-
-		$title->expects( $this->once() )
 			->method( 'getRestrictions' )
 			->will( $this->returnValue( [ 'Foo' ] ) );
 


### PR DESCRIPTION
Title class removed the method isProtected and this was replaced in this extension with 50e764570dc81357754d50ffe48319c5065af72c.

But seems it was never removed from this test.