### PR TITLE
Lowercase use of maintenance classes in tests

### DIFF
--- a/tests/phpunit/Maintenance/DisposeOutdatedEntitiesTest.php
+++ b/tests/phpunit/Maintenance/DisposeOutdatedEntitiesTest.php
@@ -3,12 +3,12 @@
 namespace SMW\Tests\Maintenance;
 
 use PHPUnit\Framework\TestCase;
-use SMW\Maintenance\DisposeOutdatedEntities;
+use SMW\Maintenance\disposeOutdatedEntities;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\PHPUnitCompat;
 
 /**
- * @covers \SMW\Maintenance\DisposeOutdatedEntities
+ * @covers \SMW\Maintenance\disposeOutdatedEntities
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -37,13 +37,13 @@ class DisposeOutdatedEntitiesTest extends TestCase {
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
-			DisposeOutdatedEntities::class,
-			new DisposeOutdatedEntities()
+			disposeOutdatedEntities::class,
+			new disposeOutdatedEntities()
 		);
 	}
 
 	public function testExecute() {
-		$instance = new DisposeOutdatedEntities();
+		$instance = new disposeOutdatedEntities();
 
 		$instance->setMessageReporter(
 			$this->spyMessageReporter

--- a/tests/phpunit/Maintenance/Jobs/MaintenanceFactoryTest.php
+++ b/tests/phpunit/Maintenance/Jobs/MaintenanceFactoryTest.php
@@ -81,7 +81,7 @@ class MaintenanceFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = new MaintenanceFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\Maintenance\RebuildPropertyStatistics',
+			'\SMW\Maintenance\rebuildPropertyStatistics',
 			$instance->newRebuildPropertyStatistics()
 		);
 	}

--- a/tests/phpunit/Maintenance/PurgeEntityCacheTest.php
+++ b/tests/phpunit/Maintenance/PurgeEntityCacheTest.php
@@ -5,7 +5,7 @@ namespace SMW\Tests\Maintenance;
 use Onoi\MessageReporter\MessageReporter;
 use PHPUnit\Framework\TestCase;
 use SMW\EntityCache;
-use SMW\Maintenance\PurgeEntityCache;
+use SMW\Maintenance\purgeEntityCache;
 use Wikimedia\Rdbms\FakeResultWrapper;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
@@ -13,7 +13,7 @@ use SMW\DIWikiPage;
 use Wikimedia\Rdbms\Database;
 
 /**
- * @covers \SMW\Maintenance\PurgeEntityCache
+ * @covers \SMW\Maintenance\purgeEntityCache
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -48,8 +48,8 @@ class PurgeEntityCacheTest extends TestCase {
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
-			PurgeEntityCache::class,
-			new PurgeEntityCache()
+			purgeEntityCache::class,
+			new purgeEntityCache()
 		);
 	}
 
@@ -85,7 +85,7 @@ class PurgeEntityCacheTest extends TestCase {
 			->method( 'invalidate' )
 			->with( $this->equalTo( $subject ) );
 
-		$instance = new PurgeEntityCache();
+		$instance = new purgeEntityCache();
 
 		$instance->setMessageReporter(
 			$this->messageReporter

--- a/tests/phpunit/Maintenance/RunImportTest.php
+++ b/tests/phpunit/Maintenance/RunImportTest.php
@@ -3,12 +3,12 @@
 namespace SMW\Tests\Maintenance;
 
 use PHPUnit\Framework\TestCase;
-use SMW\Maintenance\RunImport;
+use SMW\Maintenance\runImport;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\PHPUnitCompat;
 
 /**
- * @covers \SMW\Maintenance\RunImport
+ * @covers \SMW\Maintenance\runImport
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -37,13 +37,13 @@ class RunImportTest extends TestCase {
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
-			RunImport::class,
-			new RunImport()
+			runImport::class,
+			new runImport()
 		);
 	}
 
 	public function testExecute() {
-		$instance = new RunImport();
+		$instance = new runImport();
 
 		$instance->setMessageReporter(
 			$this->spyMessageReporter

--- a/tests/phpunit/Maintenance/UpdateQueryDependenciesTest.php
+++ b/tests/phpunit/Maintenance/UpdateQueryDependenciesTest.php
@@ -2,13 +2,13 @@
 
 namespace SMW\Tests\Maintenance;
 
-use SMW\Maintenance\UpdateQueryDependencies;
+use SMW\Maintenance\updateQueryDependencies;
 use SMW\Tests\TestEnvironment;
 use SMW\DIWikiPage;
 use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
- * @covers \SMW\Maintenance\UpdateQueryDependencies
+ * @covers \SMW\Maintenance\updateQueryDependencies
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -54,8 +54,8 @@ class UpdateQueryDependenciesTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
-			UpdateQueryDependencies::class,
-			new UpdateQueryDependencies()
+			updateQueryDependencies::class,
+			new updateQueryDependencies()
 		);
 	}
 
@@ -109,7 +109,7 @@ class UpdateQueryDependenciesTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $this->connection ) );
 
-		$instance = new UpdateQueryDependencies();
+		$instance = new updateQueryDependencies();
 
 		$instance->setMessageReporter(
 			$this->messageReporter


### PR DESCRIPTION
They were using an uppercase which failed because the maintenance classes used a lowercase at the start.