### PR TITLE
Fix docs for two SQLStore hooks

### DIFF
--- a/docs/technical/hooks/hook.listener.registerpropertychangelisteners.md
+++ b/docs/technical/hooks/hook.listener.registerpropertychangelisteners.md
@@ -22,6 +22,7 @@ MediaWikiServices::getInstance()->getHookContainer()->register( 'SMW::Listener::
 use MediaWiki\MediaWikiServices;
 use SMW\Listener\ChangeListener\ChangeRecord;
 use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
+use SMW\DIProperty;
 
 class ActOnPropertyChange {
 

--- a/docs/technical/hooks/hook.sqlstore.afterdataupdatecomplete.md
+++ b/docs/technical/hooks/hook.sqlstore.afterdataupdatecomplete.md
@@ -1,6 +1,6 @@
 * Since: 2.3
 * Description: Hook to process information after an update has been completed. Further provides `ChangeOp` to identify entities that have been added/removed during the update. (`SMWSQLStore3::updateDataAfter` was deprecated with 2.3)
-* Reference class: [`PropertyTableDefinitionBuilder.php`][PropertyTableDefinitionBuilder.php]
+* Reference class: [`SQLStoreUpdater.php`][SQLStoreUpdater.php]
 
 ### Signature
 
@@ -17,4 +17,4 @@ MediaWikiServices::getInstance()->getHookContainer()->register( 'SMW::SQLStore::
 
 ## See also
 
-[PropertyTableDefinitionBuilder.php]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/SQLStore/PropertyTableDefinitionBuilder.php
+[SQLStoreUpdater.php]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/SQLStore/SQLStoreUpdater.php

--- a/docs/technical/hooks/hook.sqlstore.beforedataupdatecomplete.md
+++ b/docs/technical/hooks/hook.sqlstore.beforedataupdatecomplete.md
@@ -1,6 +1,6 @@
 * Since: 3.1
 * Description: Hook to extend the `SemanticData` object before the update is completed. (`SMWSQLStore3::updateDataBefore` was deprecated with 3.1)
-* Reference class: `SMWSQLStore3Writers`
+* Reference class: [`SQLStoreUpdater.php`][SQLStoreUpdater.php]
 
 ### Signature
 
@@ -14,3 +14,5 @@ MediaWikiServices::getInstance()->getHookContainer()->register( 'SMW::SQLStore::
 	return true;
 } );
 ```
+
+[SQLStoreUpdater.php]:https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/SQLStore/SQLStoreUpdater.php


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated documentation references for SQLStore hooks.
	- Updated reference classes for `AfterDataUpdateComplete` and `BeforeDataUpdateComplete` hooks.
	- Added GitHub repository link for `SQLStoreUpdater.php`.
	- Enhanced documentation with new import for `DIProperty` in property change listener hook.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->