### PR TITLE
Minor clean up to ext.smw.tooltip.styles

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -131,7 +131,7 @@ return [
 	// Critical CSS for ext.smw.tooltip
 	'ext.smw.tooltip.styles' => $moduleTemplate + [
 		'styles' => [
-			'smw/util/ext.smw.tooltip.css'
+			'smw/util/ext.smw.tooltip.less'
 		],
 		'position' => 'top',
 		'targets' => [ 'mobile', 'desktop' ]

--- a/res/smw/ext.smw.css
+++ b/res/smw/ext.smw.css
@@ -111,8 +111,7 @@
 	display:none;
 }
 
-span.smwbuiltin,
-span.smwttactiveinline span.smwbuiltin {
+span.smwbuiltin {
 	font-style: italic;
 }
 

--- a/res/smw/util/ext.smw.tooltip.less
+++ b/res/smw/util/ext.smw.tooltip.less
@@ -27,29 +27,6 @@
  * @author mwjames
  */
 
-/* Tooltips, style for content of the bubble */
-div.smwtt {
-	color: #000000;
-}
-
-/* Tooltips, colored anchors? */
-span.smwttactivepersist {
-	cursor: help;
-	color: #0000C8;
-}
-
-/* Tooltips, colored anchors */
-span.smwttactiveinline {
-	color: #BB7700;
-	text-decoration: none;
-}
-
-/* Tooltips, images for tooltip icons */
-img.smwttimg {
-	padding-right: 5px;
-	padding-left: 4px;
-}
-
 /* New tooltip icon defaults */
 .smwtticon {
 	padding: 12px 12px 0 0;

--- a/res/smw/util/ext.smw.tooltip.less
+++ b/res/smw/util/ext.smw.tooltip.less
@@ -32,19 +32,6 @@ div.smwtt {
 	color: #000000;
 }
 
-/* Tooltips, show persistent tooltips for non-JavaScript clients */
-span.smwttpersist span.smwttcontent {
-	color: #888888;
-	font-style: italic;
-	font-size: 90%;
-}
-
-/* Tooltips, hide inline tooltips for non-JavaScript clients */
-span.smwttinline span.smwttcontent {
-	display: none;
-	speak: none;
-}
-
 /* Tooltips, colored anchors? */
 span.smwttactivepersist {
 	cursor: help;
@@ -63,11 +50,6 @@ img.smwttimg {
 	padding-left: 4px;
 }
 
-/* New tooltip content is always hidden */
-.smwttcontent {
-	display: none;
-}
-
 /* New tooltip icon defaults */
 .smwtticon {
 	padding: 12px 12px 0 0;
@@ -79,37 +61,48 @@ img.smwttimg {
 	background-position: left bottom;
 	background-repeat: no-repeat;
 	background-size: 12px 12px;
+
+	h2 & {
+		vertical-align: 2px;
+	}
+
+	big & {
+		vertical-align: 0px;
+	}
+
+	/* New tooltip, Individual assigned icons ( inline-block is important because the icon <span> is empty) */
+	&.info {
+		background-image: url( ../assets/smw-icon-tooltip-info.png );
+	}
+
+	&.question {
+		background-image: url( ../assets/smw-icon-tooltip-question.png );
+	}
+
+	&.service {
+		background-image: url( ../assets/smw-icon-tooltip-question.png );
+	}
+
+	&.warning {
+		background-image: url( ../assets/smw-icon-tooltip-warning.png );
+	}
+
+	&.error {
+		background-image: url( ../assets/smw-icon-tooltip-error.png );
+	}
+
+	&.note {
+		background-image: url( ../assets/smw-icon-tooltip-question.png );
+	}
 }
 
-h2 .smwtticon {
-	vertical-align: 2px;
-}
+/* New tooltip content is always hidden */
+.smwttcontent {
+	display: none;
 
-big .smwtticon {
-	vertical-align: 0px;
-}
-
-/* New tooltip, Individual assigned icons ( inline-block is important because the icon <span> is empty) */
-.smwtticon.info {
-	background-image: url( ../assets/smw-icon-tooltip-info.png );
-}
-
-.smwtticon.question {
-	background-image: url( ../assets/smw-icon-tooltip-question.png );
-}
-
-.smwtticon.service {
-	background-image: url( ../assets/smw-icon-tooltip-question.png );
-}
-
-.smwtticon.warning {
-	background-image: url( ../assets/smw-icon-tooltip-warning.png );
-}
-
-.smwtticon.error {
-	background-image: url( ../assets/smw-icon-tooltip-error.png );
-}
-
-.smwtticon.note {
-	background-image: url( ../assets/smw-icon-tooltip-question.png );
+	/* Tooltips, hide inline tooltips for non-JavaScript clients */
+	span.smwttinline & {
+		display: none;
+		speak: none;
+	}
 }

--- a/res/smw/util/ext.smw.tooltip.less
+++ b/res/smw/util/ext.smw.tooltip.less
@@ -99,10 +99,4 @@ img.smwttimg {
 /* New tooltip content is always hidden */
 .smwttcontent {
 	display: none;
-
-	/* Tooltips, hide inline tooltips for non-JavaScript clients */
-	span.smwttinline & {
-		display: none;
-		speak: none;
-	}
 }

--- a/res/smw/util/ext.smw.tooltip.less
+++ b/res/smw/util/ext.smw.tooltip.less
@@ -45,11 +45,6 @@ span.smwttinline span.smwttcontent {
 	speak: none;
 }
 
-/* Tooltips, style for image anchor for persistent tooltips */
-span.smwtticon {
-	display: none;
-}
-
 /* Tooltips, colored anchors? */
 span.smwttactivepersist {
 	cursor: help;
@@ -70,7 +65,7 @@ img.smwttimg {
 
 /* New tooltip content is always hidden */
 .smwttcontent {
-	display:none;
+	display: none;
 }
 
 /* New tooltip icon defaults */


### PR DESCRIPTION
Adding some minor clean up with the fix for https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/5936

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated tooltip styling to use LESS preprocessing

- **Style Changes**
	- Restructured tooltip icon styles
	- Added new tooltip icon styles and variants
	- Removed specific styles for certain class combinations

- **Refactor**
	- Migrated from CSS to LESS file for tooltip styles
<!-- end of auto-generated comment: release notes by coderabbit.ai -->