### PR TITLE
JsonUnserializable: Fix checking if interface exists

### DIFF
--- a/includes/compat/JsonUnserializable.php
+++ b/includes/compat/JsonUnserializable.php
@@ -2,7 +2,7 @@
 
 namespace MediaWiki\Json;
 
-if( !interface_exists( 'MediaWiki\Json\JsonUnserializable' ) ) {
+if( !interface_exists( 'JsonUnserializable' ) ) {
 
 	/**
 	 * This interface was introduced in MediaWiki 1.36 and some classes need to implement it.


### PR DESCRIPTION
Because we namespace under MediaWiki\Json, we have to either act like the class is under it or we have to use \<name>.

This should fix:

```
Warning: Cannot declare interface MediaWiki\Json\JsonUnserializable, because the name is already in use in /var/www/html/includes/json/JsonDeserializable.php on line 51
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Simplified the check for the existence of the `JsonUnserializable` interface, enhancing flexibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->