### PR TITLE
Setup: Fix support for MediaWiki 1.44

### DIFF
--- a/src/Site.php
+++ b/src/Site.php
@@ -4,7 +4,6 @@ namespace SMW;
 
 use MediaWiki\MediaWikiServices;
 use SiteStats;
-use WikiMap;
 
 /**
  * @license GPL-2.0-or-later
@@ -133,7 +132,11 @@ class Site {
 			$affix = ':' . $affix;
 		}
 
-		return WikiMap::getCurrentWikiId() . $affix;
+		if ( version_compare( MW_VERSION, '1.40', '<' ) ) {
+			return \WikiMap::getCurrentWikiId() . $affix;
+		}
+
+		return \MediaWiki\WikiMap\WikiMap::getCurrentWikiId() . $affix;
 	}
 
 	/**


### PR DESCRIPTION
WikiMap class aliase was removed in MW 1.44.
The WikiMap alias was introduced in MW 1.40, so we have to do a version check to use the old class on MW 1.39.