### PR TITLE
EditInfo: Remove unnecessary check

### DIFF
--- a/src/MediaWiki/EditInfo.php
+++ b/src/MediaWiki/EditInfo.php
@@ -94,13 +94,7 @@ class EditInfo {
 			$content->getContentHandler()->getDefaultFormat()
 		);
 
-		// #3943
-		// https://github.com/wikimedia/mediawiki/commit/fdbb64f3546e6fda0ee0ce003467b4cfb13a090f
-		if ( method_exists( $prepareEdit, 'getOutput' ) ) {
-			$this->parserOutput = $prepareEdit->getOutput();
-		} else {
-			$this->parserOutput = isset( $prepareEdit->output ) ? $prepareEdit->output : null;
-		}
+		$this->parserOutput = $prepareEdit->getOutput();
 
 		return $this;
 	}

--- a/tests/phpunit/MediaWiki/EditInfoTest.php
+++ b/tests/phpunit/MediaWiki/EditInfoTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\MediaWiki;
 
+use MediaWiki\Edit\PreparedEdit;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRecord;
 use ParserOutput;
@@ -63,9 +64,13 @@ class EditInfoTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$editInfo = (object)[];
-		$editInfo->output = new ParserOutput();
-		$editInfo->output->setExtensionData( ParserData::DATA_ID, $semanticData );
+		$output = new ParserOutput();
+		$output->setExtensionData( ParserData::DATA_ID, $semanticData );
+
+		$editInfo = $this->createMock( PreparedEdit::class );
+		$editInfo->expects( $this->any() )
+			->method( 'getOutput' )
+			->willReturn( $output );
 
 		$wikiPage = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
@@ -121,8 +126,10 @@ class EditInfoTest extends \PHPUnit\Framework\TestCase {
 			  ->willReturn( true );
 
 		# 0 No parserOutput object
-		$editInfo = (object)[];
-		$editInfo->output = null;
+		$editInfo = $this->createMock( PreparedEdit::class );
+		$editInfo->expects( $this->any() )
+			->method( 'getOutput' )
+			->willReturn( null );
 
 		$wikiPage = $this->getMockBuilder( '\WikiPage' )
 			->setConstructorArgs( [ $title ] )
@@ -142,8 +149,12 @@ class EditInfoTest extends \PHPUnit\Framework\TestCase {
 			null
 		];
 
-		$editInfo = (object)[];
-		$editInfo->output = new ParserOutput();
+		$output = new ParserOutput();
+
+		$editInfo = $this->createMock( PreparedEdit::class );
+		$editInfo->expects( $this->any() )
+			->method( 'getOutput' )
+			->willReturn( $output );
 
 		$wikiPage = $this->getMockBuilder( '\WikiPage' )
 			->setConstructorArgs( [ $title ] )
@@ -160,27 +171,7 @@ class EditInfoTest extends \PHPUnit\Framework\TestCase {
 				'revision' => $this->newRevisionStub(),
 				'user' => $user
 			],
-			$editInfo->output
-		];
-
-		$editInfo = (object)[];
-
-		$wikiPage = $this->getMockBuilder( '\WikiPage' )
-			->setConstructorArgs( [ $title ] )
-			->getMock();
-
-		$wikiPage->expects( $this->any() )
-			->method( 'prepareContentForEdit' )
-			->willReturn( $editInfo );
-
-		$provider[] = [
-			[
-				'editInfo' => $editInfo,
-				'wikiPage' => $wikiPage,
-				'revision' => $this->newRevisionStub(),
-				'user' => $user
-			],
-			null
+			$editInfo->getOutput()
 		];
 
 		return $provider;
@@ -212,10 +203,6 @@ class EditInfoTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	private function newContentStub() {
-		if ( !class_exists( 'ContentHandler' ) ) {
-			return null;
-		}
-
 		$contentHandler = $this->getMockBuilder( '\ContentHandler' )
 			->disableOriginalConstructor()
 			->getMock();


### PR DESCRIPTION
We support MW 1.39+ now and this method is in all MW versions we support. Not to mention it was introduced in MW 1.34 which was ages ago.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Simplified logic in the EditInfo class for fetching edit information.
	- Streamlined code by removing conditional checks for method and property availability.
- **Tests**
	- Enhanced test structure by replacing anonymous objects with mocks of the PreparedEdit class.
	- Improved clarity and maintainability of tests related to fetching semantic data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->