### PR TITLE
InterwikiDBIntegrationTest: Fix "Manipulating $wgHooks”

### DIFF
--- a/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
+++ b/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
@@ -52,22 +52,25 @@ class InterwikiDBIntegrationTest extends SMWIntegrationTestCase {
 			->invokeHooksFromRegistry();
 
 		// Manipulate the interwiki prefix on-the-fly
-		$GLOBALS['wgHooks']['InterwikiLoadPrefix'][] = function ( $prefix, &$interwiki ) {
-			if ( $prefix !== 'iw-test' ) {
-				return true;
+		MediaWikiServices::getInstance()->getHookContainer()->register(
+			'InterwikiLoadPrefix',
+			function ( $prefix, &$interwiki ) {
+				if ( $prefix !== 'iw-test' ) {
+					return true;
+				}
+
+				$interwiki = [
+					'iw_prefix' => 'iw-test',
+					'iw_url' => 'http://www.example.org/$1',
+					'iw_api' => false,
+					'iw_wikiid' => 'foo',
+					'iw_local' => true,
+					'iw_trans' => false,
+				];
+
+				return false;
 			}
-
-			$interwiki = [
-				'iw_prefix' => 'iw-test',
-				'iw_url' => 'http://www.example.org/$1',
-				'iw_api' => false,
-				'iw_wikiid' => 'foo',
-				'iw_local' => true,
-				'iw_trans' => false,
-			];
-
-			return false;
-		};
+		);
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
+++ b/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
@@ -70,7 +70,7 @@ class InterwikiDBIntegrationTest extends SMWIntegrationTestCase {
 	}
 
 	protected function tearDown(): void {
-		unset( $GLOBALS['wgHooks']['InterwikiLoadPrefix'] );
+		$this->clearHook( 'InterwikiLoadPrefix' );
 
 		parent::tearDown();
 	}

--- a/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
+++ b/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\Integration;
 
+use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\DIWikiPage;
 use SMW\SemanticData;
@@ -70,7 +71,7 @@ class InterwikiDBIntegrationTest extends SMWIntegrationTestCase {
 	}
 
 	protected function tearDown(): void {
-		$this->clearHook( 'InterwikiLoadPrefix' );
+		MediaWikiServices::getInstance()->getHookContainer()->clear( 'InterwikiLoadPrefix' );
 
 		parent::tearDown();
 	}


### PR DESCRIPTION
> Deprecated: Manipulating $wgHooks is deprecated, use HookContainer::clear() instead. [Called from SMW\Tests\Integration\InterwikiDBIntegrationTest::tearDown in /var/www/html/extensions/SemanticMediaWiki/tests/phpunit/Integration/InterwikiDBIntegrationTest.php at line 71] in /var/www/html/includes/debug/MWDebug.php on line 379
> Deprecated: Accessing $wgHooks directly is deprecated, use HookContainer::getHandlers() or HookContainer::register() instead. [Called from SMW\Tests\Integration\InterwikiDBIntegrationTest::setUp in /var/www/html/extensions/SemanticMediaWiki/tests/phpunit/Integration/InterwikiDBIntegrationTest.php at line 52] in /var/www/html/includes/debug/MWDebug.php on line 379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated the `tearDown` method in the `InterwikiDBIntegrationTest` class to enhance hook management during test cleanup.
	- Improved hook registration process in the `setUp` method for better encapsulation within the MediaWiki services framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->