### PR TITLE
Make various parser cache behavior configurable

### DIFF
--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -2519,7 +2519,18 @@ return ( static function () {
 		 *
 		 * @since 5.0
 		 */
-		'smwgEnableExportRDFLink' => true
+		'smwgEnableExportRDFLink' => true,
 
+		/**
+		 * Sets whether or not to set the timestamp on the ParserOutput object
+		 * Enabling this allows parser cache to be invalidated immediately
+		 *
+		 * However:
+		 * - Last modified date will become the parser cache purge time instead of the page edit time
+		 * - CDN cache might not be invalidated correctly because the revision is not old enough to be considered stale
+		 *
+		 * @since 5.1
+		 */
+		'smwgSetParserCacheTimestamp' => true,
 	];
 } )();

--- a/includes/DefaultSettings.php
+++ b/includes/DefaultSettings.php
@@ -2532,5 +2532,16 @@ return ( static function () {
 		 * @since 5.1
 		 */
 		'smwgSetParserCacheTimestamp' => true,
+
+		/**
+		 * Sets the keys that will be added to the parser cache key.
+		 * Each key will trigger a cache fragmentation.
+		 *
+		 * @since 5.1
+		 */
+		'smwgSetParserCacheKeys' => [
+			'userlang',
+			'dateformat'
+		],
 	];
 } )();

--- a/src/MediaWiki/MagicWordsFinder.php
+++ b/src/MediaWiki/MagicWordsFinder.php
@@ -5,6 +5,7 @@ namespace SMW\MediaWiki;
 use MagicWord;
 use MagicWordFactory;
 use ParserOutput;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
  * @license GPL-2.0-or-later
@@ -78,7 +79,9 @@ class MagicWordsFinder {
 	 * @param array $words
 	 */
 	public function pushMagicWordsToParserOutput( array $words ) {
-		$this->parserOutput->setTimestamp( wfTimestampNow() );
+		if ( ApplicationFactory::getInstance()->getSettings()->get( 'smwgSetParserCacheTimestamp' ) ) {
+			$this->parserOutput->setTimestamp( wfTimestampNow() );
+		}
 
 		// Filter empty lines
 		$words = array_values( array_filter( $words ) );

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -196,9 +196,11 @@ class ParserData {
 	 * @return ParserOptions|null
 	 */
 	public function addExtraParserKey( $key ) {
-		// Looks odd in 1.30 "Saved in parser cache ... idhash:19989-0!canonical!userlang!dateformat!userlang!dateformat!userlang!dateformat!userlang!dateformat and ..."
-		// threfore use the ParserOutput::recordOption instead
-		if ( $key === 'userlang' || $key === 'dateformat' ) {
+		$keysToCache = ApplicationFactory::getInstance()->getSettings()->get( 'smwgSetParserCacheKeys' ) ?? [];
+
+		if ( in_array( $key, $keysToCache ) ) {
+			// Looks odd in 1.30 "Saved in parser cache ... idhash:19989-0!canonical!userlang!dateformat!userlang!dateformat!userlang!dateformat!userlang!dateformat and ..."
+			// therefore use the ParserOutput::recordOption instead
 			$this->parserOutput->recordOption( $key );
 		} elseif ( $this->parserOptions !== null ) {
 			$this->parserOptions->addExtraKey( $key );

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -347,7 +347,9 @@ class ParserData {
 	 * @since 3.0
 	 */
 	public function markParserOutput() {
-		$this->parserOutput->setTimestamp( wfTimestampNow() );
+		if ( ApplicationFactory::getInstance()->getSettings()->get( 'smwgSetParserCacheTimestamp' ) ) {
+			$this->parserOutput->setTimestamp( wfTimestampNow() );
+		}
 
 		$this->parserOutput->setExtensionData(
 			'smw-semanticdata-status',

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -210,7 +210,8 @@ class Settings extends Options {
 			'smwgPlainList' => $GLOBALS['smwgPlainList'],
 			'smwgDetectOutdatedData' => $GLOBALS['smwgDetectOutdatedData'],
 			'smwgIgnoreUpgradeKeyCheck' => $GLOBALS['smwgIgnoreUpgradeKeyCheck'],
-			'smwgEnableExportRDFLink' => $GLOBALS['smwgEnableExportRDFLink']
+			'smwgEnableExportRDFLink' => $GLOBALS['smwgEnableExportRDFLink'],
+			'smwgSetParserCacheTimestamp' => $GLOBALS['smwgSetParserCacheTimestamp']
 		];
 
 		$this->isLoaded = true;

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -211,7 +211,8 @@ class Settings extends Options {
 			'smwgDetectOutdatedData' => $GLOBALS['smwgDetectOutdatedData'],
 			'smwgIgnoreUpgradeKeyCheck' => $GLOBALS['smwgIgnoreUpgradeKeyCheck'],
 			'smwgEnableExportRDFLink' => $GLOBALS['smwgEnableExportRDFLink'],
-			'smwgSetParserCacheTimestamp' => $GLOBALS['smwgSetParserCacheTimestamp']
+			'smwgSetParserCacheTimestamp' => $GLOBALS['smwgSetParserCacheTimestamp'],
+			'smwgSetParserCacheKeys' => $GLOBALS['smwgSetParserCacheKeys'],
 		];
 
 		$this->isLoaded = true;


### PR DESCRIPTION
#### Add the config `$smwgSetParserCacheTimestamp` to control whether SMW should mark a new timestamp for parser output.

The timestamp behavior is problematic as it:
- Breaks last modified timestamp when parser cache is enabled ([T393667](https://phabricator.wikimedia.org/T393667)).
- Prevents the adaptive TTL for CDN cache to work correctly.

#### Add the config `$smwgParserCacheKeys` to control which keys can be added to the parser cache.

The `userlang` and `dateformat` key can fragment parser cache, it should be configurable.