### PR TITLE
Fix using "SMW_PHPUNIT_DIR" const

### DIFF
--- a/tests/phpunit/Exception/JSONFileParseExceptionTest.php
+++ b/tests/phpunit/Exception/JSONFileParseExceptionTest.php
@@ -20,7 +20,7 @@ class JSONFileParseExceptionTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 		$instance = new JSONFileParseException(
-			\SMW_PHPUNIT_DIR . '/Fixtures/Exception/invalid.trailing.comma.json'
+			SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Exception/invalid.trailing.comma.json'
 		);
 
 		$this->assertContains(

--- a/tests/phpunit/Exception/JSONFileParseExceptionTest.php
+++ b/tests/phpunit/Exception/JSONFileParseExceptionTest.php
@@ -20,7 +20,7 @@ class JSONFileParseExceptionTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 		$instance = new JSONFileParseException(
-			SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Exception/invalid.trailing.comma.json'
+			\SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Exception/invalid.trailing.comma.json'
 		);
 
 		$this->assertContains(

--- a/tests/phpunit/Exception/JSONFileParseExceptionTest.php
+++ b/tests/phpunit/Exception/JSONFileParseExceptionTest.php
@@ -20,7 +20,7 @@ class JSONFileParseExceptionTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 		$instance = new JSONFileParseException(
-			SMW_PHPUNIT_DIR . '/Fixtures/Exception/invalid.trailing.comma.json'
+			\SMW_PHPUNIT_DIR . '/Fixtures/Exception/invalid.trailing.comma.json'
 		);
 
 		$this->assertContains(

--- a/tests/phpunit/Exception/JSONFileParseExceptionTest.php
+++ b/tests/phpunit/Exception/JSONFileParseExceptionTest.php
@@ -20,7 +20,7 @@ class JSONFileParseExceptionTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 		$instance = new JSONFileParseException(
-			\SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Exception/invalid.trailing.comma.json'
+			\SMW_PHPUNIT_DIR . '/Fixtures/Exception/invalid.trailing.comma.json'
 		);
 
 		$this->assertContains(

--- a/tests/phpunit/Localizer/LocalMessageProviderTest.php
+++ b/tests/phpunit/Localizer/LocalMessageProviderTest.php
@@ -27,7 +27,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( \SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->setLanguageCode( 'ja' );
 		$instance->loadMessages();
 
@@ -39,7 +39,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg_Fallback() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( \SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->setLanguageCode( 'foo' );
 		$instance->loadMessages();
 
@@ -51,7 +51,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg_WithArgs() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( \SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->setLanguageCode( 'ja' );
 		$instance->loadMessages();
 
@@ -63,7 +63,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg_NoValidKey() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( \SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->loadMessages();
 
 		$this->assertEquals(

--- a/tests/phpunit/Localizer/LocalMessageProviderTest.php
+++ b/tests/phpunit/Localizer/LocalMessageProviderTest.php
@@ -27,7 +27,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( \SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->setLanguageCode( 'ja' );
 		$instance->loadMessages();
 
@@ -39,7 +39,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg_Fallback() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( \SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->setLanguageCode( 'foo' );
 		$instance->loadMessages();
 
@@ -51,7 +51,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg_WithArgs() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( \SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->setLanguageCode( 'ja' );
 		$instance->loadMessages();
 
@@ -63,7 +63,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg_NoValidKey() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( \SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->loadMessages();
 
 		$this->assertEquals(

--- a/tests/phpunit/Localizer/LocalMessageProviderTest.php
+++ b/tests/phpunit/Localizer/LocalMessageProviderTest.php
@@ -27,7 +27,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( \SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->setLanguageCode( 'ja' );
 		$instance->loadMessages();
 
@@ -39,7 +39,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg_Fallback() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( \SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->setLanguageCode( 'foo' );
 		$instance->loadMessages();
 
@@ -51,7 +51,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg_WithArgs() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( \SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->setLanguageCode( 'ja' );
 		$instance->loadMessages();
 
@@ -63,7 +63,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg_NoValidKey() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( \SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->loadMessages();
 
 		$this->assertEquals(

--- a/tests/phpunit/Localizer/LocalMessageProviderTest.php
+++ b/tests/phpunit/Localizer/LocalMessageProviderTest.php
@@ -27,7 +27,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( \SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( \SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->setLanguageCode( 'ja' );
 		$instance->loadMessages();
 
@@ -39,7 +39,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg_Fallback() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( \SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( \SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->setLanguageCode( 'foo' );
 		$instance->loadMessages();
 
@@ -51,7 +51,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg_WithArgs() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( \SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( \SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->setLanguageCode( 'ja' );
 		$instance->loadMessages();
 
@@ -63,7 +63,7 @@ class LocalMessageProviderTest extends \PHPUnit_Framework_TestCase {
 
 	public function testMsg_NoValidKey() {
 		$instance = new LocalMessageProvider( 'test.json', 'en' );
-		$instance->setLanguageFileDir( \SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
+		$instance->setLanguageFileDir( \SMW_PHPUNIT_DIR . '/Fixtures/Localizer' );
 		$instance->loadMessages();
 
 		$this->assertEquals(

--- a/tests/phpunit/Schema/SchemaValidatorTest.php
+++ b/tests/phpunit/Schema/SchemaValidatorTest.php
@@ -65,7 +65,7 @@ class SchemaValidatorTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SchemaValidator( $jsonSchemaValidator );
 
 		$info = [
-			SchemaDefinition::SCHEMA_VALIDATION_FILE => \SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
+			SchemaDefinition::SCHEMA_VALIDATION_FILE => SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
 		];
 
 		$this->assertEmpty(
@@ -93,7 +93,7 @@ class SchemaValidatorTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SchemaValidator( $jsonSchemaValidator );
 
 		$info = [
-			SchemaDefinition::SCHEMA_VALIDATION_FILE => \SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
+			SchemaDefinition::SCHEMA_VALIDATION_FILE => SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
 		];
 
 		$this->assertNotEmpty(

--- a/tests/phpunit/Schema/SchemaValidatorTest.php
+++ b/tests/phpunit/Schema/SchemaValidatorTest.php
@@ -65,7 +65,7 @@ class SchemaValidatorTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SchemaValidator( $jsonSchemaValidator );
 
 		$info = [
-			SchemaDefinition::SCHEMA_VALIDATION_FILE => SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
+			SchemaDefinition::SCHEMA_VALIDATION_FILE => \SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
 		];
 
 		$this->assertEmpty(
@@ -93,7 +93,7 @@ class SchemaValidatorTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SchemaValidator( $jsonSchemaValidator );
 
 		$info = [
-			SchemaDefinition::SCHEMA_VALIDATION_FILE => SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
+			SchemaDefinition::SCHEMA_VALIDATION_FILE => \SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
 		];
 
 		$this->assertNotEmpty(

--- a/tests/phpunit/Schema/SchemaValidatorTest.php
+++ b/tests/phpunit/Schema/SchemaValidatorTest.php
@@ -65,7 +65,7 @@ class SchemaValidatorTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SchemaValidator( $jsonSchemaValidator );
 
 		$info = [
-			SchemaDefinition::SCHEMA_VALIDATION_FILE => \SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
+			SchemaDefinition::SCHEMA_VALIDATION_FILE => \SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
 		];
 
 		$this->assertEmpty(
@@ -93,7 +93,7 @@ class SchemaValidatorTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SchemaValidator( $jsonSchemaValidator );
 
 		$info = [
-			SchemaDefinition::SCHEMA_VALIDATION_FILE => \SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
+			SchemaDefinition::SCHEMA_VALIDATION_FILE => \SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
 		];
 
 		$this->assertNotEmpty(

--- a/tests/phpunit/Schema/SchemaValidatorTest.php
+++ b/tests/phpunit/Schema/SchemaValidatorTest.php
@@ -65,7 +65,7 @@ class SchemaValidatorTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SchemaValidator( $jsonSchemaValidator );
 
 		$info = [
-			SchemaDefinition::SCHEMA_VALIDATION_FILE => SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
+			SchemaDefinition::SCHEMA_VALIDATION_FILE => \SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
 		];
 
 		$this->assertEmpty(
@@ -93,7 +93,7 @@ class SchemaValidatorTest extends \PHPUnit_Framework_TestCase {
 		$instance = new SchemaValidator( $jsonSchemaValidator );
 
 		$info = [
-			SchemaDefinition::SCHEMA_VALIDATION_FILE => SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
+			SchemaDefinition::SCHEMA_VALIDATION_FILE => \SMW\Tests\SMW_PHPUNIT_DIR . '/Fixtures/Schema/empty_schema.json'
 		];
 
 		$this->assertNotEmpty(


### PR DESCRIPTION
We don't want to use the current files namespace to import SMW_PHPUNIT_DIR. Instead use \SMW_PHPUNIT_DIR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated constant references in test cases to ensure correct namespace resolution, preventing potential issues.
  
- **Tests**
	- Adjusted multiple test methods to utilize fully qualified names for constants, enhancing reliability of test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->