### PR TITLE
Update required environment information

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
 		"source": "https://github.com/SemanticMediaWiki/SemanticMediaWiki"
 	},
 	"require": {
-		"php": ">=7.4",
+		"php": ">=8.1",
 		"ext-mbstring": "*",
 		"composer/installers": "^2.2.0|^1.0.1",
 		"psr/log": "~1.0",

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -28,7 +28,7 @@ Increases of minimum requirements are indicated in bold.
 		<td>Future release</td>
 		<td>2025-02-22</td>
 		<td>2025-02-22</td>
-		<td><strong>8.0</strong> - 8.3</td>
+		<td><strong>8.1</strong> - 8.3</td>
 		<td><strong>1.39</strong> - 1.43</td>
 		<td></td>
 	</tr>


### PR DESCRIPTION
* Move consistently to PHP 8.1 or later, supported by test environment and RELEASE-NOTES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the PHP dependency, now requiring PHP 8.1 or higher for optimal performance and security.
- **Documentation**
	- Revised compatibility information to reflect the updated PHP version support, ensuring clarity for upcoming releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->