### PR TITLE
phpunit: Remove unused "MainWANObjectCache" case

### DIFF
--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -119,10 +119,6 @@ class TestEnvironment {
 			// MediaWiki\Services\NoSuchServiceException: No such service ...
 		}
 
-		if ( $name === 'MainWANObjectCache' ) {
-			MediaWikiServices::getInstance()->getMainWANObjectCache()->clearProcessCache();
-		}
-
 		return $this;
 	}
 


### PR DESCRIPTION
Added in 2017 by 8fe95bb1f3, for use in MwDBaseUnitTestCase.php (now known as DatabaseTestCase.php).

That call was removed in 2024 by f12a57f8ab.

Ref https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/5589.

Motivated by https://gerrit.wikimedia.org/r/c/mediawiki/core/+/1129973 which will rename this service to `WANObjectCache`, per Codesearch https://codesearch.wmcloud.org/search/?q=%5B%27%22%5DMainWANObjectCache&files=test