### PR TITLE
Add is_int check in Elastic Indexer -> fetchNativeData()

### DIFF
--- a/src/Elastic/Indexer/Indexer.php
+++ b/src/Elastic/Indexer/Indexer.php
@@ -273,7 +273,7 @@ class Indexer {
 			$id = $this->revisionGuard->getLatestRevID( $id );
 		}
 
-		if ( $id == 0 ) {
+		if ( !is_int( $id ) || $id == 0 ) {
 			return '';
 		}
 


### PR DESCRIPTION
If $id doesn't return an int or Title, just return an empty string. We can't convert a Object into a int so it fixes that error.