### PR TITLE
HooksTest: Use createMock in callLinksUpdateComplete for LinksUpdate class

### DIFF
--- a/tests/phpunit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/MediaWiki/HooksTest.php
@@ -899,9 +899,7 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( NS_SPECIAL ) );
 
-		$linksUpdate = $this->createMock( LinksUpdate::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$linksUpdate = $this->createMock( LinksUpdate::class );
 
 		$linksUpdate->expects( $this->any() )
 			->method( 'getTitle' )

--- a/tests/phpunit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/MediaWiki/HooksTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\MediaWiki;
 
+use MediaWiki\Deferred\LinksUpdate\LinksUpdate;
 use MediaWiki\Edit\PreparedEdit;
 use MediaWiki\User\UserIdentity;
 use ParserOptions;
@@ -898,7 +899,7 @@ class HooksTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( NS_SPECIAL ) );
 
-		$linksUpdate = $this->getMockBuilder( '\MediaWiki\Deferred\LinksUpdate\LinksUpdate' )
+		$linksUpdate = $this->createMock( LinksUpdate::class )
 			->disableOriginalConstructor()
 			->getMock();
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the mock creation process for the `LinksUpdate` class in tests, enhancing test reliability.
  
- **Tests**
	- Updated the `HooksTest` class to streamline the instantiation of the `LinksUpdate` mock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->