### PR TITLE
InterwikiDBIntegrationTest: Fix "Accessing $wgHooks directly is deprecated, use HookContainer::getHandlers() or HookContainer::register() instead"

### DIFF
--- a/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
+++ b/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
@@ -51,7 +51,8 @@ class InterwikiDBIntegrationTest extends SMWIntegrationTestCase {
 			->invokeHooksFromRegistry();
 
 		// Manipulate the interwiki prefix on-the-fly
-		$GLOBALS['wgHooks']['InterwikiLoadPrefix'][] = function ( $prefix, &$interwiki ) {
+
+		$this->setTemporaryHook( 'InterwikiLoadPrefix', function ( $prefix, &$interwiki ) {
 			if ( $prefix !== 'iw-test' ) {
 				return true;
 			}
@@ -66,7 +67,7 @@ class InterwikiDBIntegrationTest extends SMWIntegrationTestCase {
 			];
 
 			return false;
-		};
+		} );
 	}
 
 	protected function tearDown(): void {


### PR DESCRIPTION
> Deprecated: Accessing $wgHooks directly is deprecated, use HookContainer::getHandlers() or HookContainer::register() instead. [Called from SMW\Tests\Integration\InterwikiDBIntegrationTest::setUp in /var/www/html/extensions/SemanticMediaWiki/tests/phpunit/Integration/InterwikiDBIntegrationTest.php at line 52] in /var/www/html/includes/debug/MWDebug.php on line 379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated hook registration method in InterwikiDBIntegrationTest to improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->