### PR TITLE
Add @codeCoverageIgnore* to maintenance scripts

### DIFF
--- a/maintenance/disposeOutdatedEntities.php
+++ b/maintenance/disposeOutdatedEntities.php
@@ -13,11 +13,13 @@ use Title;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -146,5 +148,7 @@ class disposeOutdatedEntities extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = disposeOutdatedEntities::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/dumpRDF.php
+++ b/maintenance/dumpRDF.php
@@ -11,11 +11,13 @@ use Onoi\MessageReporter\CallbackMessageReporter;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * Usage:
@@ -217,6 +219,7 @@ class dumpRDF extends \Maintenance {
 	}
 
 }
-
+// @codeCoverageIgnoreStart
 $maintClass = dumpRDF::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/populateHashField.php
+++ b/maintenance/populateHashField.php
@@ -15,11 +15,13 @@ use SMW\Utils\CliMsgFormatter;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -285,5 +287,7 @@ class populateHashField extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = populateHashField::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/purgeEntityCache.php
+++ b/maintenance/purgeEntityCache.php
@@ -15,11 +15,13 @@ use SMW\Exception\PredefinedPropertyLabelMismatchException;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -234,5 +236,7 @@ class purgeEntityCache extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = purgeEntityCache::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/rebuildConceptCache.php
+++ b/maintenance/rebuildConceptCache.php
@@ -9,11 +9,13 @@ use SMW\Utils\CliMsgFormatter;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * Manage concept caches
@@ -215,5 +217,7 @@ class rebuildConceptCache extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = rebuildConceptCache::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -13,11 +13,13 @@ use InvalidArgumentException;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * Recreates all the semantic data in the database, by cycling through all


### PR DESCRIPTION
Code coverage fails on this so we use @codeCoverageIgnoreStart/End for these parts. MediaWiki does this to its maintenance scripts as well.