### PR TITLE
CacheFactory: Fix support for MediaWiki 1.44

### DIFF
--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -8,8 +8,6 @@ use Onoi\Cache\Cache;
 use Onoi\Cache\CacheFactory as OnoiCacheFactory;
 use RuntimeException;
 use SMW\Services\ServicesFactory as ApplicationFactory;
-use Title;
-use WikiMap;
 
 /**
  * @license GPL-2.0-or-later
@@ -52,19 +50,26 @@ class CacheFactory {
 	 * @return string
 	 */
 	public static function getCachePrefix() {
+		if ( version_compare( MW_VERSION, '1.40', '<' ) ) {
+			return $GLOBALS['wgCachePrefix'] === false ?
+				\WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix'];
+		}
+
 		return $GLOBALS['wgCachePrefix'] === false ?
-			WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix'];
+			MediaWiki\WikiMap\WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix'];
 	}
 
 	/**
 	 * @since 2.2
 	 *
-	 * @param Title|int|string $key
+	 * @param \MediaWiki\Title\Title|int|string $key
 	 *
 	 * @return string
 	 */
 	public static function getPurgeCacheKey( $key ) {
-		if ( $key instanceof Title ) {
+		if ( version_compare( MW_VERSION, '1.40', '<' ) && $key instanceof \Title ) {
+			$key = $key->getArticleID();
+		} elseif ( $key instanceof \MediaWiki\Title\Title ) {
 			$key = $key->getArticleID();
 		}
 

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -62,7 +62,7 @@ class CacheFactory {
 	/**
 	 * @since 2.2
 	 *
-	 * @param \MediaWiki\Title\Title|int|string $key
+	 * @param \MediaWiki\Title\Title|\Title|int|string $key
 	 *
 	 * @return string
 	 */

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -67,8 +67,10 @@ class CacheFactory {
 	 * @return string
 	 */
 	public static function getPurgeCacheKey( $key ) {
-		if ( version_compare( MW_VERSION, '1.40', '<' ) && $key instanceof \Title ) {
-			$key = $key->getArticleID();
+		if ( version_compare( MW_VERSION, '1.40', '<' ) ) {
+			if ( $key instanceof \Title ) {
+				$key = $key->getArticleID();
+			}
 		} elseif ( $key instanceof \MediaWiki\Title\Title ) {
 			$key = $key->getArticleID();
 		}

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -56,7 +56,7 @@ class CacheFactory {
 		}
 
 		return $GLOBALS['wgCachePrefix'] === false ?
-			MediaWiki\WikiMap\WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix'];
+			\MediaWiki\WikiMap\WikiMap::getCurrentWikiId() : $GLOBALS['wgCachePrefix'];
 	}
 
 	/**


### PR DESCRIPTION
WikiMap and Title class aliase was removed in MW 1.44. The WikiMap and Title aliases was introduced in MW 1.40, so we have to do a version check to use the old class on MW 1.39.