### PR TITLE
Do not lock parser when the Factbox is shown in preview mode

### DIFF
--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -118,22 +118,25 @@ class ContentParser {
 	 * @since 1.9
 	 *
 	 * @param string|null $text
+	 * @param bool $clear Whether to clear the parser cache.
 	 *
 	 * @return ContentParser
 	 */
-	public function parse( $text = null ) {
+	public function parse( ?string $text = null, bool $clear = true ) {
 		if ( $text !== null ) {
-			return $this->parseText( $text );
+			return $this->parseText( $text, $clear );
 		}
 
 		return $this->fetchFromContent();
 	}
 
-	private function parseText( $text ) {
+	private function parseText( ?string $text, bool $clear ) {
 		$this->parserOutput = $this->parser->parse(
 			$text,
 			$this->getTitle(),
-			$this->makeParserOptions()
+			$this->makeParserOptions(),
+			true,
+			$clear
 		);
 
 		return $this;

--- a/src/Factbox/CachedFactbox.php
+++ b/src/Factbox/CachedFactbox.php
@@ -334,19 +334,16 @@ class CachedFactbox {
 		}
 
 		$contentParser = $applicationFactory->newContentParser( $title );
-		$content = '';
 
 		if ( ( $content = $factbox->getContent() ) !== '' ) {
-			$contentParser->parse( $content );
+			$contentParser->parse( $content, false );
 			$content = InTextAnnotationParser::removeAnnotation(
 				$contentParser->getOutput()->getText()
 			);
 		}
 
-		$attachmentContent = '';
-
 		if ( ( $attachmentContent = $factbox->getAttachmentHTML() ) !== '' ) {
-			$contentParser->parse( $attachmentContent );
+			$contentParser->parse( $attachmentContent, false );
 			$attachmentContent = $contentParser->getOutput()->getText();
 		}
 


### PR DESCRIPTION
Do not lock parser when the Factbox is shown in preview mode.

Fixes #6090.