### PR TITLE
phpunit: override default bootstrap provided by core

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,7 +125,7 @@
 		"lint": "parallel-lint . --exclude vendor --exclude node_modules",
 		"phpcs": "phpcs -ps --cache -d memory_limit=2G",
 		"phpcs-fix": "phpcbf",
-		"phpunit": "php ${MW_INSTALL_PATH:-../..}/tests/phpunit/phpunit.php -c phpunit.xml.dist",
+		"phpunit": "php ${MW_INSTALL_PATH:-../..}/tests/phpunit/phpunit.php -c phpunit.xml.dist --bootstrap tests/bootstrap.php",
 		"phpunit:unit": "@phpunit --testsuite=semantic-mediawiki-unit",
 		"phpunit:integration": "@phpunit --testsuite semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure",
 		"phpunit-coverage": "@phpunit --testdox --coverage-text --coverage-html coverage/php --coverage-clover coverage/php/coverage.xml",


### PR DESCRIPTION
With [0] we can override bootstrap again. 

[0] https://gerrit.wikimedia.org/r/c/mediawiki/core/+/1110774

Fixes #5978

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated PHPUnit configuration to include a bootstrap file for test initialization
	- Improved test environment setup process

<!-- end of auto-generated comment: release notes by coderabbit.ai -->