### PR TITLE
CustomForm: Fix "Trying to access array offset on value of type null "

### DIFF
--- a/src/MediaWiki/Search/ProfileForm/Forms/CustomForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/CustomForm.php
@@ -66,7 +66,7 @@ class CustomForm {
 	/**
 	 * @since 3.0
 	 *
-	 * @return
+	 * @return array
 	 */
 	public function getParameters() {
 		return $this->parameters;
@@ -122,10 +122,10 @@ class CustomForm {
 
 			// Find request related value for the active form
 			if ( $this->isActiveForm ) {
-				$vals = $this->request->getArray( $name );
+				$vals = $this->request->getArray( $name, [] );
 
 				$i = $this->fieldCounter[$name];
-				$value = isset( $vals[$i] ) ? $vals[$i] : $vals;
+				$value = $vals[$i] ?? null;
 				$this->parameters[$name] = $value;
 			}
 

--- a/src/MediaWiki/Search/ProfileForm/Forms/CustomForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/CustomForm.php
@@ -125,7 +125,7 @@ class CustomForm {
 				$vals = $this->request->getArray( $name );
 
 				$i = $this->fieldCounter[$name];
-				$value = isset( $vals[$i] ) ? $vals[$i] : $vals[0];
+				$value = isset( $vals[$i] ) ? $vals[$i] : $vals;
 				$this->parameters[$name] = $value;
 			}
 

--- a/src/MediaWiki/Search/ProfileForm/Forms/CustomForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/CustomForm.php
@@ -65,10 +65,8 @@ class CustomForm {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @return array
 	 */
-	public function getParameters() {
+	public function getParameters(): array {
 		return $this->parameters;
 	}
 
@@ -125,7 +123,7 @@ class CustomForm {
 				$vals = $this->request->getArray( $name, [] );
 
 				$i = $this->fieldCounter[$name];
-				$value = $vals[$i] ?? null;
+				$value = $vals[$i] ?? '';
 				$this->parameters[$name] = $value;
 			}
 


### PR DESCRIPTION
This happens because ->getArray() can return null if it can't find the key. We fix this by instead changing the return default for getArray to an array. We then change the isset check to use new php syntax and also return a null, instead of using $vals[0]. We already check for that so this was a duplicate and was error prone.

Fixes #5644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved form input handling to ensure that when no values are found, an empty array is returned, enhancing robustness in form processing.
	- Simplified logic for value assignment in forms, improving clarity and reducing potential errors in data handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->