### PR TITLE
BrowseByProperty: Fix 'limit' api type

### DIFF
--- a/src/MediaWiki/Api/BrowseByProperty.php
+++ b/src/MediaWiki/Api/BrowseByProperty.php
@@ -123,7 +123,7 @@ class BrowseByProperty extends ApiBase {
 				ApiBase::PARAM_REQUIRED => false,
 			],
 			'limit' => [
-				ApiBase::PARAM_TYPE => 'string',
+				ApiBase::PARAM_TYPE => 'limit',
 				ApiBase::PARAM_ISMULTI => false,
 				ApiBase::PARAM_DFLT => 50,
 				ApiBase::PARAM_REQUIRED => false,


### PR DESCRIPTION
Use 'limit' over 'string' as it's failing under MW 1.43:

> MediaWiki\Api\ApiUsageException: Parameter "limit" accepts only a string value, but got 50