### PR TITLE
Fix title handling for pages with namespace-like prefixes (#6083)

### DIFF
--- a/src/Importer/ContentCreators/TextContentCreator.php
+++ b/src/Importer/ContentCreators/TextContentCreator.php
@@ -75,9 +75,9 @@ class TextContentCreator implements ContentCreator {
 			);
 		}
 
-		$title = $this->titleFactory->newFromText(
-			$name,
-			$importContents->getNamespace()
+		$title = $this->titleFactory->makeTitleSafe(
+			$importContents->getNamespace(),
+			$name
 		);
 
 		if ( $title === null ) {

--- a/tests/phpunit/Importer/ContentCreators/TextContentCreatorTest.php
+++ b/tests/phpunit/Importer/ContentCreators/TextContentCreatorTest.php
@@ -101,7 +101,7 @@ class TextContentCreatorTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( $status );
 
 		$this->titleFactory->expects( $this->atLeastOnce() )
-			->method( 'newFromText' )
+			->method( 'makeTitleSafe' )
 			->willReturn( $title );
 
 		$this->titleFactory->expects( $this->atLeastOnce() )
@@ -171,7 +171,7 @@ class TextContentCreatorTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( $status );
 
 		$this->titleFactory->expects( $this->atLeastOnce() )
-			->method( 'newFromText' )
+			->method( 'makeTitleSafe' )
 			->willReturn( $title );
 
 		$this->titleFactory->expects( $this->atLeastOnce() )
@@ -219,7 +219,7 @@ class TextContentCreatorTest extends \PHPUnit\Framework\TestCase {
 			->method( self::getDoEditContentMethod() );
 
 		$this->titleFactory->expects( $this->atLeastOnce() )
-			->method( 'newFromText' )
+			->method( 'makeTitleSafe' )
 			->willReturn( $title );
 
 		$this->titleFactory->expects( $this->atLeastOnce() )
@@ -302,7 +302,7 @@ class TextContentCreatorTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( $user );
 
 		$this->titleFactory->expects( $this->atLeastOnce() )
-			->method( 'newFromText' )
+			->method( 'makeTitleSafe' )
 			->willReturn( $title );
 
 		$this->titleFactory->expects( $this->atLeastOnce() )
@@ -377,7 +377,7 @@ class TextContentCreatorTest extends \PHPUnit\Framework\TestCase {
 			->willReturn( null );
 
 		$this->titleFactory->expects( $this->atLeastOnce() )
-			->method( 'newFromText' )
+			->method( 'makeTitleSafe' )
 			->willReturn( $title );
 
 		$this->titleFactory->expects( $this->atLeastOnce() )


### PR DESCRIPTION
When importing pages, titles containing a : (colon) could be incorrectly interpreted as having a namespace rather than being part of the page title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the process for constructing text content titles, ensuring more reliable internal handling while maintaining current functionality.
- **Tests**
	- Updated test validations to align with these internal enhancements, ensuring continued consistency and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->