### PR TITLE
SMWIntegrationTestCase: Set use-normal-tables in overrideMwServices

### DIFF
--- a/tests/phpunit/SMWIntegrationTestCase.php
+++ b/tests/phpunit/SMWIntegrationTestCase.php
@@ -209,6 +209,13 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		return $testResult;
 	}
 
+	protected function overrideMwServices( $configOverrides = null, array $services = [] ) {
+		if ( $GLOBALS['wgDBtype'] == 'mysql' ) {
+			$this->setCliArg( 'use-normal-tables', true );
+		}
+		parent::overrideMwServices( $configOverrides, $services );
+	}
+
 	protected function getStore() {
 		return StoreFactory::getStore();
 	}


### PR DESCRIPTION
Found https://github.com/SemanticMediaWiki/SemanticTasks/blob/3ffd26beb69f3a573f844ccaa793d2ab7f7a70d4/tests/phpunit/Unit/SemanticTasksMailerTest.php#L35C1-L67C3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced integration test case with a new method to override MediaWiki services during testing
	- Improved test configuration handling, specifically for MySQL database environments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->