### PR TITLE
Remove "--no-suggest" from composer install in Tesa ci

### DIFF
--- a/.github/workflows/tesa.yml
+++ b/.github/workflows/tesa.yml
@@ -35,7 +35,7 @@ jobs:
           key: composer-cache-php${{ matrix.php }}
 
       - name: Composer install
-        run: composer install --no-progress --no-suggest --no-interaction --prefer-dist --optimize-autoloader
+        run: composer install --no-progress --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Add PHPUnit
         run: composer require phpunit/phpunit:^9


### PR DESCRIPTION
"You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configuration for Composer dependency installation
	- Modified Composer command to potentially display package suggestions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->