### PR TITLE
InterwikiDBIntegrationTest: Fix "Deprecated: Creation of dynamic property"

### DIFF
--- a/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
+++ b/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
@@ -30,6 +30,8 @@ class InterwikiDBIntegrationTest extends SMWIntegrationTestCase {
 
 	private $queryResultValidator;
 	private $queryParser;
+	private $semanticDataFactory;
+	private $pageCreator;
 
 	protected function setUp(): void {
 		parent::setUp();


### PR DESCRIPTION
> Deprecated: Creation of dynamic property SMW\Tests\Integration\InterwikiDBIntegrationTest::$semanticDataFactory is deprecated in /var/www/html/extensions/SemanticMediaWiki/tests/phpunit/Integration/InterwikiDBIntegrationTest.php on line 39

> Deprecated: Creation of dynamic property SMW\Tests\Integration\InterwikiDBIntegrationTest::$pageCreator is deprecated in /var/www/html/extensions/SemanticMediaWiki/tests/phpunit/Integration/InterwikiDBIntegrationTest.php on line 42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced test infrastructure by adding new private properties for semantic data and page creation in the `InterwikiDBIntegrationTest` class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->