### PR TITLE
Remove PHPUnitCheckRunnerTest from bootstrap

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,7 +18,6 @@ $autoloader->addPsr4( 'SMW\\Test\\', __DIR__ . '/phpunit' );
 $autoloader->addPsr4( 'SMW\\Tests\\', __DIR__ . '/phpunit' );
 
 $autoloader->addClassMap( [
-	'SMW\Tests\PHPUnitCheckRunnerTest'           => __DIR__ . '/phpunit/PHPUnitCheckRunnerTest.php',
 	'SMW\Tests\DataItemTest'                     => __DIR__ . '/phpunit/includes/dataitems/DataItemTest.php',
 	'SMW\Maintenance\rebuildConceptCache'        => __DIR__ . '/../maintenance/rebuildConceptCache.php',
 	'SMW\Maintenance\rebuildData'                => __DIR__ . '/../maintenance/rebuildData.php',


### PR DESCRIPTION
It's located in another directory so this was basically loading a non-existent file (or trying).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Removed class mapping for `PHPUnitCheckRunnerTest`, which may affect test loading during execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->