### PR TITLE
Fix phpcs for most of PHPUnit

### DIFF
--- a/src/IteratorFactory.php
+++ b/src/IteratorFactory.php
@@ -19,7 +19,7 @@ class IteratorFactory {
 	/**
 	 * @since 2.5
 	 *
-	 * @param \Wikimedia\Rdbms\ResultWrapper|Iterator|array $res
+	 * @param \Wikimedia\Rdbms\IResultWrapper|Iterator|array $res
 	 *
 	 * @return ResultIterator
 	 */

--- a/src/Iterators/ResultIterator.php
+++ b/src/Iterators/ResultIterator.php
@@ -7,7 +7,7 @@ use Countable;
 use Iterator;
 use RuntimeException;
 use SeekableIterator;
-use Wikimedia\Rdbms\ResultWrapper;
+use Wikimedia\Rdbms\IResultWrapper;
 /**
  * @license GNU GPL v2+
  * @since 2.5
@@ -17,7 +17,7 @@ use Wikimedia\Rdbms\ResultWrapper;
 class ResultIterator implements Iterator, Countable, SeekableIterator {
 
 	/**
-	 * @var ResultWrapper
+	 * @var IResultWrapper
 	 */
 	public $res;
 

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -11,7 +11,7 @@ use Wikimedia\Rdbms\DBError;
 use Wikimedia\Rdbms\IDatabase;
 use Wikimedia\Rdbms\Platform\ISQLPlatform;
 use Wikimedia\Rdbms\Platform\SQLPlatform;
-use Wikimedia\Rdbms\ResultWrapper;
+use Wikimedia\Rdbms\IResultWrapper;
 use Wikimedia\ScopedCallback;
 
 /**
@@ -222,7 +222,7 @@ class Database {
 	 * @param array $options
 	 * @param array $joinConditions
 	 *
-	 * @return ResultWrapper
+	 * @return IResultWrapper
 	 * @throws UnexpectedValueException
 	 */
 	public function select( $tableName, $fields, $conditions, $fname, array $options = [], $joinConditions = [] ) {
@@ -258,7 +258,7 @@ class Database {
 			$this->tablePrefix( $tablePrefix );
 		}
 
-		if ( $results instanceof ResultWrapper ) {
+		if ( $results instanceof IResultWrapper ) {
 			return $results;
 		}
 
@@ -281,7 +281,7 @@ class Database {
 	 * @param string $fname
 	 * @param int $flags
 	 *
-	 * @return ResultWrapper
+	 * @return IResultWrapper
 	 * @throws RuntimeException
 	 */
 	public function query( $sql, $fname = __METHOD__, $flags = 0 ) {
@@ -308,7 +308,7 @@ class Database {
 	 * @param Query|string $sql
 	 * @param string $fname
 	 * @param int $flags
-	 * @return bool|\Wikimedia\Rdbms\IResultWrapper
+	 * @return bool|IResultWrapper
 	 * @throws Exception
 	 */
 	public function readQuery( $sql, $fname = __METHOD__, $flags = 0 ) {
@@ -329,7 +329,7 @@ class Database {
 	 * @param Query|string $sql
 	 * @param $fname
 	 * @param int $flags
-	 * @return bool|\Wikimedia\Rdbms\IResultWrapper
+	 * @return bool|IResultWrapper
 	 * @throws Exception
 	 */
 	private function executeQuery( IDatabase $connection, $sql, $fname, $flags ) {

--- a/tests/phpunit/Constraint/Constraints/MandatoryPropertiesConstraintTest.php
+++ b/tests/phpunit/Constraint/Constraints/MandatoryPropertiesConstraintTest.php
@@ -66,7 +66,7 @@ class MandatoryPropertiesConstraintTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'addError', 'getCallable' ] )
+			->onlyMethods( [ 'addError', 'getCallable' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->once() )

--- a/tests/phpunit/Constraint/Constraints/MustExistsConstraintTest.php
+++ b/tests/phpunit/Constraint/Constraints/MustExistsConstraintTest.php
@@ -78,7 +78,7 @@ class MustExistsConstraintTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'addError' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'addError' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )

--- a/tests/phpunit/Constraint/Constraints/NamespaceConstraintTest.php
+++ b/tests/phpunit/Constraint/Constraints/NamespaceConstraintTest.php
@@ -62,7 +62,7 @@ class NamespaceConstraintTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'addError' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'addError' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )

--- a/tests/phpunit/Constraint/Constraints/NonNegativeIntegerConstraintTest.php
+++ b/tests/phpunit/Constraint/Constraints/NonNegativeIntegerConstraintTest.php
@@ -58,7 +58,7 @@ class NonNegativeIntegerConstraintTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'addError' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'addError' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )

--- a/tests/phpunit/Constraint/Constraints/SingleValueConstraintTest.php
+++ b/tests/phpunit/Constraint/Constraints/SingleValueConstraintTest.php
@@ -66,7 +66,7 @@ class SingleValueConstraintTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'addError', 'getCallable' ] )
+			->onlyMethods( [ 'getProperty', 'addError', 'getCallable' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->once() )

--- a/tests/phpunit/Constraint/Constraints/UniqueValueConstraintTest.php
+++ b/tests/phpunit/Constraint/Constraints/UniqueValueConstraintTest.php
@@ -37,7 +37,7 @@ class UniqueValueConstraintTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'service' ] )
+			->onlyMethods( [ 'service' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )
@@ -76,7 +76,7 @@ class UniqueValueConstraintTest extends \PHPUnit\Framework\TestCase {
 	public function testCanNotValidateOnNull() {
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'getContextPage' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'getContextPage' ] )
 			->getMockForAbstractClass();
 
 		$instance = new UniqueValueConstraint(
@@ -100,7 +100,7 @@ class UniqueValueConstraintTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'getContextPage' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'getContextPage' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )
@@ -144,7 +144,7 @@ class UniqueValueConstraintTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'getContextPage', 'addError' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'getContextPage', 'addError' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )

--- a/tests/phpunit/DataValueFactoryTest.php
+++ b/tests/phpunit/DataValueFactoryTest.php
@@ -31,7 +31,7 @@ class DataValueFactoryTest extends \PHPUnit\Framework\TestCase {
 
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doRun' ] )
+			->onlyMethods( [ 'doRun' ] )
 			->getMock();
 
 		$test->expects( $this->once() )

--- a/tests/phpunit/DataValues/Number/UnitConverterTest.php
+++ b/tests/phpunit/DataValues/Number/UnitConverterTest.php
@@ -33,7 +33,7 @@ class UnitConverterTest extends \PHPUnit\Framework\TestCase {
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'fetch', 'save', 'associate' ] )
+			->onlyMethods( [ 'fetch', 'save', 'associate' ] )
 			->getMock();
 	}
 

--- a/tests/phpunit/DataValues/ReferenceValueTest.php
+++ b/tests/phpunit/DataValues/ReferenceValueTest.php
@@ -57,7 +57,7 @@ class ReferenceValueTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
+			->onlyMethods( [ 'getRedirectTarget' ] )
 			->getMockForAbstractClass();
 
 		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
@@ -89,7 +89,7 @@ class ReferenceValueTest extends \PHPUnit\Framework\TestCase {
 	public function testParseValue() {
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
+			->onlyMethods( [ 'getRedirectTarget' ] )
 			->getMockForAbstractClass();
 
 		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
@@ -139,7 +139,7 @@ class ReferenceValueTest extends \PHPUnit\Framework\TestCase {
 	public function testParseValueWithErroredDv() {
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
+			->onlyMethods( [ 'getRedirectTarget' ] )
 			->getMockForAbstractClass();
 
 		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )

--- a/tests/phpunit/DataValues/ValueFormatters/NoValueFormatterTest.php
+++ b/tests/phpunit/DataValues/ValueFormatters/NoValueFormatterTest.php
@@ -41,7 +41,7 @@ class NoValueFormatterTest extends \PHPUnit\Framework\TestCase {
 	public function testFormat() {
 		$dataItem = $this->getMockBuilder( '\SMWDataItem' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSerialization' ] )
+			->onlyMethods( [ 'getSerialization' ] )
 			->getMockForAbstractClass();
 
 		$dataItem->expects( $this->once() )
@@ -50,7 +50,7 @@ class NoValueFormatterTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'isValid', 'getDataItem' ] )
+			->onlyMethods( [ 'isValid', 'getDataItem' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->any() )

--- a/tests/phpunit/DataValues/ValueValidators/AllowsListConstraintValueValidatorTest.php
+++ b/tests/phpunit/DataValues/ValueValidators/AllowsListConstraintValueValidatorTest.php
@@ -59,7 +59,7 @@ class AllowsListConstraintValueValidatorTest extends \PHPUnit\Framework\TestCase
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'getTypeID' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'getTypeID' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->any() )
@@ -99,7 +99,7 @@ class AllowsListConstraintValueValidatorTest extends \PHPUnit\Framework\TestCase
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'getTypeID' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'getTypeID' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->any() )
@@ -152,7 +152,7 @@ class AllowsListConstraintValueValidatorTest extends \PHPUnit\Framework\TestCase
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'getTypeID' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'getTypeID' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->any() )
@@ -201,7 +201,7 @@ class AllowsListConstraintValueValidatorTest extends \PHPUnit\Framework\TestCase
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'getTypeID' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'getTypeID' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->any() )
@@ -244,7 +244,7 @@ class AllowsListConstraintValueValidatorTest extends \PHPUnit\Framework\TestCase
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'getTypeID', 'getWikiValue' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'getTypeID', 'getWikiValue' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->any() )

--- a/tests/phpunit/DataValues/ValueValidators/PatternConstraintValueValidatorTest.php
+++ b/tests/phpunit/DataValues/ValueValidators/PatternConstraintValueValidatorTest.php
@@ -72,7 +72,7 @@ class PatternConstraintValueValidatorTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'getTypeID' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'getTypeID' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->any() )

--- a/tests/phpunit/DataValues/ValueValidators/UniquenessConstraintValueValidatorTest.php
+++ b/tests/phpunit/DataValues/ValueValidators/UniquenessConstraintValueValidatorTest.php
@@ -51,7 +51,7 @@ class UniquenessConstraintValueValidatorTest extends \PHPUnit\Framework\TestCase
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'getContextPage' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'getContextPage' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )
@@ -95,7 +95,7 @@ class UniquenessConstraintValueValidatorTest extends \PHPUnit\Framework\TestCase
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getProperty', 'getDataItem', 'getContextPage' ] )
+			->onlyMethods( [ 'getProperty', 'getDataItem', 'getContextPage' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )

--- a/tests/phpunit/DisplayTitleFinderTest.php
+++ b/tests/phpunit/DisplayTitleFinderTest.php
@@ -25,7 +25,7 @@ class DisplayTitleFinderTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getWikiPageSortKey', 'service' ] )
+			->onlyMethods( [ 'getWikiPageSortKey', 'service' ] )
 			->getMockForAbstractClass();
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
@@ -208,7 +208,7 @@ class DisplayTitleFinderTest extends \PHPUnit\Framework\TestCase {
 					$this->entityCache
 				]
 			)
-			->setMethods( [ 'prefetchFromList' ] )
+			->onlyMethods( [ 'prefetchFromList' ] )
 			->getMock();
 
 		$instance->expects( $this->any() )

--- a/tests/phpunit/Elastic/Admin/ElasticClientTaskHandlerTest.php
+++ b/tests/phpunit/Elastic/Admin/ElasticClientTaskHandlerTest.php
@@ -34,7 +34,7 @@ class ElasticClientTaskHandlerTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )
@@ -84,7 +84,7 @@ class ElasticClientTaskHandlerTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/Elastic/Admin/IndicesInfoProviderTest.php
+++ b/tests/phpunit/Elastic/Admin/IndicesInfoProviderTest.php
@@ -38,7 +38,7 @@ class IndicesInfoProviderTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/Elastic/Admin/MappingsInfoProviderTest.php
+++ b/tests/phpunit/Elastic/Admin/MappingsInfoProviderTest.php
@@ -38,7 +38,7 @@ class MappingsInfoProviderTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/Elastic/Admin/NodesInfoProviderTest.php
+++ b/tests/phpunit/Elastic/Admin/NodesInfoProviderTest.php
@@ -38,7 +38,7 @@ class NodesInfoProviderTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/Elastic/Admin/ReplicationInfoProviderTest.php
+++ b/tests/phpunit/Elastic/Admin/ReplicationInfoProviderTest.php
@@ -36,7 +36,7 @@ class ReplicationInfoProviderTest extends \PHPUnit\Framework\TestCase {
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'fetch' ] )
+			->onlyMethods( [ 'fetch' ] )
 			->getMock();
 
 		$this->webRequest = $this->getMockBuilder( '\WebRequest' )
@@ -45,7 +45,7 @@ class ReplicationInfoProviderTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/Elastic/Admin/SettingsInfoProviderTest.php
+++ b/tests/phpunit/Elastic/Admin/SettingsInfoProviderTest.php
@@ -38,7 +38,7 @@ class SettingsInfoProviderTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/Elastic/ElasticFactoryTest.php
+++ b/tests/phpunit/Elastic/ElasticFactoryTest.php
@@ -377,7 +377,7 @@ class ElasticFactoryTest extends \PHPUnit\Framework\TestCase {
 
 		$instance = $this->getMockBuilder( '\SMW\Elastic\ElasticFactory' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'newRebuilder', 'newUpdateEntityCollationComplete' ] )
+			->onlyMethods( [ 'newRebuilder', 'newUpdateEntityCollationComplete' ] )
 			->getMock();
 
 		$instance->expects( $this->atLeastOnce() )
@@ -409,7 +409,7 @@ class ElasticFactoryTest extends \PHPUnit\Framework\TestCase {
 
 		$instance = $this->getMockBuilder( '\SMW\Elastic\ElasticFactory' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'newRebuilder' ] )
+			->onlyMethods( [ 'newRebuilder' ] )
 			->getMock();
 
 		$instance->expects( $this->never() )

--- a/tests/phpunit/Elastic/ElasticStoreTest.php
+++ b/tests/phpunit/Elastic/ElasticStoreTest.php
@@ -250,7 +250,7 @@ class ElasticStoreTest extends \PHPUnit\Framework\TestCase {
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSubject', 'getPropertyValues', 'getProperties', 'getSubSemanticData' ] )
+			->onlyMethods( [ 'getSubject', 'getPropertyValues', 'getProperties', 'getSubSemanticData' ] )
 			->getMock();
 
 		$semanticData->expects( $this->any() )

--- a/tests/phpunit/Elastic/Indexer/Attachment/ScopeMemoryLimiterTest.php
+++ b/tests/phpunit/Elastic/Indexer/Attachment/ScopeMemoryLimiterTest.php
@@ -94,7 +94,7 @@ class ScopeMemoryLimiterTest extends \PHPUnit\Framework\TestCase {
 		}
 		$this->testCaller = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'calledFromCallable' ] )
+			->onlyMethods( [ 'calledFromCallable' ] )
 			->getMock();
 
 		$this->testCaller->expects( $this->once() )

--- a/tests/phpunit/Elastic/Indexer/Attachment/ScopeMemoryLimiterTest.php
+++ b/tests/phpunit/Elastic/Indexer/Attachment/ScopeMemoryLimiterTest.php
@@ -94,7 +94,7 @@ class ScopeMemoryLimiterTest extends \PHPUnit\Framework\TestCase {
 		}
 		$this->testCaller = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->onlyMethods( [ 'calledFromCallable' ] )
+			->addMethods( [ 'calledFromCallable' ] )
 			->getMock();
 
 		$this->testCaller->expects( $this->once() )

--- a/tests/phpunit/Elastic/Indexer/FileIndexerTest.php
+++ b/tests/phpunit/Elastic/Indexer/FileIndexerTest.php
@@ -55,7 +55,7 @@ class FileIndexerTest extends \PHPUnit\Framework\TestCase {
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'save', 'associate', 'fetch' ] )
+			->onlyMethods( [ 'save', 'associate', 'fetch' ] )
 			->getMock();
 
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )

--- a/tests/phpunit/Elastic/Indexer/Rebuilder/RebuilderTest.php
+++ b/tests/phpunit/Elastic/Indexer/Rebuilder/RebuilderTest.php
@@ -69,7 +69,7 @@ class RebuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->once() )

