### PR TITLE
Fix test s-0011.json

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/s-0011.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/s-0011.json
@@ -78,9 +78,9 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<a rel=\"nofollow\" class=\"external free\" href=\"http://example.org/intro\">http://example.org/intro</a>",
+					"<a rel=\"nofollow\" class=\"external free\" href=\"http://example.org/intro\">.*http://example.org/intro.*</a>",
 					"<td class=\"smwtype_wpg\">Example/S0011/1</td>",
-					"<a rel=\"nofollow\" class=\"external free\" href=\"http://example.org/outro\">http://example.org/outro</a>"
+					"<a rel=\"nofollow\" class=\"external free\" href=\"http://example.org/outro\">.*http://example.org/outro.*</a>"
 				]
 			}
 		},


### PR DESCRIPTION
Fix 
10) SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest::testCaseFile with data set "s-0011.json" ('/var/www/html/extensions/Sema...1.json') Failed "#2 (parse URL in intro/outro)"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Updated test case assertions for `Special:Ask` functionality
	- Modified URL matching to use more flexible regex patterns
	- Minor formatting update (added newline at end of file)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->