### PR TITLE
Fix skipping tests on MW 1.41+

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0009.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0009.json
@@ -61,7 +61,7 @@
 	},
 	"meta": {
 		"skip-on": {
-			"mw-1.41.x": "Check connection provider, should be IProviderConnection for MW 1.41+."
+			"mediawiki": [ ">1.40", "Check connection provider, should be IProviderConnection for MW 1.41+." ]
 		},
 		"version": "2",
 		"is-incomplete": false,

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0017.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0017.json
@@ -73,7 +73,7 @@
 	},
 	"meta": {
 		"skip-on": {
-			"mw-1.41.x": "Check failing assertions for MW 1.41+."
+			"mediawiki": [ ">1.40", "Check failing assertions for MW 1.41+." ]
 		},
 		"version": "2",
 		"is-incomplete": false,


### PR DESCRIPTION
It was skipping it for MW 1.39 as well:

> MediaWiki 1.39.11 version is not supported (Check failing assertions for MW 1.41+.)