### PR TITLE
Temp. fix for values with tags rendered by templates with named params

### DIFF
--- a/src/MediaWiki/Renderer/WikitextTemplateRenderer.php
+++ b/src/MediaWiki/Renderer/WikitextTemplateRenderer.php
@@ -39,7 +39,7 @@ class WikitextTemplateRenderer {
 		$this->template .= '{{' . $templateName;
 
 		foreach ( $this->fields as $key => $value ) {
-			$this->template .= "\n|$key=$value";
+			$this->template .= "\n|$key=" . str_replace( '|', '{{!}}', $value );
 		}
 
 		$this->template .= '}}';


### PR DESCRIPTION
A fix for values with tags rendered by templates with named parameters in `{{#ask:}}.

Temporarily fixes #6223.

A permanent fix ought to be based on https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6223#issuecomment-3232513208, but this requires participation by someone knowing how unstriping works: there is a risk to break something.