### PR TITLE
PHPUnitCompat: Replace PHPUnit_Framework_TestCase with \PHPUnit\Framework\TestCase

### DIFF
--- a/tests/phpunit/PHPUnitCompat.php
+++ b/tests/phpunit/PHPUnitCompat.php
@@ -35,7 +35,7 @@ trait PHPUnitCompat {
 	 * or assertStringContainsStringIgnoringCase() instead."
 	 */
 	public static function assertContains( $needle, $haystack, $message = '', $ignoreCase = false, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false ): void {
-		if ( is_callable( [ 'PHPUnit_Framework_TestCase', 'assertStringContainsString' ] ) ) {
+		if ( is_callable( [ '\PHPUnit\Framework\TestCase', 'assertStringContainsString' ] ) ) {
 			if ( is_array( $haystack ) ) {
 				$haystack = implode( ' ', $haystack );
 			}
@@ -51,7 +51,7 @@ trait PHPUnitCompat {
 	 * or assertStringNotContainsStringIgnoringCase() instead."
 	 */
 	public static function assertNotContains( $needle, $haystack, $message = '', $ignoreCase = false, $checkForObjectIdentity = true, $checkForNonObjectIdentity = false ): void {
-		if ( is_callable( [ 'PHPUnit_Framework_TestCase', 'assertStringNotContainsString' ] ) ) {
+		if ( is_callable( [ '\PHPUnit\Framework\TestCase', 'assertStringNotContainsString' ] ) ) {
 			if ( is_array( $haystack ) ) {
 				$haystack = implode( ' ', $haystack );
 			}
@@ -69,7 +69,7 @@ trait PHPUnitCompat {
 	 * instead."
 	 */
 	public static function assertInternalType( $expected, $actual, $message = '' ): void {
-		if ( is_callable( [ 'PHPUnit_Framework_TestCase', 'assertIsArray' ] ) ) {
+		if ( is_callable( [ '\PHPUnit\Framework\TestCase', 'assertIsArray' ] ) ) {
 			if ( $expected === 'array' ) {
 				parent::assertIsArray( $actual, $message );
 			}
@@ -101,5 +101,4 @@ trait PHPUnitCompat {
 			parent::assertInternalType( $expected, $actual, $message );
 		}
 	}
-
 }

--- a/tests/phpunit/PHPUnitCompat.php
+++ b/tests/phpunit/PHPUnitCompat.php
@@ -46,7 +46,7 @@ trait PHPUnitCompat {
 	}
 
 	/**
-	 * "UUsing assertNotContains() with string haystacks is deprecated and will
+	 * "Using assertNotContains() with string haystacks is deprecated and will
 	 * not be supported in PHPUnit 9. Refactor your test to use assertStringNotContainsString()
 	 * or assertStringNotContainsStringIgnoringCase() instead."
 	 */

--- a/tests/phpunit/PHPUnitCompat.php
+++ b/tests/phpunit/PHPUnitCompat.php
@@ -11,7 +11,7 @@ namespace SMW\Tests;
 trait PHPUnitCompat {
 
 	/**
-	 * @see PHPUnit_Framework_TestCase::setExpectedException
+	 * @see \PHPUnit\Framework\TestCase::setExpectedException
 	 */
 	public function setExpectedException( $name, $message = '', $code = null ) {
 		if ( is_callable( [ $this, 'expectException' ] ) ) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated PHPUnit compatibility to align with the latest namespace structure, ensuring proper functionality of test case methods.
  
- **Chores**
	- Refactored method references for assertions to replace deprecated methods with their modern equivalents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->