### PR TITLE
Fixing 0,0e+0 result in format=sum

### DIFF
--- a/src/DataValues/Number/IntlNumberFormatter.php
+++ b/src/DataValues/Number/IntlNumberFormatter.php
@@ -147,6 +147,10 @@ class IntlNumberFormatter {
 	 * @return string
 	 */
 	public function format( $value, $precision = false, $format = '' ) {
+		if ( !is_numeric( $value ) ) {
+			$value = 0;
+		}
+
 		if ( $format === self::VALUE_FORMAT ) {
 			return $this->getValueFormattedNumberWithPrecision( $value, $precision );
 		}


### PR DESCRIPTION
fixes #6219 
"" is the value of the number if there are no result's
PHP 7.4 Behavior
"" != 0 evaluates to false
Result: displays as 0

PHP 8.1+ Behavior
"" != 0 evaluates to true (stricter type comparison)
The condition passes when it shouldn't
Result: displays as 0,0e+0