### PR TITLE
EditProtectedPropertyAnnotatorTest: Remove use of isProtected on title object in tests

### DIFF
--- a/tests/phpunit/Property/Annotators/EditProtectedPropertyAnnotatorTest.php
+++ b/tests/phpunit/Property/Annotators/EditProtectedPropertyAnnotatorTest.php
@@ -158,11 +158,6 @@ class EditProtectedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( 0 ) );
 
-		$title->expects( $this->any() )
-			->method( 'isProtected' )
-			->with( $this->equalTo( 'edit' ) )
-			->will( $this->returnValue( true ) );
-
 		#2
 		$provider[] = [
 			$title,
@@ -185,11 +180,6 @@ class EditProtectedPropertyAnnotatorTest extends \PHPUnit_Framework_TestCase {
 		$title->expects( $this->any() )
 			->method( 'getNamespace' )
 			->will( $this->returnValue( 0 ) );
-
-		$title->expects( $this->any() )
-			->method( 'isProtected' )
-			->with( $this->equalTo( 'edit' ) )
-			->will( $this->returnValue( false ) );
 
 		#3
 		$provider[] = [


### PR DESCRIPTION
Title class removed the method isProtected and this was replaced in this extension with 50e764570dc81357754d50ffe48319c5065af72c.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified test setup by removing expectations related to the `isProtected` method in the `EditProtectedPropertyAnnotatorTest` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->