### PR TITLE
Allow phpcodesniffer-composer-installer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,7 @@
 		"psr-4": {
 			"SMW\\": "src/",
 			"SMW\\Maintenance\\": "maintenance/",
+			"SMW\\Tests\\": "tests/phpunit/",
 			"Onoi\\Tesa\\": "src/Tesa/src/"
 		},
 		"psr-0": {
@@ -92,14 +93,7 @@
 			"includes/GlobalFunctions.php"
 		],
 		"classmap" : [
-			"includes/"
-		]
-	},
-	"autoload-dev": {
-		"psr-4": {
-			"SMW\\Tests\\": "tests/phpunit/"
-		},
-		"classmap" : [
+			"includes/",
 			"tests/phpunit/includes/"
 		]
 	},

--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,6 @@
 		"psr-4": {
 			"SMW\\": "src/",
 			"SMW\\Maintenance\\": "maintenance/",
-			"SMW\\Tests\\": "tests/phpunit/",
 			"Onoi\\Tesa\\": "src/Tesa/src/"
 		},
 		"psr-0": {
@@ -93,7 +92,14 @@
 			"includes/GlobalFunctions.php"
 		],
 		"classmap" : [
-			"includes/",
+			"includes/"
+		]
+	},
+	"autoload-dev": {
+		"psr-4": {
+			"SMW\\Tests\\": "tests/phpunit/"
+		},
+		"classmap" : [
 			"tests/phpunit/includes/"
 		]
 	},

--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,8 @@
 	"config": {
 		"process-timeout": 0,
 		"allow-plugins": {
-			"composer/installers": true
+			"composer/installers": true,
+			"dealerdirect/phpcodesniffer-composer-installer": true
 		}
 	},
 	"scripts": {


### PR DESCRIPTION
- [Allow phpcodesniffer-composer-installer](https://github.com/SemanticMediaWiki/SemanticMediaWiki/commit/cceb93b789d7857950cdc9ab2d4dbe26ce07d690), which should gets Tesa CI working again

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced autoloading for test classes with the addition of the `SMW\\Tests\\` namespace.
	- Improved plugin management by allowing the `dealerdirect/phpcodesniffer-composer-installer`.
  
- **Bug Fixes**
	- Adjusted classmap entries for better organization of test-related files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->