### PR TITLE
Truncate strings for hash correctly

### DIFF
--- a/src/SQLStore/EntityStore/DataItemHandlers/DIBlobHandler.php
+++ b/src/SQLStore/EntityStore/DataItemHandlers/DIBlobHandler.php
@@ -183,12 +183,12 @@ class DIBlobHandler extends DataItemHandler {
 	 */
 	private function makeHash( $string ) {
 		$length = $this->getMaxLength();
-
-		if ( mb_strlen( $string ) <= $length ) {
+		// We need to fit $string into a specified number of bytes, not characters.
+		if ( strlen( $string ) <= $length ) {
 			return $string;
 		}
-
-		return mb_substr( $string, 0, $length - 32 ) . md5( $string );
+		// Leave the first $length - 32 bytes (or less); replace the rest with a hash.
+		return mb_strcut( $string, 0, $length - 32 ) . md5( $string );
 	}
 
 	/**


### PR DESCRIPTION
Correct `DIBlobHandler::makeHash()` so that it truncates the string to the specified number of _bytes_, not _characters_; thus avoiding the SQL server fitting an UTF-8 sring into a bunary column, risking breaking a UTF-8 byte sequence with forther complications.

Fixes #5710; but, for longer strings, increases the number of appearances of unpleasant md5 hashes in factboxes, which is another issue.