### PR TITLE
pull req to Replace deprecated wfGetDB

### DIFF
--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -488,7 +488,7 @@ class SMWExportController {
 	 *
 	 * @return \Wikimedia\Rdbms\IDatabase|\Wikimedia\Rdbms\IReadableDatabase
 	 */
-	public static function getDBHandle () {
+	public static function getDBHandle() {
 		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
 			return MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
 		} else {

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -483,14 +483,14 @@ class SMWExportController {
 	 */
 	protected function printAll( $ns_restriction, $delay, $delayeach ) {
 		$linkCache = MediaWikiServices::getInstance()->getLinkCache();
-		$db = wfGetDB( DB_REPLICA );
+		$dbr = MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
 
 		$this->delay_flush = 10;
 
 		$this->serializer->startSerialization();
 		$this->serializer->serializeExpData( $this->expDataFactory->newOntologyExpData( '' ) );
 
-		$end = $db->selectField( 'page', 'max(page_id)', false, __METHOD__ );
+		$end = $dbr->selectField( 'page', 'max(page_id)', false, __METHOD__ );
 		$a_count = 0; // DEBUG
 		$d_count = 0; // DEBUG
 		$delaycount = $delayeach;
@@ -550,7 +550,7 @@ class SMWExportController {
 	public function printPageList( $offset = 0, $limit = 30 ) {
 		global $smwgNamespacesWithSemanticLinks;
 
-		$db = wfGetDB( DB_REPLICA );
+		$dbr = MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
 		$this->prepareSerialization();
 		$this->delay_flush = 35; // don't do intermediate flushes with default parameters
 		$linkCache = MediaWikiServices::getInstance()->getLinkCache();
@@ -564,10 +564,10 @@ class SMWExportController {
 				if ( $query !== '' ) {
 					$query .= ' OR ';
 				}
-				$query .= 'page_namespace = ' . $db->addQuotes( $ns );
+				$query .= 'page_namespace = ' . $dbr->addQuotes( $ns );
 			}
 		}
-		$res = $db->select( $db->tableName( 'page' ),
+		$res = $dbr->select( $dbr->tableName( 'page' ),
 							'page_id,page_title,page_namespace', $query,
 							'SMW::RDF::PrintPageList', [ 'ORDER BY' => 'page_id ASC', 'OFFSET' => $offset, 'LIMIT' => $limit ] );
 		$foundpages = false;

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -489,7 +489,7 @@ class SMWExportController {
 	 * @return \Wikimedia\Rdbms\IDatabase|\Wikimedia\Rdbms\IReadableDatabase
 	 */
 	public static function getDBHandle() {
-		if ( version_compare( MW_VERSION, '1.40', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
 			return MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
 		} else {
 			return MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_REPLICA );

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -489,7 +489,7 @@ class SMWExportController {
 	 * @return \Wikimedia\Rdbms\IDatabase|\Wikimedia\Rdbms\IReadableDatabase
 	 */
 	public static function getDBHandle() {
-		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.40', '>=' ) ) {
 			return MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
 		} else {
 			return MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_REPLICA );


### PR DESCRIPTION
Use an instance of MediaWikiServices ConnectionProvider ReplicaDatabase (for reading)
Fixes Issue #5957

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Enhanced database connection handling for improved compatibility with MediaWiki versions.
	- Updated methods to utilize a new approach for retrieving database connections consistently. 
	- Introduced a new method for obtaining a database handle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->