### PR TITLE
5.0.0 release

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -25,16 +25,16 @@ Increases of minimum requirements are indicated in bold.
 	</tr>
 	<tr>
 		<th>5.0.x</th>
-		<td>Future release</td>
-		<td>2025-02-22</td>
-		<td>2025-02-22</td>
-		<td><strong>8.1</strong> - 8.3</td>
+		<td><strong>Stable release</strong></td>
+		<td>2025-03-10</td>
+		<td>2025-03-10</td>
+		<td><strong>8.1</strong> - 8.4</td>
 		<td><strong>1.39</strong> - 1.43</td>
 		<td></td>
 	</tr>
 	<tr>
 		<th>4.2.x</th>
-		<td><strong>Stable release</strong></td>
+		<td>Obsolete release</td>
 		<td>2024-07-18</td>
 		<td>2024-07-18</td>
 		<td>7.4 - 8.2</td>

--- a/docs/releasenotes/RELEASE-NOTES-5.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-5.0.0.md
@@ -1,6 +1,6 @@
 # Semantic MediaWiki 5.0.0
 
-Released on TBD.
+Released on March 10, 2025.
 
 ## Summary
 
@@ -20,7 +20,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 ### User interface changes
 
-Some user interface changes are deployed to make user-facing front-end components more intuitive and 
+Some user interface changes are deployed to make user-facing front-end components more intuitive and
 mobile-friendly by using [Codex](https://doc.wikimedia.org/codex/main/) from Wikimedia Foundation:
 
 * Start using Codex Design tokens and improve various styles ([#5786](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/5786))

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticMediaWiki",
-	"version": "5.0.0-beta",
+	"version": "5.0.0",
 	"author": [
 		"[https://korrekt.org Markus Krötzsch]",
 		"[https://EntropyWins.wtf/mediawiki Jeroen De Dauw]",


### PR DESCRIPTION
Please add missing entries to the RELEASE-NOTES *outside* of this PR

Also finish up *breaking changes* that you want to be merged any time soon before the scheduled release on the 22nd.

For reference, here is the 5.0.0 milestone: https://github.com/SemanticMediaWiki/SemanticMediaWiki/milestone/46 The release will not be blocked on finishing that wishlist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the compatibility information to show that version 5.0.x is now stable with revised release dates and expanded PHP support, and that version 4.2.x is marked as obsolete.
  - Revised the release announcement to display the official release date and improved text formatting.

- **Chores**
  - Upgraded the extension version from a beta release to stable (5.0.0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->