### PR TITLE
Require MediaWiki 1.43

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,46 +16,22 @@ jobs:
     strategy:
       matrix:
         include:
-          - mediawiki_version: '1.39'
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mariadb:11.2"
-            coverage: false
-            experimental: false
-          - mediawiki_version: '1.39'
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mysql:8"
-            coverage: false
-            experimental: false
-          - mediawiki_version: '1.40'
-            php_version: 8.1
-            database_type: mysql
-            database_image: "mariadb:11.2"
-            coverage: false
-            experimental: false
-          - mediawiki_version: '1.41'
+          - mediawiki_version: '1.43'
             php_version: 8.1
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: true
             experimental: false
-          - mediawiki_version: '1.42'
-            php_version: 8.2
-            database_type: mysql
-            database_image: "mariadb:11.2"
-            coverage: false
-            experimental: true
           - mediawiki_version: '1.43'
             php_version: 8.2
             database_type: mysql
-            database_image: "mariadb:11.2"
+            database_image: "mariadb:11.8"
             coverage: false
-            experimental: true
+            experimental: false
           - mediawiki_version: '1.44'
             php_version: 8.2
             database_type: mysql
-            database_image: "mariadb:11.2"
+            database_image: "mariadb:11.8"
             coverage: false
             experimental: true
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ endif
 EXTENSION=SemanticMediaWiki
 
 # docker images
-MW_VERSION?=1.39
+MW_VERSION?=1.43
 PHP_VERSION?=8.1
 DB_TYPE?=mysql
 DB_IMAGE?="mariadb:11.2"

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticMediaWiki",
-	"version": "5.1.0",
+	"version": "6.0.0-beta",
 	"author": [
 		"[https://korrekt.org Markus Krötzsch]",
 		"[https://EntropyWins.wtf/mediawiki Jeroen De Dauw]",
@@ -14,7 +14,7 @@
 	"license-name": "GPL-2.0-or-later",
 	"type": "semantic",
 	"requires": {
-		"MediaWiki": ">= 1.39"
+		"MediaWiki": ">= 1.43"
 	},
 	"MessagesDirs": {
 		"SemanticMediaWiki": [


### PR DESCRIPTION
Bump SMW to 6.0.0-beta and raise minimum MediaWiki to 1.43

With the breaking changes in MW class imports and database access methods,
it is more maintainable to bump the requirements to 1.43.

5.1.0 release has been tagged for maintaining 1.39 support.