### PR TITLE
Fix casing of maintenance classes

### DIFF
--- a/maintenance/disposeOutdatedEntities.php
+++ b/maintenance/disposeOutdatedEntities.php
@@ -25,7 +25,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class disposeOutdatedEntities extends \Maintenance {
+class DisposeOutdatedEntities extends \Maintenance {
 
 	/**
 	 * @var MessageReporter
@@ -146,5 +146,5 @@ class disposeOutdatedEntities extends \Maintenance {
 
 }
 
-$maintClass = disposeOutdatedEntities::class;
+$maintClass = DisposeOutdatedEntities::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/dumpRDF.php
+++ b/maintenance/dumpRDF.php
@@ -47,7 +47,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  * @author Markus Krötzsch
  * @author mwjames
  */
-class dumpRDF extends \Maintenance {
+class DumpRDF extends \Maintenance {
 
 	/**
 	 * @var MessageReporter
@@ -220,5 +220,5 @@ class dumpRDF extends \Maintenance {
 
 }
 
-$maintClass = dumpRDF::class;
+$maintClass = DumpRDF::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/populateHashField.php
+++ b/maintenance/populateHashField.php
@@ -27,7 +27,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class populateHashField extends \Maintenance {
+class PopulateHashField extends \Maintenance {
 
 	/**
 	 * Threshold as the when the `populateHashField.php` should be used by an
@@ -285,5 +285,5 @@ class populateHashField extends \Maintenance {
 
 }
 
-$maintClass = populateHashField::class;
+$maintClass = PopulateHashField::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/purgeEntityCache.php
+++ b/maintenance/purgeEntityCache.php
@@ -27,7 +27,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class purgeEntityCache extends \Maintenance {
+class PurgeEntityCache extends \Maintenance {
 
 	/**
 	 * @var Store

--- a/maintenance/purgeEntityCache.php
+++ b/maintenance/purgeEntityCache.php
@@ -234,5 +234,5 @@ class PurgeEntityCache extends \Maintenance {
 
 }
 
-$maintClass = purgeEntityCache::class;
+$maintClass = PurgeEntityCache::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildConceptCache.php
+++ b/maintenance/rebuildConceptCache.php
@@ -69,7 +69,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  * @author Markus Krötzsch
  * @author mwjames
  */
-class rebuildConceptCache extends \Maintenance {
+class RebuildConceptCache extends \Maintenance {
 
 	public function __construct() {
 		parent::__construct();
@@ -215,5 +215,5 @@ class rebuildConceptCache extends \Maintenance {
 
 }
 
-$maintClass = rebuildConceptCache::class;
+$maintClass = RebuildConceptCache::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -56,7 +56,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  * @author Yaron Koren
  * @author Markus Krötzsch
  */
-class rebuildData extends \Maintenance {
+class RebuildData extends \Maintenance {
 
 	public function __construct() {
 		parent::__construct();
@@ -287,5 +287,5 @@ class rebuildData extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\rebuildData';
+$maintClass = RebuildData::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildElasticIndex.php
+++ b/maintenance/rebuildElasticIndex.php
@@ -25,7 +25,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class rebuildElasticIndex extends \Maintenance {
+class RebuildElasticIndex extends \Maintenance {
 
 	/**
 	 * @var Store
@@ -540,5 +540,5 @@ class rebuildElasticIndex extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\rebuildElasticIndex';
+$maintClass = RebuildElasticIndex::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildElasticMissingDocuments.php
+++ b/maintenance/rebuildElasticMissingDocuments.php
@@ -31,7 +31,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class rebuildElasticMissingDocuments extends \Maintenance {
+class RebuildElasticMissingDocuments extends \Maintenance {
 
 	/**
 	 * @var Store
@@ -407,5 +407,5 @@ class rebuildElasticMissingDocuments extends \Maintenance {
 
 }
 
-$maintClass = rebuildElasticMissingDocuments::class;
+$maintClass = RebuildElasticMissingDocuments::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildFulltextSearchTable.php
+++ b/maintenance/rebuildFulltextSearchTable.php
@@ -25,7 +25,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class rebuildFulltextSearchTable extends \Maintenance {
+class RebuildFulltextSearchTable extends \Maintenance {
 
 	/**
 	 * @var MessageReporter
@@ -245,5 +245,5 @@ class rebuildFulltextSearchTable extends \Maintenance {
 
 }
 
-$maintClass = rebuildFulltextSearchTable::class;
+$maintClass = RebuildFulltextSearchTable::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/rebuildPropertyStatistics.php
+++ b/maintenance/rebuildPropertyStatistics.php
@@ -22,7 +22,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class rebuildPropertyStatistics extends \Maintenance {
+class RebuildPropertyStatistics extends \Maintenance {
 
 	public function __construct() {
 		parent::__construct();
@@ -94,5 +94,5 @@ class rebuildPropertyStatistics extends \Maintenance {
 
 }
 
-$maintClass = rebuildPropertyStatistics::class;
+$maintClass = RebuildPropertyStatistics::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/removeDuplicateEntities.php
+++ b/maintenance/removeDuplicateEntities.php
@@ -21,7 +21,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class removeDuplicateEntities extends \Maintenance {
+class RemoveDuplicateEntities extends \Maintenance {
 
 	/**
 	 * @since 3.0
@@ -145,5 +145,5 @@ class removeDuplicateEntities extends \Maintenance {
 
 }
 
-$maintClass = removeDuplicateEntities::class;
+$maintClass = RemoveDuplicateEntities::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/runImport.php
+++ b/maintenance/runImport.php
@@ -24,7 +24,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class runImport extends \Maintenance {
+class RunImport extends \Maintenance {
 
 	/**
 	 * @var MessageReporter
@@ -126,5 +126,5 @@ class runImport extends \Maintenance {
 
 }
 
-$maintClass = runImport::class;
+$maintClass = RunImport::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/runLocalMessageCopy.php
+++ b/maintenance/runLocalMessageCopy.php
@@ -25,7 +25,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class runLocalMessageCopy extends \Maintenance {
+class RunLocalMessageCopy extends \Maintenance {
 
 	/**
 	 * @var MessageReporter
@@ -174,5 +174,5 @@ class runLocalMessageCopy extends \Maintenance {
 
 }
 
-$maintClass = runLocalMessageCopy::class;
+$maintClass = RunLocalMessageCopy::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -55,7 +55,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  * @author James Hong Kong
  */
-class setupStore extends \Maintenance {
+class SetupStore extends \Maintenance {
 
 	/**
 	 * Name of the store class configured in the "LocalSettings.php" file. Stored to
@@ -269,5 +269,5 @@ class setupStore extends \Maintenance {
 
 }
 
-$maintClass = setupStore::class;
+$maintClass = SetupStore::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/updateEntityCollation.php
+++ b/maintenance/updateEntityCollation.php
@@ -31,7 +31,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class updateEntityCollation extends \Maintenance {
+class UpdateEntityCollation extends \Maintenance {
 
 	/**
 	 * Incomplete task message
@@ -293,5 +293,5 @@ class updateEntityCollation extends \Maintenance {
 
 }
 
-$maintClass = updateEntityCollation::class;
+$maintClass = UpdateEntityCollation::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/updateEntityCountMap.php
+++ b/maintenance/updateEntityCountMap.php
@@ -25,7 +25,7 @@ if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
  *
  * @author mwjames
  */
-class updateEntityCountMap extends \Maintenance {
+class UpdateEntityCountMap extends \Maintenance {
 
 	/**
 	 * Incomplete task message
@@ -273,5 +273,5 @@ class updateEntityCountMap extends \Maintenance {
 
 }
 
-$maintClass = updateEntityCountMap::class;
+$maintClass = UpdateEntityCountMap::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/maintenance/updateQueryDependencies.php
+++ b/maintenance/updateQueryDependencies.php
@@ -20,7 +20,7 @@ require_once $basePath . '/maintenance/Maintenance.php';
  *
  * @author mwjames
  */
-class updateQueryDependencies extends \Maintenance {
+class UpdateQueryDependencies extends \Maintenance {
 
 	/**
 	 * @var MessageReporter
@@ -179,5 +179,5 @@ class updateQueryDependencies extends \Maintenance {
 
 }
 
-$maintClass = 'SMW\Maintenance\updateQueryDependencies';
+$maintClass = UpdateQueryDependencies::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );

--- a/src/Maintenance/MaintenanceFactory.php
+++ b/src/Maintenance/MaintenanceFactory.php
@@ -4,11 +4,12 @@ namespace SMW\Maintenance;
 
 use Onoi\MessageReporter\MessageReporter;
 use Onoi\MessageReporter\MessageReporterFactory;
+use SMW\Store;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\MediaWiki\ManualEntryLogger;
 use SMW\SQLStore\PropertyStatisticsStore;
-use SMW\Store;
 use SMW\Localizer\LocalMessageProvider;
+use SMW\Maintenance\RebuildPropertyStatistics;
 
 /**
  * @license GNU GPL v2+

--- a/src/SQLStore/TableBuilder/Examiner/EntityCollation.php
+++ b/src/SQLStore/TableBuilder/Examiner/EntityCollation.php
@@ -6,7 +6,7 @@ use Onoi\MessageReporter\MessageReporterAwareTrait;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder;
 use SMW\SetupFile;
-use SMW\Maintenance\updateEntityCollation as UpdateEntityCollation;
+use SMW\Maintenance\UpdateEntityCollation as UpdateEntityCollation;
 use SMW\Utils\CliMsgFormatter;
 
 /**

--- a/src/SQLStore/TableBuilder/Examiner/HashField.php
+++ b/src/SQLStore/TableBuilder/Examiner/HashField.php
@@ -4,7 +4,7 @@ namespace SMW\SQLStore\TableBuilder\Examiner;
 
 use Onoi\MessageReporter\MessageReporterAwareTrait;
 use SMW\SQLStore\SQLStore;
-use SMW\Maintenance\populateHashField as PopulateHashField;
+use SMW\Maintenance\PopulateHashField as PopulateHashField;
 use SMW\Utils\CliMsgFormatter;
 
 /**

--- a/tests/phpunit/Importer/ImporterTest.php
+++ b/tests/phpunit/Importer/ImporterTest.php
@@ -106,7 +106,7 @@ class ImporterTest extends \PHPUnit_Framework_TestCase {
 		$instance->runImport();
 	}
 
-	public function testrunImportWithError() {
+	public function testRunImportWithError() {
 		$importContents = new ImportContents();
 
 		$importContents->addError( 'Bar' );
@@ -134,7 +134,7 @@ class ImporterTest extends \PHPUnit_Framework_TestCase {
 		$instance->runImport();
 	}
 
-	public function testrunImportWithErrorDuringCreation() {
+	public function testRunImportWithErrorDuringCreation() {
 		$importContents = new ImportContents();
 		$importContents->setVersion( 1 );
 

--- a/tests/phpunit/Integration/Maintenance/DisposeOutdatedEntitiesTest.php
+++ b/tests/phpunit/Integration/Maintenance/DisposeOutdatedEntitiesTest.php
@@ -38,7 +38,7 @@ class DisposeOutdatedEntitiesTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\DisposeOutdatedEntities'
+			'\SMW\Maintenance\DisposeOutdatedEntities'
 		);
 
 		$maintenanceRunner->setMessageReporter(

--- a/tests/phpunit/Integration/Maintenance/DumpRDFTest.php
+++ b/tests/phpunit/Integration/Maintenance/DumpRDFTest.php
@@ -35,7 +35,7 @@ class DumpRDFTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\dumpRDF'
+			'\SMW\Maintenance\DumpRDF'
 		);
 
 		$maintenanceRunner->setMessageReporter(

--- a/tests/phpunit/Integration/Maintenance/PopulateHashFieldTest.php
+++ b/tests/phpunit/Integration/Maintenance/PopulateHashFieldTest.php
@@ -30,7 +30,7 @@ class PopulateHashFieldTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\populateHashField'
+			'\SMW\Maintenance\populateHashField'
 		);
 
 		$maintenanceRunner->setQuiet();

--- a/tests/phpunit/Integration/Maintenance/PopulateHashFieldTest.php
+++ b/tests/phpunit/Integration/Maintenance/PopulateHashFieldTest.php
@@ -30,7 +30,7 @@ class PopulateHashFieldTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'\SMW\Maintenance\populateHashField'
+			'\SMW\Maintenance\PopulateHashField'
 		);
 
 		$maintenanceRunner->setQuiet();

--- a/tests/phpunit/Integration/Maintenance/PurgeEntityCacheTest.php
+++ b/tests/phpunit/Integration/Maintenance/PurgeEntityCacheTest.php
@@ -30,7 +30,7 @@ class PurgeEntityCacheTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\PurgeEntityCache'
+			'\SMW\Maintenance\PurgeEntityCache'
 		);
 
 		$maintenanceRunner->setQuiet();

--- a/tests/phpunit/Integration/Maintenance/RebuildConceptCacheTest.php
+++ b/tests/phpunit/Integration/Maintenance/RebuildConceptCacheTest.php
@@ -30,7 +30,7 @@ class RebuildConceptCacheTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\RebuildConceptCache'
+			'\SMW\Maintenance\RebuildConceptCache'
 		);
 
 		$maintenanceRunner->setQuiet();

--- a/tests/phpunit/Integration/Maintenance/RebuildElasticIndexTest.php
+++ b/tests/phpunit/Integration/Maintenance/RebuildElasticIndexTest.php
@@ -42,7 +42,7 @@ class RebuildElasticIndexTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\RebuildElasticIndex'
+			'\SMW\Maintenance\RebuildElasticIndex'
 		);
 
 		$maintenanceRunner->setMessageReporter( $this->spyMessageReporter );

--- a/tests/phpunit/Integration/Maintenance/RebuildElasticMissingDocumentsTest.php
+++ b/tests/phpunit/Integration/Maintenance/RebuildElasticMissingDocumentsTest.php
@@ -44,7 +44,7 @@ class RebuildElasticMissingDocumentsTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\RebuildElasticMissingDocuments'
+			'\SMW\Maintenance\RebuildElasticMissingDocuments'
 		);
 
 		$maintenanceRunner->setMessageReporter( $this->spyMessageReporter );

--- a/tests/phpunit/Integration/Maintenance/RebuildFulltextSearchTableTest.php
+++ b/tests/phpunit/Integration/Maintenance/RebuildFulltextSearchTableTest.php
@@ -35,7 +35,7 @@ class RebuildFulltextSearchTableTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\RebuildFulltextSearchTable'
+			'\SMW\Maintenance\RebuildFulltextSearchTable'
 		);
 
 		$maintenanceRunner->setMessageReporter(

--- a/tests/phpunit/Integration/Maintenance/RemoveDuplicateEntitiesTest.php
+++ b/tests/phpunit/Integration/Maintenance/RemoveDuplicateEntitiesTest.php
@@ -30,7 +30,7 @@ class RemoveDuplicateEntitiesTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\RemoveDuplicateEntities'
+			'\SMW\Maintenance\RemoveDuplicateEntities'
 		);
 
 		$maintenanceRunner->setQuiet();

--- a/tests/phpunit/Integration/Maintenance/RunImportTest.php
+++ b/tests/phpunit/Integration/Maintenance/RunImportTest.php
@@ -38,7 +38,7 @@ class RunImportTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\RunImport'
+			'\SMW\Maintenance\RunImport'
 		);
 
 		$maintenanceRunner->setMessageReporter(

--- a/tests/phpunit/Integration/Maintenance/SetupStoreMaintenanceTest.php
+++ b/tests/phpunit/Integration/Maintenance/SetupStoreMaintenanceTest.php
@@ -46,7 +46,7 @@ class SetupStoreMaintenanceTest extends SMWIntegrationTestCase {
 	}
 
 	public function testSetupStore_Delete() {
-		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'SMW\Maintenance\SetupStore' );
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( '\SMW\Maintenance\SetupStore' );
 
 		$maintenanceRunner->setQuiet();
 
@@ -89,7 +89,7 @@ class SetupStoreMaintenanceTest extends SMWIntegrationTestCase {
 
 		$this->titleValidator->assertThatTitleIsKnown( $this->importedTitles );
 
-		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'SMW\Maintenance\SetupStore' );
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( '\SMW\Maintenance\SetupStore' );
 
 		$maintenanceRunner->setMessageReporter(
 			$this->spyMessageReporter

--- a/tests/phpunit/Integration/Maintenance/UpdateEntityCollationTest.php
+++ b/tests/phpunit/Integration/Maintenance/UpdateEntityCollationTest.php
@@ -40,7 +40,7 @@ class UpdateEntityCollationTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\UpdateEntityCollation'
+			'\SMW\Maintenance\UpdateEntityCollation'
 		);
 
 		$maintenanceRunner->setMessageReporter(

--- a/tests/phpunit/Integration/Maintenance/UpdateEntityCountMapTest.php
+++ b/tests/phpunit/Integration/Maintenance/UpdateEntityCountMapTest.php
@@ -35,7 +35,7 @@ class UpdateEntityCountMapTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\UpdateEntityCountMap'
+			'\SMW\Maintenance\UpdateEntityCountMap'
 		);
 
 		$maintenanceRunner->setMessageReporter(

--- a/tests/phpunit/Integration/Maintenance/UpdateQueryDependenciesTest.php
+++ b/tests/phpunit/Integration/Maintenance/UpdateQueryDependenciesTest.php
@@ -31,7 +31,7 @@ class UpdateQueryDependenciesTest extends SMWIntegrationTestCase {
 
 	public function testRun() {
 		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner(
-			'SMW\Maintenance\UpdateQueryDependencies'
+			'\SMW\Maintenance\UpdateQueryDependencies'
 		);
 
 		$maintenanceRunner->setQuiet();

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/DumpRdfMaintenanceTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/DumpRdfMaintenanceTest.php
@@ -82,7 +82,7 @@ class DumpRdfMaintenanceTest extends SMWIntegrationTestCase {
 
 		$this->titleValidator->assertThatTitleIsKnown( $this->importedTitles );
 
-		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'SMW\Maintenance\DumpRdf' );
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( '\SMW\Maintenance\DumpRdf' );
 		$maintenanceRunner->setQuiet();
 
 		$this->doExportForDefaultOptions( $maintenanceRunner );

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildConceptCacheMaintenanceTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildConceptCacheMaintenanceTest.php
@@ -79,7 +79,7 @@ class RebuildConceptCacheMaintenanceTest extends SMWIntegrationTestCase {
 		$conceptPage = $this->createConceptPage( 'Lorem ipsum concept', '[[Category:Lorem ipsum]]' );
 	 	$this->importedTitles[] = $conceptPage;
 
-		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'SMW\Maintenance\RebuildConceptCache' );
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( '\SMW\Maintenance\RebuildConceptCache' );
 		$maintenanceRunner->setQuiet();
 
 		$maintenanceRunner

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildDataMaintenanceTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildDataMaintenanceTest.php
@@ -91,7 +91,7 @@ class RebuildDataMaintenanceTest extends SMWIntegrationTestCase {
 			]
 		];
 
-		$this->maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'SMW\Maintenance\RebuildData' );
+		$this->maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( '\SMW\Maintenance\RebuildData' );
 		$this->maintenanceRunner->setQuiet();
 
 		$this->semanticDataFinder = new ByPageSemanticDataFinder;

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildFulltextSearchTableTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildFulltextSearchTableTest.php
@@ -50,7 +50,7 @@ class RebuildFulltextSearchTableTest extends SMWIntegrationTestCase {
 
 		$this->titleValidator->assertThatTitleIsKnown( $this->importedTitles );
 
-		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'SMW\Maintenance\RebuildFulltextSearchTable' );
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( '\SMW\Maintenance\RebuildFulltextSearchTable' );
 		$maintenanceRunner->setQuiet()->run();
 	}
 

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildPropertyStatisticsMaintenanceTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/RebuildPropertyStatisticsMaintenanceTest.php
@@ -66,7 +66,7 @@ class RebuildPropertyStatisticsMaintenanceTest extends SMWIntegrationTestCase {
 
 		$this->titleValidator->assertThatTitleIsKnown( $this->importedTitles );
 
-		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'SMW\Maintenance\RebuildPropertyStatistics' );
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( '\SMW\Maintenance\RebuildPropertyStatistics' );
 		$maintenanceRunner->setQuiet()->run();
 	}
 

--- a/tests/phpunit/Integration/MediaWiki/Import/Maintenance/UpdateEntityCollationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/Maintenance/UpdateEntityCollationTest.php
@@ -75,7 +75,7 @@ class UpdateEntityCollationTest extends SMWIntegrationTestCase {
 
 		$this->titleValidator->assertThatTitleIsKnown( $this->importedTitles );
 
-		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'SMW\Maintenance\UpdateEntityCollation' );
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( '\SMW\Maintenance\UpdateEntityCollation' );
 		$maintenanceRunner->setQuiet()->run();
 	}
 

--- a/tests/phpunit/Maintenance/DisposeOutdatedEntitiesTest.php
+++ b/tests/phpunit/Maintenance/DisposeOutdatedEntitiesTest.php
@@ -3,7 +3,7 @@
 namespace SMW\Tests\Maintenance;
 
 use PHPUnit\Framework\TestCase;
-use SMW\Maintenance\disposeOutdatedEntities;
+use SMW\Maintenance\DisposeOutdatedEntities;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\PHPUnitCompat;
 
@@ -37,13 +37,13 @@ class DisposeOutdatedEntitiesTest extends TestCase {
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
-			disposeOutdatedEntities::class,
-			new disposeOutdatedEntities()
+			DisposeOutdatedEntities::class,
+			new DisposeOutdatedEntities()
 		);
 	}
 
 	public function testExecute() {
-		$instance = new disposeOutdatedEntities();
+		$instance = new DisposeOutdatedEntities();
 
 		$instance->setMessageReporter(
 			$this->spyMessageReporter

--- a/tests/phpunit/Maintenance/DisposeOutdatedEntitiesTest.php
+++ b/tests/phpunit/Maintenance/DisposeOutdatedEntitiesTest.php
@@ -8,7 +8,7 @@ use SMW\Tests\TestEnvironment;
 use SMW\Tests\PHPUnitCompat;
 
 /**
- * @covers \SMW\Maintenance\disposeOutdatedEntities
+ * @covers \SMW\Maintenance\DisposeOutdatedEntities
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+

--- a/tests/phpunit/Maintenance/Jobs/MaintenanceFactoryTest.php
+++ b/tests/phpunit/Maintenance/Jobs/MaintenanceFactoryTest.php
@@ -81,7 +81,7 @@ class MaintenanceFactoryTest extends \PHPUnit_Framework_TestCase {
 		$instance = new MaintenanceFactory();
 
 		$this->assertInstanceOf(
-			'\SMW\Maintenance\rebuildPropertyStatistics',
+			'\SMW\Maintenance\RebuildPropertyStatistics',
 			$instance->newRebuildPropertyStatistics()
 		);
 	}

--- a/tests/phpunit/Maintenance/PurgeEntityCacheTest.php
+++ b/tests/phpunit/Maintenance/PurgeEntityCacheTest.php
@@ -5,7 +5,7 @@ namespace SMW\Tests\Maintenance;
 use Onoi\MessageReporter\MessageReporter;
 use PHPUnit\Framework\TestCase;
 use SMW\EntityCache;
-use SMW\Maintenance\purgeEntityCache;
+use SMW\Maintenance\PurgeEntityCache;
 use Wikimedia\Rdbms\FakeResultWrapper;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
@@ -13,7 +13,7 @@ use SMW\DIWikiPage;
 use Wikimedia\Rdbms\Database;
 
 /**
- * @covers \SMW\Maintenance\purgeEntityCache
+ * @covers \SMW\Maintenance\PurgeEntityCache
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -48,8 +48,8 @@ class PurgeEntityCacheTest extends TestCase {
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
-			purgeEntityCache::class,
-			new purgeEntityCache()
+			PurgeEntityCache::class,
+			new PurgeEntityCache()
 		);
 	}
 
@@ -85,7 +85,7 @@ class PurgeEntityCacheTest extends TestCase {
 			->method( 'invalidate' )
 			->with( $this->equalTo( $subject ) );
 
-		$instance = new purgeEntityCache();
+		$instance = new PurgeEntityCache();
 
 		$instance->setMessageReporter(
 			$this->messageReporter

--- a/tests/phpunit/Maintenance/RunImportTest.php
+++ b/tests/phpunit/Maintenance/RunImportTest.php
@@ -3,12 +3,12 @@
 namespace SMW\Tests\Maintenance;
 
 use PHPUnit\Framework\TestCase;
-use SMW\Maintenance\runImport;
+use SMW\Maintenance\RunImport;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\PHPUnitCompat;
 
 /**
- * @covers \SMW\Maintenance\runImport
+ * @covers \SMW\Maintenance\RunImport
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -37,13 +37,13 @@ class RunImportTest extends TestCase {
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
-			runImport::class,
-			new runImport()
+			RunImport::class,
+			new RunImport()
 		);
 	}
 
 	public function testExecute() {
-		$instance = new runImport();
+		$instance = new RunImport();
 
 		$instance->setMessageReporter(
 			$this->spyMessageReporter

--- a/tests/phpunit/Maintenance/UpdateQueryDependenciesTest.php
+++ b/tests/phpunit/Maintenance/UpdateQueryDependenciesTest.php
@@ -2,13 +2,13 @@
 
 namespace SMW\Tests\Maintenance;
 
-use SMW\Maintenance\updateQueryDependencies;
+use SMW\Maintenance\UpdateQueryDependencies;
 use SMW\Tests\TestEnvironment;
 use SMW\DIWikiPage;
 use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
- * @covers \SMW\Maintenance\updateQueryDependencies
+ * @covers \SMW\Maintenance\UpdateQueryDependencies
  * @group semantic-mediawiki
  *
  * @license GNU GPL v2+
@@ -54,8 +54,8 @@ class UpdateQueryDependenciesTest extends \PHPUnit_Framework_TestCase {
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
-			updateQueryDependencies::class,
-			new updateQueryDependencies()
+			UpdateQueryDependencies::class,
+			new UpdateQueryDependencies()
 		);
 	}
 
@@ -109,7 +109,7 @@ class UpdateQueryDependenciesTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getConnection' )
 			->will( $this->returnValue( $this->connection ) );
 
-		$instance = new updateQueryDependencies();
+		$instance = new UpdateQueryDependencies();
 
 		$instance->setMessageReporter(
 			$this->messageReporter

--- a/tests/phpunit/Utils/JSONScript/RdfTestCaseProcessor.php
+++ b/tests/phpunit/Utils/JSONScript/RdfTestCaseProcessor.php
@@ -71,7 +71,7 @@ class RdfTestCaseProcessor extends MediaWikiIntegrationTestCase {
 	}
 
 	private function assertDumpRdfOutputForCase( $case ) {
-		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( 'SMW\Maintenance\DumpRdf' );
+		$maintenanceRunner = $this->runnerFactory->newMaintenanceRunner( '\SMW\Maintenance\DumpRdf' );
 		$maintenanceRunner->setQuiet();
 
 		$maintenanceRunner->setOptions( $case['dumpRDF']['parameters'] );

--- a/tests/phpunit/Utils/Runners/RunnerFactory.php
+++ b/tests/phpunit/Utils/Runners/RunnerFactory.php
@@ -38,16 +38,16 @@ class RunnerFactory {
 	public function newMaintenanceRunner( $maintenanceClass ) {
 		switch ( $maintenanceClass ) {
 			case 'rebuildPropertyStatistics':
-				$maintenanceClass = 'SMW\Maintenance\RebuildPropertyStatistics';
+				$maintenanceClass = '\SMW\Maintenance\RebuildPropertyStatistics';
 				break;
 			case 'rebuildData':
-				$maintenanceClass = 'SMW\Maintenance\RebuildData';
+				$maintenanceClass = '\SMW\Maintenance\RebuildData';
 				break;
 			case 'rebuildConceptCache';
-				$maintenanceClass = 'SMW\Maintenance\RebuildConceptCache';
+				$maintenanceClass = '\SMW\Maintenance\RebuildConceptCache';
 				break;
 			case 'setupStore';
-				$maintenanceClass = 'SMW\Maintenance\SetupStore';
+				$maintenanceClass = '\SMW\Maintenance\SetupStore';
 				break;
 		}
 

--- a/tests/phpunit/Utils/Runners/RunnerFactory.php
+++ b/tests/phpunit/Utils/Runners/RunnerFactory.php
@@ -43,10 +43,10 @@ class RunnerFactory {
 			case 'rebuildData':
 				$maintenanceClass = '\SMW\Maintenance\RebuildData';
 				break;
-			case 'rebuildConceptCache';
+			case 'rebuildConceptCache':
 				$maintenanceClass = '\SMW\Maintenance\RebuildConceptCache';
 				break;
-			case 'setupStore';
+			case 'setupStore':
 				$maintenanceClass = '\SMW\Maintenance\SetupStore';
 				break;
 		}


### PR DESCRIPTION
Use a uppercase at start.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced command-line options for various maintenance scripts, allowing for more granular control.
- **Bug Fixes**
	- Corrected class naming conventions across multiple files to adhere to PascalCase.
	- Updated namespace references in tests to ensure proper resolution of classes.
- **Tests**
	- Adjusted test cases to reflect changes in class names and namespaces, ensuring accuracy in assertions.
- **Chores**
	- Refactored code for consistency in naming conventions and improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->