--- a/tests/phpunit/Elastic/Indexer/Replication/DocumentReplicationExaminerTest.php
+++ b/tests/phpunit/Elastic/Indexer/Replication/DocumentReplicationExaminerTest.php
@@ -38,7 +38,7 @@ class DocumentReplicationExaminerTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds', 'getConnection' ] )
+			->onlyMethods( [ 'getObjectIds', 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/Elastic/Indexer/Replication/ReplicationCheckTest.php
+++ b/tests/phpunit/Elastic/Indexer/Replication/ReplicationCheckTest.php
@@ -36,7 +36,7 @@ class ReplicationCheckTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds', 'getConnection' ] )
+			->onlyMethods( [ 'getObjectIds', 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/Elastic/Lookup/ProximityPropertyValueLookupTest.php
+++ b/tests/phpunit/Elastic/Lookup/ProximityPropertyValueLookupTest.php
@@ -32,7 +32,7 @@ class ProximityPropertyValueLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$this->idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSMWPropertyID' ] )
+			->onlyMethods( [ 'getSMWPropertyID' ] )
 			->getMock();
 
 		$this->idTable->expects( $this->any() )
@@ -41,7 +41,7 @@ class ProximityPropertyValueLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds', 'getConnection' ] )
+			->onlyMethods( [ 'getObjectIds', 'getConnection' ] )
 			->getMock();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/Elastic/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreterTest.php
+++ b/tests/phpunit/Elastic/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreterTest.php
@@ -22,7 +22,7 @@ class ClassDescriptionInterpreterTest extends \PHPUnit\Framework\TestCase {
 	public function setUp(): void {
 		$this->conditionBuilder = $this->getMockBuilder( '\SMW\Elastic\QueryEngine\ConditionBuilder' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getID', 'findHierarchyMembers', 'prepareCache' ] )
+			->onlyMethods( [ 'getID', 'findHierarchyMembers', 'prepareCache' ] )
 			->getMock();
 	}
 

--- a/tests/phpunit/Elastic/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreterTest.php
+++ b/tests/phpunit/Elastic/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreterTest.php
@@ -47,7 +47,7 @@ class ConceptDescriptionInterpreterTest extends \PHPUnit\Framework\TestCase {
 
 		$this->conditionBuilder = $this->getMockBuilder( '\SMW\Elastic\QueryEngine\ConditionBuilder' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getTermsLookup', 'getStore', 'getID', 'interpretDescription' ] )
+			->onlyMethods( [ 'getTermsLookup', 'getStore', 'getID', 'interpretDescription' ] )
 			->getMock();
 
 		$this->conditionBuilder->expects( $this->any() )

--- a/tests/phpunit/Elastic/QueryEngine/DescriptionInterpreters/ConjunctionInterpreterTest.php
+++ b/tests/phpunit/Elastic/QueryEngine/DescriptionInterpreters/ConjunctionInterpreterTest.php
@@ -25,7 +25,7 @@ class ConjunctionInterpreterTest extends \PHPUnit\Framework\TestCase {
 
 		$this->conditionBuilder = $this->getMockBuilder( '\SMW\Elastic\QueryEngine\ConditionBuilder' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'interpretDescription' ] )
+			->onlyMethods( [ 'interpretDescription' ] )
 			->getMock();
 	}
 

--- a/tests/phpunit/Elastic/QueryEngine/DescriptionInterpreters/NamespaceDescriptionInterpreterTest.php
+++ b/tests/phpunit/Elastic/QueryEngine/DescriptionInterpreters/NamespaceDescriptionInterpreterTest.php
@@ -25,7 +25,7 @@ class NamespaceDescriptionInterpreterTest extends \PHPUnit\Framework\TestCase {
 
 		$this->conditionBuilder = $this->getMockBuilder( '\SMW\Elastic\QueryEngine\ConditionBuilder' )
 			->disableOriginalConstructor()
-			->setMethods( null )
+			->onlyMethods( [] )
 			->getMock();
 	}
 

--- a/tests/phpunit/Elastic/QueryEngine/DescriptionInterpreters/SomeValueInterpreterTest.php
+++ b/tests/phpunit/Elastic/QueryEngine/DescriptionInterpreters/SomeValueInterpreterTest.php
@@ -32,7 +32,7 @@ class SomeValueInterpreterTest extends \PHPUnit\Framework\TestCase {
 
 		$this->conditionBuilder = $this->getMockBuilder( '\SMW\Elastic\QueryEngine\ConditionBuilder' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getID' ] )
+			->onlyMethods( [ 'getID' ] )
 			->getMock();
 
 		$this->conditionBuilder->setOptions( new Options(

--- a/tests/phpunit/Elastic/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreterTest.php
+++ b/tests/phpunit/Elastic/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreterTest.php
@@ -29,7 +29,7 @@ class ValueDescriptionInterpreterTest extends \PHPUnit\Framework\TestCase {
 
 		$this->conditionBuilder = $this->getMockBuilder( '\SMW\Elastic\QueryEngine\ConditionBuilder' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getID' ] )
+			->onlyMethods( [ 'getID' ] )
 			->getMock();
 
 		$this->conditionBuilder->expects( $this->any() )

--- a/tests/phpunit/Exporter/ElementFactoryTest.php
+++ b/tests/phpunit/Exporter/ElementFactoryTest.php
@@ -108,7 +108,7 @@ class ElementFactoryTest extends \PHPUnit\Framework\TestCase {
 	public function unsupportedDataItemProvider() {
 		$dataItem = $this->getMockBuilder( '\SMWDataItem' )
 			->disableOriginalConstructor()
-			->setMethods( [ '__toString' ] )
+			->onlyMethods( [ '__toString' ] )
 			->getMockForAbstractClass();
 
 		$dataItem->expects( $this->any() )

--- a/tests/phpunit/Exporter/XsdValueMapperTest.php
+++ b/tests/phpunit/Exporter/XsdValueMapperTest.php
@@ -101,7 +101,7 @@ class XsdValueMapperTest extends \PHPUnit\Framework\TestCase {
 	public function unsupportedDataItemProvider() {
 		$dataItem = $this->getMockBuilder( '\SMWDataItem' )
 			->disableOriginalConstructor()
-			->setMethods( [ '__toString' ] )
+			->onlyMethods( [ '__toString' ] )
 			->getMockForAbstractClass();
 
 		$dataItem->expects( $this->any() )

--- a/tests/phpunit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Factbox/CachedFactboxTest.php
@@ -52,7 +52,7 @@ class CachedFactboxTest extends \PHPUnit\Framework\TestCase {
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'fetch', 'save', 'saveSub', 'fetchSub', 'associate' ] )
+			->onlyMethods( [ 'fetch', 'save', 'saveSub', 'fetchSub', 'associate' ] )
 			->getMock();
 
 		$this->testEnvironment->registerObject( 'EntityCache', $this->entityCache );

--- a/tests/phpunit/Factbox/FactboxTest.php
+++ b/tests/phpunit/Factbox/FactboxTest.php
@@ -186,7 +186,7 @@ class FactboxTest extends \PHPUnit\Framework\TestCase {
 				$parserData,
 				$this->displayTitleFinder
 			] )
-			->setMethods( [ 'buildHTML' ] )
+			->onlyMethods( [ 'buildHTML' ] )
 			->getMock();
 
 		$factbox->setCheckMagicWords(

--- a/tests/phpunit/IndicatorEntityExaminerIndicators/AssociatedRevisionMismatchEntityExaminerIndicatorProviderTest.php
+++ b/tests/phpunit/IndicatorEntityExaminerIndicators/AssociatedRevisionMismatchEntityExaminerIndicatorProviderTest.php
@@ -39,7 +39,7 @@ class AssociatedRevisionMismatchEntityExaminerIndicatorProviderTest extends \PHP
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/IndicatorEntityExaminerIndicators/ConstraintErrorEntityExaminerDeferrableIndicatorProviderTest.php
+++ b/tests/phpunit/IndicatorEntityExaminerIndicators/ConstraintErrorEntityExaminerDeferrableIndicatorProviderTest.php
@@ -37,7 +37,7 @@ class ConstraintErrorEntityExaminerDeferrableIndicatorProviderTest extends \PHPU
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'service' ] )
+			->onlyMethods( [ 'getConnection', 'service' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/IndicatorEntityExaminerIndicators/ConstraintErrorEntityExaminerIndicatorProviderTest.php
+++ b/tests/phpunit/IndicatorEntityExaminerIndicators/ConstraintErrorEntityExaminerIndicatorProviderTest.php
@@ -37,7 +37,7 @@ class ConstraintErrorEntityExaminerIndicatorProviderTest extends \PHPUnit\Framew
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'service' ] )
+			->onlyMethods( [ 'getConnection', 'service' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/Integration/MediaWiki/Hooks/ParserFirstCallInitIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Hooks/ParserFirstCallInitIntegrationTest.php
@@ -43,7 +43,7 @@ class ParserFirstCallInitIntegrationTest extends SMWIntegrationTestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getQueryResult', 'getObjectIds', 'service' ] )
+			->onlyMethods( [ 'getQueryResult', 'getObjectIds', 'service' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/Integration/MediaWiki/NamespaceInfoCanonicalNameMatchTest.php
+++ b/tests/phpunit/Integration/MediaWiki/NamespaceInfoCanonicalNameMatchTest.php
@@ -48,7 +48,7 @@ class NamespaceInfoCanonicalNameMatchTest extends \PHPUnit\Framework\TestCase {
 		];
 
 		$instance = $this->getMockBuilder( '\SMW\NamespaceManager' )
-			->setMethods( [ 'isDefinedConstant' ] )
+			->onlyMethods( [ 'isDefinedConstant' ] )
 			->getMock();
 
 		$instance->expects( $this->atLeastOnce() )

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -104,7 +104,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit\Fra
 			->getMock();
 
 		$store = $this->getMockBuilder( $storeClass )
-			->setMethods( [ 'fetchQueryResult' ] )
+			->onlyMethods( [ 'fetchQueryResult' ] )
 			->getMock();
 
 		$store->expects( $this->once() )
@@ -122,7 +122,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit\Fra
 			->getMock();
 
 		$store = $this->getMockBuilder( $storeClass )
-			->setMethods( [ 'fetchQueryResult' ] )
+			->onlyMethods( [ 'fetchQueryResult' ] )
 			->getMock();
 
 		$store->expects( $this->once() )
@@ -148,7 +148,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit\Fra
 			->getMock();
 
 		$store = $this->getMockBuilder( $storeClass )
-			->setMethods( [ 'fetchQueryResult' ] )
+			->onlyMethods( [ 'fetchQueryResult' ] )
 			->getMock();
 
 		$store->expects( $this->never() )
@@ -180,7 +180,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit\Fra
 			->getMock();
 
 		$store = $this->getMockBuilder( $storeClass )
-			->setMethods( [ 'fetchQueryResult' ] )
+			->onlyMethods( [ 'fetchQueryResult' ] )
 			->getMock();
 
 		$store->expects( $this->once() )
@@ -237,7 +237,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit\Fra
 
 		$store = $this->getMockBuilder( $storeClass )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSemanticData', 'getConnection', 'service' ] )
+			->onlyMethods( [ 'getSemanticData', 'getConnection', 'service' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -296,7 +296,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit\Fra
 
 		$store = $this->getMockBuilder( $storeClass )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds', 'getPropertyTables', 'getConnection' ] )
+			->onlyMethods( [ 'getObjectIds', 'getPropertyTables', 'getConnection' ] )
 			->getMock();
 
 		$redirectUpdater = $this->getMockBuilder( '\SMW\SQLStore\RedirectUpdater' )
@@ -372,7 +372,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit\Fra
 			->willReturn( [ 42 ] );
 
 		$store = $this->getMockBuilder( $storeClass )
-			->setMethods( [ 'getPropertyTables', 'getObjectIds' ] )
+			->onlyMethods( [ 'getPropertyTables', 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -410,7 +410,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit\Fra
 			->willReturn( [ 42 ] );
 
 		$store = $this->getMockBuilder( $storeClass )
-			->setMethods( [ 'getPropertyTables', 'getObjectIds' ] )
+			->onlyMethods( [ 'getPropertyTables', 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -483,7 +483,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit\Fra
 
 		$inTextAnnotationParser = $this->getMockBuilder( '\SMW\Parser\InTextAnnotationParser' )
 			->setConstructorArgs( [ $parserData, $linksProcessor, $magicWordsFinder, $redirectTargetFinder ] )
-			->setMethods( null )
+			->onlyMethods( [] )
 			->getMock();
 
 		$hookDispatcher = $this->getMockBuilder( '\SMW\MediaWiki\HookDispatcher' )
@@ -507,7 +507,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit\Fra
 
 	public function testRegisteredAddCustomFixedPropertyTables() {
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->setMethods( null )
+			->onlyMethods( [] )
 			->getMock();
 
 		$this->mwHooksHandler->register( 'SMW::SQLStore::AddCustomFixedPropertyTables', function ( &$customFixedProperties, &$fixedPropertyTablePrefix ) {
@@ -534,7 +534,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit\Fra
 
 	public function testRegisteredAfterDataUpdateComplete() {
 		$test = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'is' ] )
+			->onlyMethods( [ 'is' ] )
 			->getMock();
 
 		$test->expects( $this->once() )
@@ -542,7 +542,7 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends \PHPUnit\Fra
 			->with( [] );
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->setMethods( [ 'getPropertyTables' ] )
+			->onlyMethods( [ 'getPropertyTables' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/IteratorFactoryTest.php
+++ b/tests/phpunit/IteratorFactoryTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests;
 
 use SMW\IteratorFactory;
+use Wikimedia\Rdbms\IResultWrapper;
 
 /**
  * @covers \SMW\IteratorFactory
@@ -20,9 +21,7 @@ class IteratorFactoryTest extends \PHPUnit\Framework\TestCase {
 	public function testCanConstructResultIterator() {
 		$instance = new IteratorFactory();
 
-		$result = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
-			->disableOriginalConstructor()
-			->getMock();
+		$result = $this->createMock( IResultWrapper::class );
 
 		$this->assertInstanceOf(
 			'\SMW\Iterators\ResultIterator',

--- a/tests/phpunit/Iterators/ResultIteratorTest.php
+++ b/tests/phpunit/Iterators/ResultIteratorTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Iterators;
 
 use SMW\Iterators\ResultIterator;
 use SMW\Tests\PHPUnitCompat;
+use Wikimedia\Rdbms\IResultWrapper;
 
 /**
  * @covers \SMW\Iterators\ResultIterator
@@ -70,9 +71,7 @@ class ResultIteratorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testdoIterateOnResultWrapper() {
-		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
-			->disableOriginalConstructor()
-			->getMock();
+		$resultWrapper = $this->createMock( IResultWrapper::class );
 
 		$resultWrapper->expects( $this->exactly( 3 ) )
 			->method( 'numRows' )

--- a/tests/phpunit/Listener/EventListener/EventListenerRegistryTest.php
+++ b/tests/phpunit/Listener/EventListener/EventListenerRegistryTest.php
@@ -44,7 +44,7 @@ class EventListenerRegistryTest extends \PHPUnit\Framework\TestCase {
 	public function testListenerCollection() {
 		$eventListenerCollection = $this->getMockBuilder( '\Onoi\EventDispatcher\EventListenerCollection' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'registerCallback' ] )
+			->onlyMethods( [ 'registerCallback' ] )
 			->getMockForAbstractClass();
 
 		$eventListenerCollection->expects( $this->any() )

--- a/tests/phpunit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
+++ b/tests/phpunit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
@@ -65,7 +65,7 @@ class JsonContentsFileReaderTest extends \PHPUnit\Framework\TestCase {
 
 	public function testReadByLanguageCodeToUseInMemoryCache() {
 		$instance = $this->getMockBuilder( JsonContentsFileReader::class )
-			->setMethods( [ 'readJSONFile', 'getFileModificationTime' ] )
+			->onlyMethods( [ 'readJSONFile', 'getFileModificationTime' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -84,7 +84,7 @@ class JsonContentsFileReaderTest extends \PHPUnit\Framework\TestCase {
 
 	public function testReadByLanguageCodeIsForcedToRereadFromFile() {
 		$instance = $this->getMockBuilder( JsonContentsFileReader::class )
-			->setMethods( [ 'readJSONFile', 'getFileModificationTime' ] )
+			->onlyMethods( [ 'readJSONFile', 'getFileModificationTime' ] )
 			->getMock();
 
 		$instance->expects( $this->exactly( 2 ) )

--- a/tests/phpunit/Localizer/MessageTest.php
+++ b/tests/phpunit/Localizer/MessageTest.php
@@ -76,7 +76,7 @@ class MessageTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( 'en' );
 
 		$instanceSpy = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'hasLanguage' ] )
+			->onlyMethods( [ 'hasLanguage' ] )
 			->getMock();
 
 		$instanceSpy->expects( $this->once() )

--- a/tests/phpunit/Maintenance/DataRebuilderTest.php
+++ b/tests/phpunit/Maintenance/DataRebuilderTest.php
@@ -38,7 +38,7 @@ class DataRebuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'newUpdateJob' ] )
+			->onlyMethods( [ 'newUpdateJob' ] )
 			->getMock();
 
 		$jobFactory->expects( $this->any() )
@@ -116,7 +116,7 @@ class DataRebuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'refreshData' ] )
+			->onlyMethods( [ 'refreshData' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->once() )
@@ -161,7 +161,7 @@ class DataRebuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [
+			->onlyMethods( [
 				'refreshData',
 				'drop' ] )
 			->getMockForAbstractClass();
@@ -212,7 +212,7 @@ class DataRebuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'refreshData' ] )
+			->onlyMethods( [ 'refreshData' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->once() )

--- a/tests/phpunit/Maintenance/DuplicateEntitiesDisposerTest.php
+++ b/tests/phpunit/Maintenance/DuplicateEntitiesDisposerTest.php
@@ -57,7 +57,7 @@ class DuplicateEntitiesDisposerTest extends \PHPUnit\Framework\TestCase {
 	public function testFindDuplicateEntityRecords() {
 		$idTable = $this->getMockBuilder( '\stdClss' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'findDuplicates' ] )
+			->onlyMethods( [ 'findDuplicates' ] )
 			->getMock();
 
 		$this->store->expects( $this->atLeastOnce() )

--- a/tests/phpunit/Maintenance/PropertyStatisticsRebuilderTest.php
+++ b/tests/phpunit/Maintenance/PropertyStatisticsRebuilderTest.php
@@ -111,7 +111,7 @@ class PropertyStatisticsRebuilderTest extends \PHPUnit\Framework\TestCase {
 	protected function newPropertyTable( $propertyTableName, $fixedPropertyTable = false ) {
 		$propertyTable = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableDefinition' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'isFixedPropertyTable', 'getName' ] )
+			->onlyMethods( [ 'isFixedPropertyTable', 'getName' ] )
 			->getMock();
 
 		$propertyTable->expects( $this->atLeastOnce() )

--- a/tests/phpunit/MediaWiki/Api/Browse/CachingLookupTest.php
+++ b/tests/phpunit/MediaWiki/Api/Browse/CachingLookupTest.php
@@ -50,7 +50,7 @@ class CachingLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$lookup = $this->getMockBuilder( '\SMW\MediaWiki\Api\Browse\Lookup' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getVersion', 'lookup' ] )
+			->onlyMethods( [ 'getVersion', 'lookup' ] )
 			->getMockForAbstractClass();
 
 		$lookup->expects( $this->atLeastOnce() )
@@ -83,7 +83,7 @@ class CachingLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$lookup = $this->getMockBuilder( '\SMW\MediaWiki\Api\Browse\Lookup' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getVersion', 'lookup' ] )
+			->onlyMethods( [ 'getVersion', 'lookup' ] )
 			->getMockForAbstractClass();
 
 		$lookup->expects( $this->never() )
@@ -112,7 +112,7 @@ class CachingLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$lookup = $this->getMockBuilder( '\SMW\MediaWiki\Api\Browse\Lookup' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getVersion', 'lookup' ] )
+			->onlyMethods( [ 'getVersion', 'lookup' ] )
 			->getMockForAbstractClass();
 
 		$lookup->expects( $this->atLeastOnce() )

--- a/tests/phpunit/MediaWiki/Api/Browse/PValueLookupTest.php
+++ b/tests/phpunit/MediaWiki/Api/Browse/PValueLookupTest.php
@@ -66,7 +66,7 @@ class PValueLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSMWPropertyID', 'isFixedPropertyTable' ] )
+			->onlyMethods( [ 'getSMWPropertyID', 'isFixedPropertyTable' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )
@@ -144,7 +144,7 @@ class PValueLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSMWPropertyID', 'isFixedPropertyTable' ] )
+			->onlyMethods( [ 'getSMWPropertyID', 'isFixedPropertyTable' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )
@@ -216,7 +216,7 @@ class PValueLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSMWPropertyID', 'isFixedPropertyTable' ] )
+			->onlyMethods( [ 'getSMWPropertyID', 'isFixedPropertyTable' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Api/BrowseTest.php
+++ b/tests/phpunit/MediaWiki/Api/BrowseTest.php
@@ -68,7 +68,7 @@ class BrowseTest extends \PHPUnit\Framework\TestCase {
 	public function testExecute( $id, $parameters = [] ) {
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSMWPropertyID' ] )
+			->onlyMethods( [ 'getSMWPropertyID' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Api/Tasks/TableStatisticsTaskTest.php
+++ b/tests/phpunit/MediaWiki/Api/Tasks/TableStatisticsTaskTest.php
@@ -27,7 +27,7 @@ class TableStatisticsTaskTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'service' ] )
+			->onlyMethods( [ 'service' ] )
 			->getMockForAbstractClass();
 
 		$this->cache = $this->getMockBuilder( '\Onoi\Cache\Cache' )

--- a/tests/phpunit/MediaWiki/Connection/CleanUpTablesTest.php
+++ b/tests/phpunit/MediaWiki/Connection/CleanUpTablesTest.php
@@ -41,7 +41,7 @@ class CleanUpTablesTest extends \PHPUnit\Framework\TestCase {
 	public function testNonPostgres() {
 		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'listTables', 'query', 'tableExists' ] )
+			->onlyMethods( [ 'listTables', 'query', 'tableExists' ] )
 			->getMockForAbstractClass();
 
 		$connection->expects( $this->atLeastOnce() )
@@ -66,7 +66,7 @@ class CleanUpTablesTest extends \PHPUnit\Framework\TestCase {
 	public function testPostgres() {
 		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'listTables', 'query', 'getType', 'tableExists' ] )
+			->onlyMethods( [ 'listTables', 'query', 'getType', 'tableExists' ] )
 			->getMockForAbstractClass();
 
 		$connection->expects( $this->atLeastOnce() )

--- a/tests/phpunit/MediaWiki/Connection/DatabaseTest.php
+++ b/tests/phpunit/MediaWiki/Connection/DatabaseTest.php
@@ -62,7 +62,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 	public function testAddQuotesMethod() {
 		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'addQuotes' ] )
+			->onlyMethods( [ 'addQuotes' ] )
 			->getMockForAbstractClass();
 
 		$database->expects( $this->once() )
@@ -99,7 +99,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 	public function testTableNameMethod( $type ) {
 		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'tableName' ] )
+			->onlyMethods( [ 'tableName' ] )
 			->getMockForAbstractClass();
 
 		$database->expects( $this->any() )
@@ -136,7 +136,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 
 		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'select' ] )
+			->onlyMethods( [ 'select' ] )
 			->getMockForAbstractClass();
 
 		$database->expects( $this->once() )
@@ -169,7 +169,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 	public function testSelectFieldMethod() {
 		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'selectField' ] )
+			->onlyMethods( [ 'selectField' ] )
 			->getMockForAbstractClass();
 
 		$database->expects( $this->once() )
@@ -210,7 +210,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 
 		$read = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getType' ] )
+			->onlyMethods( [ 'getType' ] )
 			->getMockForAbstractClass();
 
 		$read->expects( $this->any() )
@@ -227,7 +227,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 
 		$write = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'query' ] )
+			->onlyMethods( [ 'query' ] )
 			->getMockForAbstractClass();
 
 		$write->expects( $this->once() )
@@ -273,7 +273,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 	public function testSelectThrowsException() {
 		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'select' ] )
+			->onlyMethods( [ 'select' ] )
 			->getMockForAbstractClass();
 
 		if ( version_compare( MW_VERSION, '1.41', '>=' ) ) {
@@ -313,7 +313,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 	public function testQueryThrowsException() {
 		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'query' ] )
+			->onlyMethods( [ 'query' ] )
 			->getMockForAbstractClass();
 
 		$databaseException = new DBError( $database, 'foo' );
@@ -540,7 +540,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 	public function testDoQueryWithAutoCommit() {
 		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getFlag', 'clearFlag', 'setFlag', 'getType', 'query' ] )
+			->onlyMethods( [ 'getFlag', 'clearFlag', 'setFlag', 'getType', 'query' ] )
 			->getMockForAbstractClass();
 
 		$database->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Connection/DatabaseTest.php
+++ b/tests/phpunit/MediaWiki/Connection/DatabaseTest.php
@@ -130,9 +130,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testSelectMethod() {
-		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
-			->disableOriginalConstructor()
-			->getMock();
+		$resultWrapper = $this->createMock( IResultWrapper::class );
 
 		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
@@ -161,7 +159,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertInstanceOf(
-			'\Wikimedia\Rdbms\ResultWrapper',
+			IResultWrapper::class,
 			$instance->select( 'Foo', 'Bar', '', __METHOD__ )
 		);
 	}
@@ -204,9 +202,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 	 * @dataProvider querySqliteProvider
 	 */
 	public function testQueryOnSQLite( $query, $expected ) {
-		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
-			->disableOriginalConstructor()
-			->getMock();
+		$resultWrapper = $this->createMock( IResultWrapper::class );
 
 		$read = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
@@ -254,7 +250,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertInstanceOf(
-			'\Wikimedia\Rdbms\ResultWrapper',
+			IResultWrapper::class,
 			$instance->query( $query )
 		);
 	}
@@ -305,7 +301,7 @@ class DatabaseTest extends \PHPUnit\Framework\TestCase {
 		$this->expectException( 'RuntimeException' );
 
 		$this->assertInstanceOf(
-			'\Wikimedia\Rdbms\ResultWrapper',
+			IResultWrapper::class,
 			$instance->select( 'Foo', 'Bar', '', __METHOD__ )
 		);
 	}

--- a/tests/phpunit/MediaWiki/Connection/TransactionHandlerTest.php
+++ b/tests/phpunit/MediaWiki/Connection/TransactionHandlerTest.php
@@ -27,7 +27,7 @@ class TransactionHandlerTest extends \PHPUnit\Framework\TestCase {
 
 		$this->transactionProfiler = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'setSilenced' ] )
+			->onlyMethods( [ 'setSilenced' ] )
 			->getMock();
 	}
 

--- a/tests/phpunit/MediaWiki/Content/SchemaContentFormatterTest.php
+++ b/tests/phpunit/MediaWiki/Content/SchemaContentFormatterTest.php
@@ -26,7 +26,7 @@ class SchemaContentFormatterTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'service' ] )
+			->onlyMethods( [ 'service' ] )
 			->getMockForAbstractClass();
 	}
 

--- a/tests/phpunit/MediaWiki/DeepRedirectTargetResolverTest.php
+++ b/tests/phpunit/MediaWiki/DeepRedirectTargetResolverTest.php
@@ -52,7 +52,7 @@ class DeepRedirectTargetResolverTest extends \PHPUnit\Framework\TestCase {
 
 		$instance = $this->getMockBuilder( '\SMW\MediaWiki\DeepRedirectTargetResolver' )
 			->setConstructorArgs( [ $pageCreator ] )
-			->setMethods( [ 'isValidRedirectTarget', 'isRedirect' ] )
+			->onlyMethods( [ 'isValidRedirectTarget', 'isRedirect' ] )
 			->getMock();
 
 		$instance->expects( $this->atLeastOnce() )
@@ -89,7 +89,7 @@ class DeepRedirectTargetResolverTest extends \PHPUnit\Framework\TestCase {
 
 		$instance = $this->getMockBuilder( '\SMW\MediaWiki\DeepRedirectTargetResolver' )
 			->setConstructorArgs( [ $pageCreator ] )
-			->setMethods( [ 'isValidRedirectTarget', 'isRedirect' ] )
+			->onlyMethods( [ 'isValidRedirectTarget', 'isRedirect' ] )
 			->getMock();
 
 		$instance->expects( $this->atLeastOnce() )
@@ -125,7 +125,7 @@ class DeepRedirectTargetResolverTest extends \PHPUnit\Framework\TestCase {
 
 		$instance = $this->getMockBuilder( '\SMW\MediaWiki\DeepRedirectTargetResolver' )
 			->setConstructorArgs( [ $pageCreator ] )
-			->setMethods( [ 'isRedirect' ] )
+			->onlyMethods( [ 'isRedirect' ] )
 			->getMock();
 
 		$instance->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Deferred/CallableUpdateTest.php
+++ b/tests/phpunit/MediaWiki/Deferred/CallableUpdateTest.php
@@ -48,7 +48,7 @@ class CallableUpdateTest extends \PHPUnit\Framework\TestCase {
 	public function testUpdate() {
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->once() )
@@ -108,7 +108,7 @@ class CallableUpdateTest extends \PHPUnit\Framework\TestCase {
 
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->once() )
@@ -134,7 +134,7 @@ class CallableUpdateTest extends \PHPUnit\Framework\TestCase {
 	public function testWaitableUpdate() {
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->once() )
@@ -161,7 +161,7 @@ class CallableUpdateTest extends \PHPUnit\Framework\TestCase {
 	public function testUpdateWithDisabledDeferredUpdate() {
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->once() )
@@ -200,7 +200,7 @@ class CallableUpdateTest extends \PHPUnit\Framework\TestCase {
 	public function testFilterDuplicateQueueEntryByFingerprint() {
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->once() )

--- a/tests/phpunit/MediaWiki/Deferred/ChangeTitleUpdateTest.php
+++ b/tests/phpunit/MediaWiki/Deferred/ChangeTitleUpdateTest.php
@@ -25,7 +25,7 @@ class ChangeTitleUpdateTest extends \PHPUnit\Framework\TestCase {
 
 		$this->jobFactory = $this->getMockBuilder( '\SMW\MediaWiki\JobFactory' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'newUpdateJob' ] )
+			->onlyMethods( [ 'newUpdateJob' ] )
 			->getMock();
 
 		$jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )

--- a/tests/phpunit/MediaWiki/Deferred/TransactionalCallableUpdateTest.php
+++ b/tests/phpunit/MediaWiki/Deferred/TransactionalCallableUpdateTest.php
@@ -58,7 +58,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit\Framework\TestCase {
 	public function testUpdate() {
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->once() )
@@ -104,7 +104,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit\Framework\TestCase {
 
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->once() )
@@ -130,7 +130,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit\Framework\TestCase {
 	public function testWaitableUpdate() {
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->once() )
@@ -158,7 +158,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit\Framework\TestCase {
 	public function testUpdateWithDisabledDeferredUpdate() {
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->once() )
@@ -201,7 +201,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit\Framework\TestCase {
 	public function testFilterDuplicateQueueEntryByFingerprint() {
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->once() )
@@ -253,7 +253,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit\Framework\TestCase {
 
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->once() )
@@ -288,7 +288,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit\Framework\TestCase {
 
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->once() )
@@ -324,7 +324,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit\Framework\TestCase {
 
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->once() )
@@ -360,7 +360,7 @@ class TransactionalCallableUpdateTest extends \PHPUnit\Framework\TestCase {
 
 		$test = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doTest' ] )
+			->onlyMethods( [ 'doTest' ] )
 			->getMock();
 
 		$test->expects( $this->never() )

--- a/tests/phpunit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
@@ -45,12 +45,12 @@ class ArticleProtectCompleteTest extends \PHPUnit\Framework\TestCase {
 			->getMockForAbstractClass();
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'findAssociatedRev' ] )
+			->onlyMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Hooks/ArticleViewHeaderTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/ArticleViewHeaderTest.php
@@ -38,7 +38,7 @@ class ArticleViewHeaderTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Hooks/ExtensionSchemaUpdatesTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/ExtensionSchemaUpdatesTest.php
@@ -38,7 +38,7 @@ class ExtensionSchemaUpdatesTest extends \PHPUnit\Framework\TestCase {
 	public function testProcess() {
 		$this->databaseUpdater = $this->getMockBuilder( '\DatabaseUpdater' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'addExtensionUpdate' ] )
+			->onlyMethods( [ 'addExtensionUpdate' ] )
 			->getMockForAbstractClass();
 
 		$this->databaseUpdater->expects( $this->once() )

--- a/tests/phpunit/MediaWiki/Hooks/FileUploadTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/FileUploadTest.php
@@ -33,12 +33,12 @@ class FileUploadTest extends \PHPUnit\Framework\TestCase {
 		] );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'findAssociatedRev' ] )
+			->onlyMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -106,7 +106,7 @@ class FileUploadTest extends \PHPUnit\Framework\TestCase {
 
 		$pageCreator = $this->getMockBuilder( 'SMW\MediaWiki\PageCreator' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'createFilePage' ] )
+			->onlyMethods( [ 'createFilePage' ] )
 			->getMock();
 
 		$pageCreator->expects( $this->once() )

--- a/tests/phpunit/MediaWiki/Hooks/LinksUpdateCompleteTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/LinksUpdateCompleteTest.php
@@ -44,12 +44,12 @@ class LinksUpdateCompleteTest extends \PHPUnit\Framework\TestCase {
 			->getMock();
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'findAssociatedRev' ] )
+			->onlyMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -105,7 +105,7 @@ class LinksUpdateCompleteTest extends \PHPUnit\Framework\TestCase {
 		$parserOutput->setTitleText( $title->getPrefixedText() );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'findAssociatedRev' ] )
+			->onlyMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$idTable->expects( $this->atLeastOnce() )
@@ -118,7 +118,7 @@ class LinksUpdateCompleteTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'clearData', 'getObjectIds' ] )
+			->onlyMethods( [ 'clearData', 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -205,7 +205,7 @@ class LinksUpdateCompleteTest extends \PHPUnit\Framework\TestCase {
 
 		$parserData = $this->getMockBuilder( '\SMW\ParserData' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSemanticData', 'updateStore', 'markUpdate' ] )
+			->onlyMethods( [ 'getSemanticData', 'updateStore', 'markUpdate' ] )
 			->getMock();
 
 		$parserData->expects( $this->never() )

--- a/tests/phpunit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -114,7 +114,7 @@ class OutputPageParserOutputTest extends \PHPUnit\Framework\TestCase {
 
 		$factboxFactory = $this->getMockBuilder( '\SMW\Factbox\FactboxFactory' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'newCachedFactbox' ] )
+			->onlyMethods( [ 'newCachedFactbox' ] )
 			->getMock();
 
 		$factboxFactory->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -353,7 +353,7 @@ class ParserAfterTidyTest extends \PHPUnit\Framework\TestCase {
 		# 0 Runs store update
 		$store = $this->getMockBuilder( 'SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'updateData' ] )
+			->onlyMethods( [ 'updateData' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->any() )
@@ -386,7 +386,7 @@ class ParserAfterTidyTest extends \PHPUnit\Framework\TestCase {
 		# 1 No cache entry, no store update
 		$store = $this->getMockBuilder( 'SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'updateData' ] )
+			->onlyMethods( [ 'updateData' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->never() )
@@ -415,7 +415,7 @@ class ParserAfterTidyTest extends \PHPUnit\Framework\TestCase {
 		# 2 SpecialPage, no store update
 		$store = $this->getMockBuilder( 'SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'updateData' ] )
+			->onlyMethods( [ 'updateData' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->never() )
@@ -444,7 +444,7 @@ class ParserAfterTidyTest extends \PHPUnit\Framework\TestCase {
 		# 3 NS_FILE, store update
 		$store = $this->getMockBuilder( 'SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'updateData' ] )
+			->onlyMethods( [ 'updateData' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->atLeastOnce() )
@@ -486,7 +486,7 @@ class ParserAfterTidyTest extends \PHPUnit\Framework\TestCase {
 		# 4, 1131, No store update when fetch return FALSE
 		$store = $this->getMockBuilder( 'SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'updateData' ] )
+			->onlyMethods( [ 'updateData' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->never() )

--- a/tests/phpunit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/MediaWiki/HooksTest.php
@@ -602,7 +602,7 @@ class HooksTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'deleteSubject' ] )
+			->onlyMethods( [ 'deleteSubject' ] )
 			->getMock();
 
 		$this->testEnvironment->registerObject( 'Store', $store );
@@ -736,7 +736,7 @@ class HooksTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyTables', 'getPropertyTableInfoFetcher', 'getObjectIds' ] )
+			->onlyMethods( [ 'getPropertyTables', 'getPropertyTableInfoFetcher', 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -878,12 +878,12 @@ class HooksTest extends \PHPUnit\Framework\TestCase {
 		$handler = 'LinksUpdateComplete';
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'findAssociatedRev' ] )
+			->onlyMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds', 'updateData' ] )
+			->onlyMethods( [ 'getObjectIds', 'updateData' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -1338,7 +1338,7 @@ class HooksTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyTables', 'getPropertyTableInfoFetcher' ] )
+			->onlyMethods( [ 'getPropertyTables', 'getPropertyTableInfoFetcher' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -1668,12 +1668,12 @@ class HooksTest extends \PHPUnit\Framework\TestCase {
 		$handler = 'SMW::Store::AfterQueryResultLookupComplete';
 
 		$idTableLookup = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'warmUpCache' ] )
+			->onlyMethods( [ 'warmUpCache' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds', 'getPropertyValues' ] )
+			->onlyMethods( [ 'getObjectIds', 'getPropertyValues' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -1698,12 +1698,12 @@ class HooksTest extends \PHPUnit\Framework\TestCase {
 		$handler = 'SMW::Browse::AfterIncomingPropertiesLookupComplete';
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'getId' ] )
+			->onlyMethods( [ 'exists', 'getId' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds', 'getPropertyValues' ] )
+			->onlyMethods( [ 'getObjectIds', 'getPropertyValues' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/JobQueueTest.php
+++ b/tests/phpunit/MediaWiki/JobQueueTest.php
@@ -73,7 +73,7 @@ class JobQueueTest extends \PHPUnit\Framework\TestCase {
 	public function testAck() {
 		$job = $this->getMockBuilder( '\Job' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getType', 'run' ] )
+			->onlyMethods( [ 'getType', 'run' ] )
 			->getMock();
 
 		$job->expects( $this->atLeastOnce() )
@@ -102,7 +102,7 @@ class JobQueueTest extends \PHPUnit\Framework\TestCase {
 	public function testDeleteWithDisabledCache() {
 		$jobQueue = $this->getMockBuilder( '\JobQueue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'assertNotReadOnly', 'doDelete', 'doFlushCaches' ] )
+			->onlyMethods( [ 'assertNotReadOnly', 'doDelete', 'doFlushCaches' ] )
 			->getMockForAbstractClass();
 
 		$jobQueue->expects( $this->any() )
@@ -165,7 +165,7 @@ class JobQueueTest extends \PHPUnit\Framework\TestCase {
 	public function testGetQueueSize() {
 		$jobQueue = $this->getMockBuilder( '\JobQueue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doGetSize', 'doFlushCaches' ] )
+			->onlyMethods( [ 'doGetSize', 'doFlushCaches' ] )
 			->getMockForAbstractClass();
 
 		$jobQueue->expects( $this->once() )
@@ -188,7 +188,7 @@ class JobQueueTest extends \PHPUnit\Framework\TestCase {
 	public function testHasPendingJob() {
 		$jobQueue = $this->getMockBuilder( '\JobQueue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doGetSize' ] )
+			->onlyMethods( [ 'doGetSize' ] )
 			->getMockForAbstractClass();
 
 		$jobQueue->expects( $this->once() )
@@ -210,7 +210,7 @@ class JobQueueTest extends \PHPUnit\Framework\TestCase {
 	public function testHasPendingJobWithLegacyName() {
 		$jobQueue = $this->getMockBuilder( '\JobQueue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'doGetSize' ] )
+			->onlyMethods( [ 'doGetSize' ] )
 			->getMockForAbstractClass();
 
 		$jobQueue->expects( $this->once() )

--- a/tests/phpunit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
+++ b/tests/phpunit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
@@ -164,7 +164,7 @@ class ChangePropagationDispatchJobTest extends \PHPUnit\Framework\TestCase {
 		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getSMWPropertyID' ] )
+			->onlyMethods( [ 'getSMWPropertyID' ] )
 			->getMock();
 
 		$propertyTableInfoFetcher = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableInfoFetcher' )

--- a/tests/phpunit/MediaWiki/Jobs/ParserCachePurgeJobTest.php
+++ b/tests/phpunit/MediaWiki/Jobs/ParserCachePurgeJobTest.php
@@ -60,7 +60,7 @@ class ParserCachePurgeJobTest extends \PHPUnit\Framework\TestCase {
 
 		$instance = $this->getMockBuilder( ParserCachePurgeJob::class )
 			->setConstructorArgs( [ $title, $parameters ] )
-			->setMethods( [ 'newWikiPage' ] )
+			->onlyMethods( [ 'newWikiPage' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )

--- a/tests/phpunit/MediaWiki/Jobs/RefreshJobTest.php
+++ b/tests/phpunit/MediaWiki/Jobs/RefreshJobTest.php
@@ -75,7 +75,7 @@ class RefreshJobTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( $parameters['spos'] );
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
-			->setMethods( [ 'refreshData' ] )
+			->onlyMethods( [ 'refreshData' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $expectedToRun )

--- a/tests/phpunit/MediaWiki/Jobs/UpdateDispatcherJobTest.php
+++ b/tests/phpunit/MediaWiki/Jobs/UpdateDispatcherJobTest.php
@@ -117,7 +117,7 @@ class UpdateDispatcherJobTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [
+			->onlyMethods( [
 				'getProperties',
 				'getInProperties' ] )
 			->getMockForAbstractClass();
@@ -143,7 +143,7 @@ class UpdateDispatcherJobTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [
+			->onlyMethods( [
 				'getProperties',
 				'getInProperties',
 				'getAllPropertySubjects',
@@ -188,7 +188,7 @@ class UpdateDispatcherJobTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [
+			->onlyMethods( [
 				'getAllPropertySubjects',
 				] )
 			->getMockForAbstractClass();
@@ -216,7 +216,7 @@ class UpdateDispatcherJobTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [
+			->onlyMethods( [
 				'getAllPropertySubjects',
 				'getPropertyValues',
 				'getProperties',
@@ -273,7 +273,7 @@ class UpdateDispatcherJobTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [
+			->onlyMethods( [
 				'getAllPropertySubjects',
 				'getPropertyValues',
 				'getProperties',

--- a/tests/phpunit/MediaWiki/Jobs/UpdateJobTest.php
+++ b/tests/phpunit/MediaWiki/Jobs/UpdateJobTest.php
@@ -35,12 +35,12 @@ class UpdateJobTest extends \PHPUnit\Framework\TestCase {
 		] );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'findAssociatedRev' ] )
+			->onlyMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds', 'getPropertyValues', 'updateData' ] )
+			->onlyMethods( [ 'getObjectIds', 'getPropertyValues', 'updateData' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -179,7 +179,7 @@ class UpdateJobTest extends \PHPUnit\Framework\TestCase {
 		$this->testEnvironment->registerObject( 'ContentParser', $contentParser );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'findAssociatedRev' ] )
+			->onlyMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$idTable->expects( $this->atLeastOnce() )
@@ -192,7 +192,7 @@ class UpdateJobTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'clearData', 'getObjectIds' ] )
+			->onlyMethods( [ 'clearData', 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -248,12 +248,12 @@ class UpdateJobTest extends \PHPUnit\Framework\TestCase {
 		$this->testEnvironment->registerObject( 'ContentParser', $contentParser );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'findAssociatedRev' ] )
+			->onlyMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyValues', 'getObjectIds' ] )
+			->onlyMethods( [ 'getPropertyValues', 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -277,7 +277,7 @@ class UpdateJobTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'updateData' ] )
+			->onlyMethods( [ 'updateData' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->once() )
@@ -311,7 +311,7 @@ class UpdateJobTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'updateData', 'getPropertyValues' ] )
+			->onlyMethods( [ 'updateData', 'getPropertyValues' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/MagicWordsFinderTest.php
+++ b/tests/phpunit/MediaWiki/MagicWordsFinderTest.php
@@ -82,7 +82,7 @@ class MagicWordsFinderTest extends \PHPUnit\Framework\TestCase {
 	public function testSetGetMagicWordsOnLegacyStorage() {
 		$instance = $this->getMockBuilder( '\SMW\MediaWiki\MagicWordsFinder' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'hasExtensionData' ] )
+			->onlyMethods( [ 'hasExtensionData' ] )
 			->getMock();
 
 		$instance->expects( $this->any() )
@@ -108,7 +108,7 @@ class MagicWordsFinderTest extends \PHPUnit\Framework\TestCase {
 
 		$instance = $this->getMockBuilder( '\SMW\MediaWiki\MagicWordsFinder' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'hasExtensionData' ] )
+			->onlyMethods( [ 'hasExtensionData' ] )
 			->getMock();
 
 		$instance->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/ManualEntryLoggerTest.php
+++ b/tests/phpunit/MediaWiki/ManualEntryLoggerTest.php
@@ -61,7 +61,7 @@ class ManualEntryLoggerTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( 42 );
 
 		$instance = $this->getMockBuilder( '\SMW\MediaWiki\ManualEntryLogger' )
-			->setMethods( [ 'newManualLogEntryForType' ] )
+			->onlyMethods( [ 'newManualLogEntryForType' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -91,7 +91,7 @@ class ManualEntryLoggerTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( 42 );
 
 		$instance = $this->getMockBuilder( '\SMW\MediaWiki\ManualEntryLogger' )
-			->setMethods( [ 'newManualLogEntryForType' ] )
+			->onlyMethods( [ 'newManualLogEntryForType' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )

--- a/tests/phpunit/MediaWiki/Page/ListBuilder/ItemListBuilderTest.php
+++ b/tests/phpunit/MediaWiki/Page/ListBuilder/ItemListBuilderTest.php
@@ -61,7 +61,7 @@ class ItemListBuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertySubjects', 'service' ] )
+			->onlyMethods( [ 'getPropertySubjects', 'service' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Page/ListBuilder/ValueListBuilderTest.php
+++ b/tests/phpunit/MediaWiki/Page/ListBuilder/ValueListBuilderTest.php
@@ -72,7 +72,7 @@ class ValueListBuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getAllPropertySubjects', 'getPropertyValues', 'getWikiPageSortKey', 'service' ] )
+			->onlyMethods( [ 'getAllPropertySubjects', 'getPropertyValues', 'getWikiPageSortKey', 'service' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->once() )
@@ -112,7 +112,7 @@ class ValueListBuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getAllPropertySubjects', 'getPropertyValues', 'getWikiPageSortKey', 'service' ] )
+			->onlyMethods( [ 'getAllPropertySubjects', 'getPropertyValues', 'getWikiPageSortKey', 'service' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->once() )

--- a/tests/phpunit/MediaWiki/Page/PropertyPageTest.php
+++ b/tests/phpunit/MediaWiki/Page/PropertyPageTest.php
@@ -49,11 +49,7 @@ class PropertyPageTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertSame(
-<<<<<<< HEAD
 			null,
-=======
-			'',
->>>>>>> 258d5a32c (Fix phpcs for most of PHPUnit)
 			$instance->view()
 		);
 	}

--- a/tests/phpunit/MediaWiki/Page/PropertyPageTest.php
+++ b/tests/phpunit/MediaWiki/Page/PropertyPageTest.php
@@ -49,7 +49,11 @@ class PropertyPageTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertSame(
+<<<<<<< HEAD
 			null,
+=======
+			'',
+>>>>>>> 258d5a32c (Fix phpcs for most of PHPUnit)
 			$instance->view()
 		);
 	}

--- a/tests/phpunit/MediaWiki/PageInfoProviderTest.php
+++ b/tests/phpunit/MediaWiki/PageInfoProviderTest.php
@@ -229,7 +229,7 @@ class PageInfoProviderTest extends \PHPUnit\Framework\TestCase {
 	public function testWikiFilePage_MEDIA_TYPE( $file, $expected ) {
 		$wikiFilePage = $this->getMockBuilder( '\WikiFilePage' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'isFilePage', 'getFile' ] )
+			->onlyMethods( [ 'isFilePage', 'getFile' ] )
 			->getMock();
 
 		$wikiFilePage->expects( $this->any() )
@@ -251,7 +251,7 @@ class PageInfoProviderTest extends \PHPUnit\Framework\TestCase {
 	public function testWikiFilePage_MIME_TYPE( $file, $expected ) {
 		$wikiFilePage = $this->getMockBuilder( '\WikiFilePage' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'isFilePage', 'getFile' ] )
+			->onlyMethods( [ 'isFilePage', 'getFile' ] )
 			->getMock();
 
 		$wikiFilePage->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Search/ExtendedSearchEngineTest.php
+++ b/tests/phpunit/MediaWiki/Search/ExtendedSearchEngineTest.php
@@ -57,7 +57,7 @@ class ExtendedSearchEngineTest extends \PHPUnit\Framework\TestCase {
 
 		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSearchEngine' ] )
+			->onlyMethods( [ 'getSearchEngine' ] )
 			->getMockForAbstractClass();
 
 		$connection->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Search/ExtendedSearchTest.php
+++ b/tests/phpunit/MediaWiki/Search/ExtendedSearchTest.php
@@ -30,7 +30,7 @@ class ExtendedSearchTest extends \PHPUnit\Framework\TestCase {
 
 		$this->fallbackSearchEngine = $this->getMockBuilder( 'SearchEngine' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'replacePrefixes', 'searchTitle', 'searchText' ] )
+			->onlyMethods( [ 'replacePrefixes', 'searchTitle', 'searchText' ] )
 			->getMock();
 	}
 

--- a/tests/phpunit/MediaWiki/Search/SearchEngineFactoryTest.php
+++ b/tests/phpunit/MediaWiki/Search/SearchEngineFactoryTest.php
@@ -70,7 +70,7 @@ class SearchEngineFactoryTest extends \PHPUnit\Framework\TestCase {
 
 		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSearchEngine' ] )
+			->onlyMethods( [ 'getSearchEngine' ] )
 			->getMockForAbstractClass();
 
 		$connection->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Search/SearchResultSetTest.php
+++ b/tests/phpunit/MediaWiki/Search/SearchResultSetTest.php
@@ -41,7 +41,7 @@ class SearchResultSetTest extends \PHPUnit\Framework\TestCase {
 
 		$this->queryResult = $this->getMockBuilder( 'SMWQueryResult' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getQuery', 'getResults' ] )
+			->onlyMethods( [ 'getQuery', 'getResults' ] )
 			->getMock();
 
 		$pageMock = $this->getMockBuilder( 'SMW\DIWikiPage' )
@@ -150,7 +150,7 @@ class SearchResultSetTest extends \PHPUnit\Framework\TestCase {
 
 		$queryResult = $this->getMockBuilder( 'SMWQueryResult' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getQuery', 'getResults' ] )
+			->onlyMethods( [ 'getQuery', 'getResults' ] )
 			->getMock();
 
 		$queryResult->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Specials/Admin/Alerts/MaintenanceAlertsTaskHandlerTest.php
+++ b/tests/phpunit/MediaWiki/Specials/Admin/Alerts/MaintenanceAlertsTaskHandlerTest.php
@@ -28,7 +28,7 @@ class MaintenanceAlertsTaskHandlerTest extends \PHPUnit\Framework\TestCase {
 	public function testGetHtml() {
 		$taskHandler = $this->getMockBuilder( '\SMW\MediaWiki\Specials\Admin\TaskHandler' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getHtml' ] )
+			->onlyMethods( [ 'getHtml' ] )
 			->getMockForAbstractClass();
 
 		$taskHandler->expects( $this->once() )

--- a/tests/phpunit/MediaWiki/Specials/Admin/AlertsTaskHandlerTest.php
+++ b/tests/phpunit/MediaWiki/Specials/Admin/AlertsTaskHandlerTest.php
@@ -47,7 +47,7 @@ class AlertsTaskHandlerTest extends \PHPUnit\Framework\TestCase {
 	public function testGetHtml() {
 		$taskHandler = $this->getMockBuilder( '\SMW\MediaWiki\Specials\Admin\TaskHandler' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getName', 'getHtml' ] )
+			->onlyMethods( [ 'getName', 'getHtml' ] )
 			->getMockForAbstractClass();
 
 		$taskHandler->expects( $this->once() )

--- a/tests/phpunit/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandlerTest.php
+++ b/tests/phpunit/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandlerTest.php
@@ -36,7 +36,7 @@ class EntityLookupTaskHandlerTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Specials/Ask/NavigationLinksWidgetTest.php
+++ b/tests/phpunit/MediaWiki/Specials/Ask/NavigationLinksWidgetTest.php
@@ -86,7 +86,7 @@ class NavigationLinksWidgetTest extends \PHPUnit\Framework\TestCase {
 
 		$urlArgs = $this->getMockBuilder( '\SMW\Utils\UrlArgs' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'get', 'set' ] )
+			->onlyMethods( [ 'get', 'set' ] )
 			->getMock();
 
 		$urlArgs->expects( $this->at( 0 ) )

--- a/tests/phpunit/MediaWiki/Specials/Browse/ValueFormatterTest.php
+++ b/tests/phpunit/MediaWiki/Specials/Browse/ValueFormatterTest.php
@@ -44,7 +44,7 @@ class ValueFormatterTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getDataItem' ] )
+			->onlyMethods( [ 'getDataItem' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->once() )

--- a/tests/phpunit/MediaWiki/Specials/SearchByProperty/QueryResultLookupTest.php
+++ b/tests/phpunit/MediaWiki/Specials/SearchByProperty/QueryResultLookupTest.php
@@ -109,7 +109,7 @@ class QueryResultLookupTest extends \PHPUnit\Framework\TestCase {
 
 	public function testDoQueryLinksReferences() {
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getId' ] )
+			->onlyMethods( [ 'getId' ] )
 			->getMock();
 
 		$idTable->expects( $this->atLeastOnce() )
@@ -118,7 +118,7 @@ class QueryResultLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Specials/SpecialMissingRedirectAnnotationsTest.php
+++ b/tests/phpunit/MediaWiki/Specials/SpecialMissingRedirectAnnotationsTest.php
@@ -27,7 +27,7 @@ class SpecialMissingRedirectAnnotationsTest extends \PHPUnit\Framework\TestCase 
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'service' ] )
+			->onlyMethods( [ 'service' ] )
 			->getMockForAbstractClass();
 
 		$this->testEnvironment->registerObject( 'Store', $this->store );

--- a/tests/phpunit/MediaWiki/Specials/SpecialPagePropertyTest.php
+++ b/tests/phpunit/MediaWiki/Specials/SpecialPagePropertyTest.php
@@ -27,7 +27,7 @@ class SpecialPagePropertyTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyValues', 'service' ] )
+			->onlyMethods( [ 'getPropertyValues', 'service' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/MediaWiki/Specials/SpecialSearchByPropertyTest.php
+++ b/tests/phpunit/MediaWiki/Specials/SpecialSearchByPropertyTest.php
@@ -32,7 +32,7 @@ class SpecialSearchByPropertyTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyTableIdReferenceFinder', 'getPropertyValues', 'getPropertySubjects', 'service' ] )
+			->onlyMethods( [ 'getPropertyTableIdReferenceFinder', 'getPropertyValues', 'getPropertySubjects', 'service' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/Parser/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Parser/InTextAnnotationParserTest.php
@@ -279,7 +279,7 @@ class InTextAnnotationParserTest extends \PHPUnit\Framework\TestCase {
 
 		$stripMarkerDecoder = $this->getMockBuilder( '\SMW\MediaWiki\StripMarkerDecoder' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'canUse', 'hasStripMarker', 'unstrip' ] )
+			->onlyMethods( [ 'canUse', 'hasStripMarker', 'unstrip' ] )
 			->getMock();
 
 		$stripMarkerDecoder->expects( $this->once() )

--- a/tests/phpunit/ParserDataTest.php
+++ b/tests/phpunit/ParserDataTest.php
@@ -227,7 +227,7 @@ class ParserDataTest extends \PHPUnit\Framework\TestCase {
 
 	public function testUpdateStore() {
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'findAssociatedRev' ] )
+			->onlyMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )
@@ -240,7 +240,7 @@ class ParserDataTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'clearData', 'getObjectIds' ] )
+			->onlyMethods( [ 'clearData', 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->once() )
@@ -369,7 +369,7 @@ class ParserDataTest extends \PHPUnit\Framework\TestCase {
 
 		$parserOutput = $this->getMockBuilder( 'ParserOutput' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'setLimitReportData' ] )
+			->onlyMethods( [ 'setLimitReportData' ] )
 			->getMock();
 
 		$parserOutput->expects( $this->once() )

--- a/tests/phpunit/ProcessingErrorMsgHandlerTest.php
+++ b/tests/phpunit/ProcessingErrorMsgHandlerTest.php
@@ -174,7 +174,7 @@ class ProcessingErrorMsgHandlerTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getErrors', 'getProperty' ] )
+			->onlyMethods( [ 'getErrors', 'getProperty' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )
@@ -210,7 +210,7 @@ class ProcessingErrorMsgHandlerTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getErrors', 'getProperty' ] )
+			->onlyMethods( [ 'getErrors', 'getProperty' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )
@@ -246,7 +246,7 @@ class ProcessingErrorMsgHandlerTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getErrors', 'getErrorsByType', 'getProperty' ] )
+			->onlyMethods( [ 'getErrors', 'getErrorsByType', 'getProperty' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )

--- a/tests/phpunit/Property/Annotators/CategoryPropertyAnnotatorTest.php
+++ b/tests/phpunit/Property/Annotators/CategoryPropertyAnnotatorTest.php
@@ -205,7 +205,7 @@ class CategoryPropertyAnnotatorTest extends \PHPUnit\Framework\TestCase {
 	public function testAddCategoryOnInvalidRedirect() {
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
+			->onlyMethods( [ 'getRedirectTarget' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->atLeastOnce() )

--- a/tests/phpunit/Property/ChangePropagationNotifierTest.php
+++ b/tests/phpunit/Property/ChangePropagationNotifierTest.php
@@ -125,7 +125,7 @@ class ChangePropagationNotifierTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( 'SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyValues', 'getSemanticData' ] )
+			->onlyMethods( [ 'getPropertyValues', 'getSemanticData' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/Property/SpecificationLookupTest.php
+++ b/tests/phpunit/Property/SpecificationLookupTest.php
@@ -33,12 +33,12 @@ class SpecificationLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'service' ] )
+			->onlyMethods( [ 'service' ] )
 			->getMockForAbstractClass();
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'save', 'fetch', 'associate', 'fetchSub', 'saveSub', 'delete', 'invalidate' ] )
+			->onlyMethods( [ 'save', 'fetch', 'associate', 'fetchSub', 'saveSub', 'delete', 'invalidate' ] )
 			->getMock();
 
 		$this->monolingualTextLookup = $this->getMockBuilder( '\SMW\SQLStore\Lookup\MonolingualTextLookup' )

--- a/tests/phpunit/Protection/ProtectionValidatorTest.php
+++ b/tests/phpunit/Protection/ProtectionValidatorTest.php
@@ -32,7 +32,7 @@ class ProtectionValidatorTest extends \PHPUnit\Framework\TestCase {
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'save', 'contains', 'fetch', 'associate', 'invalidate', 'delete' ] )
+			->onlyMethods( [ 'save', 'contains', 'fetch', 'associate', 'invalidate', 'delete' ] )
 			->getMock();
 
 		$this->permissionManager = $this->getMockBuilder( '\SMW\MediaWiki\PermissionManager' )

--- a/tests/phpunit/Query/DescriptionBuilderRegistryTest.php
+++ b/tests/phpunit/Query/DescriptionBuilderRegistryTest.php
@@ -81,7 +81,7 @@ class DescriptionBuilderRegistryTest extends \PHPUnit\Framework\TestCase {
 	public function testRegisterAdditionalDescriptionBuilder() {
 		$descriptionBuilder = $this->getMockBuilder( '\SMW\Query\DescriptionBuilders\DescriptionBuilder' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'isBuilderFor' ] )
+			->onlyMethods( [ 'isBuilderFor' ] )
 			->getMockForAbstractClass();
 
 		$descriptionBuilder->expects( $this->once() )

--- a/tests/phpunit/Query/DescriptionBuilders/SomeValueDescriptionBuilderTest.php
+++ b/tests/phpunit/Query/DescriptionBuilders/SomeValueDescriptionBuilderTest.php
@@ -52,7 +52,7 @@ class SomeValueDescriptionBuilderTest extends \PHPUnit\Framework\TestCase {
 	public function testNewDescription( $value, $decription ) {
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'isValid', 'getDataItem', 'getProperty', 'setUserValue' ] )
+			->onlyMethods( [ 'isValid', 'getDataItem', 'getProperty', 'setUserValue' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->once() )
@@ -87,7 +87,7 @@ class SomeValueDescriptionBuilderTest extends \PHPUnit\Framework\TestCase {
 	public function testnNewDescriptionForLikeNotLike( $value ) {
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'setUserValue' ] )
+			->onlyMethods( [ 'setUserValue' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->once() )
@@ -104,7 +104,7 @@ class SomeValueDescriptionBuilderTest extends \PHPUnit\Framework\TestCase {
 	public function testInvalidDataValueRetunsThingDescription() {
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'isValid' ] )
+			->onlyMethods( [ 'isValid' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->any() )
@@ -133,7 +133,7 @@ class SomeValueDescriptionBuilderTest extends \PHPUnit\Framework\TestCase {
 	public function testWikiPageValueOnNonMainNamespace() {
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'isValid', 'getDataItem', 'getProperty', 'setUserValue' ] )
+			->onlyMethods( [ 'isValid', 'getDataItem', 'getProperty', 'setUserValue' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )

--- a/tests/phpunit/Query/DescriptionFactoryTest.php
+++ b/tests/phpunit/Query/DescriptionFactoryTest.php
@@ -199,7 +199,7 @@ class DescriptionFactoryTest extends \PHPUnit\Framework\TestCase {
 	public function testCanConstructDescriptionFromInvalidDataValue() {
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'isValid' ] )
+			->onlyMethods( [ 'isValid' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )
@@ -217,7 +217,7 @@ class DescriptionFactoryTest extends \PHPUnit\Framework\TestCase {
 	public function testCanConstructDescriptionFromValidDataValue() {
 		$dataValue = $this->getMockBuilder( '\SMWDataValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'isValid', 'getProperty', 'getDataItem', 'getWikiValue' ] )
+			->onlyMethods( [ 'isValid', 'getProperty', 'getDataItem', 'getWikiValue' ] )
 			->getMockForAbstractClass();
 
 		$dataValue->expects( $this->atLeastOnce() )
@@ -267,7 +267,7 @@ class DescriptionFactoryTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMW\DataValues\MonolingualTextValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'isValid', 'getProperty', 'getDataItem' ] )
+			->onlyMethods( [ 'isValid', 'getProperty', 'getDataItem' ] )
 			->getMock();
 
 		$dataValue->expects( $this->atLeastOnce() )
@@ -324,7 +324,7 @@ class DescriptionFactoryTest extends \PHPUnit\Framework\TestCase {
 
 		$dataValue = $this->getMockBuilder( '\SMW\DataValues\MonolingualTextValue' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'isValid', 'getProperty', 'getDataItem' ] )
+			->onlyMethods( [ 'isValid', 'getProperty', 'getDataItem' ] )
 			->getMock();
 
 		$dataValue->expects( $this->atLeastOnce() )

--- a/tests/phpunit/Query/QuerySourceFactoryTest.php
+++ b/tests/phpunit/Query/QuerySourceFactoryTest.php
@@ -102,7 +102,7 @@ class QuerySourceFactoryTest extends \PHPUnit\Framework\TestCase {
 	public function testGetFromAnotherFakeSourceThatImplementsStoreAware() {
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->once() )

--- a/tests/phpunit/Query/Result/FilterMapTest.php
+++ b/tests/phpunit/Query/Result/FilterMapTest.php
@@ -29,7 +29,7 @@ class FilterMapTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/Query/Result/ItemFetcherTest.php
+++ b/tests/phpunit/Query/Result/ItemFetcherTest.php
@@ -26,7 +26,7 @@ class ItemFetcherTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'service', 'getPropertyValues' ] )
+			->onlyMethods( [ 'service', 'getPropertyValues' ] )
 			->getMockForAbstractClass();
 
 		$this->requestOptions = $this->getMockBuilder( '\SMW\RequestOptions' )

--- a/tests/phpunit/Query/ResultPrinters/AggregatablePrinterTest.php
+++ b/tests/phpunit/Query/ResultPrinters/AggregatablePrinterTest.php
@@ -59,7 +59,7 @@ class AggregatablePrinterTest extends \PHPUnit\Framework\TestCase {
 	public function testGetResultTextErrorMessage( $setup, $expected ) {
 		$queryResult = $this->getMockBuilder( '\SMWQueryResult' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getErrors', 'getNext', 'addErrors' ] )
+			->onlyMethods( [ 'getErrors', 'getNext', 'addErrors' ] )
 			->getMock();
 
 		$queryResult->expects( $this->any() )
@@ -285,7 +285,7 @@ class AggregatablePrinterTest extends \PHPUnit\Framework\TestCase {
 
 			$resultArray = $this->getMockBuilder( '\SMWResultArray' )
 				->disableOriginalConstructor()
-				->setMethods( [ 'getText', 'getPrintRequest', 'getNextDataValue', 'getNextDataItem' ] )
+				->onlyMethods( [ 'getText', 'getPrintRequest', 'getNextDataValue', 'getNextDataItem' ] )
 				->getMock();
 
 			$resultArray->expects( $this->any() )

--- a/tests/phpunit/Query/ResultPrinters/FileExportPrinterTest.php
+++ b/tests/phpunit/Query/ResultPrinters/FileExportPrinterTest.php
@@ -20,7 +20,7 @@ class FileExportPrinterTest extends \PHPUnit\Framework\TestCase {
 
 		$fileExportPrinter = $this->getMockBuilder( '\SMW\Query\ResultPrinters\FileExportPrinter' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getFileResult', 'getMimeType', 'getFileName' ] )
+			->onlyMethods( [ 'getFileResult', 'getMimeType', 'getFileName' ] )
 			->getMockForAbstractClass();
 
 		// #4375 (needs to be accessed first)

--- a/tests/phpunit/QueryTest.php
+++ b/tests/phpunit/QueryTest.php
@@ -169,7 +169,7 @@ class QueryTest extends \PHPUnit\Framework\TestCase {
 	public function testGetHash() {
 		$description = $this->getMockBuilder( '\SMW\Query\Language\Description' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getFingerprint' ] )
+			->onlyMethods( [ 'getFingerprint' ] )
 			->getMockForAbstractClass();
 
 		$instance = new Query( $description, Query::INLINE_QUERY );

--- a/tests/phpunit/SPARQLStore/QueryEngine/ConditionBuilderTest.php
+++ b/tests/phpunit/SPARQLStore/QueryEngine/ConditionBuilderTest.php
@@ -759,7 +759,7 @@ class ConditionBuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$diWikiPage = $this->getMockBuilder( '\SMW\DIWikiPage' )
 			->setConstructorArgs( [ 'Bar', NS_MAIN ] )
-			->setMethods( [ 'getTitle' ] )
+			->onlyMethods( [ 'getTitle' ] )
 			->getMock();
 
 		$diWikiPage->expects( $this->atLeastOnce() )
@@ -776,7 +776,7 @@ class ConditionBuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$instance = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\ConditionBuilder' )
 			->setConstructorArgs( [ $this->descriptionInterpreterFactory ] )
-			->setMethods( [ 'isSetFlag' ] )
+			->onlyMethods( [ 'isSetFlag' ] )
 			->getMock();
 
 		$instance->expects( $this->at( 0 ) )
@@ -820,7 +820,7 @@ class ConditionBuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$diWikiPage = $this->getMockBuilder( '\SMW\DIWikiPage' )
 			->setConstructorArgs( [ 'Bar', NS_MAIN ] )
-			->setMethods( [ 'getTitle' ] )
+			->onlyMethods( [ 'getTitle' ] )
 			->getMock();
 
 		$diWikiPage->expects( $this->atLeastOnce() )
@@ -831,7 +831,7 @@ class ConditionBuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$instance = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\ConditionBuilder' )
 			->setConstructorArgs( [ $this->descriptionInterpreterFactory ] )
-			->setMethods( [ 'isSetFlag' ] )
+			->onlyMethods( [ 'isSetFlag' ] )
 			->getMock();
 
 		$instance->expects( $this->at( 0 ) )

--- a/tests/phpunit/SPARQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreterTest.php
+++ b/tests/phpunit/SPARQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreterTest.php
@@ -66,7 +66,7 @@ class ValueDescriptionInterpreterTest extends \PHPUnit\Framework\TestCase {
 	public function testCreateFalseConditionForNotSupportedDataItemType( $dataItem ) {
 		$conditionBuilder = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\ConditionBuilder' )
 			->setConstructorArgs( [ $this->descriptionInterpreterFactory ] )
-			->setMethods( [ 'isSetFlag' ] )
+			->onlyMethods( [ 'isSetFlag' ] )
 			->getMock();
 
 		$conditionBuilder->expects( $this->once() )
@@ -116,7 +116,7 @@ class ValueDescriptionInterpreterTest extends \PHPUnit\Framework\TestCase {
 
 		$conditionBuilder = $this->getMockBuilder( '\SMW\SPARQLStore\QueryEngine\ConditionBuilder' )
 			->setConstructorArgs( [ $this->descriptionInterpreterFactory ] )
-			->setMethods( [ 'tryToFindRedirectVariableForDataItem' ] )
+			->onlyMethods( [ 'tryToFindRedirectVariableForDataItem' ] )
 			->getMock();
 
 		$conditionBuilder->expects( $this->once() )

--- a/tests/phpunit/SPARQLStore/QueryEngine/QueryEngineTest.php
+++ b/tests/phpunit/SPARQLStore/QueryEngine/QueryEngineTest.php
@@ -316,7 +316,7 @@ class QueryEngineTest extends \PHPUnit\Framework\TestCase {
 
 		$connection = $this->getMockBuilder( '\SMW\SPARQLStore\RepositoryConnection' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'select' ] )
+			->onlyMethods( [ 'select' ] )
 			->getMockForAbstractClass();
 
 		$connection->expects( $this->once() )
@@ -407,7 +407,7 @@ class QueryEngineTest extends \PHPUnit\Framework\TestCase {
 
 		$connection = $this->getMockBuilder( '\SMW\SPARQLStore\RepositoryConnection' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'ask' ] )
+			->onlyMethods( [ 'ask' ] )
 			->getMockForAbstractClass();
 
 		$connection->expects( $this->once() )
@@ -466,7 +466,7 @@ class QueryEngineTest extends \PHPUnit\Framework\TestCase {
 		// interface hence the use of the concrete class
 		$connection = $this->getMockBuilder( '\SMW\SPARQLStore\RepositoryConnectors\GenericRepositoryConnector' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSparqlForSelect' ] )
+			->onlyMethods( [ 'getSparqlForSelect' ] )
 			->getMock();
 
 		$connection->expects( $this->once() )

--- a/tests/phpunit/SPARQLStore/SPARQLStoreTest.php
+++ b/tests/phpunit/SPARQLStore/SPARQLStoreTest.php
@@ -165,7 +165,7 @@ class SPARQLStoreTest extends \PHPUnit\Framework\TestCase {
 
 		$respositoryConnection = $this->getMockBuilder( '\SMW\SPARQLStore\RespositoryConnection' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'insertDelete' ] )
+			->onlyMethods( [ 'insertDelete' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
@@ -177,7 +177,7 @@ class SPARQLStoreTest extends \PHPUnit\Framework\TestCase {
 
 		$instance = $this->getMockBuilder( '\SMW\SPARQLStore\SPARQLStore' )
 			->setConstructorArgs( [ $store ] )
-			->setMethods( [ 'doSparqlDataDelete', 'getConnection' ] )
+			->onlyMethods( [ 'doSparqlDataDelete', 'getConnection' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -222,7 +222,7 @@ class SPARQLStoreTest extends \PHPUnit\Framework\TestCase {
 			->method( 'insertData' );
 
 		$instance = $this->getMockBuilder( '\SMW\SPARQLStore\SPARQLStore' )
-			->setMethods( [ 'doSparqlDataDelete', 'getConnection' ] )
+			->onlyMethods( [ 'doSparqlDataDelete', 'getConnection' ] )
 			->getMock();
 
 		$instance->expects( $this->once() )
@@ -261,7 +261,7 @@ class SPARQLStoreTest extends \PHPUnit\Framework\TestCase {
 			->method( 'insertData' );
 
 		$instance = $this->getMockBuilder( '\SMW\SPARQLStore\SPARQLStore' )
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMock();
 
 		$instance->expects( $this->atLeastOnce() )
@@ -292,11 +292,11 @@ class SPARQLStoreTest extends \PHPUnit\Framework\TestCase {
 
 		$idLookup = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'warmUpCache' ] )
+			->onlyMethods( [ 'warmUpCache' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/EntityIdManagerTest.php
+++ b/tests/phpunit/SQLStore/EntityIdManagerTest.php
@@ -145,7 +145,7 @@ class EntityIdManagerTest extends \PHPUnit\Framework\TestCase {
 
 		$this->entityIdFinder = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\EntityIdFinder' )
 			->setConstructorArgs( [ $this->connection, $this->propertyTableHashes, $idCacheManager ] )
-			->setMethods( null )
+			->onlyMethods( [] )
 			->getMock();
 
 		$this->factory->expects( $this->any() )

--- a/tests/phpunit/SQLStore/EntityStore/DataItemHandlers/DIWikiPageHandlerTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/DataItemHandlers/DIWikiPageHandlerTest.php
@@ -66,7 +66,7 @@ class DIWikiPageHandlerTest extends \PHPUnit\Framework\TestCase {
 	public function testMutableMethodAccess() {
 		// EntityIdTable
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getSMWPageID', 'makeSMWPageID' ] )
+			->onlyMethods( [ 'getSMWPageID', 'makeSMWPageID' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )

--- a/tests/phpunit/SQLStore/EntityStore/DuplicateFinderTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/DuplicateFinderTest.php
@@ -32,7 +32,7 @@ class DuplicateFinderTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMock();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/EntityStore/IdChangerTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/IdChangerTest.php
@@ -39,7 +39,7 @@ class IdChangerTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'getPropertyTables' ] )
+			->onlyMethods( [ 'getConnection', 'getPropertyTables' ] )
 			->getMock();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/EntityStore/IdEntityFinderTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/IdEntityFinderTest.php
@@ -52,7 +52,7 @@ class IdEntityFinderTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/EntityStore/PropertiesLookupTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/PropertiesLookupTest.php
@@ -63,7 +63,7 @@ class PropertiesLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'getSQLOptions', 'getSQLConditions' ] )
+			->onlyMethods( [ 'getConnection', 'getSQLOptions', 'getSQLConditions' ] )
 			->getMock();
 
 		$store->expects( $this->atLeastOnce() )
@@ -117,7 +117,7 @@ class PropertiesLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMock();
 
 		$store->expects( $this->atLeastOnce() )

--- a/tests/phpunit/SQLStore/EntityStore/PropertySubjectsLookupTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/PropertySubjectsLookupTest.php
@@ -66,7 +66,7 @@ class PropertySubjectsLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'getDataItemHandlerForDIType', 'getSQLOptions', 'getSQLConditions' ] )
+			->onlyMethods( [ 'getConnection', 'getDataItemHandlerForDIType', 'getSQLOptions', 'getSQLConditions' ] )
 			->getMock();
 
 		$store->expects( $this->atLeastOnce() )
@@ -131,7 +131,7 @@ class PropertySubjectsLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'getDataItemHandlerForDIType' ] )
+			->onlyMethods( [ 'getConnection', 'getDataItemHandlerForDIType' ] )
 			->getMock();
 
 		$store->expects( $this->atLeastOnce() )

--- a/tests/phpunit/SQLStore/EntityStore/SemanticDataLookupTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/SemanticDataLookupTest.php
@@ -37,7 +37,7 @@ class SemanticDataLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'findPropertyTableID', 'getDataItemHandlerForDIType', 'getObjectIds' ] )
+			->onlyMethods( [ 'findPropertyTableID', 'getDataItemHandlerForDIType', 'getObjectIds' ] )
 			->getMock();
 
 		$this->store->expects( $this->any() )
@@ -230,7 +230,7 @@ class SemanticDataLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSMWPropertyID' ] )
+			->onlyMethods( [ 'getSMWPropertyID' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )

--- a/tests/phpunit/SQLStore/EntityStore/StubSemanticDataTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/StubSemanticDataTest.php
@@ -62,7 +62,7 @@ class StubSemanticDataTest extends \PHPUnit\Framework\TestCase {
 			->setConstructorArgs( [
 				DIWikiPage::newFromText( __METHOD__ ),
 				$this->store ] )
-			->setMethods( [
+			->onlyMethods( [
 				'getProperties',
 				'isRedirect',
 				'getPropertyValues' ] )

--- a/tests/phpunit/SQLStore/EntityStore/SubobjectListFinderTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/SubobjectListFinderTest.php
@@ -54,7 +54,7 @@ class SubobjectListFinderTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMock();
 
 		$store->expects( $this->atLeastOnce() )
@@ -100,7 +100,7 @@ class SubobjectListFinderTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'getDataItemHandlerForDIType' ] )
+			->onlyMethods( [ 'getConnection', 'getDataItemHandlerForDIType' ] )
 			->getMock();
 
 		$store->expects( $this->atLeastOnce() )

--- a/tests/phpunit/SQLStore/EntityStore/TraversalPropertyLookupTest.php
+++ b/tests/phpunit/SQLStore/EntityStore/TraversalPropertyLookupTest.php
@@ -57,7 +57,7 @@ class TraversalPropertyLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'getDataItemHandlerForDIType', 'getSQLOptions', 'getSQLConditions' ] )
+			->onlyMethods( [ 'getConnection', 'getDataItemHandlerForDIType', 'getSQLOptions', 'getSQLConditions' ] )
 			->getMock();
 
 		$store->expects( $this->atLeastOnce() )
@@ -116,7 +116,7 @@ class TraversalPropertyLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'getDataItemHandlerForDIType' ] )
+			->onlyMethods( [ 'getConnection', 'getDataItemHandlerForDIType' ] )
 			->getMock();
 
 		$store->expects( $this->atLeastOnce() )

--- a/tests/phpunit/SQLStore/Installer/VersionExaminerTest.php
+++ b/tests/phpunit/SQLStore/Installer/VersionExaminerTest.php
@@ -48,7 +48,7 @@ class VersionExaminerTest extends \PHPUnit\Framework\TestCase {
 	public function testRequirements() {
 		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getServerInfo' ] )
+			->onlyMethods( [ 'getServerInfo' ] )
 			->getMockForAbstractClass();
 
 		$connection->expects( $this->atLeastOnce() )
@@ -78,7 +78,7 @@ class VersionExaminerTest extends \PHPUnit\Framework\TestCase {
 	public function testRequirements_InvalidDefined() {
 		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getServerInfo' ] )
+			->onlyMethods( [ 'getServerInfo' ] )
 			->getMockForAbstractClass();
 
 		$connection->expects( $this->atLeastOnce() )
@@ -99,7 +99,7 @@ class VersionExaminerTest extends \PHPUnit\Framework\TestCase {
 	public function testMeetsVersionMinRequirement() {
 		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getServerInfo' ] )
+			->onlyMethods( [ 'getServerInfo' ] )
 			->getMockForAbstractClass();
 
 		$connection->expects( $this->atLeastOnce() )
@@ -128,7 +128,7 @@ class VersionExaminerTest extends \PHPUnit\Framework\TestCase {
 	public function testMeetsVersionMinRequirement_FailsMinimumRequirement() {
 		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getServerInfo' ] )
+			->onlyMethods( [ 'getServerInfo' ] )
 			->getMockForAbstractClass();
 
 		$connection->expects( $this->atLeastOnce() )

--- a/tests/phpunit/SQLStore/InstallerTest.php
+++ b/tests/phpunit/SQLStore/InstallerTest.php
@@ -99,7 +99,7 @@ class InstallerTest extends \PHPUnit\Framework\TestCase {
 
 		$tableBuilder = $this->getMockBuilder( '\SMW\SQLStore\TableBuilder\TableBuilder' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'create' ] )
+			->onlyMethods( [ 'create' ] )
 			->getMockForAbstractClass();
 
 		$tableBuilder->expects( $this->once() )
@@ -163,7 +163,7 @@ class InstallerTest extends \PHPUnit\Framework\TestCase {
 
 		$tableBuilder = $this->getMockBuilder( '\SMW\SQLStore\TableBuilder\TableBuilder' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'create' ] )
+			->onlyMethods( [ 'create' ] )
 			->getMockForAbstractClass();
 
 		$tableBuilder->expects( $this->once() )
@@ -208,7 +208,7 @@ class InstallerTest extends \PHPUnit\Framework\TestCase {
 
 		$tableBuilder = $this->getMockBuilder( '\SMW\SQLStore\TableBuilder\TableBuilder' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'create' ] )
+			->onlyMethods( [ 'create' ] )
 			->getMockForAbstractClass();
 
 		$instance = new Installer(
@@ -239,7 +239,7 @@ class InstallerTest extends \PHPUnit\Framework\TestCase {
 
 		$tableBuilder = $this->getMockBuilder( '\SMW\SQLStore\TableBuilder\TableBuilder' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'drop' ] )
+			->onlyMethods( [ 'drop' ] )
 			->getMockForAbstractClass();
 
 		$tableBuilder->expects( $this->once() )

--- a/tests/phpunit/SQLStore/Lookup/ChangePropagationEntityLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/ChangePropagationEntityLookupTest.php
@@ -84,7 +84,7 @@ class ChangePropagationEntityLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$entityIdManager = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSMWPropertyID', 'getDataItemPoolHashListFor' ] )
+			->onlyMethods( [ 'getSMWPropertyID', 'getDataItemPoolHashListFor' ] )
 			->getMock();
 
 		$entityIdManager->expects( $this->any() )

--- a/tests/phpunit/SQLStore/Lookup/EntityUniquenessLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/EntityUniquenessLookupTest.php
@@ -2,8 +2,16 @@
 
 namespace SMW\Tests\SQLStore\Lookup;
 
+use SMWDIBlob;
+use SMW\DIProperty;
+use SMW\IteratorFactory;
+use SMW\RequestOptions;
+use SMW\MediaWiki\Database;
+use SMW\SQLStore\PropertyTableInfoFetcher;
+use SMW\SQLStore\TableDefinition;
 use SMW\SQLStore\Lookup\EntityUniquenessLookup;
 use SMW\DIWikiPage;
+use Wikimedia\Rdbms\IResultWrapper;
 
 /**
  * @covers \SMW\SQLStore\Lookup\EntityUniquenessLookup
@@ -21,9 +29,7 @@ class EntityUniquenessLookupTest extends \PHPUnit\Framework\TestCase {
 	private $iteratorFactory;
 
 	protected function setUp(): void {
-		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->connection = $this->createMock( Database::class );
 
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
@@ -34,9 +40,7 @@ class EntityUniquenessLookupTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getConnection' )
 			->willReturn( $this->connection );
 
-		$this->iteratorFactory = $this->getMockBuilder( '\SMW\IteratorFactory' )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->iteratorFactory = $this->createMock( IteratorFactory::class );
 	}
 
 	public function testCanConstruct() {
@@ -55,9 +59,7 @@ class EntityUniquenessLookupTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getWhereConds' )
 			->willReturn( [ 'o_hash' => '' ] );
 
-		$propertyTableInfoFetcher = $this->getMockBuilder( '\SMW\SQLStore\PropertyTableInfoFetcher' )
-			->disableOriginalConstructor()
-			->getMock();
+		$propertyTableInfoFetcher = $this->createMock( PropertyTableInfoFetcher::class );
 
 		$propertyTableInfoFetcher->expects( $this->any() )
 			->method( 'findTableIdForProperty' )
@@ -80,9 +82,7 @@ class EntityUniquenessLookupTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getPropertyTableInfoFetcher' )
 			->willReturn( $propertyTableInfoFetcher );
 
-		$propertyTable = $this->getMockBuilder( '\SMW\SQLStore\TableDefinition' )
-			->disableOriginalConstructor()
-			->getMock();
+		$propertyTable = $this->createMock( TableDefinition::class );
 
 		$propertyTable->expects( $this->once() )
 			->method( 'usesIdSubject' )
@@ -108,9 +108,7 @@ class EntityUniquenessLookupTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getPropertyTables' )
 			->willReturn( [ '_foo' => $propertyTable ] );
 
-		$requestOptions = $this->getMockBuilder( '\SMW\RequestOptions' )
-			->disableOriginalConstructor()
-			->getMock();
+		$requestOptions = $this->createMock( RequestOptions::class );
 
 		$requestOptions->expects( $this->any() )
 			->method( 'getExtraConditions' )
@@ -120,9 +118,7 @@ class EntityUniquenessLookupTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getLimit' )
 			->willReturn( 42 );
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
-			->disableOriginalConstructor()
-			->getMock();
+		$connection = $this->createMock( Database::class );
 
 		$connection->expects( $this->any() )
 			->method( 'addQuotes' )
@@ -134,9 +130,7 @@ class EntityUniquenessLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$query = new \SMW\MediaWiki\Connection\Query( $connection );
 
-		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
-			->disableOriginalConstructor()
-			->getMock();
+		$resultWrapper = $this->createMock( IResultWrapper::class );
 
 		$this->connection->expects( $this->atLeastOnce() )
 			->method( 'newQuery' )
@@ -151,13 +145,9 @@ class EntityUniquenessLookupTest extends \PHPUnit\Framework\TestCase {
 			$this->iteratorFactory
 		);
 
-		$property = $this->getMockBuilder( '\SMW\DIProperty' )
-			->disableOriginalConstructor()
-			->getMock();
+		$property = $this->createMock( DIProperty::class );
 
-		$dataItem = $this->getMockBuilder( '\SMWDIBlob' )
-			->disableOriginalConstructor()
-			->getMock();
+		$dataItem = $this->createMock( SMWDIBlob::class );
 
 		$instance->checkConstraint( $property, $dataItem, $requestOptions );
 

--- a/tests/phpunit/SQLStore/Lookup/EntityUniquenessLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/EntityUniquenessLookupTest.php
@@ -27,7 +27,7 @@ class EntityUniquenessLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMock();
 
 		$this->store->expects( $this->any() )
@@ -65,7 +65,7 @@ class EntityUniquenessLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'getPropertyTables', 'getPropertyTableInfoFetcher', 'getDataItemHandlerForDIType' ] )
+			->onlyMethods( [ 'getConnection', 'getPropertyTables', 'getPropertyTableInfoFetcher', 'getDataItemHandlerForDIType' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/Lookup/ErrorLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/ErrorLookupTest.php
@@ -28,7 +28,7 @@ class ErrorLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMock();
 
 		$this->store->expects( $this->any() )
@@ -77,7 +77,7 @@ class ErrorLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'getPropertyTables', 'findDiTypeTableId', 'getObjectIds', 'findPropertyTableID' ] )
+			->onlyMethods( [ 'getConnection', 'getPropertyTables', 'findDiTypeTableId', 'getObjectIds', 'findPropertyTableID' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -150,7 +150,7 @@ class ErrorLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'getPropertyTables', 'findDiTypeTableId', 'getObjectIds', 'findPropertyTableID' ] )
+			->onlyMethods( [ 'getConnection', 'getPropertyTables', 'findDiTypeTableId', 'getObjectIds', 'findPropertyTableID' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/Lookup/ErrorLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/ErrorLookupTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\SQLStore\Lookup;
 use SMW\SQLStore\Lookup\ErrorLookup;
 use SMW\DIWikiPage;
 use SMW\RequestOptions;
+use Wikimedia\Rdbms\IResultWrapper;
 
 /**
  * @covers \SMW\SQLStore\Lookup\ErrorLookup
@@ -106,9 +107,7 @@ class ErrorLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$query = new \SMW\MediaWiki\Connection\Query( $this->connection );
 
-		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
-			->disableOriginalConstructor()
-			->getMock();
+		$resultWrapper = $this->createMock( IResultWrapper::class );
 
 		$this->connection->expects( $this->atLeastOnce() )
 			->method( 'newQuery' )
@@ -179,9 +178,7 @@ class ErrorLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$query = new \SMW\MediaWiki\Connection\Query( $this->connection );
 
-		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
-			->disableOriginalConstructor()
-			->getMock();
+		$resultWrapper = $this->createMock( IResultWrapper::class );
 
 		$this->connection->expects( $this->atLeastOnce() )
 			->method( 'newQuery' )

--- a/tests/phpunit/SQLStore/Lookup/ProximityPropertyValueLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/ProximityPropertyValueLookupTest.php
@@ -58,7 +58,7 @@ class ProximityPropertyValueLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSMWPropertyID', 'isFixedPropertyTable' ] )
+			->onlyMethods( [ 'getSMWPropertyID', 'isFixedPropertyTable' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )
@@ -139,7 +139,7 @@ class ProximityPropertyValueLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSMWPropertyID', 'isFixedPropertyTable' ] )
+			->onlyMethods( [ 'getSMWPropertyID', 'isFixedPropertyTable' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )

--- a/tests/phpunit/SQLStore/Lookup/RedirectTargetLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/RedirectTargetLookupTest.php
@@ -28,7 +28,7 @@ class RedirectTargetLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/Lookup/UsageStatisticsListLookupTest.php
+++ b/tests/phpunit/SQLStore/Lookup/UsageStatisticsListLookupTest.php
@@ -114,7 +114,7 @@ class UsageStatisticsListLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$objectIdFetcher = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSMWPropertyID' ] )
+			->onlyMethods( [ 'getSMWPropertyID' ] )
 			->getMock();
 
 		$this->store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -32,7 +32,7 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit\Framework\TestCase {
 			->getMock();
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getDataItemById' ] )
+			->onlyMethods( [ 'getDataItemById' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )
@@ -301,7 +301,7 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit\Framework\TestCase {
 
 	public function testCleanUpOnTransactionIdleAvoidOnSubobject() {
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getDataItemById' ] )
+			->onlyMethods( [ 'getDataItemById' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )
@@ -359,7 +359,7 @@ class PropertyTableIdReferenceDisposerTest extends \PHPUnit\Framework\TestCase {
 		}
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getDataItemById' ] )
+			->onlyMethods( [ 'getDataItemById' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )

--- a/tests/phpunit/SQLStore/PropertyTableRowDifferTest.php
+++ b/tests/phpunit/SQLStore/PropertyTableRowDifferTest.php
@@ -52,7 +52,7 @@ class PropertyTableRowDifferTest extends \PHPUnit\Framework\TestCase {
 		$propertyTables = [];
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->setMethods( [ 'getPropertyTables' ] )
+			->onlyMethods( [ 'getPropertyTables' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -82,7 +82,7 @@ class PropertyTableRowDifferTest extends \PHPUnit\Framework\TestCase {
 		$propertyTables = [];
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->setMethods( [ 'getPropertyTables' ] )
+			->onlyMethods( [ 'getPropertyTables' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -130,7 +130,7 @@ class PropertyTableRowDifferTest extends \PHPUnit\Framework\TestCase {
 		$propertyTables = [ $propertyTable ];
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->setMethods( [ 'getPropertyTables' ] )
+			->onlyMethods( [ 'getPropertyTables' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -211,7 +211,7 @@ class PropertyTableRowDifferTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyTables', 'getConnection', 'getObjectIds' ] )
+			->onlyMethods( [ 'getPropertyTables', 'getConnection', 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/PropertyTableRowMapperTest.php
+++ b/tests/phpunit/SQLStore/PropertyTableRowMapperTest.php
@@ -40,7 +40,7 @@ class PropertyTableRowMapperTest extends \PHPUnit\Framework\TestCase {
 		$propertyTables = [];
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->setMethods( [ 'getPropertyTables' ] )
+			->onlyMethods( [ 'getPropertyTables' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -99,7 +99,7 @@ class PropertyTableRowMapperTest extends \PHPUnit\Framework\TestCase {
 		$propertyTables = [ 'smw_foo' => $propertyTable ];
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->setMethods( [ 'getPropertyTables', 'findPropertyTableID', 'getObjectIds' ] )
+			->onlyMethods( [ 'getPropertyTables', 'findPropertyTableID', 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -171,7 +171,7 @@ class PropertyTableRowMapperTest extends \PHPUnit\Framework\TestCase {
 		$propertyTables = [ 'smw_foo' => $propertyTable ];
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->setMethods( [ 'getPropertyTables', 'findPropertyTableID', 'getObjectIds' ] )
+			->onlyMethods( [ 'getPropertyTables', 'findPropertyTableID', 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/QueryDependency/DependencyLinksTableUpdaterTest.php
+++ b/tests/phpunit/SQLStore/QueryDependency/DependencyLinksTableUpdaterTest.php
@@ -48,7 +48,7 @@ class DependencyLinksTableUpdaterTest extends \PHPUnit\Framework\TestCase {
 
 	public function testAddToUpdateList() {
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getId' ] )
+			->onlyMethods( [ 'getId' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )
@@ -86,7 +86,7 @@ class DependencyLinksTableUpdaterTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMockForAbstractClass();
 
 		$store->setConnectionManager( $connectionManager );
@@ -141,7 +141,7 @@ class DependencyLinksTableUpdaterTest extends \PHPUnit\Framework\TestCase {
 
 	public function testAddDependenciesFromQueryResultWhereObjectIdIsYetUnknownWhichRequiresToCreateTheIdOnTheFly() {
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getId', 'makeSMWPageID' ] )
+			->onlyMethods( [ 'getId', 'makeSMWPageID' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )
@@ -183,7 +183,7 @@ class DependencyLinksTableUpdaterTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMockForAbstractClass();
 
 		$store->setConnectionManager( $connectionManager );

--- a/tests/phpunit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -203,7 +203,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit\Framework\TestCase {
 		$row->s_id = 1001;
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getDataItemPoolHashListFor' ] )
+			->onlyMethods( [ 'getDataItemPoolHashListFor' ] )
 			->getMock();
 
 		$idTable->expects( $this->once() )
@@ -231,7 +231,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMockForAbstractClass();
 
 		$store->setConnectionManager( $connectionManager );
@@ -269,7 +269,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit\Framework\TestCase {
 		$row->s_id = 1001;
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getDataItemPoolHashListFor' ] )
+			->onlyMethods( [ 'getDataItemPoolHashListFor' ] )
 			->getMock();
 
 		$idTable->expects( $this->once() )
@@ -297,7 +297,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMockForAbstractClass();
 
 		$store->setConnectionManager( $connectionManager );
@@ -360,7 +360,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -479,7 +479,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit\Framework\TestCase {
 
 	public function testTryDoUpdateDependenciesByForWhenDependencyListReturnsEmpty() {
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getId' ] )
+			->onlyMethods( [ 'getId' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )
@@ -488,7 +488,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->any() )
@@ -649,7 +649,7 @@ class QueryDependencyLinksStoreTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyValues' ] )
+			->onlyMethods( [ 'getPropertyValues' ] )
 			->getMock();
 
 		$store->setConnectionManager( $connectionManager );

--- a/tests/phpunit/SQLStore/QueryEngine/ConditionBuilderTest.php
+++ b/tests/phpunit/SQLStore/QueryEngine/ConditionBuilderTest.php
@@ -175,7 +175,7 @@ class ConditionBuilderTest extends \PHPUnit\Framework\TestCase {
 
 	public function testClassDescription() {
 		$objectIds = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getSMWPageID' ] )
+			->onlyMethods( [ 'getSMWPageID' ] )
 			->getMock();
 
 		$objectIds->expects( $this->any() )

--- a/tests/phpunit/SQLStore/QueryEngine/DescriptionInterpreterFactoryTest.php
+++ b/tests/phpunit/SQLStore/QueryEngine/DescriptionInterpreterFactoryTest.php
@@ -22,7 +22,7 @@ class DescriptionInterpreterFactoryTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMockForAbstractClass();
 
 		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )

--- a/tests/phpunit/SQLStore/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreterTest.php
+++ b/tests/phpunit/SQLStore/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreterTest.php
@@ -49,7 +49,7 @@ class ClassDescriptionInterpreterTest extends \PHPUnit\Framework\TestCase {
 	 */
 	public function testCompileDescription( $description, $pageId, $expected ) {
 		$objectIds = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getSMWPageID' ] )
+			->onlyMethods( [ 'getSMWPageID' ] )
 			->getMock();
 
 		$objectIds->expects( $this->any() )

--- a/tests/phpunit/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreterTest.php
+++ b/tests/phpunit/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreterTest.php
@@ -72,7 +72,7 @@ class ConceptDescriptionInterpreterTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( true );
 
 		$objectIds = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getSMWPageID' ] )
+			->onlyMethods( [ 'getSMWPageID' ] )
 			->getMock();
 
 		$objectIds->expects( $this->any() )
@@ -103,7 +103,7 @@ class ConceptDescriptionInterpreterTest extends \PHPUnit\Framework\TestCase {
 	 */
 	public function testInterpretDescription( $description, $concept, $expected ) {
 		$objectIds = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getSMWPageID' ] )
+			->onlyMethods( [ 'getSMWPageID' ] )
 			->getMock();
 
 		$objectIds->expects( $this->any() )

--- a/tests/phpunit/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreterTest.php
+++ b/tests/phpunit/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreterTest.php
@@ -99,7 +99,7 @@ class SomePropertyInterpreterTest extends \PHPUnit\Framework\TestCase {
 
 	public function testinterpretDescriptionForNonIdSubject() {
 		$proptable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'usesIdSubject' ] )
+			->onlyMethods( [ 'usesIdSubject' ] )
 			->getMock();
 
 		$proptable->expects( $this->any() )
@@ -154,7 +154,7 @@ class SomePropertyInterpreterTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( '_txt' );
 
 		$proptable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'usesIdSubject' ] )
+			->onlyMethods( [ 'usesIdSubject' ] )
 			->getMock();
 
 		$proptable->expects( $this->any() )
@@ -215,7 +215,7 @@ class SomePropertyInterpreterTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( [ $indexField => 'fixedFooWhereCond' ] );
 
 		$objectIds = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getSMWPropertyID', 'getSMWPageID' ] )
+			->onlyMethods( [ 'getSMWPropertyID', 'getSMWPageID' ] )
 			->getMock();
 
 		$objectIds->expects( $this->any() )
@@ -436,7 +436,7 @@ class SomePropertyInterpreterTest extends \PHPUnit\Framework\TestCase {
 
 		$valueDescription = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSQLCondition', 'getDataItem' ] )
+			->onlyMethods( [ 'getSQLCondition', 'getDataItem' ] )
 			->getMock();
 
 		$valueDescription->expects( $this->any() )

--- a/tests/phpunit/SQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreterTest.php
+++ b/tests/phpunit/SQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreterTest.php
@@ -51,7 +51,7 @@ class ValueDescriptionInterpreterTest extends \PHPUnit\Framework\TestCase {
 	 */
 	public function testInterpretDescription( $description, $expected ) {
 		$objectIds = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getSMWPageID' ] )
+			->onlyMethods( [ 'getSMWPageID' ] )
 			->getMock();
 
 		$objectIds->expects( $this->any() )

--- a/tests/phpunit/SQLStore/Rebuilder/EntityValidatorTest.php
+++ b/tests/phpunit/SQLStore/Rebuilder/EntityValidatorTest.php
@@ -39,7 +39,7 @@ class EntityValidatorTest extends \PHPUnit\Framework\TestCase {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'exists' ] )
+			->onlyMethods( [ 'exists' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )
@@ -48,7 +48,7 @@ class EntityValidatorTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/Rebuilder/RebuilderTest.php
+++ b/tests/phpunit/SQLStore/Rebuilder/RebuilderTest.php
@@ -54,7 +54,7 @@ class RebuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'exists' ] )
+			->onlyMethods( [ 'exists' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )
@@ -63,7 +63,7 @@ class RebuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
+			->onlyMethods( [ 'getObjectIds' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->any() )
@@ -115,7 +115,7 @@ class RebuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -199,7 +199,7 @@ class RebuilderTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'getObjectIds' ] )
+			->onlyMethods( [ 'getConnection', 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/RedirectStoreTest.php
+++ b/tests/phpunit/SQLStore/RedirectStoreTest.php
@@ -41,7 +41,7 @@ class RedirectStoreTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( null )
+			->onlyMethods( [] )
 			->getMock();
 
 		$this->connectionManager = $this->getMockBuilder( '\SMW\Connection\ConnectionManager' )
@@ -206,7 +206,7 @@ class RedirectStoreTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyTables' ] )
+			->onlyMethods( [ 'getPropertyTables' ] )
 			->getMock();
 
 		$store->setConnectionManager( $this->connectionManager );
@@ -270,7 +270,7 @@ class RedirectStoreTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyTables' ] )
+			->onlyMethods( [ 'getPropertyTables' ] )
 			->getMock();
 
 		$store->setConnectionManager( $this->connectionManager );
@@ -307,7 +307,7 @@ class RedirectStoreTest extends \PHPUnit\Framework\TestCase {
 	public function testUpdateRedirectNotEnabled() {
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyTables' ] )
+			->onlyMethods( [ 'getPropertyTables' ] )
 			->getMock();
 
 		$store->expects( $this->never() )

--- a/tests/phpunit/SQLStore/SQLStoreUpdaterTest.php
+++ b/tests/phpunit/SQLStore/SQLStoreUpdaterTest.php
@@ -161,7 +161,7 @@ class SQLStoreUpdaterTest extends \PHPUnit\Framework\TestCase {
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
 			->setConstructorArgs( [ DIWikiPage::newFromTitle( $title ) ] )
-			->setMethods( null )
+			->onlyMethods( [] )
 			->getMock();
 
 		$objectIdGenerator = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\EntityIdManager' )
@@ -220,7 +220,7 @@ class SQLStoreUpdaterTest extends \PHPUnit\Framework\TestCase {
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
 			->setConstructorArgs( [ DIWikiPage::newFromTitle( $title ) ] )
-			->setMethods( null )
+			->onlyMethods( [] )
 			->getMock();
 
 		$idTable = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\EntityIdManager' )
@@ -276,7 +276,7 @@ class SQLStoreUpdaterTest extends \PHPUnit\Framework\TestCase {
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
 			->setConstructorArgs( [ DIWikiPage::newFromTitle( $title ) ] )
-			->setMethods( [ 'getPropertyValues' ] )
+			->onlyMethods( [ 'getPropertyValues' ] )
 			->getMock();
 
 		$semanticData->expects( $this->once() )
@@ -328,7 +328,7 @@ class SQLStoreUpdaterTest extends \PHPUnit\Framework\TestCase {
 
 		$semanticData = $this->getMockBuilder( '\SMW\SemanticData' )
 			->setConstructorArgs( [ DIWikiPage::newFromTitle( $title ) ] )
-			->setMethods( [ 'getPropertyValues' ] )
+			->onlyMethods( [ 'getPropertyValues' ] )
 			->getMock();
 
 		$semanticData->expects( $this->once() )

--- a/tests/phpunit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
+++ b/tests/phpunit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
@@ -2,9 +2,12 @@
 
 namespace SMW\Tests\SQLStore\TableBuilder\Examiner;
 
+use SMW\Maintenance\populateHashField;
+use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder\Examiner\HashField;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\PHPUnitCompat;
+use Wikimedia\Rdbms\IResultWrapper;
 
 /**
  * @covers \SMW\SQLStore\TableBuilder\Examiner\HashField
@@ -27,13 +30,9 @@ class HashFieldTest extends \PHPUnit\Framework\TestCase {
 		parent::setUp();
 		$this->spyMessageReporter = TestEnvironment::getUtilityFactory()->newSpyMessageReporter();
 
-		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->store = $this->createMock( SQLStore::class );
 
-		$this->populateHashField = $this->getMockBuilder( '\SMW\Maintenance\populateHashField' )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->populateHashField = $this->createMock( populateHashField::class );
 	}
 
 	public function testCanConstruct() {
@@ -44,9 +43,7 @@ class HashFieldTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testCheck_Populate() {
-		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
-			->disableOriginalConstructor()
-			->getMock();
+		$resultWrapper = $this->createMock( IResultWrapper::class );
 
 		$resultWrapper->expects( $this->once() )
 			->method( 'numRows' )
@@ -74,9 +71,7 @@ class HashFieldTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testCheck_Incomplete() {
-		$resultWrapper = $this->getMockBuilder( '\Wikimedia\Rdbms\ResultWrapper' )
-			->disableOriginalConstructor()
-			->getMock();
+		$resultWrapper = $this->createMock( IResultWrapper::class );
 
 		$resultWrapper->expects( $this->once() )
 			->method( 'numRows' )

--- a/tests/phpunit/SQLStore/TableBuilder/Examiner/IdBorderTest.php
+++ b/tests/phpunit/SQLStore/TableBuilder/Examiner/IdBorderTest.php
@@ -130,7 +130,7 @@ class IdBorderTest extends \PHPUnit\Framework\TestCase {
 		];
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'moveSMWPageID' ] )
+			->onlyMethods( [ 'moveSMWPageID' ] )
 			->getMock();
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )

--- a/tests/phpunit/SQLStore/TableBuilder/Examiner/PredefinedPropertiesTest.php
+++ b/tests/phpunit/SQLStore/TableBuilder/Examiner/PredefinedPropertiesTest.php
@@ -49,7 +49,7 @@ class PredefinedPropertiesTest extends \PHPUnit\Framework\TestCase {
 		];
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getPropertyInterwiki', 'moveSMWPageID', 'getPropertyTableHashes' ] )
+			->onlyMethods( [ 'getPropertyInterwiki', 'moveSMWPageID', 'getPropertyTableHashes' ] )
 			->getMock();
 
 		$idTable->expects( $this->atLeastOnce() )
@@ -69,7 +69,7 @@ class PredefinedPropertiesTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds', 'getConnection' ] )
+			->onlyMethods( [ 'getObjectIds', 'getConnection' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -103,7 +103,7 @@ class PredefinedPropertiesTest extends \PHPUnit\Framework\TestCase {
 		];
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'moveSMWPageID', 'getPropertyInterwiki' ] )
+			->onlyMethods( [ 'moveSMWPageID', 'getPropertyInterwiki' ] )
 			->getMock();
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
@@ -127,7 +127,7 @@ class PredefinedPropertiesTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds', 'getConnection' ] )
+			->onlyMethods( [ 'getObjectIds', 'getConnection' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -152,7 +152,7 @@ class PredefinedPropertiesTest extends \PHPUnit\Framework\TestCase {
 
 	public function testCheckOnInvalidProperty() {
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getPropertyInterwiki', 'moveSMWPageID' ] )
+			->onlyMethods( [ 'getPropertyInterwiki', 'moveSMWPageID' ] )
 			->getMock();
 
 		$idTable->expects( $this->never() )
@@ -164,7 +164,7 @@ class PredefinedPropertiesTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds', 'getConnection' ] )
+			->onlyMethods( [ 'getObjectIds', 'getConnection' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/TableBuilder/TableBuildExaminerTest.php
+++ b/tests/phpunit/SQLStore/TableBuilder/TableBuildExaminerTest.php
@@ -102,12 +102,12 @@ class TableBuildExaminerTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( 'smw_object_ids' );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'moveSMWPageID' ] )
+			->onlyMethods( [ 'moveSMWPageID' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection', 'getObjectIds' ] )
+			->onlyMethods( [ 'getConnection', 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -148,7 +148,7 @@ class TableBuildExaminerTest extends \PHPUnit\Framework\TestCase {
 	public function testCheckOnPostDestruction() {
 		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'listTables' ] )
+			->onlyMethods( [ 'listTables' ] )
 			->getMockForAbstractClass();
 
 		$connection->expects( $this->atLeastOnce() )
@@ -157,7 +157,7 @@ class TableBuildExaminerTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -186,7 +186,7 @@ class TableBuildExaminerTest extends \PHPUnit\Framework\TestCase {
 	public function testGetDatabaseInfo() {
 		$connection = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getType', 'getServerInfo' ] )
+			->onlyMethods( [ 'getType', 'getServerInfo' ] )
 			->getMockForAbstractClass();
 
 		$connection->expects( $this->once() )
@@ -199,7 +199,7 @@ class TableBuildExaminerTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getConnection' ] )
+			->onlyMethods( [ 'getConnection' ] )
 			->getMock();
 
 		$store->expects( $this->any() )

--- a/tests/phpunit/SQLStore/TableBuilder/TableSchemaManagerTest.php
+++ b/tests/phpunit/SQLStore/TableBuilder/TableSchemaManagerTest.php
@@ -167,7 +167,7 @@ class TableSchemaManagerTest extends \PHPUnit\Framework\TestCase {
 
 		$dataItemHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getTableIndexes' ] )
+			->onlyMethods( [ 'getTableIndexes' ] )
 			->getMockForAbstractClass();
 
 		$dataItemHandler->expects( $this->once() )
@@ -225,7 +225,7 @@ class TableSchemaManagerTest extends \PHPUnit\Framework\TestCase {
 
 		$dataItemHandler = $this->getMockBuilder( '\SMW\SQLStore\EntityStore\DataItemHandler' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getTableIndexes' ] )
+			->onlyMethods( [ 'getTableIndexes' ] )
 			->getMockForAbstractClass();
 
 		$dataItemHandler->expects( $this->once() )

--- a/tests/phpunit/Schema/Filters/CompositeFilterTest.php
+++ b/tests/phpunit/Schema/Filters/CompositeFilterTest.php
@@ -73,7 +73,7 @@ class CompositeFilterTest extends \PHPUnit\Framework\TestCase {
 	public function testSortMatches() {
 		$rule_1 = $this->getMockBuilder( '\SMW\Schema\Rule' )
 			->disableOriginalConstructor()
-			->setMethods( null )
+			->onlyMethods( [] )
 			->getMock();
 
 		$rule_1->incrFilterScore();

--- a/tests/phpunit/Services/DataValueServicesContainerBuildTest.php
+++ b/tests/phpunit/Services/DataValueServicesContainerBuildTest.php
@@ -69,12 +69,12 @@ class DataValueServicesContainerBuildTest extends \PHPUnit\Framework\TestCase {
 
 		$this->schemaFactory = $this->getMockBuilder( '\SMW\Schema\SchemaFactory' )
 			->disableOriginalConstructor()
-			->setMethods( null )
+			->onlyMethods( [] )
 			->getMock();
 
 		$this->constraintFactory = $this->getMockBuilder( '\SMW\ConstraintFactory' )
 			->disableOriginalConstructor()
-			->setMethods( null )
+			->onlyMethods( [] )
 			->getMock();
 
 		$this->entityCache = $this->getMockBuilder( '\SMW\EntityCache' )

--- a/tests/phpunit/Services/ServicesContainerTest.php
+++ b/tests/phpunit/Services/ServicesContainerTest.php
@@ -28,7 +28,7 @@ class ServicesContainerTest extends \PHPUnit\Framework\TestCase {
 	public function testGet() {
 		$mock = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'runService' ] )
+			->onlyMethods( [ 'runService' ] )
 			->getMock();
 
 		$mock->expects( $this->once() )
@@ -62,7 +62,7 @@ class ServicesContainerTest extends \PHPUnit\Framework\TestCase {
 	public function testGet_MultipleArgs() {
 		$fake = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'runService' ] )
+			->onlyMethods( [ 'runService' ] )
 			->getMock();
 
 		$fake->expects( $this->once() )
@@ -81,7 +81,7 @@ class ServicesContainerTest extends \PHPUnit\Framework\TestCase {
 	public function testAdd() {
 		$fake = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'runService' ] )
+			->onlyMethods( [ 'runService' ] )
 			->getMock();
 
 		$fake->expects( $this->once() )
@@ -96,7 +96,7 @@ class ServicesContainerTest extends \PHPUnit\Framework\TestCase {
 	public function testAddClosure() {
 		$fake = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'runService' ] )
+			->onlyMethods( [ 'runService' ] )
 			->getMock();
 
 		$fake->expects( $this->once() )

--- a/tests/phpunit/SortLetterTest.php
+++ b/tests/phpunit/SortLetterTest.php
@@ -21,7 +21,7 @@ class SortLetterTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		$this->store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getWikiPageSortKey' ] )
+			->onlyMethods( [ 'getWikiPageSortKey' ] )
 			->getMockForAbstractClass();
 
 		$this->collator = $this->getMockBuilder( '\SMW\MediaWiki\Collator' )

--- a/tests/phpunit/Updater/DataUpdaterTest.php
+++ b/tests/phpunit/Updater/DataUpdaterTest.php
@@ -67,7 +67,7 @@ class DataUpdaterTest extends \PHPUnit\Framework\TestCase {
 			->getMock();
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists' ] )
+			->onlyMethods( [ 'exists' ] )
 			->getMock();
 
 		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Database' )
@@ -76,7 +76,7 @@ class DataUpdaterTest extends \PHPUnit\Framework\TestCase {
 
 		$this->store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds', 'getConnection', 'getPropertyValues', 'updateData' ] )
+			->onlyMethods( [ 'getObjectIds', 'getConnection', 'getPropertyValues', 'updateData' ] )
 			->getMock();
 
 		$this->store->expects( $this->any() )
@@ -186,7 +186,7 @@ class DataUpdaterTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'updateData' ] )
+			->onlyMethods( [ 'updateData' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->once() )
@@ -256,7 +256,7 @@ class DataUpdaterTest extends \PHPUnit\Framework\TestCase {
 		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists' ] )
+			->onlyMethods( [ 'exists' ] )
 			->getMock();
 
 		$idTable->expects( $this->atLeastOnce() )
@@ -265,7 +265,7 @@ class DataUpdaterTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'clearData', 'getObjectIds' ] )
+			->onlyMethods( [ 'clearData', 'getObjectIds' ] )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -376,12 +376,12 @@ class DataUpdaterTest extends \PHPUnit\Framework\TestCase {
 		$semanticData = $this->semanticDataFactory->setSubject( $wikiPage )->newEmptySemanticData();
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists' ] )
+			->onlyMethods( [ 'exists' ] )
 			->getMock();
 
 		$store = $this->getMockBuilder( '\SMW\SQLStore\SQLStore' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'updateData' ] )
+			->onlyMethods( [ 'updateData' ] )
 			->getMock();
 
 		$store->expects( $this->once() )

--- a/tests/phpunit/Utils/JsonSchemaValidatorTest.php
+++ b/tests/phpunit/Utils/JsonSchemaValidatorTest.php
@@ -52,7 +52,7 @@ class JsonSchemaValidatorTest extends \PHPUnit\Framework\TestCase {
 		}
 
 		$data = $this->getMockBuilder( JsonSerializable::class )
-			->setMethods( [ 'jsonSerialize' ] )
+			->onlyMethods( [ 'jsonSerialize' ] )
 			->getMock();
 
 		$data->expects( $this->any() )
@@ -60,7 +60,7 @@ class JsonSchemaValidatorTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( json_encode( [ 'Foo' ] ) );
 
 		$schemaValidator = $this->getMockBuilder( SchemaValidator::class )
-			->setMethods( [ 'check' ] )
+			->onlyMethods( [ 'check' ] )
 			->getMock();
 
 		$instance = new JsonSchemaValidator(
@@ -84,7 +84,7 @@ class JsonSchemaValidatorTest extends \PHPUnit\Framework\TestCase {
 		}
 
 		$data = $this->getMockBuilder( JsonSerializable::class )
-			->setMethods( [ 'jsonSerialize' ] )
+			->onlyMethods( [ 'jsonSerialize' ] )
 			->getMock();
 
 		$data->expects( $this->any() )
@@ -92,7 +92,7 @@ class JsonSchemaValidatorTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( json_encode( [ 'Foo' ] ) );
 
 		$schemaValidator = $this->getMockBuilder( SchemaValidator::class )
-			->setMethods( [ 'check' ] )
+			->onlyMethods( [ 'check' ] )
 			->getMock();
 
 		$schemaValidator->expects( $this->any() )

--- a/tests/phpunit/Utils/Mock/CoreMockObjectRepository.php
+++ b/tests/phpunit/Utils/Mock/CoreMockObjectRepository.php
@@ -89,7 +89,7 @@ class CoreMockObjectRepository extends \PHPUnit\Framework\TestCase implements Mo
 		}
 
 		$collector = $this->getMockBuilder( '\SMW\Store\CacheableResultCollector' )
-			->setMethods( $methods )
+			->onlyMethods( $methods )
 			->getMock();
 
 		$collector->expects( $this->any() )
@@ -116,7 +116,7 @@ class CoreMockObjectRepository extends \PHPUnit\Framework\TestCase implements Mo
 		$methods = $this->builder->getInvokedMethods();
 
 		$dependencyObject = $this->getMockBuilder( 'SMW\DependencyObject' )
-			->setMethods( $methods )
+			->onlyMethods( $methods )
 			->getMock();
 
 		foreach ( $methods as $method ) {
@@ -139,7 +139,7 @@ class CoreMockObjectRepository extends \PHPUnit\Framework\TestCase implements Mo
 		$methods = $this->builder->getInvokedMethods();
 
 		$dependencyObject = $this->getMockBuilder( 'SMW\NullDependencyContainer' )
-			->setMethods( $methods )
+			->onlyMethods( $methods )
 			->getMock();
 
 		foreach ( $methods as $method ) {
@@ -412,7 +412,7 @@ class CoreMockObjectRepository extends \PHPUnit\Framework\TestCase implements Mo
 
 		$idTable = $this->getMockBuilder( 'stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getIdTable' ] )
+			->onlyMethods( [ 'getIdTable' ] )
 			->getMock();
 
 		$idTable->expects( $this->any() )
@@ -421,7 +421,7 @@ class CoreMockObjectRepository extends \PHPUnit\Framework\TestCase implements Mo
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( $methods )
+			->onlyMethods( $methods )
 			->getMock();
 
 		$store->expects( $this->any() )
@@ -507,7 +507,7 @@ class CoreMockObjectRepository extends \PHPUnit\Framework\TestCase implements Mo
 
 		$dataItem = $this->getMockBuilder( 'SMWDataItem' )
 			->disableOriginalConstructor()
-			->setMethods( $methods )
+			->onlyMethods( $methods )
 			->getMock();
 
 		foreach ( $methods as $method ) {
@@ -601,7 +601,7 @@ class CoreMockObjectRepository extends \PHPUnit\Framework\TestCase implements Mo
 		$methods = array_unique( array_merge( $requiredAbstractMethods, $this->builder->getInvokedMethods() ) );
 
 		$queryDescription = $this->getMockBuilder( '\SMWDescription' )
-			->setMethods( $methods )
+			->onlyMethods( $methods )
 			->getMock();
 
 		foreach ( $methods as $method ) {

--- a/tests/phpunit/Utils/Mock/IteratorMockBuilder.php
+++ b/tests/phpunit/Utils/Mock/IteratorMockBuilder.php
@@ -81,7 +81,7 @@ class IteratorMockBuilder extends \PHPUnit\Framework\TestCase {
 	public function getMockForIterator() {
 		$instance = $this->getMockBuilder( $this->iteratorClass )
 			->disableOriginalConstructor()
-			->setMethods( $this->methods )
+			->onlyMethods( $this->methods )
 			->getMock();
 
 		if ( !$instance instanceof \Iterator ) {

--- a/tests/phpunit/Utils/Mock/MediaWikiMockObjectRepository.php
+++ b/tests/phpunit/Utils/Mock/MediaWikiMockObjectRepository.php
@@ -401,7 +401,7 @@ class MediaWikiMockObjectRepository extends \PHPUnit\Framework\TestCase implemen
 
 		$database = $this->getMockBuilder( '\Wikimedia\Rdbms\Database' )
 			->disableOriginalConstructor()
-			->setMethods( $methods )
+			->onlyMethods( $methods )
 			->getMock();
 
 		foreach ( $this->builder->getInvokedMethods() as $method ) {
@@ -454,7 +454,7 @@ class MediaWikiMockObjectRepository extends \PHPUnit\Framework\TestCase implemen
 
 		$contentHandler = $this->getMockBuilder( 'ContentHandler' )
 			->disableOriginalConstructor()
-			->setMethods( $methods )
+			->onlyMethods( $methods )
 			->getMock();
 
 		foreach ( $methods as $method ) {

--- a/tests/phpunit/includes/DataValues/RecordValueTest.php
+++ b/tests/phpunit/includes/DataValues/RecordValueTest.php
@@ -58,7 +58,7 @@ class RecordValueTest extends \PHPUnit\Framework\TestCase {
 
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
+			->onlyMethods( [ 'getRedirectTarget' ] )
 			->getMockForAbstractClass();
 
 		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
@@ -90,7 +90,7 @@ class RecordValueTest extends \PHPUnit\Framework\TestCase {
 	public function testParseValue() {
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
+			->onlyMethods( [ 'getRedirectTarget' ] )
 			->getMockForAbstractClass();
 
 		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
@@ -140,7 +140,7 @@ class RecordValueTest extends \PHPUnit\Framework\TestCase {
 	public function testParseValueWithErroredDv() {
 		$store = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
+			->onlyMethods( [ 'getRedirectTarget' ] )
 			->getMockForAbstractClass();
 
 		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )

--- a/tests/phpunit/includes/querypages/QueryPageTest.php
+++ b/tests/phpunit/includes/querypages/QueryPageTest.php
@@ -31,7 +31,7 @@ class QueryPageTest extends \PHPUnit\Framework\TestCase {
 	 */
 	private function newInstance( $search = '' ) {
 		$queryPage = $this->getMockBuilder( '\SMW\QueryPage' )
-			->setMethods( [ 'getResults', 'formatResult' ] )
+			->onlyMethods( [ 'getResults', 'formatResult' ] )
 			->getMock();
 
 		$context = $this->newContext( [ 'property' => $search ] );

--- a/tests/phpunit/includes/storage/StoreTest.php
+++ b/tests/phpunit/includes/storage/StoreTest.php
@@ -203,7 +203,7 @@ class StoreTest extends SMWIntegrationTestCase {
 
 		$instance = $this->getMockBuilder( '\SMW\Store' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getPropertyValues' ] )
+			->onlyMethods( [ 'getPropertyValues' ] )
 			->getMockForAbstractClass();
 
 		$instance->expects( $this->once() )


### PR DESCRIPTION
* MediaWiki.PHPUnit.MockBoilerplate.returnValue
* MediaWiki.PHPUnit.MockBoilerplate.ConstraintEqualTo
* MediaWiki.PHPUnit.MockBoilerplate.onConsecutiveCalls
* MediaWiki.PHPUnit.MockBoilerplate.returnArgument
* MediaWiki.PHPUnit.DeprecatedPHPUnitMethods.AssertInternalTypeLiteral
* MediaWiki.PHPUnit.AssertionOrder.WrongOrder
* MediaWiki.PHPUnit.SetMethods.SetMethods
* MediaWiki.PHPUnit.AssertEquals.Int
* MediaWiki.PHPUnit.MockBoilerplate.returnCallback
* MediaWiki.PHPUnit.AssertEquals.False
* MediaWiki.PHPUnit.AssertEquals.Null
* MediaWiki.PHPUnit.AssertEquals.FalsyString
* MediaWiki.PHPUnit.AssertEquals.True
* MediaWiki.PHPUnit.MockBoilerplate.throwException
* MediaWiki.PHPUnit.MockBoilerplate.returnSelf
* MediaWiki.PHPUnit.AssertEquals.IntegerString
* MediaWiki.PHPUnit.AssertEquals.NumericString
* MediaWiki.PHPUnit.SpecificAssertions.assertIsArray
* MediaWiki.PHPUnit.MockBoilerplate.returnValueMap
* MediaWiki.PHPUnit.MockBoilerplate.ExactlyOnce