### PR TITLE
JSONScriptTestCaseRunner: Remove unneeded definition of testDatabaseTableBuilder var

### DIFF
--- a/tests/phpunit/JSONScriptTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptTestCaseRunner.php
@@ -7,7 +7,6 @@ use SMW\Localizer\Localizer;
 use SMW\Tests\Utils\JSONScript\JsonTestCaseContentHandler;
 use SMW\Tests\Utils\JSONScript\JsonTestCaseFileHandler;
 use SMW\Tests\Utils\UtilityFactory;
-use SMW\Tests\Utils\Connection\TestDatabaseTableBuilder;
 
 /**
  * The `JSONScriptTestCaseRunner` is a convenience provider for `Json` formatted
@@ -28,11 +27,6 @@ use SMW\Tests\Utils\Connection\TestDatabaseTableBuilder;
  * @author mwjames
  */
 abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
-
-	/**
-	 * @var TestDatabaseTableBuilder
-	 */
-	protected $testDatabaseTableBuilder;
 
 	/**
 	 * @var FileReader


### PR DESCRIPTION
It's already defined in SMWIntegrationTestCase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed deprecated property to streamline test case execution.
  
- **New Features**
	- Introduced a new preferred method for page creation, enhancing flexibility in testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->