### PR TITLE
Fix skipping tests on MW 1.41+

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0009.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0009.json
@@ -61,7 +61,7 @@
 	},
 	"meta": {
 		"skip-on": {
-			"mw-1.40>": "Check connection provider, should be IProviderConnection for MW 1.41+."
+			">mw-1.40": "Check connection provider, should be IProviderConnection for MW 1.41+."
 		},
 		"version": "2",
 		"is-incomplete": false,

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0009.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0009.json
@@ -16,6 +16,9 @@
 			"type": "parser",
 			"about": "#0",
 			"subject": "Example/S0009/1",
+			"skip-on": {
+				"mediawiki": [ ">1.40", "Check connection provider, should be IProviderConnection for MW 1.41+." ]
+			},
 			"assert-store": {
 				"semantic-data": {
 					"strictPropertyValueMatch": false,
@@ -34,6 +37,9 @@
 		{
 			"type": "special",
 			"about": "#1 results matched by the SMWSearch extension",
+			"skip-on": {
+				"mediawiki": [ ">1.40", "Check connection provider, should be IProviderConnection for MW 1.41+." ]
+			},
 			"special-page": {
 				"page": "Search",
 				"query-parameters": "",
@@ -60,9 +66,6 @@
 		}
 	},
 	"meta": {
-		"skip-on": {
-			">mw-1.40": "Check connection provider, should be IProviderConnection for MW 1.41+."
-		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0009.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0009.json
@@ -61,7 +61,7 @@
 	},
 	"meta": {
 		"skip-on": {
-			"mediawiki": [ ">1.40", "Check connection provider, should be IProviderConnection for MW 1.41+." ]
+			"mw-1.40>": "Check connection provider, should be IProviderConnection for MW 1.41+."
 		},
 		"version": "2",
 		"is-incomplete": false,

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0009.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0009.json
@@ -61,7 +61,7 @@
 	},
 	"meta": {
 		"skip-on": {
-			"mw-1.41.x": "Check connection provider, should be IProviderConnection for MW 1.41+."
+			"mediawiki": [ ">1.40", "Check connection provider, should be IProviderConnection for MW 1.41+." ]
 		},
 		"version": "2",
 		"is-incomplete": false,

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0017.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0017.json
@@ -73,7 +73,7 @@
 	},
 	"meta": {
 		"skip-on": {
-			"mw-1.41.x": "Check failing assertions for MW 1.41+."
+			"mediawiki": [ ">1.40", "Check failing assertions for MW 1.41+." ]
 		},
 		"version": "2",
 		"is-incomplete": false,

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0017.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0017.json
@@ -73,7 +73,7 @@
 	},
 	"meta": {
 		"skip-on": {
-			"mw-1.40>": "Check failing assertions for MW 1.41+."
+			">mw-1.40": "Check failing assertions for MW 1.41+."
 		},
 		"version": "2",
 		"is-incomplete": false,

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0017.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0017.json
@@ -16,6 +16,9 @@
 		{
 			"type": "special",
 			"about": "#0",
+			"skip-on": {
+				"mediawiki": [ ">1.40", "Check failing assertions for MW 1.41+." ]
+			},
 			"special-page": {
 				"page": "Types",
 				"query-parameters": "",
@@ -31,6 +34,9 @@
 		{
 			"type": "special",
 			"about": "#1 (Monolingual text)",
+			"skip-on": {
+				"mediawiki": [ ">1.40", "Check failing assertions for MW 1.41+." ]
+			},
 			"special-page": {
 				"page": "Types",
 				"query-parameters": "Monolingual text",
@@ -46,6 +52,9 @@
 		{
 			"type": "special",
 			"about": "#2 (Foobar, unknown)",
+			"skip-on": {
+				"mediawiki": [ ">1.40", "Check failing assertions for MW 1.41+." ]
+			},
 			"special-page": {
 				"page": "Types",
 				"query-parameters": "Foobar",
@@ -72,9 +81,6 @@
 		}
 	},
 	"meta": {
-		"skip-on": {
-			">mw-1.40": "Check failing assertions for MW 1.41+."
-		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0017.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0017.json
@@ -73,7 +73,7 @@
 	},
 	"meta": {
 		"skip-on": {
-			"mediawiki": [ ">1.40", "Check failing assertions for MW 1.41+." ]
+			"mw-1.40>": "Check failing assertions for MW 1.41+."
 		},
 		"version": "2",
 		"is-incomplete": false,


### PR DESCRIPTION
It was skipping it for MW 1.39 as well:

> MediaWiki 1.39.11 version is not supported (Check failing assertions for MW 1.41+.)