### PR TITLE
tesa: enable intl php extension in CI

### DIFF
--- a/.github/workflows/tesa.yml
+++ b/.github/workflows/tesa.yml
@@ -24,7 +24,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: mbstring
+          extensions: mbstring, intl
           tools: composer, cs2pr
           coverage: pcov
 

--- a/Tesa/tests/phpunit/Integration/JaTokenizerTest.php
+++ b/Tesa/tests/phpunit/Integration/JaTokenizerTest.php
@@ -25,8 +25,8 @@ class JaTokenizerTest extends TestCase {
 			$sanitizerFactory->newGenericRegExTokenizer()
 		);
 
-		if ( !$tokenier->isAvailable() || INTL_ICU_VERSION != '54.1' ) {
-			$this->markTestSkipped( 'ICU extension is not available or does not match the expected version constraint.' );
+		if ( !$tokenier->isAvailable() ) {
+			$this->markTestSkipped( 'ICU extension is not available.' );
 		}
 
 		$this->assertEquals(

--- a/Tesa/tests/phpunit/Unit/Tokenizer/IcuWordBoundaryTokenizerTest.php
+++ b/Tesa/tests/phpunit/Unit/Tokenizer/IcuWordBoundaryTokenizerTest.php
@@ -19,8 +19,8 @@ class IcuWordBoundaryTokenizerTest extends TestCase {
 	protected function setUp(): void {
 		$instance = new IcuWordBoundaryTokenizer();
 
-		if ( !$instance->isAvailable() || INTL_ICU_VERSION != '54.1' ) {
-			$this->markTestSkipped( 'ICU extension is not available or does not match the expected version constraint.' );
+		if ( !$instance->isAvailable() ) {
+			$this->markTestSkipped( 'ICU extension is not available.' );
 		}
 	}
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added `intl` extension support in PHP GitHub Actions workflow

- **Tests**
	- Updated `JaTokenizerTest` to simplify ICU extension availability check
	- Updated `IcuWordBoundaryTokenizerTest` to simplify ICU extension availability check
<!-- end of auto-generated comment: release notes by coderabbit.ai -->