### PR TITLE
EditProtectedPropertyAnnotatorTest: Don't call getRestrictions on title object

### DIFF
--- a/tests/phpunit/Property/Annotators/EditProtectedPropertyAnnotatorTest.php
+++ b/tests/phpunit/Property/Annotators/EditProtectedPropertyAnnotatorTest.php
@@ -122,10 +122,6 @@ class EditProtectedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( 0 ) );
 
-		$title->expects( $this->any() )
-			->method( 'getRestrictions' )
-			->will( $this->returnValue( [] ) );
-
 		$provider = [];
 
 		#0 no EditProtectionRight
@@ -167,10 +163,6 @@ class EditProtectedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			->with( $this->equalTo( 'edit' ) )
 			->will( $this->returnValue( true ) );
 
-		$title->expects( $this->any() )
-			->method( 'getRestrictions' )
-			->will( $this->returnValue( [ 'Foo' ] ) );
-
 		#2
 		$provider[] = [
 			$title,
@@ -198,9 +190,6 @@ class EditProtectedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			->method( 'isProtected' )
 			->with( $this->equalTo( 'edit' ) )
 			->will( $this->returnValue( false ) );
-
-		$title->expects( $this->never() )
-			->method( 'getRestrictions' );
 
 		#3
 		$provider[] = [


### PR DESCRIPTION
This was replaced in this codebase with 770be518d9783782a24bb7062599725816bcb458. Not to mention that this was removed in newer MW versions (1.42/1.41).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed mock expectations for the `getRestrictions` method in tests, enhancing test reliability.
  
- **Refactor**
	- Adjusted the interaction between the `EditProtectedPropertyAnnotatorTest` and the `Title` mock.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->