### PR TITLE
SearchResultSet: Remove termMatches

### DIFF
--- a/src/MediaWiki/Search/SearchResultSet.php
+++ b/src/MediaWiki/Search/SearchResultSet.php
@@ -170,30 +170,6 @@ class SearchResultSet extends \SearchResultSet {
 		return $this->count;
 	}
 
-	/**
-	 * Return an array of regular expression fragments for matching
-	 * the search terms as parsed by the engine in a text extract.
-	 *
-	 * This is a temporary hack for MW versions that can not cope
-	 * with no search term being returned (<1.24).
-	 *
-	 * @deprecated remove once min supported MW version has \SearchHighlighter::highlightNone()
-	 *
-	 * @return string[]
-	 */
-	public function termMatches() {
-		if ( ( $tokens = $this->getTokens() ) !== [] ) {
-			return $tokens;
-		}
-
-		if ( method_exists( '\SearchHighlighter', 'highlightNone' ) ) {
-			return [];
-		}
-
-		// Will cause the highlighter to match every line start, thus returning the first few lines of found pages.
-		return [ '^' ];
-	}
-
 	private function getTokens() {
 		$tokens = [];
 


### PR DESCRIPTION
We now support the minimum MW version that has that method.