### PR TITLE
Clean JsonSchemaValidator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,7 +57,7 @@
 		"onoi/callback-container": "~2.0",
 		"symfony/css-selector": "^5|^4|^3.3",
 		"seld/jsonlint": "^1.7",
-		"justinrainbow/json-schema": "~5.2",
+		"justinrainbow/json-schema": "^6.0|^5.2",
 		"jeroen/file-fetcher": "^6|^5|^4.4",
 		"wikimedia/cdb": "^3|^2|^1",
 		"wikimedia/textcat": "^2|^1.1"

--- a/src/Utils/JsonSchemaValidator.php
+++ b/src/Utils/JsonSchemaValidator.php
@@ -14,37 +14,15 @@ use JsonSerializable;
  */
 class JsonSchemaValidator {
 
-	/**
-	 * @var SchemaValidator
-	 */
-	private $schemaValidator;
+	private ?SchemaValidator $schemaValidator;
+	private bool $isValid = true;
+	private array $errors = [];
 
-	/**
-	 * @var boolen
-	 */
-	private $isValid = true;
-
-	/**
-	 * @var
-	 */
-	private $errors = [];
-
-	/**
-	 * @since 3.0
-	 *
-	 * @param SchemaValidator|null $schemaValidator
-	 */
 	public function __construct( ?SchemaValidator $schemaValidator = null ) {
 		$this->schemaValidator = $schemaValidator;
 	}
 
-	/**
-	 * @since 3.0
-	 *
-	 * @param JsonSerializable $data
-	 * @param string|null $schemaLink
-	 */
-	public function validate( JsonSerializable $data, $schemaLink = null ) {
+	public function validate( JsonSerializable $data, ?string $schemaLink = null ): void {
 		// Raise an error because we expect the validator to be available
 		// when at the same time a schema link is present
 		if ( $this->schemaValidator === null && $schemaLink !== null ) {
@@ -65,7 +43,7 @@ class JsonSchemaValidator {
 
 		// https://github.com/justinrainbow/json-schema
 		try {
-			$this->schemaValidator->check(
+			$this->schemaValidator->validate(
 				$data,
 				(object)[ '$ref' => 'file://' . $schemaLink ]
 			);
@@ -78,30 +56,15 @@ class JsonSchemaValidator {
 		}
 	}
 
-	/**
-	 * @since 3.0
-	 *
-	 * @param boolean
-	 */
-	public function hasSchemaValidator() {
+	public function hasSchemaValidator(): bool {
 		return $this->schemaValidator !== null;
 	}
 
-	/**
-	 * @since 3.0
-	 *
-	 * @param boolean
-	 */
-	public function isValid() {
+	public function isValid(): bool {
 		return $this->isValid;
 	}
 
-	/**
-	 * @since 3.0
-	 *
-	 * @return
-	 */
-	public function getErrors() {
+	public function getErrors(): array {
 		return $this->errors;
 	}
 

--- a/tests/phpunit/Utils/JsonSchemaValidatorTest.php
+++ b/tests/phpunit/Utils/JsonSchemaValidatorTest.php
@@ -60,7 +60,7 @@ class JsonSchemaValidatorTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( json_encode( [ 'Foo' ] ) );
 
 		$schemaValidator = $this->getMockBuilder( SchemaValidator::class )
-			->setMethods( [ 'check' ] )
+			->setMethods( [ 'validate' ] )
 			->getMock();
 
 		$instance = new JsonSchemaValidator(
@@ -92,11 +92,11 @@ class JsonSchemaValidatorTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( json_encode( [ 'Foo' ] ) );
 
 		$schemaValidator = $this->getMockBuilder( SchemaValidator::class )
-			->setMethods( [ 'check' ] )
+			->setMethods( [ 'validate' ] )
 			->getMock();
 
 		$schemaValidator->expects( $this->any() )
-			->method( 'check' )
+			->method( 'validate' )
 			->willThrowException( new ResourceNotFoundException() );
 
 		$instance = new JsonSchemaValidator(


### PR DESCRIPTION
Replaces usage of deprecated `check` method

Adds installability with justinrainbow/json-schema 6.x, so closes https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6064