### PR TITLE
PostProcHandlerTest: Don't skip test in testPurgePageOnQueryDependency

### DIFF
--- a/tests/phpunit/PostProcHandlerTest.php
+++ b/tests/phpunit/PostProcHandlerTest.php
@@ -260,10 +260,6 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			]
 		);
 
-		$this->markTestSkipped(
-			"Check smwLikelyOutdatedDependencies set up for MW >= 1.39"
-		);
-
 		$title = $this->getMockBuilder( '\Title' )
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/phpunit/PostProcHandlerTest.php
+++ b/tests/phpunit/PostProcHandlerTest.php
@@ -2,11 +2,18 @@
 
 namespace SMW\Tests;
 
+use Title;
 use SMW\DIWikiPage;
+use SMW\EntityCache;
+use SMW\NamespaceExaminer;
 use SMW\PostProcHandler;
 use SMW\SQLStore\ChangeOp\ChangeDiff;
+use SMW\SQLStore\ChangeOp\FieldChangeOp;
+use SMW\SQLStore\ChangeOp\TableChangeOp;
+use SMW\SQLStore\QueryDependency\DependencyLinksValidator;
 use SMW\Tests\PHPUnitCompat;
 use SMW\DependencyValidator;
+use WebRequest;
 
 /**
  * @covers \SMW\PostProcHandler
@@ -70,7 +77,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getLatestRevID' )
 			->will( $this->returnValue( 42 ) );
 
-		$webRequest = $this->getMockBuilder( '\WebRequest' )
+		$webRequest = $this->getMockBuilder( WebRequest::class );
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -111,9 +118,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			]
 		);
 
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
+		$title = $this->createMock( Title::class );
 
 		$title->expects( $this->atLeastOnce() )
 			->method( 'getDBKey' )
@@ -127,9 +132,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getLatestRevID' )
 			->will( $this->returnValue( 42 ) );
 
-		$webRequest = $this->getMockBuilder( '\WebRequest' )
-			->disableOriginalConstructor()
-			->getMock();
+		$webRequest = $this->createMock( WebRequest::class );
 
 		$webRequest->expects( $this->once() )
 			->method( 'getCookie' )
@@ -185,9 +188,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getLatestRevID' )
 			->will( $this->returnValue( 42 ) );
 
-		$webRequest = $this->getMockBuilder( '\WebRequest' )
-			->disableOriginalConstructor()
-			->getMock();
+		$webRequest = $this->createMock( WebRequest::class );
 
 		$webRequest->expects( $this->once() )
 			->method( 'getCookie' )
@@ -212,9 +213,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			]
 		);
 
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
+		$title = $this->createMock( Title::class );
 
 		$title->expects( $this->atLeastOnce() )
 			->method( 'getDBKey' )
@@ -228,9 +227,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getLatestRevID' )
 			->will( $this->returnValue( 42 ) );
 
-		$webRequest = $this->getMockBuilder( '\WebRequest' )
-			->disableOriginalConstructor()
-			->getMock();
+		$webRequest = $this->createMock( WebRequest::class );
 
 		$webRequest->expects( $this->once() )
 			->method( 'getCookie' )
@@ -260,11 +257,11 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			]
 		);
 
-		$title = $this->createMock( '\Title' );
+		$title = $this->createMock( Title::class );
 
-		$dependencyLinksValidator = $this->createMock( '\SMW\SQLStore\QueryDependency\DependencyLinksValidator' );
-		$namespaceExaminer = $this->createMock( '\SMW\NamespaceExaminer' );
-		$entityCache = $this->createMock( '\SMW\EntityCache' );
+		$dependencyLinksValidator = $this->createMock( DependencyLinksValidator::class );
+		$namespaceExaminer = $this->createMock( NamespaceExaminer::class );
+		$entityCache = $this->createMock( EntityCache::class );
 		$dependencyValidator = new DependencyValidator(
 			$namespaceExaminer,
 			$dependencyLinksValidator,
@@ -280,7 +277,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( NS_MAIN ) );
 
-		$webRequest = $this->createMock( '\WebRequest' );
+		$webRequest = $this->createMock( WebRequest::class );
 
 		$this->assertContains(
 			'<div class="smw-postproc page-purge" data-subject="#0##" data-title="Foo" data-msg="smw-purge-update-dependencies" data-forcelinkupdate="1"></div>',
@@ -292,17 +289,13 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 	 * @dataProvider validPropertyKey
 	 */
 	public function testGetHtmlOnCookieAndValidChangeDiff( $key ) {
-		$fieldChangeOp = $this->getMockBuilder( '\SMW\SQLStore\ChangeOp\FieldChangeOp' )
-			->disableOriginalConstructor()
-			->getMock();
+		$fieldChangeOp = $this->createMock( FieldChangeOp::class );
 
 		$fieldChangeOp->expects( $this->any() )
 			->method( 'get' )
 			->will( $this->returnValue( 42 ) );
 
-		$tableChangeOp = $this->getMockBuilder( '\SMW\SQLStore\ChangeOp\TableChangeOp' )
-			->disableOriginalConstructor()
-			->getMock();
+		$tableChangeOp = $this->getMockBuilder( TableChangeOp::class );
 
 		$tableChangeOp->expects( $this->any() )
 			->method( 'getFieldChangeOps' )
@@ -329,9 +322,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			$this->cache
 		);
 
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
+		$title = $this->createMock( Title::class );
 
 		$title->expects( $this->atLeastOnce() )
 			->method( 'getDBKey' )
