### PR TITLE
Fix overriding 'origin' in the ChangePropagation* job classes

### DIFF
--- a/src/MediaWiki/Jobs/ChangePropagationClassUpdateJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationClassUpdateJob.php
@@ -27,9 +27,10 @@ class ChangePropagationClassUpdateJob extends ChangePropagationUpdateJob {
 	 * @param array $params job parameters
 	 */
 	public function __construct( Title $title, $params = [] ) {
-		$params = $params + [
-			'origin' => 'ChangePropagationClassUpdateJob'
-		];
+		$params = array_merge(
+			$params,
+			[ 'origin' => 'ChangePropagationClassUpdateJob' ]
+		);
 
 		parent::__construct( $title, $params, self::JOB_COMMAND );
 	}

--- a/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
@@ -54,7 +54,7 @@ class ChangePropagationUpdateJob extends Job {
 
 		$updateJob = new UpdateJob(
 			$this->getTitle(),
-			$this->params + [ 'origin' => 'ChangePropagationUpdateJob' ]
+			array_merge( $this->params, [ 'origin' => 'ChangePropagationUpdateJob' ] )
 		);
 
 		$updateJob->run();


### PR DESCRIPTION
We have to merge rather than use +. The later doesn't merge it.

So for instance `$params + ['origin' => 'test']` won't make $params this `$params = ['origin' => 'test']` if it already has 'origin'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Enhanced the internal handling of configuration parameters for background tasks to ensure more predictable and consistent operations. No visible changes have been introduced for end-users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->