### PR TITLE
Initialise parser output if even parser state is not cleared

### DIFF
--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -130,13 +130,15 @@ class ContentParser {
 	}
 
 	private function parseText( ?string $text, bool $clear ) {
-		$this->parserOutput = $this->parser->parse(
-			$text,
-			$this->getTitle(),
-			$this->makeParserOptions(),
-			true,
-			$clear
-		);
+		$options = $this->makeParserOptions();
+
+		// Deal with uninitialised parser output:
+		if ( !$clear ) {
+			$this->parser->setOptions( $options );
+			$this->parser->clearState();
+		}
+
+		$this->parserOutput = $this->parser->parse( $text, $this->getTitle(), $options, true, $clear );
 
 		return $this;
 	}


### PR DESCRIPTION
Initialise parser output if even parser state is not cleared, avoiding errors caused by uninitialised `parser->mOutput`, but preserving a saveguard against parser state clearing while parsing while displaying FactBox in page preview.

Hopefully, fixes #6204 and #6120.