### PR TITLE
DIUriHandler: Fix "Data truncated for column 'o_serialized' at row 1"  errors

### DIFF
--- a/src/SQLStore/EntityStore/DataItemHandlers/DIUriHandler.php
+++ b/src/SQLStore/EntityStore/DataItemHandlers/DIUriHandler.php
@@ -109,7 +109,7 @@ class DIUriHandler extends DataItemHandler {
 
 		return [
 			'o_blob' => $text,
-			'o_serialized' => $serialization,
+			'o_serialized' => substr( $serialization, 0, $this->getMaxLength() ),
 		];
 	}
 

--- a/src/SQLStore/EntityStore/DataItemHandlers/DIUriHandler.php
+++ b/src/SQLStore/EntityStore/DataItemHandlers/DIUriHandler.php
@@ -90,7 +90,8 @@ class DIUriHandler extends DataItemHandler {
 	 * {@inheritDoc}
 	 */
 	public function getWhereConds( DataItem $dataItem ) {
-		return [ 'o_serialized' => rawurldecode( $dataItem->getSerialization() ) ];
+		$serialization = rawurldecode( $dataItem->getSerialization() );
+		return [ 'o_serialized' => substr( $serialization, 0, $this->getMaxLength() ) ];
 	}
 
 	/**


### PR DESCRIPTION
Due to https://github.com/wikimedia/mediawiki/commit/551ec29ea676cc73cd127b2f9cfc9bedcfc9fdc5 it now throws an error. It's to mimic behaviour for when mysql is in strict mode and is switched on for CI by default.

Instead of relying on MySQL to do the truncation which in strict mode throws an error, we do the truncation software side.

This makes it a noop for installs without strict mode enabled. It fixes installs that have strict mode enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of serialized data by implementing length restrictions
	- Ensured data truncation to prevent potential database storage issues

<!-- end of auto-generated comment: release notes by coderabbit.ai -->