### PR TITLE
Use semantically correct heading and drop custom heading styles

### DIFF
--- a/res/smw/special/ext.smw.special.css
+++ b/res/smw/special/ext.smw.special.css
@@ -227,30 +227,6 @@
 	padding: 10px 0 10px 0;
 }
 
-.smw-admin h3,
-h3.smw-title,
-h4.smw-title,
-h3 .smw-title {
-	background: #f5f5f5;
-	padding: 2px 5px;
-	margin-top: 10px !important;
-	margin-bottom: 10px !important;
-}
-
-.smw-admin h3,
-h3.smw-title {
-	background: unset;
-    padding: 2px 5px;
-    margin-top: 10px !important;
-    margin-bottom: 10px !important;
-    color: #000;
-    padding-right: 10px;
-    font-weight: 400 !important;
-    font-size: 18px !important;
-    border-bottom: 1px solid #ddd;
-    line-height: 2.3 !important;
-}
-
 /**
  * Responsive settings
  */

--- a/src/Elastic/Admin/ElasticClientTaskHandler.php
+++ b/src/Elastic/Admin/ElasticClientTaskHandler.php
@@ -107,7 +107,7 @@ class ElasticClientTaskHandler extends TaskHandler implements ActionableTask {
 		);
 
 		$html = Html::rawElement(
-			'h3',
+			'h2',
 			[],
 			$this->msg( 'smw-admin-supplementary-elastic-section-subtitle' )
 		) . Html::rawElement(
@@ -153,7 +153,7 @@ class ElasticClientTaskHandler extends TaskHandler implements ActionableTask {
 		$config = $connection->getConfig();
 
 		$html = Html::rawElement(
-			'h3',
+			'h2',
 			[ 'class' => 'smw-title' ],
 			$this->msg( [ 'smw-admin-supplementary-elastic-replication-header-title' ] )
 		) . Html::rawElement(
@@ -161,7 +161,7 @@ class ElasticClientTaskHandler extends TaskHandler implements ActionableTask {
 			[],
 			$this->msg( [ 'smw-admin-supplementary-elastic-no-connection' ], Message::PARSE )
 		) . Html::rawElement(
-			'h4',
+			'h3',
 			[ 'class' => 'smw-title' ],
 			$this->msg( [ 'smw-admin-supplementary-elastic-endpoints' ] )
 		) . Html::rawElement(

--- a/src/MediaWiki/Specials/Admin/Alerts/DeprecationNoticeTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Alerts/DeprecationNoticeTaskHandler.php
@@ -203,7 +203,7 @@ class DeprecationNoticeTaskHandler extends TaskHandler {
 		}
 
 		$html = Html::rawElement(
-			'h4',
+			'h3',
 			[],
 			$this->msg( $title )
 		) . Html::rawElement(

--- a/src/MediaWiki/Specials/Admin/Maintenance/DataRefreshJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/DataRefreshJobTaskHandler.php
@@ -79,7 +79,7 @@ class DataRefreshJobTaskHandler extends TaskHandler implements ActionableTask {
 	 */
 	public function getHtml() {
 		$this->htmlFormRenderer
-			->addHeader( 'h4', $this->msg( 'smw_smwadmin_datarefresh' ) )
+			->addHeader( 'h3', $this->msg( 'smw_smwadmin_datarefresh' ) )
 			->addParagraph( $this->msg( 'smw_smwadmin_datarefreshdocu' ) );
 
 		if ( !$this->hasFeature( SMW_ADM_REFRESH ) ) {

--- a/src/MediaWiki/Specials/Admin/Maintenance/DisposeJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/DisposeJobTaskHandler.php
@@ -97,7 +97,7 @@ class DisposeJobTaskHandler extends TaskHandler implements ActionableTask {
 
 		// smw-admin-outdateddisposal
 		$this->htmlFormRenderer
-				->addHeader( 'h4', $this->msg( 'smw-admin-outdateddisposal-title' ) )
+				->addHeader( 'h3', $this->msg( 'smw-admin-outdateddisposal-title' ) )
 				->addParagraph(
 					$this->msg( 'smw-admin-outdateddisposal-intro', Message::PARSE ),
 					[

--- a/src/MediaWiki/Specials/Admin/Maintenance/FulltextSearchTableRebuildJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/FulltextSearchTableRebuildJobTaskHandler.php
@@ -92,7 +92,7 @@ class FulltextSearchTableRebuildJobTaskHandler extends TaskHandler implements Ac
 
 		if ( $this->hasFeature( SMW_ADM_FULLT ) && !$this->hasPendingJob() ) {
 			$this->htmlFormRenderer
-				->addHeader( 'h4', $this->msg( 'smw-admin-fulltext-title' ) )
+				->addHeader( 'h3', $this->msg( 'smw-admin-fulltext-title' ) )
 				->addParagraph( $this->msg( 'smw-admin-fulltext-intro', Message::PARSE ), [ 'class' => 'plainlinks' ] )
 				->setMethod( 'post' )
 				->addHiddenField( 'action', 'fulltrebuild' )
@@ -107,7 +107,7 @@ class FulltextSearchTableRebuildJobTaskHandler extends TaskHandler implements Ac
 				);
 		} elseif ( $this->hasFeature( SMW_ADM_FULLT ) ) {
 			$this->htmlFormRenderer
-				->addHeader( 'h4', $this->msg( 'smw-admin-fulltext-title' ) )
+				->addHeader( 'h3', $this->msg( 'smw-admin-fulltext-title' ) )
 				->addParagraph( $this->msg( 'smw-admin-fulltext-intro', Message::PARSE ), [ 'class' => 'plainlinks' ] )
 				->addParagraph(
 					Html::element(

--- a/src/MediaWiki/Specials/Admin/Maintenance/PropertyStatsRebuildJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/PropertyStatsRebuildJobTaskHandler.php
@@ -92,7 +92,7 @@ class PropertyStatsRebuildJobTaskHandler extends TaskHandler implements Actionab
 
 		// smw-admin-propertystatistics
 		$this->htmlFormRenderer
-				->addHeader( 'h4', $this->msg( 'smw-admin-propertystatistics-title' ) )
+				->addHeader( 'h3', $this->msg( 'smw-admin-propertystatistics-title' ) )
 				->addParagraph( $this->msg( 'smw-admin-propertystatistics-intro', Message::PARSE ), [ 'class' => 'plainlinks' ] );
 
 		if ( $this->hasFeature( SMW_ADM_PSTATS ) && !$this->hasPendingJob() ) {

--- a/src/MediaWiki/Specials/Admin/Maintenance/TableSchemaTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/TableSchemaTaskHandler.php
@@ -88,7 +88,7 @@ class TableSchemaTaskHandler extends TaskHandler implements ActionableTask {
 			->setName( 'buildtables' )
 			->setMethod( 'get' )
 			->addHiddenField( 'action', $this->getTask() )
-			->addHeader( 'h3', $this->msg( 'smw-admin-db' ) )
+			->addHeader( 'h2', $this->msg( 'smw-admin-db' ) )
 			->addParagraph( $this->msg( 'smw-admin-dbdocu' ) );
 
 		$this->htmlFormRenderer

--- a/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
@@ -171,7 +171,7 @@ class EntityLookupTaskHandler extends TaskHandler implements ActionableTask {
 			->setMethod( 'get' )
 			->addHiddenField( 'action', 'lookup' )
 			->addParagraph( $error )
-			->addHeader( 'h3', $this->msg( 'smw-admin-idlookup-title' ), [ 'class' => 'smw-title' ] )
+			->addHeader( 'h2', $this->msg( 'smw-admin-idlookup-title' ), [ 'class' => 'smw-title' ] )
 			->addParagraph( $this->msg( 'smw-admin-idlookup-docu' ) )
 			->addInputField(
 				$this->msg( 'smw-admin-objectid' ),
@@ -199,7 +199,7 @@ class EntityLookupTaskHandler extends TaskHandler implements ActionableTask {
 			->setMethod( 'get' )
 			->addHiddenField( 'action', 'lookup' )
 			->addHiddenField( 'id', $id )
-			->addHeader( 'h3', $this->msg( 'smw-admin-iddispose-title' ), [ 'class' => 'smw-title' ] )
+			->addHeader( 'h2', $this->msg( 'smw-admin-iddispose-title' ), [ 'class' => 'smw-title' ] )
 			->addParagraph( $this->msg( 'smw-admin-iddispose-docu', Message::PARSE ), [ 'class' => 'plainlinks' ] )
 			->addInputField(
 				$this->msg( 'smw-admin-objectid' ),

--- a/src/MediaWiki/Specials/Admin/Supplement/OperationalStatisticsListTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/OperationalStatisticsListTaskHandler.php
@@ -169,7 +169,7 @@ class OperationalStatisticsListTaskHandler extends TaskHandler implements Action
 		}
 
 		$this->outputFormatter->addHTML(
-			Html::element( 'h3', [ 'class' => 'smw-title' ], $this->msg( 'smw-admin-statistics-extra' ) )
+			Html::element( 'h2', [ 'class' => 'smw-title' ], $this->msg( 'smw-admin-statistics-extra' ) )
 		);
 
 		$this->outputFormatter->addHTML(

--- a/src/MediaWiki/Specials/Admin/Supplement/TableStatisticsTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/TableStatisticsTaskHandler.php
@@ -170,7 +170,7 @@ class TableStatisticsTaskHandler extends TaskHandler implements ActionableTask {
 			[],
 			$this->msg( 'smw-admin-supplementary-operational-table-statistics-legend-general', Message::PARSE )
 		) . Html::rawElement(
-			'h4',
+			'h3',
 			[],
 			'smw_object_ids'
 		) . Html::rawElement(
@@ -178,7 +178,7 @@ class TableStatisticsTaskHandler extends TaskHandler implements ActionableTask {
 			[],
 			$this->msg( 'smw-admin-supplementary-operational-table-statistics-legend-id-table', Message::PARSE )
 		) . Html::rawElement(
-			'h4',
+			'h3',
 			[],
 			'smw_di_blob'
 		) . Html::rawElement(

--- a/src/MediaWiki/Specials/Admin/SupplementTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/SupplementTaskHandler.php
@@ -116,7 +116,7 @@ class SupplementTaskHandler extends TaskHandler implements ActionableTask {
 			],
 			$this->msg( 'smw-admin-supplementary-section-intro', Message::PARSE )
 		) . Html::rawElement(
-			'h3',
+			'h2',
 			[],
 			$this->msg( 'smw-admin-supplementary-section-subtitle' )
 		);

--- a/src/MediaWiki/Specials/Admin/SupportListTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/SupportListTaskHandler.php
@@ -63,7 +63,7 @@ class SupportListTaskHandler extends TaskHandler {
 		];
 
 		return Html::rawElement(
-			'h3',
+			'h2',
 			[],
 			$this->msg( 'smw-admin-environment' )
 		) . Html::rawElement(
@@ -76,7 +76,7 @@ class SupportListTaskHandler extends TaskHandler {
 	private function supportForm() {
 		$this->htmlFormRenderer
 			->setName( 'support' )
-			->addHeader( 'h3', $this->msg( 'smw-admin-support' ) )
+			->addHeader( 'h2', $this->msg( 'smw-admin-support' ) )
 			->addParagraph( $this->msg( 'smw-admin-supportdocu' ) )
 			->addParagraph(
 				Html::rawElement( 'ul', [],
@@ -95,7 +95,7 @@ class SupportListTaskHandler extends TaskHandler {
 			->setName( 'announce' )
 			->setMethod( 'get' )
 			->setActionUrl( 'https://wikiapiary.com/wiki/WikiApiary:Semantic_MediaWiki_Registry' )
-			->addHeader( 'h3', $this->msg( 'smw-admin-announce' ) )
+			->addHeader( 'h2', $this->msg( 'smw-admin-announce' ) )
 			->addParagraph( $this->msg( 'smw-admin-announce-text' ) )
 			->addSubmitButton(
 				$this->msg( 'smw-admin-announce' ),


### PR DESCRIPTION
The headings used on Special:Admin should be one level higher (e.g. h2 instead of h3) because of the hierarchy on the page. And SMW should let the skin control the heading styles instead of defining its own.

![image](https://github.com/user-attachments/assets/e598b126-7776-4e6f-8cdd-57de30a27c2d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated heading levels across multiple admin interface components from `<h3>` and `<h4>` to `<h2>` and `<h3>` to improve semantic HTML structure
	- Removed custom CSS styling for admin section headings

- **Refactor**
	- Simplified HTML heading hierarchy in various admin task handlers
	- Standardized header levels in admin interface components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->