### PR TITLE
PunctuationRegExTokenizer: Fix "Passing null to parameter #3 ($limit) of type int is deprecated"

### DIFF
--- a/src/Tesa/src/Tokenizer/PunctuationRegExTokenizer.php
+++ b/src/Tesa/src/Tokenizer/PunctuationRegExTokenizer.php
@@ -71,7 +71,7 @@ class PunctuationRegExTokenizer implements Tokenizer {
 			'＿－・，、；：！？．。…◆★◇□■（）【】《》〈〉；：“”＂〃＇｀［］｛｝｢｣＠＊＼／＆＃％｀＾＋＜＝＞｜～≪≫─＄＂_\-･,､;:!?.｡()[\]{}「」@*\/&#%`^+<=>|~«»$"\s'
 		);
 
-		$result = preg_split( '/[' . $pattern . ']+/u', $string, null, PREG_SPLIT_NO_EMPTY );
+		$result = preg_split( '/[' . $pattern . ']+/u', $string, -1, PREG_SPLIT_NO_EMPTY );
 
 		if ( $result === false ) {
 			$result = [];


### PR DESCRIPTION
Use -1 which means no limit.