### PR TITLE
LocalTime: Fix "Creation of dynamic property DateTime::$hasLocalTimeCorrection is deprecated"

### DIFF
--- a/src/MediaWiki/LocalTime.php
+++ b/src/MediaWiki/LocalTime.php
@@ -20,6 +20,8 @@ class LocalTime {
 	 */
 	private static $localTimeOffset = 0;
 
+	public static bool readonly $hasLocalTimeCorrection = false;
+
 	/**
 	 * @since 3.0
 	 *
@@ -48,14 +50,13 @@ class LocalTime {
 		$data = explode( '|', $tz, 3 );
 
 		// DateTime is mutable, keep track of possible changes
-		// TODO: Illegal dynamic property (#5421)
-		$dateTime->hasLocalTimeCorrection = false;
+		static::$hasLocalTimeCorrection = false;
 
 		if ( $data[0] == 'ZoneInfo' ) {
 			try {
 				$userTZ = new DateTimeZone( $data[2] );
 				$dateTime->setTimezone( $userTZ );
-				$dateTime->hasLocalTimeCorrection = true;
+				static::$hasLocalTimeCorrection = true;
 				return $dateTime;
 			} catch ( \Exception $e ) {
 				// Unrecognized timezone, default to 'Offset' with the stored offset.
@@ -95,7 +96,7 @@ class LocalTime {
 			$dateTime->sub( $dateInterval );
 		}
 
-		$dateTime->hasLocalTimeCorrection = true;
+		static::$hasLocalTimeCorrection = true;
 
 		return $dateTime;
 	}

--- a/src/MediaWiki/LocalTime.php
+++ b/src/MediaWiki/LocalTime.php
@@ -20,7 +20,7 @@ class LocalTime {
 	 */
 	private static $localTimeOffset = 0;
 
-	public static bool readonly $hasLocalTimeCorrection = false;
+	public static bool $hasLocalTimeCorrection = false;
 
 	/**
 	 * @since 3.0

--- a/tests/phpunit/MediaWiki/LocalTimeTest.php
+++ b/tests/phpunit/MediaWiki/LocalTimeTest.php
@@ -22,7 +22,7 @@ class LocalTimeTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertFalse(
-			$dateTime->hasLocalTimeCorrection
+			LocalTime::$hasLocalTimeCorrection
 		);
 	}
 
@@ -33,7 +33,7 @@ class LocalTimeTest extends \PHPUnit\Framework\TestCase {
 		$dateTime = LocalTime::getLocalizedTime( $dti );
 
 		$this->assertTrue(
-			$dateTime->hasLocalTimeCorrection
+			LocalTime::$hasLocalTimeCorrection
 		);
 
 		$this->assertEquals(
@@ -49,7 +49,7 @@ class LocalTimeTest extends \PHPUnit\Framework\TestCase {
 		$dateTime = LocalTime::getLocalizedTime( $dti );
 
 		$this->assertTrue(
-			$dateTime->hasLocalTimeCorrection
+			LocalTime::$hasLocalTimeCorrection
 		);
 
 		$this->assertEquals(
@@ -65,7 +65,7 @@ class LocalTimeTest extends \PHPUnit\Framework\TestCase {
 		$dateTime = LocalTime::getLocalizedTime( $dti, 'ZoneInfo|+120|Europe/Berlin' );
 
 		$this->assertTrue(
-			$dateTime->hasLocalTimeCorrection
+			LocalTime::$hasLocalTimeCorrection
 		);
 
 		$this->assertEquals(
@@ -80,7 +80,7 @@ class LocalTimeTest extends \PHPUnit\Framework\TestCase {
 		$dateTime = LocalTime::getLocalizedTime( $dti, 'ZoneInfo|+125|Foo' );
 
 		$this->assertTrue(
-			$dateTime->hasLocalTimeCorrection
+			LocalTime::$hasLocalTimeCorrection
 		);
 
 		$this->assertEquals(


### PR DESCRIPTION
We don't appear to use this anywhere other than the test, so we add the property to LocalTime, and have the test use that.