### PR TITLE
FeedExportPrinter: Fix "Optional parameter $title declared before required parameter $text"

### DIFF
--- a/src/Query/ResultPrinters/FeedExportPrinter.php
+++ b/src/Query/ResultPrinters/FeedExportPrinter.php
@@ -414,7 +414,7 @@ final class FeedExportPrinter extends ResultPrinter implements ExportPrinter {
 		return $feedItem;
 	}
 
-	private function parse( ?Title $title = null, $text ) {
+	private function parse( ?Title $title, $text ) {
 		if ( $title === null ) {
 			return $text;
 		}


### PR DESCRIPTION
This fixes the deprecated notice whilst keeping it a noop. A optional being before a required makes it required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated method signature in `FeedExportPrinter` class to require a title parameter
	- Removed optional default value for title in parsing method

<!-- end of auto-generated comment: release notes by coderabbit.ai -->