### PR TITLE
Replace references to SMWElasticStore with SMW\Elastic\ElasticStore

### DIFF
--- a/data/config/elastic-fileingest.php
+++ b/data/config/elastic-fileingest.php
@@ -26,7 +26,7 @@ return [
 	/**
 	 * @see $smwgDefaultStore
 	 */
-	'smwgDefaultStore' => 'SMWElasticStore',
+	'smwgDefaultStore' => 'SMW\Elastic\ElasticStore',
 
 	/**
 	 * @see $smwgElasticsearchConfig

--- a/src/Elastic/ElasticStore.php
+++ b/src/Elastic/ElasticStore.php
@@ -366,7 +366,7 @@ class ElasticStore extends SQLStore {
 			);
 
 			$this->messageReporter->reportMessage(
-				"\n" . $cliMsgFormatter->twoCols( "Query engine:", 'SMWElasticStore' )
+				"\n" . $cliMsgFormatter->twoCols( "Query engine:", 'SMW\Elastic\ElasticStore' )
 			);
 
 			$this->messageReporter->reportMessage( "\nChecking indices ...\n" );
@@ -415,7 +415,7 @@ class ElasticStore extends SQLStore {
 			);
 
 			$this->messageReporter->reportMessage(
-				"\n" . $cliMsgFormatter->twoCols( "Query engine:", 'SMWElasticStore' )
+				"\n" . $cliMsgFormatter->twoCols( "Query engine:", 'SMW\Elastic\ElasticStore' )
 			);
 
 			$this->messageReporter->reportMessage( "\nDropped index ...\n" );

--- a/src/Elastic/README.md
+++ b/src/Elastic/README.md
@@ -38,7 +38,7 @@ The `ElasticStore` provides the same query features (given those are tested) as 
 
 Before the ElasticStore (hereby Elasticsearch) can be used as drop-in replacement for the existing `SQLStore` based `QueryEngine` the following settings and operations are required:
 
-- Set `$GLOBALS['smwgDefaultStore'] = 'SMWElasticStore';` (see [`$smwgDefaultStore`][smw:smwgDefaultStore])
+- Set `$GLOBALS['smwgDefaultStore'] = 'SMW\Elastic\ElasticStore';` (see [`$smwgDefaultStore`][smw:smwgDefaultStore])
 - Set `$GLOBALS['smwgElasticsearchEndpoints'] = [ ... ];` (see [`$smwgElasticsearchEndpoints`][smw:smwgElasticsearchEndpoints])
 - Run `php setupStore.php` or `php update.php`
 - Rebuild the index using `php rebuildElasticIndex.php` (see [`rebuildElasticIndex.php`][smw:rebuildElasticIndex.php])

--- a/src/Elastic/docs/usage.md
+++ b/src/Elastic/docs/usage.md
@@ -2,7 +2,7 @@
 
 To use the `ElasticStore` (hereby Elasticsearch) as a drop-in replacement for the existing `SQLStore` based `QueryEngine` the following settings require some changes:
 
-- Set `$GLOBALS['smwgDefaultStore'] = 'SMWElasticStore';`
+- Set `$GLOBALS['smwgDefaultStore'] = 'SMW\Elastic\ElasticStore';`
 - Set `$GLOBALS['smwgElasticsearchEndpoints'] = [ ... ];` (see the [documentation][es:conf:hosts] for how to maintain inline or extended host parameters as it takes the same attributes as outlined in the official documentation, or see a [configuration example][conf:example])
 - Run `php setupStore.php` or `php update.php`
 - Rebuild the index using `php rebuildElasticIndex.php`

--- a/src/MediaWiki/Search/ProfileForm/ProfileForm.php
+++ b/src/MediaWiki/Search/ProfileForm/ProfileForm.php
@@ -351,7 +351,7 @@ class ProfileForm {
 		// TODO this information should come from the store and not being
 		// derived from a class! How should such characteristic be represented?
 		$features = [
-			'best' => is_a( $this->store, "SMWElasticStore" )
+			'best' => is_a( $this->store, "SMW\Elastic\ElasticStore" )
 		];
 
 		$form = $sortForm->makeFields( $features );

--- a/tests/phpunit/Elastic/ConfigTest.php
+++ b/tests/phpunit/Elastic/ConfigTest.php
@@ -37,7 +37,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase {
 
 	public function testIsDefaultStore_True() {
 		$instance = new Config(
-			[ Config::DEFAULT_STORE => 'SMWElasticStore' ]
+			[ Config::DEFAULT_STORE => 'SMW\Elastic\ElasticStore' ]
 		);
 
 		$this->assertTrue(

--- a/tests/phpunit/Elastic/Connection/ConnectionProviderTest.php
+++ b/tests/phpunit/Elastic/Connection/ConnectionProviderTest.php
@@ -45,7 +45,7 @@ class ConnectionProviderTest extends \PHPUnit\Framework\TestCase {
 	public function testGetConnection_MissingEndpointsThrowsException() {
 		$config = new Config(
 			[
-				Config::DEFAULT_STORE => 'SMWElasticStore'
+				Config::DEFAULT_STORE => 'SMW\Elastic\ElasticStore'
 			]
 		);
 
@@ -86,7 +86,7 @@ class ConnectionProviderTest extends \PHPUnit\Framework\TestCase {
 
 		$config = new Config(
 			[
-				Config::DEFAULT_STORE => 'SMWElasticStore',
+				Config::DEFAULT_STORE => 'SMW\Elastic\ElasticStore',
 				Config::ELASTIC_ENDPOINTS => [ 'foo' ]
 			]
 		);
@@ -111,7 +111,7 @@ class ConnectionProviderTest extends \PHPUnit\Framework\TestCase {
 
 		$config = new Config(
 			[
-				Config::DEFAULT_STORE => 'SMWElasticStore',
+				Config::DEFAULT_STORE => 'SMW\Elastic\ElasticStore',
 				Config::ELASTIC_ENDPOINTS => [ 'foo' ]
 			]
 		);

--- a/tests/phpunit/JSONScriptServicesTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptServicesTestCaseRunner.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests;
 
 use SMW\DataValueFactory;
+use SMW\Elastic\ElasticStore;
 use SMW\Listener\EventListener\EventHandler;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SPARQLStore\TurtleTriplesBuilder;
@@ -155,7 +156,7 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 		parent::getPermittedSettings();
 
 		$elasticsearchConfig = function ( $val ) {
-			if ( $this->getStore() instanceof \SMWElasticStore ) {
+			if ( $this->getStore() instanceof ElasticStore ) {
 				$config = $this->getStore()->getConnection( 'elastic' )->getConfig();
 
 				foreach ( $val as $key => $value ) {


### PR DESCRIPTION
Fixes #6057

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default store identifier throughout the application to a fully qualified, namespaced format.
- **Documentation**
  - Revised configuration instructions to reflect the new, namespaced store reference.
- **Tests**
  - Adjusted test configurations to align with the updated default store value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->