### PR TITLE
mediawiki: Fix support for MW 1.42 in 'WikiImporter'

### DIFF
--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -55,40 +55,8 @@ return [
 	 * @return callable
 	 */
 	'WikiImporter' => function ( $containerBuilder, \ImportSource $importSource ) {
-		$containerBuilder->registerExpectedReturnType( 'WikiImporter', '\WikiImporter' );
 		$services = MediaWikiServices::getInstance();
-
-		// MW 1.41 or lower
-		if ( version_compare( MW_VERSION, '1.42', '<' ) ) {
-			return new WikiImporter(
-				$importSource,
-				$containerBuilder->create( 'MainConfig' ),
-				$services->getHookContainer(),
-				$services->getContentLanguage(),
-				$services->getNamespaceInfo(),
-				$services->getTitleFactory(),
-				$services->getWikiPageFactory(),
-				$services->getWikiRevisionUploadImporter(),
-				$services->getPermissionManager(),
-				$services->getContentHandlerFactory(),
-				$services->getSlotRoleRegistry()
-			);
-		}
-
-		// MW 1.42+
-		return new WikiImporter(
-			$importSource,
-			RequestContext::getMain()->getAuthority(),
-			$containerBuilder->create( 'MainConfig' ),
-			$services->getHookContainer(),
-			$services->getContentLanguage(),
-			$services->getNamespaceInfo(),
-			$services->getTitleFactory(),
-			$services->getWikiPageFactory(),
-			$services->getWikiRevisionUploadImporter(),
-			$services->getContentHandlerFactory(),
-			$services->getSlotRoleRegistry()
-		);
+		return $services->getWikiImporterFactory->getWikiImporter( $importSource );
 	},
 
 	/**

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -56,7 +56,7 @@ return [
 	 */
 	'WikiImporter' => function ( $containerBuilder, \ImportSource $importSource ) {
 		$services = MediaWikiServices::getInstance();
-		return $services->getWikiImporterFactory->getWikiImporter(
+		return $services->getWikiImporterFactory()->getWikiImporter(
 			$importSource,
 			RequestContext::getMain()->getAuthority()
 		);

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -77,7 +77,7 @@ return [
 		// MW 1.42+
 		return new WikiImporter(
 			$importSource,
-			RequestContext::getMain()->getAuthority(),
+			\RequestContext::getMain()->getAuthority(),
 			$containerBuilder->create( 'MainConfig' ),
 			$services->getHookContainer(),
 			$services->getContentLanguage(),

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -8,7 +8,6 @@ use JobQueueGroup;
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\User\UserOptionsLookup;
-use RequestContext;
 use SMW\MediaWiki\FileRepoFinder;
 use SMW\MediaWiki\NamespaceInfo;
 use SMW\MediaWiki\PermissionManager;

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -8,6 +8,7 @@ use JobQueueGroup;
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\User\UserOptionsLookup;
+use RequestContext;
 use SMW\MediaWiki\FileRepoFinder;
 use SMW\MediaWiki\NamespaceInfo;
 use SMW\MediaWiki\PermissionManager;
@@ -55,7 +56,10 @@ return [
 	 */
 	'WikiImporter' => function ( $containerBuilder, \ImportSource $importSource ) {
 		$services = MediaWikiServices::getInstance();
-		return $services->getWikiImporterFactory->getWikiImporter( $importSource );
+		return $services->getWikiImporterFactory->getWikiImporter(
+			$importSource,
+			RequestContext::getMain()->getAuthority()
+		);
 	},
 
 	/**

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -8,6 +8,7 @@ use JobQueueGroup;
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\User\UserOptionsLookup;
+use RequestContext;
 use SMW\MediaWiki\FileRepoFinder;
 use SMW\MediaWiki\NamespaceInfo;
 use SMW\MediaWiki\PermissionManager;
@@ -77,7 +78,7 @@ return [
 		// MW 1.42+
 		return new WikiImporter(
 			$importSource,
-			\RequestContext::getMain()->getAuthority(),
+			RequestContext::getMain()->getAuthority(),
 			$containerBuilder->create( 'MainConfig' ),
 			$services->getHookContainer(),
 			$services->getContentLanguage(),

--- a/src/Services/mediawiki.php
+++ b/src/Services/mediawiki.php
@@ -56,8 +56,28 @@ return [
 	'WikiImporter' => function ( $containerBuilder, \ImportSource $importSource ) {
 		$containerBuilder->registerExpectedReturnType( 'WikiImporter', '\WikiImporter' );
 		$services = MediaWikiServices::getInstance();
+
+		// MW 1.41 or lower
+		if ( version_compare( MW_VERSION, '1.42', '<' ) ) {
+			return new WikiImporter(
+				$importSource,
+				$containerBuilder->create( 'MainConfig' ),
+				$services->getHookContainer(),
+				$services->getContentLanguage(),
+				$services->getNamespaceInfo(),
+				$services->getTitleFactory(),
+				$services->getWikiPageFactory(),
+				$services->getWikiRevisionUploadImporter(),
+				$services->getPermissionManager(),
+				$services->getContentHandlerFactory(),
+				$services->getSlotRoleRegistry()
+			);
+		}
+
+		// MW 1.42+
 		return new WikiImporter(
 			$importSource,
+			RequestContext::getMain()->getAuthority(),
 			$containerBuilder->create( 'MainConfig' ),
 			$services->getHookContainer(),
 			$services->getContentLanguage(),
@@ -65,7 +85,6 @@ return [
 			$services->getTitleFactory(),
 			$services->getWikiPageFactory(),
 			$services->getWikiRevisionUploadImporter(),
-			$services->getPermissionManager(),
 			$services->getContentHandlerFactory(),
 			$services->getSlotRoleRegistry()
 		);

--- a/tests/phpunit/Utils/Runners/XmlImportRunner.php
+++ b/tests/phpunit/Utils/Runners/XmlImportRunner.php
@@ -80,7 +80,7 @@ class XmlImportRunner {
 
 		$services = MediaWikiServices::getInstance();
 
-		$import = $services->getWikiImporterFactory()->getWikiImporter(
+		$importer = $services->getWikiImporterFactory()->getWikiImporter(
 			$source->value,
 			RequestContext::getMain()->getAuthority()
 		);

--- a/tests/phpunit/Utils/Runners/XmlImportRunner.php
+++ b/tests/phpunit/Utils/Runners/XmlImportRunner.php
@@ -80,7 +80,7 @@ class XmlImportRunner {
 
 		$services = MediaWikiServices::getInstance();
 
-		$import = $services->getWikiImporterFactory->getWikiImporter(
+		$import = $services->getWikiImporterFactory()->getWikiImporter(
 			$source->value,
 			RequestContext::getMain()->getAuthority()
 		);

--- a/tests/phpunit/Utils/Runners/XmlImportRunner.php
+++ b/tests/phpunit/Utils/Runners/XmlImportRunner.php
@@ -80,7 +80,10 @@ class XmlImportRunner {
 
 		$services = MediaWikiServices::getInstance();
 
-		$import = $services->getWikiImporterFactory->getWikiImporter( $source->value );
+		$import = $services->getWikiImporterFactory->getWikiImporter(
+			$source->value,
+			RequestContext::getMain()->getAuthority()
+		);
 		$importer->setDebug( $this->verbose );
 
 		$reporter = new ImportReporter(

--- a/tests/phpunit/Utils/Runners/XmlImportRunner.php
+++ b/tests/phpunit/Utils/Runners/XmlImportRunner.php
@@ -80,21 +80,39 @@ class XmlImportRunner {
 		}
 
 		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'main' );
-
 		$services = MediaWikiServices::getInstance();
-		$importer = new WikiImporter(
-			$source->value,
-			$config,
-			$services->getHookContainer(),
-			$services->getContentLanguage(),
-			$services->getNamespaceInfo(),
-			$services->getTitleFactory(),
-			$services->getWikiPageFactory(),
-			$services->getWikiRevisionUploadImporter(),
-			$services->getPermissionManager(),
-			$services->getContentHandlerFactory(),
-			$services->getSlotRoleRegistry()
-		);
+
+		// MW 1.41 or lower
+ 		if ( version_compare( MW_VERSION, '1.42', '<' ) ) {
+			$importer = new WikiImporter(
+				$source->value,
+				$config,
+				$services->getHookContainer(),
+				$services->getContentLanguage(),
+				$services->getNamespaceInfo(),
+				$services->getTitleFactory(),
+				$services->getWikiPageFactory(),
+				$services->getWikiRevisionUploadImporter(),
+				$services->getPermissionManager(),
+				$services->getContentHandlerFactory(),
+				$services->getSlotRoleRegistry()
+			);
+		} else {
+			// MW 1.42+
+			$importer = new WikiImporter(
+				$source->value,
+				\RequestContext::getMain()->getAuthority(),
+				$config,
+				$services->getHookContainer(),
+				$services->getContentLanguage(),
+				$services->getNamespaceInfo(),
+				$services->getTitleFactory(),
+				$services->getWikiPageFactory(),
+				$services->getWikiRevisionUploadImporter(),
+				$services->getContentHandlerFactory(),
+				$services->getSlotRoleRegistry()
+			);
+		}
 		$importer->setDebug( $this->verbose );
 
 		$reporter = new ImportReporter(

--- a/tests/phpunit/Utils/Runners/XmlImportRunner.php
+++ b/tests/phpunit/Utils/Runners/XmlImportRunner.php
@@ -69,7 +69,6 @@ class XmlImportRunner {
 	public function run() {
 		$this->unregisterUploadsource();
 		$start = microtime( true );
-		$config = null;
 
 		$source = ImportStreamSource::newFromFile(
 			$this->assertThatFileIsReadableOrThrowException( $this->file )
@@ -79,40 +78,9 @@ class XmlImportRunner {
 			throw new RuntimeException( 'Import returned with error(s) ' . serialize( $source->errors ) );
 		}
 
-		$config = MediaWikiServices::getInstance()->getConfigFactory()->makeConfig( 'main' );
 		$services = MediaWikiServices::getInstance();
 
-		// MW 1.41 or lower
-		if ( version_compare( MW_VERSION, '1.42', '<' ) ) {
-			$importer = new WikiImporter(
-				$source->value,
-				$config,
-				$services->getHookContainer(),
-				$services->getContentLanguage(),
-				$services->getNamespaceInfo(),
-				$services->getTitleFactory(),
-				$services->getWikiPageFactory(),
-				$services->getWikiRevisionUploadImporter(),
-				$services->getPermissionManager(),
-				$services->getContentHandlerFactory(),
-				$services->getSlotRoleRegistry()
-			);
-		} else {
-			// MW 1.42+
-			$importer = new WikiImporter(
-				$source->value,
-				RequestContext::getMain()->getAuthority(),
-				$config,
-				$services->getHookContainer(),
-				$services->getContentLanguage(),
-				$services->getNamespaceInfo(),
-				$services->getTitleFactory(),
-				$services->getWikiPageFactory(),
-				$services->getWikiRevisionUploadImporter(),
-				$services->getContentHandlerFactory(),
-				$services->getSlotRoleRegistry()
-			);
-		}
+		$import = $services->getWikiImporterFactory->getWikiImporter( $source->value );
 		$importer->setDebug( $this->verbose );
 
 		$reporter = new ImportReporter(

--- a/tests/phpunit/Utils/Runners/XmlImportRunner.php
+++ b/tests/phpunit/Utils/Runners/XmlImportRunner.php
@@ -101,7 +101,7 @@ class XmlImportRunner {
 			// MW 1.42+
 			$importer = new WikiImporter(
 				$source->value,
-				\RequestContext::getMain()->getAuthority(),
+				RequestContext::getMain()->getAuthority(),
 				$config,
 				$services->getHookContainer(),
 				$services->getContentLanguage(),

--- a/tests/phpunit/Utils/Runners/XmlImportRunner.php
+++ b/tests/phpunit/Utils/Runners/XmlImportRunner.php
@@ -83,7 +83,7 @@ class XmlImportRunner {
 		$services = MediaWikiServices::getInstance();
 
 		// MW 1.41 or lower
- 		if ( version_compare( MW_VERSION, '1.42', '<' ) ) {
+		if ( version_compare( MW_VERSION, '1.42', '<' ) ) {
 			$importer = new WikiImporter(
 				$source->value,
 				$config,


### PR DESCRIPTION
The constructor was changed with https://github.com/wikimedia/mediawiki/commit/64001f0ecd6ffdd8a639e4aed0289afc6bd1e539#diff-81ab53e2d79bfc77e91773c25ac399efeaa16486044dea310100d719b14b2cf9R26

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Compatibility**
	- Enhanced support for different MediaWiki versions by simplifying the `WikiImporter` service instantiation.
	- Updated method signatures to ensure compatibility across MediaWiki versions 1.42 and below.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->