### PR TITLE
HooksTest: Fix using class LinksUpdate

### DIFF
--- a/tests/phpunit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/MediaWiki/HooksTest.php
@@ -898,7 +898,7 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( NS_SPECIAL ) );
 
-		$linksUpdate = $this->getMockBuilder( '\LinksUpdate' )
+		$linksUpdate = $this->getMockBuilder( '\MediaWiki\Deferred\LinksUpdate\LinksUpdate;' )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/MediaWiki/HooksTest.php
@@ -898,7 +898,7 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( NS_SPECIAL ) );
 
-		$linksUpdate = $this->getMockBuilder( '\MediaWiki\Deferred\LinksUpdate\LinksUpdate;' )
+		$linksUpdate = $this->getMockBuilder( '\MediaWiki\Deferred\LinksUpdate\LinksUpdate' )
 			->disableOriginalConstructor()
 			->getMock();
 


### PR DESCRIPTION
Since 1.38, it has been namespaced under MediaWiki\Deferred\LinksUpdate.