### PR TITLE
ChangePropagationDispatchJob: Don't presume job will be run on same server

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-5.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-5.0.0.md
@@ -17,6 +17,13 @@ Anyone using MediaWiki 1.41 or above or PHP 8.1 or above is recommended to upgra
 
 For more detailed information, see the [compatibility matrix](../COMPATIBILITY.md#compatibility).
 
+## Breaking changes
+
+- [#6021](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6021) ChangePropagationDispatchJob: Don't presume job will be run on same server
+
+  The param 'dataFile' and 'checkSum' have been dropped in ChangePropagationDispatchJob. No longer is a temp file created, instead the contents is supplied
+  in the 'data' param.
+
 ## Upgrading
 
 There is no need to run the "update.php" maintenance script or any of the rebuild data scripts.

--- a/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
@@ -277,7 +277,7 @@ class ChangePropagationDispatchJob extends Job {
 		// Filter duplicates
 		$contents = implode( "\n", array_keys( array_flip( $data ) ) );
 
-		$checkSum = md5( $contents ); 
+		$checkSum = md5( $contents );
 
 		$changePropagationDispatchJob = new ChangePropagationDispatchJob(
 			$this->getTitle(),

--- a/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
@@ -191,7 +191,7 @@ class ChangePropagationDispatchJob extends Job {
 		$subject = DIWikiPage::newFromTitle( $this->getTitle() );
 
 		if ( $this->hasParameter( 'data' ) ) {
-			return $this->dispatchFromFile( $subject, $this->getParameter( 'data' ) );
+			return $this->dispatchFromData( $subject, $this->getParameter( 'data' ) );
 		}
 
 		if ( $this->hasParameter( 'schema_change_propagation' ) ) {
@@ -291,7 +291,7 @@ class ChangePropagationDispatchJob extends Job {
 		$changePropagationDispatchJob->lazyPush();
 	}
 
-	private function dispatchFromFile( $subject, $data ) {
+	private function dispatchFromData( $subject, $data ) {
 		$applicationFactory = ApplicationFactory::getInstance();
 		$cache = $applicationFactory->getCache();
 

--- a/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
@@ -260,11 +260,11 @@ class ChangePropagationDispatchJob extends Job {
 		$i = 0;
 
 		foreach ( $chunkedIterator as $chunk ) {
-			$this->pushChangePropagationDispatchJob( $tempFile, $i++, $chunk );
+			$this->pushChangePropagationDispatchJob( $i++, $chunk );
 		}
 	}
 
-	private function pushChangePropagationDispatchJob( $tempFile, $num, $chunk ) {
+	private function pushChangePropagationDispatchJob( $num, $chunk ) {
 		$data = [];
 		// Used as a job key
 		$file = "smw_chgprop_$num\_tmp";

--- a/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
@@ -266,8 +266,6 @@ class ChangePropagationDispatchJob extends Job {
 
 	private function pushChangePropagationDispatchJob( $num, $chunk ) {
 		$data = [];
-		// Used as a job key
-		$file = "smw_chgprop_$num\_tmp";
 
 		// Filter any subobject
 		foreach ( $chunk as $val ) {
@@ -284,7 +282,7 @@ class ChangePropagationDispatchJob extends Job {
 			[
 				'data' => $contents
 			] + self::newRootJobParams(
-				"ChangePropagationDispatchJob:$file:$checkSum"
+				"ChangePropagationDispatchJob:smw_chgprop_$num\_tmp:$checkSum"
 			)
 		);
 

--- a/tests/phpunit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
+++ b/tests/phpunit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
@@ -145,15 +145,6 @@ class ChangePropagationDispatchJobTest extends \PHPUnit\Framework\TestCase {
 	public function testFindAndDispatchOnPropertyEntity() {
 		$subject = DIWikiPage::newFromText( 'Foo', SMW_NS_PROPERTY );
 
-		$tempFile = $this->getMockBuilder( '\SMW\Utils\TempFile' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$tempFile->expects( $this->atLeastOnce() )
-			->method( 'write' );
-
-		$this->testEnvironment->registerObject( 'TempFile', $tempFile );
-
 		$jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
 			->disableOriginalConstructor()
 			->getMock();


### PR DESCRIPTION
Fixes support for change propagation (wikimedia new job runner). Don't presume a job will run on the same server. So instead of creating temp files, we just pass the contents as a param.

Fixes #5929

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Streamlined background processing by switching from temporary file reliance to direct data handling for improved efficiency.
	- Updated data input methods to simplify operations and enhance processing reliability.
	- Simplified checksum verification by computing directly from data input.
	- Notable removal of parameters related to temporary files in job execution.

- **Tests**
	- Removed mock handling of temporary files in test cases, simplifying the testing process.

- **Documentation**
	- Added a "Breaking changes" section to release notes, highlighting the removal of parameters and changes in data handling for the `ChangePropagationDispatchJob`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->