### PR TITLE
SMW\ResultPrinter -> SMW\Query\ResultPrinters\ResultPrinter

### DIFF
--- a/includes/SemanticMediaWiki.php
+++ b/includes/SemanticMediaWiki.php
@@ -109,7 +109,7 @@ class SemanticMediaWiki {
 		/** @} */
 
 		/** @{
-		 * SMW\ResultPrinter related constants that define
+		 * SMW\Query\ResultPrinters\ResultPrinter related constants that define
 		 * how/if headers should be displayed
 		 */
 		define( 'SMW_HEADERS_SHOW', 2 );

--- a/tests/phpunit/QueryPrinterRegistryTestCase.php
+++ b/tests/phpunit/QueryPrinterRegistryTestCase.php
@@ -3,7 +3,7 @@
 namespace SMW\Tests;
 
 /**
- * Base class for SMW\ResultPrinter tests.
+ * Base class for \SMW\Query\ResultPrinters\ResultPrinter tests.
  *
  * @group SMW
  * @group SMWExtension
@@ -17,7 +17,7 @@ abstract class QueryPrinterRegistryTestCase extends QueryPrinterTestCase {
 
 	/**
 	 * Returns the names of the formats supported by the
-	 * \SMW\ResultPrinter being tested.
+	 * \SMW\Query\ResultPrinters\ResultPrinter being tested.
 	 *
 	 * @since 1.8
 	 *
@@ -49,7 +49,7 @@ abstract class QueryPrinterRegistryTestCase extends QueryPrinterTestCase {
 	 * @param string $format
 	 * @param bool $isInline
 	 *
-	 * @return \SMW\ResultPrinter
+	 * @return \SMW\Query\ResultPrinters\ResultPrinter
 	 */
 	protected function newInstance( $format, $isInline ) {
 		$class = $this->getClass();
@@ -82,6 +82,6 @@ abstract class QueryPrinterRegistryTestCase extends QueryPrinterTestCase {
 	public function testConstructor( $format, $isInline ) {
 		$instance = $this->newInstance( $format, $isInline );
 
-		$this->assertInstanceOf( '\SMW\ResultPrinter', $instance );
+		$this->assertInstanceOf( '\SMW\Query\ResultPrinters\ResultPrinter', $instance );
 	}
 }

--- a/tests/phpunit/QueryPrinterRegistryTestCase.php
+++ b/tests/phpunit/QueryPrinterRegistryTestCase.php
@@ -5,8 +5,6 @@ namespace SMW\Tests;
 use SMW\Query\ResultPrinters\ResultPrinter;
 
 /**
- * Base class for ResultPrinter tests.
- *
  * @group SMW
  * @group SMWExtension
  *

--- a/tests/phpunit/QueryPrinterRegistryTestCase.php
+++ b/tests/phpunit/QueryPrinterRegistryTestCase.php
@@ -2,8 +2,10 @@
 
 namespace SMW\Tests;
 
+use SMW\Query\ResultPrinters\ResultPrinter;
+
 /**
- * Base class for \SMW\Query\ResultPrinters\ResultPrinter tests.
+ * Base class for ResultPrinter tests.
  *
  * @group SMW
  * @group SMWExtension
@@ -17,7 +19,7 @@ abstract class QueryPrinterRegistryTestCase extends QueryPrinterTestCase {
 
 	/**
 	 * Returns the names of the formats supported by the
-	 * \SMW\Query\ResultPrinters\ResultPrinter being tested.
+	 * ResultPrinter being tested.
 	 *
 	 * @since 1.8
 	 *
@@ -49,7 +51,7 @@ abstract class QueryPrinterRegistryTestCase extends QueryPrinterTestCase {
 	 * @param string $format
 	 * @param bool $isInline
 	 *
-	 * @return \SMW\Query\ResultPrinters\ResultPrinter
+	 * @return ResultPrinter
 	 */
 	protected function newInstance( $format, $isInline ) {
 		$class = $this->getClass();
@@ -82,6 +84,6 @@ abstract class QueryPrinterRegistryTestCase extends QueryPrinterTestCase {
 	public function testConstructor( $format, $isInline ) {
 		$instance = $this->newInstance( $format, $isInline );
 
-		$this->assertInstanceOf( '\SMW\Query\ResultPrinters\ResultPrinter', $instance );
+		$this->assertInstanceOf( ResultPrinter::class, $instance );
 	}
 }


### PR DESCRIPTION
The "SMW\ResultPrinter" alias was removed. Fix references to the alias. Also the test was failing because it was using the alias that has been removed. I did not notice this as this class seems to be used only in the extensions?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Enhanced internal documentation to improve clarity and consistency regarding the `ResultPrinter` class.
- **Tests**
  - Updated test annotations and validation messages to align with current standards.

These improvements ensure better maintainability and clearer guidance for developers, with no changes affecting the functionalities experienced by end users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->