### PR TITLE
Normalizer: Fix "mb_strtolower(): Argument #2 ($encoding) must be a valid encoding, "" given"

### DIFF
--- a/Tesa/src/Normalizer.php
+++ b/Tesa/src/Normalizer.php
@@ -63,9 +63,7 @@ class Normalizer {
 	 * @return string
 	 */
 	public static function toLowercase( $text ) {
-		$encoding = mb_detect_encoding( $text ) ?
-			mb_detect_encoding( $text ) :
-			'UTF-8';
+		$encoding = mb_detect_encoding( $text ) ?: 'UTF-8';
 		return mb_strtolower( $text, $encoding );
 	}
 
@@ -82,9 +80,7 @@ class Normalizer {
 			return $text;
 		}
 
-		$encoding = mb_detect_encoding( $text ) ?
-			mb_detect_encoding( $text ) :
-			'UTF-8';
+		$encoding = mb_detect_encoding( $text ) ?: 'UTF-8';
 		$lastWholeWordPosition = $length;
 
 		if ( strpos( $text, ' ' ) !== false ) {

--- a/Tesa/src/Normalizer.php
+++ b/Tesa/src/Normalizer.php
@@ -42,11 +42,11 @@ class Normalizer {
 			$halfWidth = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
 
 			// http://php.net/manual/en/function.str-split.php, mb_str_split
-			$length = mb_strlen( $fullWidth, "UTF-8" );
+			$length = mb_strlen( $fullWidth, 'UTF-8' );
 			$full = [];
 
 			for ( $i = 0; $i < $length; $i += 1 ) {
-				$full[] = mb_substr( $fullWidth, $i, 1, "UTF-8" );
+				$full[] = mb_substr( $fullWidth, $i, 1, 'UTF-8' );
 			}
 
 			$half = str_split( $halfWidth );
@@ -63,7 +63,10 @@ class Normalizer {
 	 * @return string
 	 */
 	public static function toLowercase( $text ) {
-		return mb_strtolower( $text, mb_detect_encoding( $text ) );
+		$encoding = mb_detect_encoding( $text ) ?
+			mb_detect_encoding( $text ) :
+			'UTF-8';
+		return mb_strtolower( $text, $encoding );
 	}
 
 	/**
@@ -79,7 +82,9 @@ class Normalizer {
 			return $text;
 		}
 
-		$encoding = mb_detect_encoding( $text );
+		$encoding = mb_detect_encoding( $text ) ?
+			mb_detect_encoding( $text ) :
+			'UTF-8';
 		$lastWholeWordPosition = $length;
 
 		if ( strpos( $text, ' ' ) !== false ) {


### PR DESCRIPTION
If mb_detect_encoding returns an empty string then return a default of UTF-8.

Fixes #5639

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced text processing reliability by ensuring a valid text encoding is always applied, reducing potential errors.
  
- **Refactor**
  - Streamlined text handling methods for consistent and predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->