### PR TITLE
PropertyTableUpdater: Fix "Data truncated for column 'o_serialized' at row 1" errors

### DIFF
--- a/src/SQLStore/PropertyTableUpdater.php
+++ b/src/SQLStore/PropertyTableUpdater.php
@@ -7,6 +7,7 @@ use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
 use SMW\Parameters;
 use SMW\SQLStore\Exception\TableMissingIdFieldException;
 use SMW\Store;
+use Wikimedia\Rdbms\DBQueryError;
 
 /**
  * @private

--- a/src/SQLStore/PropertyTableUpdater.php
+++ b/src/SQLStore/PropertyTableUpdater.php
@@ -191,11 +191,16 @@ class PropertyTableUpdater {
 		$connection = $this->store->getConnection( 'mw.db' );
 		$tableName = $propertyTable->getName();
 
-		$connection->insert(
-			$tableName,
-			$rows,
-			__METHOD__ . "-$tableName"
-		);
+		// Due to https://github.com/wikimedia/mediawiki/commit/551ec29ea676cc73cd127b2f9cfc9bedcfc9fdc5
+		// we have to cap this in a try and catch to keep previous behaviour. This is for MW 1.42+.
+		try {
+			$connection->insert(
+				$tableName,
+				$rows,
+				__METHOD__ . "-$tableName"
+			);
+		} catch ( DBQueryError $e ) {
+		}
 	}
 
 	private function delete( PropertyTableDefinition $propertyTable, array $rows ) {


### PR DESCRIPTION
Due to https://github.com/wikimedia/mediawiki/commit/551ec29ea676cc73cd127b2f9cfc9bedcfc9fdc5 it now throws an error. It's to mimic behaviour for when mysql is in strict mode and is switched on for CI by default. Instead of switching this off for CI let's just put this in a try and catch.

This doesn't fix the truncation problem but it does bring back previous behaviour for MW 1.42+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced database insertion error handling to improve stability with MediaWiki version 1.42 and later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->