### PR TITLE
GlobalFunctions: Fix support for MW 1.44

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -161,8 +161,13 @@ function &smwfGetStore() {
  * @return string
  */
 function smwfCacheKey( $namespace, $key ) {
-	$cachePrefix = $GLOBALS['wgCachePrefix'] === false ?
-		WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix'];
+	if ( version_compare( MW_VERSION, '1.40', '<' ) ) {
+		$cachePrefix = $GLOBALS['wgCachePrefix'] === false ?
+			WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix'];
+	} else {
+		$cachePrefix = $GLOBALS['wgCachePrefix'] === false ?
+			MediaWiki\WikiMap\WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix'];
+	}
 
 	if ( $namespace[0] !== ':' ) {
 		$namespace = ':' . $namespace;
@@ -191,7 +196,11 @@ function smwfGetLinker() {
 	static $linker = false;
 
 	if ( $linker === false ) {
-		$linker = new Linker();
+		if ( version_compare( MW_VERSION, '1.40', '<' ) ) {
+			$linker = new Linker();
+		} else {
+			$linker = new MediaWiki\Linker\Linker();
+		}
 	}
 
 	return $linker;


### PR DESCRIPTION
WikiMap and Linker class aliases were removed in MW 1.44. The aliases were introduced in MW 1.40, so we have to do a version check to use the old class on MW 1.39.