### PR TITLE
Issue 5934 - fix test errors Argument #1 ($url) must be of type string, null given for MW 1.43

### DIFF
--- a/tests/phpunit/MediaWiki/Search/SearchResultSetTest.php
+++ b/tests/phpunit/MediaWiki/Search/SearchResultSetTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\MediaWiki\Search;
 
 use SMW\MediaWiki\Search\SearchResultSet;
 use SMW\DIWikiPage;
+use Title;
 
 /**
  * @covers \SMW\MediaWiki\Search\SearchResultSet
@@ -166,13 +167,21 @@ class SearchResultSetTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testNewSearchSuggestionSet() {
-		$title = $this->getMockBuilder( '\Title' )
+		$title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$title->expects( $this->any() )
 			->method( 'exists' )
 			->willReturn( true );
+
+		$title->expects( $this->any() )
+			->method( 'getText' )
+			->willReturn( 'MockPageTitle' );
+
+		$title->expects( $this->any() )
+			->method( 'getFullURL' )
+			->willReturn( 'https://example.com/mock-page-title' );
 
 		$page = $this->getMockBuilder( '\SMW\DIWikiPage' )
 			->disableOriginalConstructor()
@@ -215,7 +224,7 @@ class SearchResultSetTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testNewSearchSuggestionSet_FilterSameTitle() {
-		$title = $this->getMockBuilder( '\Title' )
+		$title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -226,6 +235,14 @@ class SearchResultSetTest extends \PHPUnit\Framework\TestCase {
 		$title->expects( $this->any() )
 			->method( 'getPrefixedDBKey' )
 			->willReturn( 'Foo' );
+
+		$title->expects( $this->any() )
+			->method( 'getText' )
+			->willReturn( 'MockPageTitle' );
+
+		$title->expects( $this->any() )
+			->method( 'getFullURL' )
+			->willReturn( 'https://example.com/mock-page-title' );
 
 		$page_1 = $this->getMockBuilder( '\SMW\DIWikiPage' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
This PR is related to the issue #5934. 

This PR contains:

- updated `SearchResultSetTest.php` 
- mocked `Title` object to `getFullURL()` in the test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Improved test coverage for search functionality
	- Enhanced mock behavior for Title objects in search-related tests
	- Updated type references for more precise testing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->