### PR TITLE
issue-5421 SMW should not add dynamic property to MediaWiki's WikiFilePage

### DIFF
--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -168,9 +168,10 @@ class MwCollaboratorFactory {
 	public function newPageInfoProvider(
 		WikiPage $wikiPage,
 		?RevisionRecord $revision = null,
-		?User $user = null
+		?User $user = null,
+		?bool $fileReUploadStatus = true
 	) {
-		$pageInfoProvider = new PageInfoProvider( $wikiPage, $revision, $user );
+		$pageInfoProvider = new PageInfoProvider( $wikiPage, $revision, $user, $fileReUploadStatus );
 
 		$pageInfoProvider->setRevisionGuard(
 			$this->applicationFactory->singleton( 'RevisionGuard' )

--- a/src/MediaWiki/PageInfoProvider.php
+++ b/src/MediaWiki/PageInfoProvider.php
@@ -47,6 +47,8 @@ class PageInfoProvider implements PageInfo {
 	 */
 	private $revisionLookup;
 
+	private bool $fileReUploadStatus;
+
 	/**
 	 * @since 1.9
 	 *
@@ -57,11 +59,13 @@ class PageInfoProvider implements PageInfo {
 	public function __construct(
 		WikiPage $wikiPage,
 		?RevisionRecord $revision = null,
-		?User $user = null
+		?User $user = null,
+		?bool $fileReUploadStatus = true
 	) {
 		$this->wikiPage = $wikiPage;
 		$this->revision = $revision;
 		$this->user = $user;
+		$this->fileReUploadStatus = $fileReUploadStatus;
 	}
 
 	/**
@@ -97,7 +101,7 @@ class PageInfoProvider implements PageInfo {
 	 */
 	public function isNewPage() {
 		if ( $this->isFilePage() ) {
-			return isset( $this->wikiPage->smwFileReUploadStatus ) ? !$this->wikiPage->smwFileReUploadStatus : false;
+			return $this->fileReUploadStatus === false;
 		}
 
 		$revision = $this->revision ??

--- a/tests/phpunit/MediaWiki/Hooks/FileUploadTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/FileUploadTest.php
@@ -128,11 +128,6 @@ class FileUploadTest extends \PHPUnit\Framework\TestCase {
 		$this->assertTrue(
 			$instance->process( $file, $reUploadStatus )
 		);
-
-		$this->assertEquals(
-			$wikiFilePage->smwFileReUploadStatus,
-			$reUploadStatus
-		);
 	}
 
 	public function testTryToProcessDisabledNamespace() {

--- a/tests/phpunit/MediaWiki/PageInfoProviderTest.php
+++ b/tests/phpunit/MediaWiki/PageInfoProviderTest.php
@@ -214,11 +214,10 @@ class PageInfoProviderTest extends \PHPUnit\Framework\TestCase {
 			->getMock();
 
 		if ( $uploadStatus !== null ) {
-			// TODO: Illegal dynamic property (#5421)
-			$wikiFilePage->smwFileReUploadStatus = $uploadStatus;
+			$instance = new PageInfoProvider( $wikiFilePage, null, null, $uploadStatus );
+		} else {
+			$instance = new PageInfoProvider( $wikiFilePage );
 		}
-
-		$instance = new PageInfoProvider( $wikiFilePage );
 
 		$this->assertEquals( $expected, $instance->isNewPage() );
 	}


### PR DESCRIPTION
dynamic property was only used in one place (PageInfoProvider). moved it from File to the InfoProvider