### PR TITLE
ResultPrinter: Fix "Passing null to parameter #1 ($string) of type string is deprecated"

### DIFF
--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -608,7 +608,7 @@ abstract class ResultPrinter implements IResultPrinter {
 	 * @return string
 	 */
 	protected function escapeText( $text, $outputmode ) {
-		return $outputmode == SMW_OUTPUT_HTML ? htmlspecialchars( $text ) : $text;
+		return $outputmode == SMW_OUTPUT_HTML ? htmlspecialchars( $text ?? '' ) : $text;
 	}
 
 	/**


### PR DESCRIPTION
> Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /var/www/html/extensions/SemanticResultFormats/extensions/SemanticMediaWiki/src/Query/ResultPrinters/ResultPrinter.php on line 611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of null values in text processing to prevent errors.
  
- **Refactor**
	- Enhanced the robustness of the text escaping method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->