### PR TITLE
CliMsgFormatter: Fix “Deprecated: Implicit conversion from float x to int loses precision”

### DIFF
--- a/src/Utils/CliMsgFormatter.php
+++ b/src/Utils/CliMsgFormatter.php
@@ -420,8 +420,8 @@ class CliMsgFormatter {
 
 	private function trimContent( $content, $maxLen = self::MAX_LEN ) {
 		$length = mb_strlen( $content ) - 1;
-		$startOff = ( $maxLen / 2 ) - 3;
-		$endOff = ( $maxLen / 2 ) - 3;
+		$startOff = (int)floor( ( $maxLen / 2 ) - 3 );
+		$endOff = (int)floor( ( $maxLen / 2 ) - 3 );
 
 		if ( $length >= $maxLen ) {
 			$content = mb_substr( $content, 0, $startOff ) . ' ... ' . mb_substr( $content, $length - $endOff );


### PR DESCRIPTION
Fixes #6092