### PR TITLE
CJKSimpleCharacterRegExTokenizer: Fix "preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated"

### DIFF
--- a/src/Tesa/src/Tokenizer/CJKSimpleCharacterRegExTokenizer.php
+++ b/src/Tesa/src/Tokenizer/CJKSimpleCharacterRegExTokenizer.php
@@ -70,7 +70,7 @@ class CJKSimpleCharacterRegExTokenizer implements Tokenizer {
 			'([\s\、，,。／？《》〈〉；：“”＂〃＇｀［］｛｝＼｜～！－＝＿＋）（()＊…—─％￥…◆★◇□■【】＃·啊吧把并被才从的得当对但到地而该过个给还和叫将就可来了啦里没你您哪那呢去却让使是时省随他我为现县向像象要由矣已以也又与于在之这则最乃\/\(\)\[\]{}<>\r\n"]|(?<!\d)\.(?!\d))'
 		);
 
-		$result = preg_split( '/' . $pattern . '/u', $string, null, PREG_SPLIT_NO_EMPTY );
+		$result = preg_split( '/' . $pattern . '/u', $string, -1, PREG_SPLIT_NO_EMPTY );
 
 		if ( $result !== false ) {
 			return $result;


### PR DESCRIPTION
> PHP Deprecated:  preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated in /home/runner/work/SemanticMediaWiki/SemanticMediaWiki/Tesa/src/Tokenizer/CJKSimpleCharacterRegExTokenizer.php on line 73

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved tokenization for CJK (Chinese, Japanese, Korean) text processing by adjusting substring splitting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->