### PR TITLE
Call parent constructor in subclasses of UploadBase

### DIFF
--- a/tests/phpunit/Utils/File/LocalFileUpload.php
+++ b/tests/phpunit/Utils/File/LocalFileUpload.php
@@ -48,6 +48,7 @@ class LocalFileUpload extends UploadBase {
 	public function __construct( $localUploadPath = '', $desiredDestName = '' ) {
 		$this->localUploadPath = $localUploadPath;
 		$this->desiredDestName = $desiredDestName;
+		parent::__construct();
 	}
 
 	/**


### PR DESCRIPTION
This if for compatibility with a potential change in MW core. In the event that change doesn't make it in, calling the constructor is nonetheless good practise and won't have any negative impacts.

See https://gerrit.wikimedia.org/r/c/mediawiki/core/+/1172856