### PR TITLE
ConceptCache: Use getType instead of global wgDBtype

### DIFF
--- a/src/SQLStore/ConceptCache.php
+++ b/src/SQLStore/ConceptCache.php
@@ -90,8 +90,6 @@ class ConceptCache {
 	 * @return string[] array with error messages
 	 */
 	public function refresh( Title $concept ) {
-		global $wgDBtype;
-
 		$db = $this->store->getConnection();
 
 		$cid = $this->store->smwIds->getSMWPageID( $concept->getDBkey(), SMW_NS_CONCEPT, '', '' );
@@ -130,7 +128,7 @@ class ConceptCache {
 		// MySQL just uses INSERT IGNORE, no extra conditions
 		$where = $querySegment->where;
 
-		if ( $wgDBtype == 'postgres' ) {
+		if ( $db->getType() == 'postgres' ) {
 			// PostgresQL: no INSERT IGNORE, check for duplicates explicitly
 			// This code doesn't work and has created all sorts of issues therefore use LEFT JOIN instead
 			// http://people.planetpostgresql.org/dfetter/index.php?/archives/48-Adding-Only-New-Rows-INSERT-IGNORE,-Done-Right.html
@@ -141,7 +139,7 @@ class ConceptCache {
 			$querySegment->from = str_replace( 'INNER JOIN', 'LEFT JOIN', $querySegment->from );
 		}
 
-		$db->query( "INSERT " . ( ( $wgDBtype == 'postgres' ) ? '' : 'IGNORE ' ) .
+		$db->query( "INSERT " . ( ( $db->getType() == 'postgres' ) ? '' : 'IGNORE ' ) .
 			"INTO $concCacheTableName" .
 			" SELECT DISTINCT {$querySegment->joinfield} AS s_id, $cid AS o_id FROM " .
 			$db->tableName( $querySegment->joinTable ) . " AS {$querySegment->alias}" .


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated database type detection mechanism to use connection object method instead of global variable
  - Maintained existing database-specific query logic for PostgreSQL and INSERT statements

<!-- end of auto-generated comment: release notes by coderabbit.ai -->