### PR TITLE
Minor cleanups on tab styles

### DIFF
--- a/res/Resources.php
+++ b/res/Resources.php
@@ -33,7 +33,7 @@ return [
 			'smw/ext.smw.css',
 			'smw/ext.smw.dropdown.css',
 			'smw/ext.smw.table.css',
-			'smw/ext.smw.tabs.css',
+			'smw/ext.smw.tabs.less',
 			'smw/smw.indicators.css',
 			'smw/smw.jsonview.css'
 		],

--- a/res/smw/content/smw.schema.css
+++ b/res/smw/content/smw.schema.css
@@ -177,13 +177,12 @@ h3.smw-title {
 }
 
 .smw-schema input.nav-tab:checked + label.nav-label  {
-	border: 1px solid #ddd;
-	border-top: 2px solid #337ab7;
-	border-bottom: 1px solid #fff;
+	border-top-color: 2px solid #337ab7;
+	border-bottom-color: 1px solid #fff;
 }
 
 .smw-schema input.nav-tab:checked + label.nav-label.error-label {
-	border-top: 2px solid #cc0000;
+	border-top-color: #cc0000;
 }
 
 .skin-chameleon .content-no-highlight {

--- a/res/smw/ext.smw.page.css
+++ b/res/smw/ext.smw.page.css
@@ -388,16 +388,16 @@
 .smw-property input.nav-tab:checked + label.nav-label.smw-tab-warning,
 .smw-concept input.nav-tab:checked + label.nav-label.smw-tab-warning,
 .smw-types input.nav-tab:checked + label.nav-label.smw-tab-warning {
-    border-top: 2px solid rgb(204,0,0);
+    border-top-color: rgb( 204, 0, 0 );
 }
 
 .smw-property input.nav-tab:checked + label.nav-label.smw-tab-spec,
 .smw-concept input.nav-tab:checked + label.nav-label.smw-tab-spec {
-    border-top: 2px solid orange;
+    border-top-color: orange;
 }
 
 .smw-property input.nav-tab:checked + label#tab-label-smw-property-constraint.nav-label {
-	border-top: 2px solid #42c0fb;
+	border-top-color: #42c0fb;
 }
 
 /**

--- a/res/smw/ext.smw.tabs.less
+++ b/res/smw/ext.smw.tabs.less
@@ -26,97 +26,102 @@
  * @licence GNU GPL v2+
  * @author mwjames
  */
-.smw-tabs {
-	margin-top: 10px;
-	clear: both;
-}
 
-.smw-tabs section, .smw-tabs .subtab-content {
-	display: none;
-	padding: 0 0 0 0;
-	border-top: 1px solid #ddd;
-}
-
-.smw-tabs input.nav-tab {
-	display: none;
-}
-
-.smw-tabs label.nav-label {
-	display: inline-block;
-	margin: 0 0 -1px;
-	padding: 5px 25px;
-	font-weight: normal;
-	text-align: center;
-	color: #bbb;
-	border: 1px solid transparent;
-}
-
-.smw-tabs label.nav-label:before {
-	font-weight: normal;
-	margin-right: 10px;
-}
-
-.smw-tabs label.nav-label[for*='1']:before { content: ''; }
-.smw-tabs label.nav-label[for*='2']:before { content: ''; }
-.smw-tabs label.nav-label[for*='3']:before { content: ''; }
-.smw-tabs label.nav-label[for*='4']:before { content: ''; }
-
-.smw-tabs label.nav-label:hover {
-	color: #888;
-	cursor: pointer;
-}
-
-.smw-tabs input.nav-tab:checked + label.nav-label {
-	color: #24292e;
-	border: 1px solid #ddd;
-	border-top: 2px solid #337ab7;
-	border-bottom: 1px solid #fff;
-}
-
-.smw-tabs input.nav-tab:checked + label.nav-label.cached {
-    border-top: 2px solid orange;
-}
+@import 'tokens.less';
 
 .smw-tab-icon {
 	margin-left: -10px;
 	margin-right: 10px;
 }
 
