### PR TITLE
Add footer icon spacing

### DIFF
--- a/src/Setup.php
+++ b/src/Setup.php
@@ -354,11 +354,11 @@ final class Setup {
 			return;
 		}
 
-		if ( isset( $vars['wgFooterIcons']['poweredby']['semanticmediawiki'] ) ) {
+		if ( isset( $vars['wgFooterIcons']['poweredbysmw']['semanticmediawiki'] ) ) {
 			return;
 		}
 
-		$vars['wgFooterIcons']['poweredby']['semanticmediawiki'] = [
+		$vars['wgFooterIcons']['poweredbysmw']['semanticmediawiki'] = [
 			'src' => Logo::get( 'footer' ),
 			'url' => 'https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki',
 			'alt' => 'Powered by Semantic MediaWiki',

--- a/tests/phpunit/SetupTest.php
+++ b/tests/phpunit/SetupTest.php
@@ -218,7 +218,7 @@ class SetupTest extends \PHPUnit\Framework\TestCase {
 	public function testRegisterFooterIcon() {
 		$config = $this->defaultConfig;
 
-		$config['wgFooterIcons']['poweredby'] = [];
+		$config['wgFooterIcons']['poweredbysmw'] = [];
 
 		$instance = new Setup();
 
@@ -229,7 +229,7 @@ class SetupTest extends \PHPUnit\Framework\TestCase {
 		$config = $instance->init( $config, 'Foo' );
 
 		$this->assertNotEmpty(
-			$config['wgFooterIcons']['poweredby']['semanticmediawiki']
+			$config['wgFooterIcons']['poweredbysmw']['semanticmediawiki']
 		);
 	}
 


### PR DESCRIPTION
Previously in some skins, there were no space between the "Powered by SMW" and the "Powered by MW" footer icon because they are using the same key. We should use a separate key instead to preserve the spacing.