### PR TITLE
Partially fix support for MediaWiki 1.44

### DIFF
--- a/src/MediaWiki/Jobs/PropertyStatisticsRebuildJob.php
+++ b/src/MediaWiki/Jobs/PropertyStatisticsRebuildJob.php
@@ -4,7 +4,7 @@ namespace SMW\MediaWiki\Jobs;
 
 use SMW\MediaWiki\Job;
 use SMW\Services\ServicesFactory as ApplicationFactory;
-use Title;
+use MediaWiki\Title\Title;
 
 /**
  * @license GPL-2.0-or-later


### PR DESCRIPTION
This fixes it enough to get tests to run (although doesn't fix it). it only fixes the installation step in the test.