### PR TITLE
CdbStopwordAnalyzer: Fix "strtolower(): Passing null to parameter #1 ($string) of type string is deprecated"

### DIFF
--- a/src/Tesa/src/StopwordAnalyzer/CdbStopwordAnalyzer.php
+++ b/src/Tesa/src/StopwordAnalyzer/CdbStopwordAnalyzer.php
@@ -94,7 +94,7 @@ class CdbStopwordAnalyzer implements StopwordAnalyzer {
 	 *
 	 * @return bool
 	 */
-	public static function createCdbByLanguage( $location, $language ) {
+	public static function createCdbByLanguage( string $location, string $language ) {
 		$language = strtolower( $language );
 		$source = $location . $language . '.json';
 

--- a/src/Tesa/src/StopwordAnalyzer/CdbStopwordAnalyzer.php
+++ b/src/Tesa/src/StopwordAnalyzer/CdbStopwordAnalyzer.php
@@ -67,8 +67,8 @@ class CdbStopwordAnalyzer implements StopwordAnalyzer {
 	 *
 	 * @return string
 	 */
-	public static function getTargetByLanguage( string $language ) {
-		return self::getLocation() . 'cdb/' . strtolower( $language ) . '.cdb';
+	public static function getTargetByLanguage( $language ) {
+		return self::getLocation() . 'cdb/' . strtolower( $language ?? '' ) . '.cdb';
 	}
 
 	/**
@@ -94,8 +94,8 @@ class CdbStopwordAnalyzer implements StopwordAnalyzer {
 	 *
 	 * @return bool
 	 */
-	public static function createCdbByLanguage( string $location, string $language ) {
-		$language = strtolower( $language );
+	public static function createCdbByLanguage( $location, $language ) {
+		$language = strtolower( $language ?? '' );
 		$source = $location . $language . '.json';
 
 		if ( !file_exists( $source ) ) {

--- a/src/Tesa/src/StopwordAnalyzer/CdbStopwordAnalyzer.php
+++ b/src/Tesa/src/StopwordAnalyzer/CdbStopwordAnalyzer.php
@@ -67,7 +67,7 @@ class CdbStopwordAnalyzer implements StopwordAnalyzer {
 	 *
 	 * @return string
 	 */
-	public static function getTargetByLanguage( $language ) {
+	public static function getTargetByLanguage( string $language ) {
 		return self::getLocation() . 'cdb/' . strtolower( $language ) . '.cdb';
 	}
 


### PR DESCRIPTION
> PHP Deprecated:  strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /home/runner/work/SemanticMediaWiki/SemanticMediaWiki/src/Tesa/src/StopwordAnalyzer/CdbStopwordAnalyzer.php on line 71