### PR TITLE
Load mediawiki.codex.messagebox.styles module for message boxes

### DIFF
--- a/src/MediaWiki/Hooks/ArticleViewHeader.php
+++ b/src/MediaWiki/Hooks/ArticleViewHeader.php
@@ -126,6 +126,7 @@ class ArticleViewHeader implements HookListener {
 			);
 		}
 
+		$output->addModuleStyles( [ 'mediawiki.codex.messagebox.styles' ] );
 		$output->addHTML( $message );
 
 		// No Message means `useParserCache`otherwise refresh the output to

--- a/src/MediaWiki/Hooks/BeforePageDisplay.php
+++ b/src/MediaWiki/Hooks/BeforePageDisplay.php
@@ -70,6 +70,7 @@ class BeforePageDisplay implements HookListener {
 		}
 
 		if ( $this->getOption( 'incomplete_tasks', [] ) !== [] ) {
+			$outputPage->addModuleStyles( [ 'mediawiki.codex.messagebox.styles' ] );
 			$outputPage->prependHTML( $this->createIncompleteSetupTaskNotification( $title ) );
 		}
 

--- a/src/MediaWiki/Specials/SpecialAdmin.php
+++ b/src/MediaWiki/Specials/SpecialAdmin.php
@@ -62,8 +62,11 @@ class SpecialAdmin extends SpecialPage {
 		$output->setPageTitle( $this->msg_text( 'smw-title' ) );
 		$output->addHelpLink( $this->msg_text( 'smw-admin-helplink' ), true );
 
-		$output->addModuleStyles( 'ext.smw.styles' );
-		$output->addModuleStyles( 'ext.smw.special.styles' );
+		$output->addModuleStyles( [
+			'ext.smw.styles',
+			'ext.smw.special.styles',
+			'mediawiki.codex.messagebox.styles'	
+		] );
 		$output->addModules( 'ext.smw.admin' );
 
 		$applicationFactory = ApplicationFactory::getInstance();

--- a/src/MediaWiki/Specials/SpecialAdmin.php
+++ b/src/MediaWiki/Specials/SpecialAdmin.php
@@ -65,7 +65,7 @@ class SpecialAdmin extends SpecialPage {
 		$output->addModuleStyles( [
 			'ext.smw.styles',
 			'ext.smw.special.styles',
-			'mediawiki.codex.messagebox.styles'	
+			'mediawiki.codex.messagebox.styles'
 		] );
 		$output->addModules( 'ext.smw.admin' );
 

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -196,7 +196,8 @@ class SpecialAsk extends SpecialPage {
 			'ext.smw.styles',
 			'ext.smw.ask.styles',
 			'ext.smw.page.styles',
-			'ext.smw.table.styles'
+			'ext.smw.table.styles',
+			'mediawiki.codex.messagebox.styles'
 		] );
 
 		$out->addModuleStyles(

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -75,7 +75,8 @@ class SpecialBrowse extends SpecialPage {
 			'mediawiki.ui.button',
 			'mediawiki.ui.input',
 			'ext.smw.factbox.styles',
-			'ext.smw.browse.styles'
+			'ext.smw.browse.styles',
+			'mediawiki.codex.messagebox.styles'
 		] );
 
 		$out->addModules( [

--- a/src/ParserFunctions/ConceptParserFunction.php
+++ b/src/ParserFunctions/ConceptParserFunction.php
@@ -72,7 +72,10 @@ class ConceptParserFunction {
 	 * @return string|null
 	 */
 	public function parse( array $rawParams ) {
-		$this->parserData->getOutput()->addModules( [ 'ext.smw.styles' ] );
+		$this->parserData->getOutput()->addModuleStyles( [ 
+			'ext.smw.styles',
+			'mediawiki.codex.messagebox.styles'
+		] );
 
 		$title = $this->parserData->getTitle();
 		$property = new DIProperty( '_CONC' );

--- a/src/ParserFunctions/ConceptParserFunction.php
+++ b/src/ParserFunctions/ConceptParserFunction.php
@@ -72,7 +72,7 @@ class ConceptParserFunction {
 	 * @return string|null
 	 */
 	public function parse( array $rawParams ) {
-		$this->parserData->getOutput()->addModuleStyles( [ 
+		$this->parserData->getOutput()->addModuleStyles( [
 			'ext.smw.styles',
 			'mediawiki.codex.messagebox.styles'
 		] );


### PR DESCRIPTION
Related: [T375287](https://phabricator.wikimedia.org/T375287)

Fixes: #6013

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **Style Improvements**
  - Added `mediawiki.codex.messagebox.styles` module across multiple components to enhance message box styling.
  - Streamlined module style loading in various special pages and parser functions.

- **User Interface**
  - Refined visual presentation of message boxes and system interfaces, improving overall user experience.

The changes focus on improving the visual consistency and styling of message-related elements throughout the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->