### PR TITLE
Update actions/cache@v2 to actions/cache@v4

### DIFF
--- a/.github/workflows/tesa.yml
+++ b/.github/workflows/tesa.yml
@@ -29,7 +29,7 @@ jobs:
           coverage: pcov
 
       - name: Cache Composer cache
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: ~/.composer/cache
           key: composer-cache-php${{ matrix.php }}


### PR DESCRIPTION
> Your workflow is using a version of actions/cache that is scheduled for deprecation, actions/cache@v2. Please update your workflow to use either v3 or v4 of actions/cache

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the caching action in the GitHub Actions workflow for improved performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->