### PR TITLE
Fix "Squiz.PHP.NonExecutableCode.Unreachable" phpcs

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -60,7 +60,6 @@
 		<exclude name="MediaWiki.Commenting.PropertyDocumentation.NotShortBoolVar" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.MissingParamName" />
 		<exclude name="MediaWiki.Commenting.PhpunitAnnotations.NotClass" />
-		<exclude name="Squiz.PHP.NonExecutableCode.Unreachable" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.NotShortIntParam" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.ParamNameNoMatch" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.NotShortIntReturn" />

--- a/includes/IdeAliases.php
+++ b/includes/IdeAliases.php
@@ -12,6 +12,8 @@
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 
+// phpcs:disable Squiz.PHP.NonExecutableCode.Unreachable
+
 throw new Exception( 'Not an actual source file' );
 
 class SMWDataItemException extends SMW\Exception\DataItemException {

--- a/src/DataValues/TemperatureValue.php
+++ b/src/DataValues/TemperatureValue.php
@@ -179,13 +179,10 @@ class TemperatureValue extends NumberValue {
 		switch ( $unit ) {
 			case 'K':
 				return $number;
-			break;
 			case '°C':
 				return $number + 273.15;
-			break;
 			case '°F':
 				return ( $number - 32 ) / 1.8 + 273.15;
-			break;
 			case '°R':
 				return ( $number ) / 1.8;
 		}
@@ -197,16 +194,12 @@ class TemperatureValue extends NumberValue {
 		switch ( $unit ) {
 			case 'K':
 				return $number;
-			break;
 			case '°C':
 				return $number - 273.15;
-			break;
 			case '°F':
 				return ( $number - 273.15 ) * 1.8 + 32;
-			break;
 			case '°R':
 				return ( $number ) * 1.8;
-			break;
 			// default: unit not supported
 		}
 

--- a/src/Exporter/ExporterFactory.php
+++ b/src/Exporter/ExporterFactory.php
@@ -57,11 +57,9 @@ class ExporterFactory {
 			case 'application/x-turtle':
 			case 'turtle':
 				return $this->newTurtleSerializer();
-				break;
 			case 'application/rdf+xml':
 			case 'rdfxml':
 				return $this->newRDFXMLSerializer();
-				break;
 		}
 
 		throw new InvalidArgumentException( "$type is not matchable to a registered serializer!" );

--- a/src/MediaWiki/Api/TaskFactory.php
+++ b/src/MediaWiki/Api/TaskFactory.php
@@ -85,25 +85,18 @@ class TaskFactory {
 		switch ( $type ) {
 			case 'update':
 				return new UpdateTask( $applicationFactory->newJobFactory() );
-				break;
 			case 'check-query':
 				return new CheckQueryTask( $applicationFactory->getStore() );
-				break;
 			case 'run-entity-examiner':
 				return $this->newEntityExaminerTask( $user );
-				break;
 			case 'duplicate-lookup':
 				return $this->newDuplicateLookupTask();
-				break;
 			case 'table-statistics':
 				return $this->newTableStatisticsTask();
-				break;
 			case 'insert-job':
 				return new InsertJobTask( $applicationFactory->newJobFactory() );
-				break;
 			case 'run-joblist':
 				return new JobListTask( $applicationFactory->getJobQueue() );
-				break;
 		}
 
 		if ( is_array( self::$services ) && isset( self::$services[$type] ) && is_callable( self::$services[$type] ) ) {

--- a/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilter.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilter.php
@@ -182,10 +182,8 @@ class ValueFilter {
 		switch ( $type ) {
 			case DataItem::TYPE_NUMBER:
 				return 'TYPE_NUMBER';
-				break;
 			default:
 				return '';
-				break;
 		}
 	}
 

--- a/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
+++ b/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
@@ -38,13 +38,11 @@ class FulltextSearchTableFactory {
 					$this->newTextSanitizer(),
 					$this->newSearchTable( $store )
 				);
-				break;
 			case 'sqlite':
 				return new SQLiteValueMatchConditionBuilder(
 					$this->newTextSanitizer(),
 					$this->newSearchTable( $store )
 				);
-				break;
 		}
 
 		return new ValueMatchConditionBuilder( $this->newTextSanitizer(), $this->newSearchTable( $store ) );

--- a/tests/phpunit/Benchmark/PageImportBenchmarkRunner.php
+++ b/tests/phpunit/Benchmark/PageImportBenchmarkRunner.php
@@ -88,7 +88,6 @@ class PageImportBenchmarkRunner implements BenchmarkReporter {
 		switch ( $ext ) {
 			case 'xml':
 				return $this->doXmlImport( $file, $case );
-				break;
 			default:
 				# code...
 				break;

--- a/tests/phpunit/MediaWiki/Jobs/FulltextSearchTableUpdateJobTest.php
+++ b/tests/phpunit/MediaWiki/Jobs/FulltextSearchTableUpdateJobTest.php
@@ -85,8 +85,6 @@ class FulltextSearchTableUpdateJobTest extends \PHPUnit\Framework\TestCase {
 				]
 			]
 		];
-
-		return $provider;
 	}
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Code Quality**
	- Removed unnecessary `break` statements in multiple PHP files to simplify control flow
	- Updated PHP CodeSniffer configuration to include checks for unreachable code

- **Tests**
	- Modified `FulltextSearchTableUpdateJobTest` parameter provider method

The changes primarily focus on code cleanup and improving code analysis standards across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->