### PR TITLE
Database: Remove unnecessary checks

### DIFF
--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -755,7 +755,7 @@ class Database {
 	public function onTransactionResolution( callable $callback, $fname = __METHOD__ ) {
 		$connection = $this->connRef->getConnection( 'write' );
 
-		if ( method_exists( $connection, 'onTransactionResolution' ) && $connection->trxLevel() ) {
+		if ( $connection->trxLevel() ) {
 			$connection->onTransactionResolution( $callback, $fname );
 		}
 	}
@@ -767,13 +767,7 @@ class Database {
 	 */
 	public function onTransactionCommitOrIdle( callable $callback ) {
 		$connection = $this->connRef->getConnection( 'write' );
-
-		// https://gerrit.wikimedia.org/r/#/c/mediawiki/core/+/432036/
-		if ( method_exists( $connection, 'onTransactionCommitOrIdle' ) ) {
-			$connection->onTransactionCommitOrIdle( $callback );
-		} else {
-			$connection->onTransactionCommitOrIdle( $callback );
-		}
+		$connection->onTransactionCommitOrIdle( $callback );
 	}
 
 	/**
@@ -805,5 +799,4 @@ class Database {
 
 		return $text;
 	}
-
 }


### PR DESCRIPTION
We support MW 1.39+ so these checks are unnecessary, as the functions are in this release.

Not to mention a useless if/else calling the same thing.