### PR TITLE
Remove use of isProtected on title object in tests

### DIFF
--- a/tests/phpunit/Property/Annotators/EditProtectedPropertyAnnotatorTest.php
+++ b/tests/phpunit/Property/Annotators/EditProtectedPropertyAnnotatorTest.php
@@ -123,11 +123,6 @@ class EditProtectedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			->will( $this->returnValue( 0 ) );
 
 		$title->expects( $this->any() )
-			->method( 'isProtected' )
-			->with( $this->equalTo( 'edit' ) )
-			->will( $this->returnValue( true ) );
-
-		$title->expects( $this->any() )
 			->method( 'getRestrictions' )
 			->will( $this->returnValue( [] ) );
 

--- a/tests/phpunit/Protection/EditProtectionUpdaterTest.php
+++ b/tests/phpunit/Protection/EditProtectionUpdaterTest.php
@@ -129,11 +129,6 @@ class EditProtectionUpdaterTest extends \PHPUnit_Framework_TestCase {
 			->getMock();
 
 		$title->expects( $this->once() )
-			->method( 'isProtected' )
-			->with( $this->equalTo( 'edit' ) )
-			->will( $this->returnValue( true ) );
-
-		$title->expects( $this->once() )
 			->method( 'getRestrictions' )
 			->will( $this->returnValue( [ 'Foo' ] ) );
 
@@ -183,11 +178,6 @@ class EditProtectionUpdaterTest extends \PHPUnit_Framework_TestCase {
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$title->expects( $this->once() )
-			->method( 'isProtected' )
-			->with( $this->equalTo( 'edit' ) )
-			->will( $this->returnValue( true ) );
 
 		$title->expects( $this->once() )
 			->method( 'getRestrictions' )


### PR DESCRIPTION
Title class removed the method isProtected and this was replaced in this extension with 50e764570dc81357754d50ffe48319c5065af72c.