### PR TITLE
Fix "Use of ImportReporter::__construct without $context was deprecated"

### DIFF
--- a/tests/phpunit/Utils/Runners/XmlImportRunner.php
+++ b/tests/phpunit/Utils/Runners/XmlImportRunner.php
@@ -85,14 +85,23 @@ class XmlImportRunner {
 		);
 		$importer->setDebug( $this->verbose );
 
-		$reporter = new ImportReporter(
-			$importer,
-			false,
-			'',
-			false
-		);
-
-		$reporter->setContext( $this->acquireRequestContext() );
+		if ( version_compare( MW_VERSION, '1.43', '>=' ) ) {
+			$reporter = new ImportReporter(
+				$importer,
+				false,
+				'',
+				false,
+				$this->acquireRequestContext()
+			);
+		} else {
+			$reporter = new ImportReporter(
+				$importer,
+				false,
+				'',
+				false
+			);
+			$reporter->setContext( $this->acquireRequestContext() );
+		}
 		$reporter->open();
 		$this->exception = false;
 

--- a/tests/phpunit/Utils/Runners/XmlImportRunner.php
+++ b/tests/phpunit/Utils/Runners/XmlImportRunner.php
@@ -85,7 +85,7 @@ class XmlImportRunner {
 		);
 		$importer->setDebug( $this->verbose );
 
-		if ( version_compare( MW_VERSION, '1.43', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
 			$reporter = new ImportReporter(
 				$importer,
 				false,


### PR DESCRIPTION
> Deprecated: Use of ImportReporter::__construct without $context was deprecated in MediaWiki 1.42. [Called from SMW\Tests\Utils\Runners\XmlImportRunner::run in /var/www/html/extensions/SemanticMediaWiki/tests/phpunit/Utils/Runners/XmlImportRunner.php at line 88] in /var/www/html/includes/debug/MWDebug.php on line 385