### PR TITLE
QueryPage: Fix "contains 1 abstract method"

### DIFF
--- a/includes/querypages/PropertiesQueryPage.php
+++ b/includes/querypages/PropertiesQueryPage.php
@@ -273,10 +273,10 @@ class PropertiesQueryPage extends QueryPage {
 	}
 
 	/**
-	 * @return array|bool
+	 * @return array|null
 	 */
-	public function getQueryInfo() {
-		return false;
+	public function getQueryInfo(): ?array {
+		return null;
 	}
 
 }

--- a/includes/querypages/QueryPage.php
+++ b/includes/querypages/QueryPage.php
@@ -247,4 +247,11 @@ abstract class QueryPage extends \QueryPage {
 
 		return $num;
 	}
+
+	/**
+	 * @return array|bool
+	 */
+	public function getQueryInfo() {
+		return null;
+	}
 }

--- a/includes/querypages/QueryPage.php
+++ b/includes/querypages/QueryPage.php
@@ -249,7 +249,7 @@ abstract class QueryPage extends \QueryPage {
 	}
 
 	/**
-	 * @return array|bool
+	 * @return array|null
 	 */
 	public function getQueryInfo() {
 		return null;

--- a/includes/querypages/QueryPage.php
+++ b/includes/querypages/QueryPage.php
@@ -251,7 +251,7 @@ abstract class QueryPage extends \QueryPage {
 	/**
 	 * @return array|null
 	 */
-	public function getQueryInfo() {
+	public function getQueryInfo(): ?array {
 		return null;
 	}
 }


### PR DESCRIPTION
In MW 1.43, getQueryInfo was made abstract so we have to declare it. Before MW 1.43 it returned null so we return null here.

Also fix getQueryInfo  return type in PropertiesQueryPage.php. It has to match the one in QueryPage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to retrieve query-related information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->