### PR TITLE
Issue 5932 - fix failing test Trying to configure method "getOption" which cannot be configured for MW 1.43

### DIFF
--- a/tests/phpunit/MediaWiki/Preference/PreferenceExaminerTest.php
+++ b/tests/phpunit/MediaWiki/Preference/PreferenceExaminerTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\MediaWiki\Preference;
 
+use MediaWiki\User\UserOptionsLookup;
 use SMW\MediaWiki\Preference\PreferenceExaminer;
 use SMW\Tests\PHPUnitCompat;
 
@@ -36,20 +37,20 @@ class PreferenceExaminerTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testHasPreferenceOf() {
-		$this->user->expects( $this->any() )
+		$userOptionsLookup = $this->createMock( UserOptionsLookup::class );
+	
+		$userOptionsLookup->expects( $this->any() )
 			->method( 'getOption' )
-			->with( 'foo' )
+			->with( $this->user, 'foo', false )
 			->willReturn( false );
-
-		$instance = new PreferenceExaminer();
-
-		$instance->setUser( $this->user );
-
+	
+		$instance = new PreferenceExaminer( $this->user, $userOptionsLookup );
+	
 		$this->assertIsBool(
-
 			$instance->hasPreferenceOf( 'foo' )
 		);
 	}
+
 
 	public function testHasPreferenceOf_NoUser() {
 		$instance = new PreferenceExaminer();

--- a/tests/phpunit/MediaWiki/Preference/PreferenceExaminerTest.php
+++ b/tests/phpunit/MediaWiki/Preference/PreferenceExaminerTest.php
@@ -38,19 +38,18 @@ class PreferenceExaminerTest extends \PHPUnit\Framework\TestCase {
 
 	public function testHasPreferenceOf() {
 		$userOptionsLookup = $this->createMock( UserOptionsLookup::class );
-	
+
 		$userOptionsLookup->expects( $this->any() )
 			->method( 'getOption' )
 			->with( $this->user, 'foo', false )
 			->willReturn( false );
-	
+
 		$instance = new PreferenceExaminer( $this->user, $userOptionsLookup );
-	
+
 		$this->assertIsBool(
 			$instance->hasPreferenceOf( 'foo' )
 		);
 	}
-
 
 	public function testHasPreferenceOf_NoUser() {
 		$instance = new PreferenceExaminer();


### PR DESCRIPTION
This PR is related to the issue #5932.

This PR contains:

- update `PreferenceExaminerTest.php`
- instead of `User->getOption()` which is deprecated and removed in MW 1.43 use `UserOptionsLookup->getOption()`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated `PreferenceExaminerTest` to improve testing of user preference functionality
	- Enhanced test method with new dependency `UserOptionsLookup`

- **Refactor**
	- Modified constructor of `PreferenceExaminer` to accept additional parameter for user options lookup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->