### PR TITLE
PHP 8 fix for SMW_PageSchemas.php

### DIFF
--- a/includes/SMW_PageSchemas.php
+++ b/includes/SMW_PageSchemas.php
@@ -227,7 +227,7 @@ class SMWPageSchemas extends PSExtensionHandler {
 		$propertyDropdownAttrs = [
 			'id' => 'property_dropdown',
 			'name' => 'smw_property_type_num',
-			'value' => $propType
+			'value' => $propType ?? ''
 		];
 		$html_text .= "Type: " . Xml::tags( 'select', $propertyDropdownAttrs, $select_body ) . "</p>\n";
 


### PR DESCRIPTION
Creating a new Page Schemas schema currently leads to an error with PHP 8, because the MediaWiki code calls htmlspecialchars() on null.