### PR TITLE
Change dev-master to 5.x-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -76,7 +76,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "4.x-dev"
+			"dev-master": "5.x-dev"
 		}
 	},
 	"autoload": {


### PR DESCRIPTION
Since the next release is going to be v5, lets change dev-master to 5.x-dev alias.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated version aliasing for the development branch from "4.x-dev" to "5.x-dev" in project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->