### PR TITLE
Revert "RecursiveTextProcessor: getOutput before initialization was deprecated in MediaWiki 1.42"

### DIFF
--- a/src/Parser/RecursiveTextProcessor.php
+++ b/src/Parser/RecursiveTextProcessor.php
@@ -295,11 +295,6 @@ class RecursiveTextProcessor {
 
 	private function getParserOutputSafe(): ?ParserOutput {
 		try {
-			// The getOutput() method is deprecated in MW 1.42 before initializing
-			// So we need to check if the parser was initialized.
-			if ( version_compare( MW_VERSION, '1.42', '>=' ) && $this->parser->getOptions() === null ) {
-				$this->parser->resetOutput();
-			}
 			return $this->parser->getOutput();
 		} catch ( Error $e ) {
 			return null;


### PR DESCRIPTION
Reverts SemanticMediaWiki/SemanticMediaWiki#6047

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined output processing by removing outdated conditions, resulting in more consistent and reliable performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->