### PR TITLE
SMWIntegrationTestCase: Override DB_PREFIX and set as sunittest_

### DIFF
--- a/tests/phpunit/SMWIntegrationTestCase.php
+++ b/tests/phpunit/SMWIntegrationTestCase.php
@@ -34,6 +34,11 @@ use PHPUnit\Framework\TestResult;
  */
 abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 
+	/**
+	 * Table name prefix.
+	 */
+	public const DB_PREFIX = 'sunittest_';
+
     /**
 	 * @var TestEnvironment
 	 */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new constant for standardized database table naming in unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->