### PR TITLE
Fix "TypeError: MediaWiki\Parser\Sanitizer::decodeCharReferences(): Argument #1 ($text) must be of type string"

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -58,20 +58,20 @@ function smwfNormalTitleText( $text ) {
  * Escapes text in a way that allows it to be used as XML content (e.g. as a
  * string value for some property).
  *
- * @param string $text
+ * @param string|null $text
  */
-function smwfXMLContentEncode( string $text ) {
-	return str_replace( [ '&', '<', '>' ], [ '&amp;', '&lt;', '&gt;' ], Sanitizer::decodeCharReferences( $text ) );
+function smwfXMLContentEncode( ?string $text ) {
+	return str_replace( [ '&', '<', '>' ], [ '&amp;', '&lt;', '&gt;' ], Sanitizer::decodeCharReferences( $text ?? '' ) );
 }
 
 /**
  * Decodes character references and inserts Unicode characters instead, using
  * the MediaWiki Sanitizer.
  *
- * @param string $text
+ * @param string|null $text
  */
-function smwfHTMLtoUTF8( string $text ) {
-	return Sanitizer::decodeCharReferences( $text );
+function smwfHTMLtoUTF8( ?string $text ) {
+	return Sanitizer::decodeCharReferences( $text ?? '' );
 }
 
 /**

--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -60,7 +60,7 @@ function smwfNormalTitleText( $text ) {
  *
  * @param string $text
  */
-function smwfXMLContentEncode( $text ) {
+function smwfXMLContentEncode( string $text ) {
 	return str_replace( [ '&', '<', '>' ], [ '&amp;', '&lt;', '&gt;' ], Sanitizer::decodeCharReferences( $text ) );
 }
 
@@ -70,7 +70,7 @@ function smwfXMLContentEncode( $text ) {
  *
  * @param string $text
  */
-function smwfHTMLtoUTF8( $text ) {
+function smwfHTMLtoUTF8( string $text ) {
 	return Sanitizer::decodeCharReferences( $text );
 }
 

--- a/src/SQLStore/EntityStore/DataItemHandlers/DIConceptHandler.php
+++ b/src/SQLStore/EntityStore/DataItemHandlers/DIConceptHandler.php
@@ -112,7 +112,7 @@ class DIConceptHandler extends DataItemHandler {
 		if ( is_array( $dbkeys ) && count( $dbkeys ) == 5 ) {
 			return new DIConcept(
 				$dbkeys[0],
-				smwfXMLContentEncode( $dbkeys[1] ),
+				smwfXMLContentEncode( $dbkeys[1] ?? '' ),
 				$dbkeys[2],
 				$dbkeys[3],
 				$dbkeys[4]

--- a/src/SQLStore/EntityStore/DataItemHandlers/DIConceptHandler.php
+++ b/src/SQLStore/EntityStore/DataItemHandlers/DIConceptHandler.php
@@ -112,7 +112,7 @@ class DIConceptHandler extends DataItemHandler {
 		if ( is_array( $dbkeys ) && count( $dbkeys ) == 5 ) {
 			return new DIConcept(
 				$dbkeys[0],
-				smwfXMLContentEncode( $dbkeys[1] ?? '' ),
+				smwfXMLContentEncode( $dbkeys[1] ),
 				$dbkeys[2],
 				$dbkeys[3],
 				$dbkeys[4]


### PR DESCRIPTION
> [c5533f9548fee2de28afa694] [no req]   TypeError: MediaWiki\Parser\Sanitizer::decodeCharReferences(): Argument #1 ($text) must be of type string, null given, called in D:\Program Files\Apache\htdocs\testwiki\extensions\SemanticMediaWiki\includes\GlobalFunctions.php on line 64

Fixes #6005

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of null inputs in XML content encoding and HTML to UTF-8 conversion functions
	- Enhanced function robustness by adding null input support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->