-.smw-tabs label.nav-label .smw-tab-icon {
-	opacity: 0.5;
-}
+.smw-tabs {
+	margin-top: 10px;
+	clear: both;
 
-.smw-tabs label.nav-label:hover .smw-tab-icon {
-	opacity: 0.7;
-}
-
-.smw-tabs input.nav-tab:checked + label.nav-label .smw-tab-icon {
-	opacity: 1;
-}
-
-/**
- * Responsive settings
- */
-@media screen and (max-width: 800px) {
-	.smw-tabs {
+	@media ( max-width: @max-width-breakpoint-mobile ) {
 		display: flex;
 		flex-direction: column;
 	}
 
-	.smw-tabs label.nav-label {
-		text-align: unset;
+	section,
+	.subtab-content {
+		display: none;
+		padding: 0;
+		border-top: @border-base;
+	}
+
+	label.nav-label {
+		display: inline-block;
+		margin: 0 0 -1px;
 		padding: 5px 25px;
-		border-top: 1px solid;
+		font-weight: normal;
+		text-align: center;
+		color: @color-base;
+		border-block-width: 2px 1px;
+		border-inline-width: 1px;
+		border-style: solid;
+		border-color: transparent;
+
+		@media ( max-width: @max-width-breakpoint-mobile ) {
+			text-align: unset;
+			padding: 5px 25px;
+			border-top-color: @border-color-subtle;
+		}
+
+		.smw-tab-icon {
+			opacity: @opacity-icon-base;
+
+			@media ( max-width: @max-width-breakpoint-mobile ) {
+				margin-left: 0;
+			}
+		}
+
+		&::before {
+			margin-right: 10px;
+			font-weight: normal;
+		}
+
+		&[for*='1'],
+		&[for*='2'],
+		&[for*='3'],
+		&[for*='4'] {
+			&::before {
+				content: '';
+			}
+		}
+
+		&:hover {
+			color: @color-base--hover;
+			cursor: pointer;
+
+			.smw-tab-icon {
+				opacity: @opacity-icon-base--hover;
+			}
+		}
 	}
 
-	.smw-tabs label.nav-label .smw-tab-icon {
-		margin-left: 0px;
-	}
+	input.nav-tab {
+		display: none;
 
-	.smw-tabs input.nav-tab:checked + label.nav-label {
-		border-left: 0px !important;
-		border-right: 0px !important;
-		background-color: #f9f9f9a8;
+		&:checked + label.nav-label {
+			color: @color-emphasized;
+			border-top-color: @color-progressive;
+			border-inline-color: @border-color-base;
+			border-bottom-color: @background-color-base;
+
+			@media ( max-width: @max-width-breakpoint-mobile ) {
+				border-inline-color: transparent;
+				background-color: @background-color-progressive-subtle;
+			}
+
+			&.cached {
+				border-top-color: orange;
+			}
+
+			.smw-tab-icon {
+				opacity: @opacity-icon-base--selected;
+			}
+		}
 	}
 }
 
@@ -135,16 +140,16 @@
  * https://codepen.io/markcaron/pen/MvGRYV
  */
 .smw-tabset > input[type="radio"] {
-  position: absolute;
-  left: -200vw;
+	position: absolute;
+	left: -200vw;
 }
 
 .smw-tabset > input[type="checkbox"] {
-  display: none;
+	display: none;
 }
 
 .smw-tabset .tab-panel {
-  display: none;
+	display: none;
 }
 
 .smw-tabset > input:first-child:checked ~ .tab-panels > .tab-panel:first-child,
@@ -153,79 +158,79 @@
 .smw-tabset > input:nth-child(7):checked ~ .tab-panels > .tab-panel:nth-child(4),
 .smw-tabset > input:nth-child(9):checked ~ .tab-panels > .tab-panel:nth-child(5),
 .smw-tabset > input:nth-child(11):checked ~ .tab-panels > .tab-panel:nth-child(6) {
-  display: block;
+	display: block;
 }
 
 .smw-tabset > label {
-  position: relative;
-  display: inline-block;
-  padding: 15px 15px 25px;
-  border: 1px solid transparent;
-  border-bottom: 0;
-  cursor: pointer;
-  font-weight: 300;
-  color: #8d8d8d;
-  margin-bottom: 0px;
+	position: relative;
+	display: inline-block;
+	padding: 15px 15px 25px;
+	border: 1px solid transparent;
+	border-bottom: 0;
+	cursor: pointer;
+	font-weight: 300;
+	color: #8d8d8d;
+	margin-bottom: 0px;
 }
 
 .smw-tabset > label::after {
-  content: "";
-  position: absolute;
-  left: 15px;
-  bottom: 10px;
-  width: 22px;
-  height: 4px;
-  background: #8d8d8d;
+	content: "";
+	position: absolute;
+	left: 15px;
+	bottom: 10px;
+	width: 22px;
+	height: 4px;
+	background: #8d8d8d;
 }
 
 .smw-tabset > input:focus + label,
 .smw-tabset > input:checked + label {
-  color: #06c;
+	color: #06c;
 }
 
 .smw-tabset > input:focus + label::after,
 .smw-tabset > input:checked + label::after {
-  background: #06c;
+	background: #06c;
 }
 
 .smw-tabset > input:focus + label.smw-indicator-severity-error::after,
 .smw-tabset > input:checked + label.smw-indicator-severity-error::after {
-  background: #d33;
+	background: #d33;
 }
 
 .smw-tabset > input:focus + label.smw-indicator-severity-warning::after,
 .smw-tabset > input:checked + label.smw-indicator-severity-warning::after {
-  background: #ffa500;
+	background: #ffa500;
 }
 
 .smw-tabset > label:hover {
-  color: #444;
+	color: #444;
 }
 
 .smw-tabset > label:hover::after {
-  background: #444;
+	background: #444;
 }
 
 .smw-tabset > input:checked + label {
-  border-color: #ccc;
-  border-bottom: 1px solid #fff;
-  margin-bottom: -1px;
-  border-top: 2px solid #06c;
+	border-color: #ccc;
+	border-bottom: 1px solid #fff;
+	margin-bottom: -1px;
+	border-top: 2px solid #06c;
 }
 
 .smw-tabset > input:checked + label.smw-indicator-severity-error {
-  border-top: 2px solid #d33;
-  color: #d33;
+	border-top: 2px solid #d33;
+	color: #d33;
 }
 
 .smw-tabset > input:checked + label.smw-indicator-severity-warning {
-  border-top: 2px solid #ffa500;
-  color: #ffa500;
+	border-top: 2px solid #ffa500;
+	color: #ffa500;
 }
 
 .tab-panel {
-  padding: 30px 0;
-  border-top: 1px solid #ccc;
+	padding: 30px 0;
+	border-top: 1px solid #ccc;
 }
 
 .smw-issue-panel > label {
@@ -237,11 +242,11 @@
 }
 
 .smw-issue-panel > label::after {
-  left: 5px;
-  bottom: 3px;
-  width: 12px;
-  height: 2px;
-  background: #8d8d8d;
+	left: 5px;
+	bottom: 3px;
+	width: 12px;
+	height: 2px;
+	background: #8d8d8d;
 }
 
 .smw-issue-panel .tab-panel {
@@ -252,8 +257,8 @@
 }
 
 .smw-issue-panel .tab-panel:after2 {
-  content: "";
-  display: block;
-  height: 10px;
-  width: 100%;
+	content: "";
+	display: block;
+	height: 10px;
+	width: 100%;
 }

--- a/res/smw/special/ext.smw.special.ask.css
+++ b/res/smw/special/ext.smw.special.ask.css
@@ -564,11 +564,11 @@ display: inline-block;
 }
 
 .smw-tabs input.nav-tab:checked + label.nav-label.result-cache {
-    border-top: 2px solid orange;
+    border-top-color: orange;
 }
 
 .smw-tabs input.nav-tab:checked + label.nav-label.clipboard-bookmark {
-    border:0;
+    border: 0;
 }
 
 .smw-tabs input.nav-tab:checked + label.nav-label.edit-action {
@@ -587,7 +587,7 @@ display: inline-block;
 }
 
 .smw-tabs input.nav-tab:checked + label.nav-label.compact-action {
-    border:0;
+    border: 0;
 }
 
 /**

--- a/res/smw/special/ext.smw.special.css
+++ b/res/smw/special/ext.smw.special.css
@@ -182,12 +182,6 @@
 	display: block;
 }
 
-.smw-tab-icon,
-.smw-tab-alert-symbol {
-	margin-left: -10px;
-	margin-right: 10px;
-}
-
 .smw-icon-alert {
 	background-image: url( ../assets/smw-icon-alert.svg );
 	background-repeat: no-repeat;
@@ -196,22 +190,19 @@
 }
 
 .smw-admin section {
-	border: 0px solid #aaa;
-	padding: 5px 0 0 0 !important;
+	padding-top: 5px !important;
 }
 
 .smw-admin input.nav-tab:checked + label.nav-label {
-	border: 1px solid #aaa;
-	border-top: 2px solid orange;
-	border-bottom: 1px solid #fff;
+	border-top-color: orange;
 }
 
 .smw-admin input.nav-tab:checked + label.nav-label.smw-tab-warning {
-	border-top: 2px solid rgb(204, 0, 0);
+	border-top-color: rgb( 204, 0, 0 );
 }
 
 .smw-admin input.nav-tab:checked + label.nav-label.smw-tab-notice {
-    border-top: 2px solid rgb(255, 178, 15);
+    border-top-color: rgb( 255, 178, 15 );
 }
 
 .client-nojs .smw-admin-supplementary-duplookup-content:after {
@@ -259,20 +250,5 @@ h3.smw-title {
 		display: flex;
 		flex-direction: column;
 		flex-wrap: wrap;
-	}
-
-	.smw-tabs.smw-admin {
-		display: flex;
-		flex-direction: column;
-	}
-
-	.smw-tabs.smw-admin label.nav-label {
-		text-align: unset;
-		border-top: 1px solid;
-	}
-
-	.smw-tabs.smw-admin input.nav-tab:checked + label.nav-label {
-		border-left: 0px;
-		border-right: 0px;
 	}
 }

--- a/src/MediaWiki/Specials/SpecialAdmin.php
+++ b/src/MediaWiki/Specials/SpecialAdmin.php
@@ -164,7 +164,7 @@ class SpecialAdmin extends SpecialPage {
 
 		$htmlTabs->tab(
 			'alerts',
-			'<span class="smw-icon-alert smw-tab-icon"></span>' . $this->msg_text( 'smw-admin-tab-alerts' ),
+			'<span class="smw-icon-alert smw-tab-icon skin-invert"></span>' . $this->msg_text( 'smw-admin-tab-alerts' ),
 			[
 				'hide'  => $alertsSection === '',
 				'class' => 'smw-tab-warning'


### PR DESCRIPTION
Cleaning up some of the tab styles code to use design tokens to support dark mode. Will follow up with a proper clean up in the future to update the styles and discard unused code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Styling Updates**
	- Transitioned tab styles from CSS to LESS for improved maintainability
	- Updated border properties across multiple style files
	- Refined responsive design for tab components
	- Simplified CSS rules for admin interface

- **Minor Enhancements**
	- Updated tab icon class in admin special page to include `skin-invert`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->