### PR TITLE
Remove content format from SchemaContentHandler constructor

### DIFF
--- a/src/MediaWiki/Content/SchemaContentHandler.php
+++ b/src/MediaWiki/Content/SchemaContentHandler.php
@@ -26,7 +26,7 @@ use WikiPage;
 class SchemaContentHandler extends JsonContentHandler {
 
 	public function __construct() {
-		parent::__construct( CONTENT_MODEL_SMW_SCHEMA, [ CONTENT_FORMAT_JSON ] );
+		parent::__construct( CONTENT_MODEL_SMW_SCHEMA );
 	}
 
 	/**


### PR DESCRIPTION
Fixes:

```
[cdccd15d001bbe45b42e41e5] [no req]   TypeError: MediaWiki\Content\JsonContentHandler::__construct(): Argument #2 ($parsoidParserFactory) must be of type ?MediaWiki\Parser\Parsoid\ParsoidParserFactory, array given, called in /srv/http/mediawiki/extensions/SemanticMediaWiki/src/MediaWiki/Content/SchemaContentHandler.php on line 29
```

This is a noop change for MW 1.43-1.44 since there was only one param and not two. But in master (MW 1.45) [0] was done.

[0] https://github.com/wikimedia/mediawiki/commit/5866f1aa8b5a73773586ed82d97836f59efe7b39

Fixes #6245