### PR TITLE
Fixes "InvalidArgumentException: No matchable hierarchy type, expected a property or category entity."

### DIFF
--- a/tests/phpunit/JSONScriptTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptTestCaseRunner.php
@@ -153,6 +153,11 @@ abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
 			Localizer::clear();
 			// #4682, Avoid any surprises when the `wgLanguageCode` is changed during a test
 			\SMW\NamespaceManager::clear();
+
+			// Fixes #5951.
+			MediaWikiServices::getInstance()->resetServiceForTesting( 'TitleParser' );
+			MediaWikiServices::getInstance()->resetServiceForTesting( '_MediaWikiTitleCodec' );
+
 			$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
 			$lang = $languageFactory->getLanguage( $val );
 

--- a/tests/phpunit/JSONScriptTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptTestCaseRunner.php
@@ -154,8 +154,7 @@ abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
 			// #4682, Avoid any surprises when the `wgLanguageCode` is changed during a test
 			\SMW\NamespaceManager::clear();
 
-			// Reset title-related services to prevent stale language objects
-			// that could cause InvalidArgumentException. See #5951.
+			// Reset title-related services to prevent stale language objects. See #5951.
 			$this->testEnvironment->resetMediaWikiService( 'TitleParser' );
 			$this->testEnvironment->resetMediaWikiService( '_MediaWikiTitleCodec' );
 

--- a/tests/phpunit/JSONScriptTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptTestCaseRunner.php
@@ -154,9 +154,10 @@ abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
 			// #4682, Avoid any surprises when the `wgLanguageCode` is changed during a test
 			\SMW\NamespaceManager::clear();
 
-			// Fixes #5951.
-			MediaWikiServices::getInstance()->resetServiceForTesting( 'TitleParser' );
-			MediaWikiServices::getInstance()->resetServiceForTesting( '_MediaWikiTitleCodec' );
+			// Reset title-related services to prevent stale language objects
+			// that could cause InvalidArgumentException. See #5951.
+			$this->testEnvironment->resetMediaWikiService( 'TitleParser' );
+			$this->testEnvironment->resetMediaWikiService( '_MediaWikiTitleCodec' );
 
 			$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
 			$lang = $languageFactory->getLanguage( $val );


### PR DESCRIPTION
This was due to services caching before we set / change ContentServices, and thus when using Title::newFromText it was using a stale language object deep down. Specifically in MediaWikiTitleCodec.

We fixed this by resetting TitleParser and _MediaWikiTitleCodec services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Enhanced test environment setup by adding service reset mechanisms for MediaWiki services during testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->