### PR TITLE
Fix "Use of MediaWiki\Config\ConfigFactory::getDefaultInstance was deprecated in MediaWiki 1.27"

### DIFF
--- a/tests/phpunit/Utils/Runners/XmlImportRunner.php
+++ b/tests/phpunit/Utils/Runners/XmlImportRunner.php
@@ -79,10 +79,7 @@ class XmlImportRunner {
 			throw new RuntimeException( 'Import returned with error(s) ' . serialize( $source->errors ) );
 		}
 
-		// WikiImporter::__construct without a Config instance was deprecated in MediaWiki 1.25.
-		if ( class_exists( '\ConfigFactory' ) ) {
-			$config = \ConfigFactory::getDefaultInstance()->makeConfig( 'main' );
-		}
+		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'main' );
 
 		$services = MediaWikiServices::getInstance();
 		$importer = new WikiImporter(


### PR DESCRIPTION
> Deprecated: Use of MediaWiki\Config\ConfigFactory::getDefaultInstance was deprecated in MediaWiki 1.27. [Called from SMW\Tests\Utils\Runners\XmlImportRunner::run in /var/www/html/extensions/SemanticMediaWiki/tests/phpunit/Utils/Runners/XmlImportRunner.php at line 84] in /var/www/html/includes/debug/MWDebug.php on line 379


This was removed in MW 1.43 with https://github.com/wikimedia/mediawiki/commit/6f808c3ac982ccecff0d6c63af3b41a501451cfc#diff-8c897af7e6d5851b7b61ee192d5d5a3fb5231640bf9d85b4a693ae355d758573L53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated configuration retrieval method in XML import runner to align with current MediaWiki framework standards
	- Removed deprecated configuration initialization approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->