### PR TITLE
Fix "Indirect modification of overloaded property SMW\MediaWiki\Exception\ExtendedPermissionsError::$errors has no effect" on MW 1.43+

### DIFF
--- a/src/MediaWiki/Exception/ExtendedPermissionsError.php
+++ b/src/MediaWiki/Exception/ExtendedPermissionsError.php
@@ -27,14 +27,15 @@ class ExtendedPermissionsError extends PermissionsError {
 			foreach ( $this->status->getMessages() as $msg ) {
 				$this->errorArray[] = $msg->getKey();
 			}
-			
+
 			// Push SMW specific messages to appear first, PermissionsError will
 			// generate a list of required permissions
 			array_unshift( $this->errorArray, $errors );
 
-			$this->status->fatal( ...$this->errorArray );
+			$status = \MediaWiki\Permissions\PermissionStatus::newEmpty();
+			$status->fatal( ...$this->errorArray );
 
-			$this->status = $this->status;
+			$this->status = $status;
 		} else {
 			// Push SMW specific messages to appear first, PermissionsError will
 			// generate a list of required permissions

--- a/src/MediaWiki/Exception/ExtendedPermissionsError.php
+++ b/src/MediaWiki/Exception/ExtendedPermissionsError.php
@@ -33,6 +33,8 @@ class ExtendedPermissionsError extends PermissionsError {
 			array_unshift( $this->errorArray, $errors );
 
 			$this->status->fatal( ...$this->errorArray );
+
+			$this->status = $this->status;
 		} else {
 			// Push SMW specific messages to appear first, PermissionsError will
 			// generate a list of required permissions

--- a/src/MediaWiki/Exception/ExtendedPermissionsError.php
+++ b/src/MediaWiki/Exception/ExtendedPermissionsError.php
@@ -12,6 +12,9 @@ use PermissionsError;
  */
 class ExtendedPermissionsError extends PermissionsError {
 
+	// Used on MW 1.43+
+	private array $errorArray = [];
+
 	/**
 	 * @since  2.5
 	 *
@@ -20,9 +23,20 @@ class ExtendedPermissionsError extends PermissionsError {
 	public function __construct( $permission, $errors = [] ) {
 		parent::__construct( $permission, [] );
 
-		// Push SMW specific messages to appear first, PermissionsError will
-		// generate a list of required permissions
-		array_unshift( $this->errors, $errors );
-	}
+		if ( version_compare( MW_VERSION, '1.43', '>=' ) ) {
+			foreach ( $this->status->getMessages() as $msg ) {
+				$this->errorArray[] = $msg->getKey();
+			}
+			
+			// Push SMW specific messages to appear first, PermissionsError will
+			// generate a list of required permissions
+			array_unshift( $this->errorArray, $errors );
 
+			$this->status->fatal( ...$this->errorArray );
+		} else {
+			// Push SMW specific messages to appear first, PermissionsError will
+			// generate a list of required permissions
+			array_unshift( $this->errors, $errors );
+		}
+	}
 }


### PR DESCRIPTION
```
1) SMW\Tests\MediaWiki\Exception\ExtendedPermissionsErrorTest::testCanConstruct
Indirect modification of overloaded property SMW\MediaWiki\Exception\ExtendedPermissionsError::$errors has no effect

/var/www/html/extensions/SemanticMediaWiki/src/MediaWiki/Exception/ExtendedPermissionsError.php:25
/var/www/html/extensions/SemanticMediaWiki/tests/phpunit/MediaWiki/Exception/ExtendedPermissionsErrorTest.php:21
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling mechanism for permissions errors across different MediaWiki versions.
	- Enhanced error message management to ensure consistent reporting based on MediaWiki version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->