### PR TITLE
Collator: Remove unnecessary check

### DIFF
--- a/src/MediaWiki/Collator.php
+++ b/src/MediaWiki/Collator.php
@@ -59,12 +59,7 @@ class Collator {
 
 		if ( !isset( self::$instance[$collationName] ) ) {
 			$services = MediaWikiServices::getInstance();
-			// BC for MW <= 1.36
-			if ( method_exists( $services, 'getCollationFactory' ) ) {
-				$collation = $services->getCollationFactory()->makeCollation( $collationName );
-			} else {
-				$collation = Collation::factory( $collationName );
-			}
+			$collation = $services->getCollationFactory()->makeCollation( $collationName );
 
 			self::$instance[$collationName] = new self( $collation, $collationName );
 		}


### PR DESCRIPTION
We support MW 1.39+.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Simplified the `Collator` class singleton method by removing backward compatibility checks for older MediaWiki versions.
	- Streamlined the process of obtaining a `Collation` instance by directly calling the `getCollationFactory()` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->