### PR TITLE
Fix spelling errors in method names related to description handling

### DIFF
--- a/src/Query/Parser/LegacyParser.php
+++ b/src/Query/Parser/LegacyParser.php
@@ -640,7 +640,7 @@ class LegacyParser implements Parser {
 						$value
 					);
 
-					$this->queryToken->addFromDesciption( $outerDesription );
+					$this->queryToken->addFromDescription( $outerDesription );
 					$innerdesc = $this->descriptionProcessor->asOr(
 						$innerdesc,
 						$outerDesription
@@ -717,7 +717,7 @@ class LegacyParser implements Parser {
 					$chunk
 				);
 
-				$this->queryToken->addFromDesciption( $outerDesription );
+				$this->queryToken->addFromDescription( $outerDesription );
 
 				$description = $this->descriptionProcessor->asOr(
 					$description,

--- a/src/Query/QueryToken.php
+++ b/src/Query/QueryToken.php
@@ -75,15 +75,15 @@ class QueryToken {
 	 *
 	 * @param Description $description
 	 */
-	public function addFromDesciption( Description $description ) {
+	public function addFromDescription( Description $description ) {
 		if ( $description instanceof Conjunction ) {
 			foreach ( $description->getDescriptions() as $desc ) {
-				return $this->addFromDesciption( $desc );
+				return $this->addFromDescription( $desc );
 			}
 		}
 
 		if ( $description instanceof SomeProperty ) {
-			return $this->addFromDesciption( $description->getDescription() );
+			return $this->addFromDescription( $description->getDescription() );
 		}
 
 		if ( !$description instanceof ValueDescription ) {

--- a/tests/phpunit/Query/QueryTokenTest.php
+++ b/tests/phpunit/Query/QueryTokenTest.php
@@ -34,10 +34,10 @@ class QueryTokenTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * @dataProvider descriptionProvider
 	 */
-	public function testAddFromDesciption( $description, $expected ) {
+	public function testAddFromDescription( $description, $expected ) {
 		$instance = new QueryToken();
 
-		$instance->addFromDesciption( $description );
+		$instance->addFromDescription( $description );
 
 		$this->assertEquals(
 			$expected,
@@ -45,7 +45,7 @@ class QueryTokenTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function testMulitpleAddFromDesciption() {
+	public function testMulitpleAddFromDescription() {
 		$instance = new QueryToken();
 
 		$description = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
@@ -60,7 +60,7 @@ class QueryTokenTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getDataItem' )
 			->willReturn( $this->dataItemFactory->newDIBlob( 'abc Foo 123' ) );
 
-		$instance->addFromDesciption( $description );
+		$instance->addFromDescription( $description );
 
 		$description = $this->getMockBuilder( '\SMW\Query\Language\ValueDescription' )
 			->disableOriginalConstructor()
@@ -70,7 +70,7 @@ class QueryTokenTest extends \PHPUnit\Framework\TestCase {
 			->method( 'getDataItem' )
 			->willReturn( $this->dataItemFactory->newDIWikiPage( '~*123 bar 456' ) );
 
-		$instance->addFromDesciption( $description );
+		$instance->addFromDescription( $description );
 
 		$this->assertEquals(
 			[
@@ -90,7 +90,7 @@ class QueryTokenTest extends \PHPUnit\Framework\TestCase {
 	public function testHighlight( $description, $text, $type, $expected ) {
 		$instance = new QueryToken();
 
-		$instance->addFromDesciption( $description );
+		$instance->addFromDescription( $description );
 		$instance->setOutputFormat( '-hL' );
 
 		$this->assertEquals(


### PR DESCRIPTION
Fix spelling errors in method names related to description handling

Bug: [T201491](https://phabricator.wikimedia.org/T201491)