### PR TITLE
SMW_Infolink: Fix "explode(): Passing null to parameter #2 ($string) of type string is deprecated"

### DIFF
--- a/includes/SMW_Infolink.php
+++ b/includes/SMW_Infolink.php
@@ -563,7 +563,7 @@ class SMWInfolink {
 
 		if ( is_array( $titleParam ) ) {
 			return $titleParam;
-		} elseif ( $titleParam && $titleParam !== '' ) {
+		} elseif ( is_string( $titleParam ) && $titleParam !== '' ) {
 			// unescape $p; escaping scheme: all parameters rawurlencoded, "-" and "/" urlencoded, all "%" replaced by "-", parameters then joined with /
 			$ps = explode( '/', $titleParam ); // params separated by / here (compatible with wiki link syntax)
 

--- a/includes/SMW_Infolink.php
+++ b/includes/SMW_Infolink.php
@@ -563,7 +563,7 @@ class SMWInfolink {
 
 		if ( is_array( $titleParam ) ) {
 			return $titleParam;
-		} elseif ( $titleParam !== '' ) {
+		} elseif ( $titleParam && $titleParam !== '' ) {
 			// unescape $p; escaping scheme: all parameters rawurlencoded, "-" and "/" urlencoded, all "%" replaced by "-", parameters then joined with /
 			$ps = explode( '/', $titleParam ); // params separated by / here (compatible with wiki link syntax)
 


### PR DESCRIPTION
> PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in /srv/mediawiki/sanat.csc.fi/tags/2024-12-27_07:59:39/extensions/SemanticMediaWiki/includes/SMW_Infolink.php on line 568

Fixes #5924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced type safety in parameter decoding logic by ensuring the title parameter is a non-empty string before processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->