### PR TITLE
Fix SMW_PHPUNIT_DIR showing as missing by defining it in Setup.php

### DIFF
--- a/src/Setup.php
+++ b/src/Setup.php
@@ -168,7 +168,7 @@ final class Setup {
 		}
 
 		if ( !defined( 'SMW_PHPUNIT_DIR' ) ) {
-			define( 'SMW_PHPUNIT_DIR', __DIR__ . '/../phpunit' );
+			define( 'SMW_PHPUNIT_DIR', __DIR__ . '/../tests/phpunit' );
 		}
 
 		$vars['wgLogTypes'][] = 'smw';

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -167,6 +167,10 @@ final class Setup {
 			define( 'SMW_PHPUNIT_AUTOLOADER_FILE', "$smwDir/tests/autoloader.php" );
 		}
 
+		if ( !defined( 'SMW_PHPUNIT_DIR' ) ) {
+			define( 'SMW_PHPUNIT_DIR', __DIR__ . '/../phpunit' );
+		}
+
 		$vars['wgLogTypes'][] = 'smw';
 		$vars['wgFilterLogTypes']['smw'] = true;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new constant for PHPUnit test directory configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->