### PR TITLE
TestDatabaseTableBuilder: On MW 1.42+ Don't use listViews

### DIFF
--- a/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php
+++ b/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php
@@ -160,7 +160,12 @@ class TestDatabaseTableBuilder {
 			__METHOD__
 		);
 
-		if ( $dbConnection->getType() === 'mysql' && method_exists( $dbConnection, 'listViews' ) ) {
+		// MW < 1.42
+		if (
+			version_compare( MW_VERSION, '1.42', '<' ) &&
+			$dbConnection->getType() === 'mysql' &&
+			method_exists( $dbConnection, 'listViews' )
+		) {
 
 			# bug 43571: cannot clone VIEWs under MySQL
 			$views = $dbConnection->listViews(


### PR DESCRIPTION
This was deprecated in [0] due to listTables removing views now.

[0] https://github.com/wikimedia/mediawiki/commit/c55379d5b8ba96c0af0cac02c5d8c02752565088

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Adjusted logic for handling MySQL views to ensure compatibility with MediaWiki versions prior to 1.42.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->