### PR TITLE
Lowercase use of maintenance classes

### DIFF
--- a/src/Maintenance/MaintenanceFactory.php
+++ b/src/Maintenance/MaintenanceFactory.php
@@ -114,7 +114,7 @@ class MaintenanceFactory {
 	 * @return RebuildPropertyStatistics
 	 */
 	public function newRebuildPropertyStatistics() {
-		return new RebuildPropertyStatistics();
+		return new rebuildPropertyStatistics();
 	}
 
 	/**

--- a/src/Maintenance/MaintenanceFactory.php
+++ b/src/Maintenance/MaintenanceFactory.php
@@ -111,7 +111,7 @@ class MaintenanceFactory {
 	/**
 	 * @since 2.4
 	 *
-	 * @return RebuildPropertyStatistics
+	 * @return rebuildPropertyStatistics
 	 */
 	public function newRebuildPropertyStatistics() {
 		return new rebuildPropertyStatistics();

--- a/tests/phpunit/Utils/Runners/RunnerFactory.php
+++ b/tests/phpunit/Utils/Runners/RunnerFactory.php
@@ -38,7 +38,7 @@ class RunnerFactory {
 	public function newMaintenanceRunner( $maintenanceClass ) {
 		switch ( $maintenanceClass ) {
 			case 'rebuildPropertyStatistics':
-				$maintenanceClass = 'SMW\Maintenance\RebuildPropertyStatistics';
+				$maintenanceClass = 'SMW\Maintenance\rebuildPropertyStatistics';
 				break;
 			case 'rebuildData':
 				$maintenanceClass = 'SMW\Maintenance\RebuildData';

--- a/tests/phpunit/Utils/Runners/RunnerFactory.php
+++ b/tests/phpunit/Utils/Runners/RunnerFactory.php
@@ -41,13 +41,13 @@ class RunnerFactory {
 				$maintenanceClass = 'SMW\Maintenance\rebuildPropertyStatistics';
 				break;
 			case 'rebuildData':
-				$maintenanceClass = 'SMW\Maintenance\RebuildData';
+				$maintenanceClass = 'SMW\Maintenance\rebuildData';
 				break;
 			case 'rebuildConceptCache';
-				$maintenanceClass = 'SMW\Maintenance\RebuildConceptCache';
+				$maintenanceClass = 'SMW\Maintenance\rebuildConceptCache';
 				break;
 			case 'setupStore';
-				$maintenanceClass = 'SMW\Maintenance\SetupStore';
+				$maintenanceClass = 'SMW\Maintenance\setupStore';
 				break;
 		}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Corrected the return value of the property statistics rebuild method to ensure proper instantiation.
	- Fixed a syntax error in the maintenance runner method to prevent unexpected behavior.

- **Documentation**
	- Updated method signature documentation to reflect changes in return values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->