### PR TITLE
Add @codeCoverageIgnore* to maintenance scripts

### DIFF
--- a/maintenance/disposeOutdatedEntities.php
+++ b/maintenance/disposeOutdatedEntities.php
@@ -13,11 +13,13 @@ use Title;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -146,5 +148,7 @@ class disposeOutdatedEntities extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = disposeOutdatedEntities::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/dumpRDF.php
+++ b/maintenance/dumpRDF.php
@@ -11,11 +11,13 @@ use Onoi\MessageReporter\CallbackMessageReporter;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * Usage:
@@ -218,5 +220,7 @@ class dumpRDF extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = dumpRDF::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/populateHashField.php
+++ b/maintenance/populateHashField.php
@@ -15,11 +15,13 @@ use SMW\Utils\CliMsgFormatter;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -285,5 +287,7 @@ class populateHashField extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = populateHashField::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/purgeEntityCache.php
+++ b/maintenance/purgeEntityCache.php
@@ -15,11 +15,13 @@ use SMW\Exception\PredefinedPropertyLabelMismatchException;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -234,5 +236,7 @@ class purgeEntityCache extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = purgeEntityCache::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/rebuildConceptCache.php
+++ b/maintenance/rebuildConceptCache.php
@@ -9,11 +9,13 @@ use SMW\Utils\CliMsgFormatter;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * Manage concept caches
@@ -215,5 +217,7 @@ class rebuildConceptCache extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = rebuildConceptCache::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -13,11 +13,13 @@ use InvalidArgumentException;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * Recreates all the semantic data in the database, by cycling through all
@@ -286,6 +288,7 @@ class rebuildData extends \Maintenance {
 	}
 
 }
-
+// @codeCoverageIgnoreStart
 $maintClass = rebuildData::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/rebuildElasticIndex.php
+++ b/maintenance/rebuildElasticIndex.php
@@ -13,11 +13,13 @@ use SMW\Utils\CliMsgFormatter;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -540,5 +542,7 @@ class rebuildElasticIndex extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = rebuildElasticIndex::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/rebuildElasticMissingDocuments.php
+++ b/maintenance/rebuildElasticMissingDocuments.php
@@ -19,11 +19,13 @@ use SMW\Elastic\Jobs\FileIngestJob;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -407,5 +409,7 @@ class rebuildElasticMissingDocuments extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = rebuildElasticMissingDocuments::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/rebuildFulltextSearchTable.php
+++ b/maintenance/rebuildFulltextSearchTable.php
@@ -13,11 +13,13 @@ use SMW\Utils\CliMsgFormatter;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -245,5 +247,7 @@ class rebuildFulltextSearchTable extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = rebuildFulltextSearchTable::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/rebuildPropertyStatistics.php
+++ b/maintenance/rebuildPropertyStatistics.php
@@ -8,11 +8,13 @@ use SMW\Setup;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * Maintenance script for rebuilding the property usage statistics.
@@ -94,5 +96,7 @@ class rebuildPropertyStatistics extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = rebuildPropertyStatistics::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/removeDuplicateEntities.php
+++ b/maintenance/removeDuplicateEntities.php
@@ -9,11 +9,13 @@ use SMW\Utils\CliMsgFormatter;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -145,5 +147,7 @@ class removeDuplicateEntities extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = removeDuplicateEntities::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/runImport.php
+++ b/maintenance/runImport.php
@@ -12,11 +12,13 @@ use SMW\Maintenance\MaintenanceCheck;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -126,5 +128,7 @@ class runImport extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = runImport::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/runLocalMessageCopy.php
+++ b/maintenance/runLocalMessageCopy.php
@@ -13,11 +13,13 @@ use SMW\Localizer\CopyLocalMessages;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -174,5 +176,7 @@ class runLocalMessageCopy extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = runLocalMessageCopy::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/setupStore.php
+++ b/maintenance/setupStore.php
@@ -15,11 +15,13 @@ use SMW\Utils\CliMsgFormatter;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * Sets up the storage backend currently selected in the "LocalSettings.php"
@@ -269,5 +271,7 @@ class setupStore extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = setupStore::class;
 require_once ( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/updateEntityCollation.php
+++ b/maintenance/updateEntityCollation.php
@@ -19,11 +19,13 @@ use SMW\Maintenance\MaintenanceCheck;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -293,5 +295,7 @@ class updateEntityCollation extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = updateEntityCollation::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/updateEntityCountMap.php
+++ b/maintenance/updateEntityCountMap.php
@@ -13,11 +13,13 @@ use SMW\Utils\CliMsgFormatter;
 /**
  * Load the required class
  */
+// @codeCoverageIgnoreStart
 if ( getenv( 'MW_INSTALL_PATH' ) !== false ) {
 	require_once getenv( 'MW_INSTALL_PATH' ) . '/maintenance/Maintenance.php';
 } else {
 	require_once __DIR__ . '/../../../maintenance/Maintenance.php';
 }
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -272,5 +274,7 @@ class updateEntityCountMap extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = updateEntityCountMap::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd

--- a/maintenance/updateQueryDependencies.php
+++ b/maintenance/updateQueryDependencies.php
@@ -12,7 +12,9 @@ use Title;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
+// @codeCoverageIgnoreStart
 require_once $basePath . '/maintenance/Maintenance.php';
+// @codeCoverageIgnoreEnd
 
 /**
  * @license GNU GPL v2+
@@ -179,5 +181,7 @@ class updateQueryDependencies extends \Maintenance {
 
 }
 
+// @codeCoverageIgnoreStart
 $maintClass = updateQueryDependencies::class;
 require_once( RUN_MAINTENANCE_IF_MAIN );
+// @codeCoverageIgnoreEnd


### PR DESCRIPTION
Code coverage fails on this so we use @codeCoverageIgnoreStart/End for these parts. MediaWiki does this to its maintenance scripts as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Maintenance Updates**
	- Added code coverage ignore annotations to multiple maintenance scripts
	- Improved code coverage management for maintenance classes
	- Updated class instantiation syntax in some maintenance scripts

- **Code Quality**
	- Refined code coverage handling for maintenance-related files
	- Standardized code coverage ignore blocks across multiple scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->