### PR TITLE
SQLStore/Installer: Fix support for MediaWiki 1.44

### DIFF
--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -395,7 +395,7 @@ class Installer implements MessageReporter {
 		if ( version_compare( MW_VERSION, '1.40', '<' ) ) {
 			$title = \Title::newFromText( 'SMW\SQLStore\Installer' );
 		} else {
-			$title = MediaWiki\Title\Title::newFromText( 'SMW\SQLStore\Installer' );
+			$title = \MediaWiki\Title\Title::newFromText( 'SMW\SQLStore\Installer' );
 		}
 
 		$propertyStatisticsRebuildJob = new PropertyStatisticsRebuildJob(

--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -392,7 +392,11 @@ class Installer implements MessageReporter {
 			$this->cliMsgFormatter->firstCol( "... Property statistics rebuild job ...", 3 )
 		);
 
-		$title = \Title::newFromText( 'SMW\SQLStore\Installer' );
+		if ( version_compare( MW_VERSION, '1.40', '<' ) ) {
+			$title = \Title::newFromText( 'SMW\SQLStore\Installer' );
+		} else {
+			$title = MediaWiki\Title\Title::newFromText( 'SMW\SQLStore\Installer' );
+		}
 
 		$propertyStatisticsRebuildJob = new PropertyStatisticsRebuildJob(
 			$title,


### PR DESCRIPTION
Title class aliase was removed in MW 1.44.
The Title alias was introduced in MW 1.40, so we have to do a version check to use the old class on MW 1.39.