### PR TITLE
Also test with PHP 8.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - mediawiki_version: '1.39'
-            php_version: 8.1
+            php_version: 8.0
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration to adjust PHP version for MediaWiki 1.39 from 8.1 to 8.0
	- Maintained existing CI/CD pipeline structure and test configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->