@@ -345,9 +336,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getLatestRevID' )
 			->will( $this->returnValue( 42 ) );
 
-		$webRequest = $this->getMockBuilder( '\WebRequest' )
-			->disableOriginalConstructor()
-			->getMock();
+		$webRequest = $this->createMock( WebRequest::class );
 
 		$webRequest->expects( $this->once() )
 			->method( 'getCookie' )

--- a/tests/phpunit/PostProcHandlerTest.php
+++ b/tests/phpunit/PostProcHandlerTest.php
@@ -74,9 +74,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getLatestRevID' )
 			->will( $this->returnValue( 42 ) );
 
-		$webRequest = $this->getMockBuilder( WebRequest::class );
-			->disableOriginalConstructor()
-			->getMock();
+		$webRequest = $this->createMock( WebRequest::class );
 
 		$webRequest->expects( $this->once() )
 			->method( 'getCookie' )
@@ -290,7 +288,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			->method( 'get' )
 			->will( $this->returnValue( 42 ) );
 
-		$tableChangeOp = $this->getMockBuilder( TableChangeOp::class );
+		$tableChangeOp = $this->createMock( TableChangeOp::class );
 
 		$tableChangeOp->expects( $this->any() )
 			->method( 'getFieldChangeOps' )

--- a/tests/phpunit/PostProcHandlerTest.php
+++ b/tests/phpunit/PostProcHandlerTest.php
@@ -2,6 +2,9 @@
 
 namespace SMW\Tests;
 
+use Onoi\Cache\Cache;
+use ParserOutput;
+use SMWQuery;
 use Title;
 use SMW\DIWikiPage;
 use SMW\EntityCache;
@@ -34,13 +37,9 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->parserOutput = $this->getMockBuilder( '\ParserOutput' )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->parserOutput = $this->createMock( ParserOutput::class );
 
-		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->cache = $this->createMock( Cache::class );
 	}
 
 	public function testCanConstruct() {
@@ -61,9 +60,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			$this->cache
 		);
 
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
+		$title = $this->createMock( Title::class );
 
 		$title->expects( $this->atLeastOnce() )
 			->method( 'getDBKey' )
@@ -172,9 +169,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			]
 		);
 
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
+		$title = $this->createMock( Title::class );
 
 		$title->expects( $this->atLeastOnce() )
 			->method( 'getDBKey' )
@@ -399,9 +394,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function queryProvider() {
-		$query = $this->getMockBuilder( '\SMWQuery' )
-			->disableOriginalConstructor()
-			->getMock();
+		$query = $this->createMock( SMWQuery::class );
 
 		$query->expects( $this->any() )
 			->method( 'toArray' )

--- a/tests/phpunit/PostProcHandlerTest.php
+++ b/tests/phpunit/PostProcHandlerTest.php
@@ -2,10 +2,9 @@
 
 namespace SMW\Tests;
 
-use Onoi\Cache\Cache;
 use ParserOutput;
+use Onoi\Cache\Cache;
 use SMWQuery;
-use Title;
 use SMW\DIWikiPage;
 use SMW\EntityCache;
 use SMW\NamespaceExaminer;
@@ -16,6 +15,7 @@ use SMW\SQLStore\ChangeOp\TableChangeOp;
 use SMW\SQLStore\QueryDependency\DependencyLinksValidator;
 use SMW\Tests\PHPUnitCompat;
 use SMW\DependencyValidator;
+use Title;
 use WebRequest;
 
 /**

--- a/tests/phpunit/PostProcHandlerTest.php
+++ b/tests/phpunit/PostProcHandlerTest.php
@@ -260,11 +260,17 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			]
 		);
 
-		$title = $this->getMockBuilder( '\Title' )
-			->disableOriginalConstructor()
-			->getMock();
+		$title = $this->createMock( '\Title' );
 
-		DependencyValidator:: markTitle( $title );
+		$dependencyLinksValidator = $this->createMock( '\SMW\SQLStore\QueryDependency\DependencyLinksValidator' );
+		$namespaceExaminer = $this->createMock( '\SMW\NamespaceExaminer' );
+		$entityCache = $this->createMock( '\SMW\EntityCache' );
+		$dependencyValidator = new DependencyValidator(
+			$namespaceExaminer,
+			$dependencyLinksValidator,
+			$entityCache
+		);
+		$dependencyValidator->markTitle( $title );
 
 		$title->expects( $this->atLeastOnce() )
 			->method( 'getPrefixedDBKey' )
@@ -274,9 +280,7 @@ class PostProcHandlerTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getNamespace' )
 			->will( $this->returnValue( NS_MAIN ) );
 
-		$webRequest = $this->getMockBuilder( '\WebRequest' )
-			->disableOriginalConstructor()
-			->getMock();
+		$webRequest = $this->createMock( '\WebRequest' );
 
 		$this->assertContains(
 			'<div class="smw-postproc page-purge" data-subject="#0##" data-title="Foo" data-msg="smw-purge-update-dependencies" data-forcelinkupdate="1"></div>',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Removed an inactive test case to streamline the testing suite.

- **Tests**
	- Enhanced test methods to validate the behavior of the `PostProcHandler` class under various conditions using mock objects.
	- Updated mock creation process for improved efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->