### PR TITLE
PropertiesQueryPage: Fix getQueryInfo value to be null

### DIFF
--- a/includes/querypages/PropertiesQueryPage.php
+++ b/includes/querypages/PropertiesQueryPage.php
@@ -273,7 +273,7 @@ class PropertiesQueryPage extends QueryPage {
 	}
 
 	/**
-	 * @return array|bool
+	 * @return array|null
 	 */
 	public function getQueryInfo() {
 		return null;

--- a/includes/querypages/PropertiesQueryPage.php
+++ b/includes/querypages/PropertiesQueryPage.php
@@ -276,7 +276,7 @@ class PropertiesQueryPage extends QueryPage {
 	 * @return array|bool
 	 */
 	public function getQueryInfo() {
-		return false;
+		return null;
 	}
 
 }

--- a/includes/querypages/PropertiesQueryPage.php
+++ b/includes/querypages/PropertiesQueryPage.php
@@ -275,7 +275,7 @@ class PropertiesQueryPage extends QueryPage {
 	/**
 	 * @return array|null
 	 */
-	public function getQueryInfo() {
+	public function getQueryInfo(): ?array {
 		return null;
 	}
 


### PR DESCRIPTION
This matches before it was made abstract. It uses isset checks and returns true even if you use false.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the output of the query method to enhance result interpretation, allowing for a null return value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->