### PR TITLE
Fix test p-0110.json

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0110.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0110.json
@@ -22,7 +22,7 @@
 			"subject": "Test/P0110/2",
 			"assert-output": {
 				"to-contain": [
-					"title=\"A unique_value_constraint constraint is assigned to the &quot;Has Url&quot; property which only permits unique value assignments and the .*http://example.org/Foo.* value annotation was already found to be annotated in the &quot;Test/P0110/1&quot; subject.\"",
+					"title=\"A unique_value_constraint constraint is assigned to the &quot;Has Url&quot; property which only permits unique value assignments and the \\(-\\{R\\|\\)?http://example.org/Foo\\(\\}-\\)? value annotation was already found to be annotated in the &quot;Test/P0110/1&quot; subject.\"",
 					"<span class=\"smwttcontent\">A &lt;code&gt;unique_value_constraint&lt;/code&gt; constraint is assigned to the \"<a href=.*>Has Url</a>\" property which only permits unique value assignments and the <i><a rel=\"nofollow\" class=\"external free\" href=\"http://example.org/Foo\">http://example.org/Foo</a></i> value annotation was already found to be annotated in the \"Test/P0110/1\" subject.</span>"
 				]
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0110.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0110.json
@@ -22,7 +22,7 @@
 			"subject": "Test/P0110/2",
 			"assert-output": {
 				"to-contain": [
-					"title=\"A unique_value_constraint constraint is assigned to the &quot;Has Url&quot; property which only permits unique value assignments and the (-\{R\|)?http://example.org/Foo(\}-)? value annotation was already found to be annotated in the &quot;Test/P0110/1&quot; subject.\"",
+					"title=\"A unique_value_constraint constraint is assigned to the &quot;Has Url&quot; property which only permits unique value assignments and the .*http://example.org/Foo.* value annotation was already found to be annotated in the &quot;Test/P0110/1&quot; subject.\"",
 					"<span class=\"smwttcontent\">A &lt;code&gt;unique_value_constraint&lt;/code&gt; constraint is assigned to the \"<a href=.*>Has Url</a>\" property which only permits unique value assignments and the <i><a rel=\"nofollow\" class=\"external free\" href=\"http://example.org/Foo\">http://example.org/Foo</a></i> value annotation was already found to be annotated in the \"Test/P0110/1\" subject.</span>"
 				]
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0110.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0110.json
@@ -22,7 +22,7 @@
 			"subject": "Test/P0110/2",
 			"assert-output": {
 				"to-contain": [
-					"title=\"A unique_value_constraint constraint is assigned to the &quot;Has Url&quot; property which only permits unique value assignments and the \\(-\\{R\\|\\)?http://example.org/Foo\\(\\}-\\)? value annotation was already found to be annotated in the &quot;Test/P0110/1&quot; subject.\"",
+					"title=\"A unique_value_constraint constraint is assigned to the &quot;Has Url&quot; property which only permits unique value assignments and the .*http://example.org/Foo.* value annotation was already found to be annotated in the &quot;Test/P0110/1&quot; subject.\"",
 					"<span class=\"smwttcontent\">A &lt;code&gt;unique_value_constraint&lt;/code&gt; constraint is assigned to the \"<a href=.*>Has Url</a>\" property which only permits unique value assignments and the <i><a rel=\"nofollow\" class=\"external free\" href=\"http://example.org/Foo\">http://example.org/Foo</a></i> value annotation was already found to be annotated in the \"Test/P0110/1\" subject.</span>"
 				]
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0110.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0110.json
@@ -22,7 +22,7 @@
 			"subject": "Test/P0110/2",
 			"assert-output": {
 				"to-contain": [
-					"title=\"A unique_value_constraint constraint is assigned to the &quot;Has Url&quot; property which only permits unique value assignments and the http://example.org/Foo value annotation was already found to be annotated in the &quot;Test/P0110/1&quot; subject.\"",
+					"title=\"A unique_value_constraint constraint is assigned to the &quot;Has Url&quot; property which only permits unique value assignments and the (-\{R\|)?http://example.org/Foo(\}-)? value annotation was already found to be annotated in the &quot;Test/P0110/1&quot; subject.\"",
 					"<span class=\"smwttcontent\">A &lt;code&gt;unique_value_constraint&lt;/code&gt; constraint is assigned to the \"<a href=.*>Has Url</a>\" property which only permits unique value assignments and the <i><a rel=\"nofollow\" class=\"external free\" href=\"http://example.org/Foo\">http://example.org/Foo</a></i> value annotation was already found to be annotated in the \"Test/P0110/1\" subject.</span>"
 				]
 			}


### PR DESCRIPTION
Fix 
2) SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest::testCaseFile with data set "p-0110.json" ('/var/www/html/extensions/Sema...0.json') Failed "#0 error tooltip, title does not include <a> elements"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
	- Updated a parser test case configuration to accommodate more flexible URL error message validation.
	- Modified error tooltip assertion for unique value constraint test to allow broader URL format variations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->