### PR TITLE
Add unit test

### DIFF
--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -488,7 +488,7 @@ class SMWExportController {
 	 *
 	 * @return \Wikimedia\Rdbms\IDatabase|\Wikimedia\Rdbms\IReadableDatabase
 	 */
-	public static function getDBHandle () {
+	public static function getDBHandle() {
 		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
 			return MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
 		} else {

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -483,14 +483,14 @@ class SMWExportController {
 	 */
 	protected function printAll( $ns_restriction, $delay, $delayeach ) {
 		$linkCache = MediaWikiServices::getInstance()->getLinkCache();
-		$db = wfGetDB( DB_REPLICA );
+		$dbr = MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
 
 		$this->delay_flush = 10;
 
 		$this->serializer->startSerialization();
 		$this->serializer->serializeExpData( $this->expDataFactory->newOntologyExpData( '' ) );
 
-		$end = $db->selectField( 'page', 'max(page_id)', false, __METHOD__ );
+		$end = $dbr->selectField( 'page', 'max(page_id)', false, __METHOD__ );
 		$a_count = 0; // DEBUG
 		$d_count = 0; // DEBUG
 		$delaycount = $delayeach;
@@ -550,7 +550,7 @@ class SMWExportController {
 	public function printPageList( $offset = 0, $limit = 30 ) {
 		global $smwgNamespacesWithSemanticLinks;
 
-		$db = wfGetDB( DB_REPLICA );
+		$dbr = MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
 		$this->prepareSerialization();
 		$this->delay_flush = 35; // don't do intermediate flushes with default parameters
 		$linkCache = MediaWikiServices::getInstance()->getLinkCache();
@@ -564,10 +564,10 @@ class SMWExportController {
 				if ( $query !== '' ) {
 					$query .= ' OR ';
 				}
-				$query .= 'page_namespace = ' . $db->addQuotes( $ns );
+				$query .= 'page_namespace = ' . $dbr->addQuotes( $ns );
 			}
 		}
-		$res = $db->select( $db->tableName( 'page' ),
+		$res = $dbr->select( $dbr->tableName( 'page' ),
 							'page_id,page_title,page_namespace', $query,
 							'SMW::RDF::PrintPageList', [ 'ORDER BY' => 'page_id ASC', 'OFFSET' => $offset, 'LIMIT' => $limit ] );
 		$foundpages = false;

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -489,7 +489,7 @@ class SMWExportController {
 	 * @return \Wikimedia\Rdbms\IDatabase|\Wikimedia\Rdbms\IReadableDatabase
 	 */
 	public static function getDBHandle() {
-		if ( version_compare( MW_VERSION, '1.40', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
 			return MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
 		} else {
 			return MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_REPLICA );

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -489,10 +489,14 @@ class SMWExportController {
 	 * @return \Wikimedia\Rdbms\IDatabase|\Wikimedia\Rdbms\IReadableDatabase
 	 */
 	public static function getDBHandle() {
-		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
-			return MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
-		} else {
-			return MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_REPLICA );
+		try {
+			if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
+				return MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
+			} else {
+				return MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_REPLICA );
+			}
+		} catch ( Exception $e ) {
+			throw new RuntimeException( 'Failed to obtain database handle: ' . $e->getMessage(), 0, $e );
 		}
 	}
 

--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -489,7 +489,7 @@ class SMWExportController {
 	 * @return \Wikimedia\Rdbms\IDatabase|\Wikimedia\Rdbms\IReadableDatabase
 	 */
 	public static function getDBHandle() {
-		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
+		if ( version_compare( MW_VERSION, '1.40', '>=' ) ) {
 			return MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
 		} else {
 			return MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_REPLICA );

--- a/tests/phpunit/Exporter/Controller/GetDBHandleTest.php
+++ b/tests/phpunit/Exporter/Controller/GetDBHandleTest.php
@@ -6,12 +6,13 @@ use MediaWiki\MediaWikiServices;
 use PHPUnit\Framework\TestCase;
 
 /**
+ * @group semantic-mediawiki
+ *
  * @license GPL-2.0-or-later
  * @since 5.0-alpha
  *
  * @author freephile
  */
-
 class GetDBHandleTest extends TestCase {
 
 	/**
@@ -19,6 +20,9 @@ class GetDBHandleTest extends TestCase {
 	 */
 	public function testGetDBHandle() {
 		$mwVersion = MW_VERSION;
+
+		// Store original instance for cleanup
+		$originalServices = MediaWikiServices::getInstance();
 
 		if ( version_compare( $mwVersion, '1.42', '>=' ) ) {
 			$connectionProvider = $this->createMock( \Wikimedia\Rdbms\ConnectionProvider::class );
@@ -31,10 +35,27 @@ class GetDBHandleTest extends TestCase {
 			MediaWikiServices::setInstanceForTesting( $mediaWikiServices );
 
 			$this->assertSame( $replicaDatabase, SMWExportController::getDBHandle() );
+
+			// Test error condition
+			$connectionProvider = $this->createMock( \Wikimedia\Rdbms\ConnectionProvider::class );
+			$connectionProvider->method( 'getReplicaDatabase' )
+				->willThrowException( new \RuntimeException( 'Connection failed' ) );
+
+			$mediaWikiServices = $this->createMock( MediaWikiServices::class );
+			$mediaWikiServices->method( 'getConnectionProvider' )
+				->willReturn( $connectionProvider );
+
+			MediaWikiServices::setInstanceForTesting( $mediaWikiServices );
+
+			$this->expectException( \RuntimeException::class );
+			SMWExportController::getDBHandle();
 		} else {
 			$dbLoadBalancer = $this->createMock( \Wikimedia\Rdbms\LoadBalancer::class );
 			$replicaDatabase = $this->createMock( \Wikimedia\Rdbms\IDatabase::class );
-			$dbLoadBalancer->method( 'getConnection' )->with( DB_REPLICA )->willReturn( $replicaDatabase );
+			$dbLoadBalancer->expects( $this->once() )
+				->method( 'getConnection' )
+				->with( DB_REPLICA )
+				->willReturn( $replicaDatabase );
 
 			$mediaWikiServices = $this->createMock( MediaWikiServices::class );
 			$mediaWikiServices->method( 'getDBLoadBalancer' )->willReturn( $dbLoadBalancer );
@@ -43,5 +64,8 @@ class GetDBHandleTest extends TestCase {
 
 			$this->assertSame( $replicaDatabase, SMWExportController::getDBHandle() );
 		}
+
+		// Cleanup
+		MediaWikiServices::setInstanceForTesting( $originalServices );
 	}
 }

--- a/tests/phpunit/Exporter/Controller/GetDBHandleTest.php
+++ b/tests/phpunit/Exporter/Controller/GetDBHandleTest.php
@@ -5,44 +5,43 @@ namespace SMW\Tests\Exporter\Controller;
 use MediaWiki\MediaWikiServices;
 use PHPUnit\Framework\TestCase;
 
-
 /**
- * @covers \SMW\Exporter\SMWExportController
- * @group semantic-mediawiki
- *
  * @license GPL-2.0-or-later
  * @since 5.0-alpha
  *
  * @author freephile
  */
 
-class SMW_ExportControllerTest extends TestCase {
+class GetDBHandleTest extends TestCase {
 
+	/**
+	 * @covers \SMW\Exporter\SMWExportController::getDBHandle
+	 */
 	public function testGetDBHandle() {
 		$mwVersion = MW_VERSION;
 
-		if (version_compare($mwVersion, '1.42', '>=')) {
-			$connectionProvider = $this->createMock(\Wikimedia\Rdbms\ConnectionProvider::class);
-			$replicaDatabase = $this->createMock(\Wikimedia\Rdbms\IDatabase::class);
-			$connectionProvider->method('getReplicaDatabase')->willReturn($replicaDatabase);
+		if ( version_compare( $mwVersion, '1.42', '>=' ) ) {
+			$connectionProvider = $this->createMock( \Wikimedia\Rdbms\ConnectionProvider::class );
+			$replicaDatabase = $this->createMock( \Wikimedia\Rdbms\IDatabase::class );
+			$connectionProvider->method( 'getReplicaDatabase' )->willReturn( $replicaDatabase );
 
-			$mediaWikiServices = $this->createMock(MediaWikiServices::class);
-			$mediaWikiServices->method('getConnectionProvider')->willReturn($connectionProvider);
+			$mediaWikiServices = $this->createMock( MediaWikiServices::class );
+			$mediaWikiServices->method( 'getConnectionProvider' )->willReturn( $connectionProvider );
 
-			MediaWikiServices::setInstanceForTesting($mediaWikiServices);
+			MediaWikiServices::setInstanceForTesting( $mediaWikiServices );
 
-			$this->assertSame($replicaDatabase, SMWExportController::getDBHandle());
+			$this->assertSame( $replicaDatabase, SMWExportController::getDBHandle() );
 		} else {
-			$dbLoadBalancer = $this->createMock(\Wikimedia\Rdbms\LoadBalancer::class);
-			$replicaDatabase = $this->createMock(\Wikimedia\Rdbms\IDatabase::class);
-			$dbLoadBalancer->method('getConnection')->with(DB_REPLICA)->willReturn($replicaDatabase);
+			$dbLoadBalancer = $this->createMock( \Wikimedia\Rdbms\LoadBalancer::class );
+			$replicaDatabase = $this->createMock( \Wikimedia\Rdbms\IDatabase::class );
+			$dbLoadBalancer->method( 'getConnection' )->with( DB_REPLICA )->willReturn( $replicaDatabase );
 
-			$mediaWikiServices = $this->createMock(MediaWikiServices::class);
-			$mediaWikiServices->method('getDBLoadBalancer')->willReturn($dbLoadBalancer);
+			$mediaWikiServices = $this->createMock( MediaWikiServices::class );
+			$mediaWikiServices->method( 'getDBLoadBalancer' )->willReturn( $dbLoadBalancer );
 
-			MediaWikiServices::setInstanceForTesting($mediaWikiServices);
+			MediaWikiServices::setInstanceForTesting( $mediaWikiServices );
 
-			$this->assertSame($replicaDatabase, SMWExportController::getDBHandle());
+			$this->assertSame( $replicaDatabase, SMWExportController::getDBHandle() );
 		}
 	}
 }

--- a/tests/phpunit/Exporter/Controller/GetDBHandleTest.php
+++ b/tests/phpunit/Exporter/Controller/GetDBHandleTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SMW\Tests\Exporter\Controller;
+
+use MediaWiki\MediaWikiServices;
+use PHPUnit\Framework\TestCase;
+
+
+/**
+ * @covers \SMW\Exporter\SMWExportController
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 5.0-alpha
+ *
+ * @author freephile
+ */
+
+class SMW_ExportControllerTest extends TestCase {
+
+	public function testGetDBHandle() {
+		$mwVersion = MW_VERSION;
+
+		if (version_compare($mwVersion, '1.42', '>=')) {
+			$connectionProvider = $this->createMock(\Wikimedia\Rdbms\ConnectionProvider::class);
+			$replicaDatabase = $this->createMock(\Wikimedia\Rdbms\IDatabase::class);
+			$connectionProvider->method('getReplicaDatabase')->willReturn($replicaDatabase);
+
+			$mediaWikiServices = $this->createMock(MediaWikiServices::class);
+			$mediaWikiServices->method('getConnectionProvider')->willReturn($connectionProvider);
+
+			MediaWikiServices::setInstanceForTesting($mediaWikiServices);
+
+			$this->assertSame($replicaDatabase, SMWExportController::getDBHandle());
+		} else {
+			$dbLoadBalancer = $this->createMock(\Wikimedia\Rdbms\LoadBalancer::class);
+			$replicaDatabase = $this->createMock(\Wikimedia\Rdbms\IDatabase::class);
+			$dbLoadBalancer->method('getConnection')->with(DB_REPLICA)->willReturn($replicaDatabase);
+
+			$mediaWikiServices = $this->createMock(MediaWikiServices::class);
+			$mediaWikiServices->method('getDBLoadBalancer')->willReturn($dbLoadBalancer);
+
+			MediaWikiServices::setInstanceForTesting($mediaWikiServices);
+
+			$this->assertSame($replicaDatabase, SMWExportController::getDBHandle());
+		}
+	}
+}


### PR DESCRIPTION
I added a unit test for SMWExportController::getDBHandle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new method for handling database connections across different MediaWiki versions.
	- Enhanced database interaction logic in the export controller.

- **Tests**
	- Added comprehensive unit tests for the new database connection method.

- **Refactor**
	- Updated database connection retrieval to be more version-aware and flexible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->