### PR TITLE
Replace removed "LanguageEn::getConverter()" method

### DIFF
--- a/src/Localizer/Localizer.php
+++ b/src/Localizer/Localizer.php
@@ -283,7 +283,9 @@ class Localizer {
 	 * @return string a string representation of the namespace
 	 */
 	public function convertNamespace( $ns, $variant = null ): string {
-		return $this->contentLanguage->getConverter()->convertNamespace( $ns, $variant );
+		$services = MediaWikiServices::getInstance();
+		$langConverter = $services->getLanguageConverterFactory()->getLanguageConverter( $this->contentLanguage );
+		return $langConverter->convertNamespace( $ns, $variant );
 	}
 
 	/**


### PR DESCRIPTION
We require MW 1.39+ so this does not break any support.

This method were removed in https://gerrit.wikimedia.org/r/c/mediawiki/core/+/936685