### PR TITLE
SchemaContentHandler: Replace setText with setContentHolderText method

### DIFF
--- a/src/MediaWiki/Content/SchemaContentHandler.php
+++ b/src/MediaWiki/Content/SchemaContentHandler.php
@@ -224,7 +224,7 @@ class SchemaContentHandler extends JsonContentHandler {
 				$e->getType()
 			);
 
-			$output->setText(
+			$output->setContentHolderText(
 				$contentFormatter->getText( $content->getText() )
 			);
 
@@ -275,7 +275,7 @@ class SchemaContentHandler extends JsonContentHandler {
 			$schemaFactory->getType( $schema->get( 'type' ) )
 		);
 
-		$output->setText(
+		$output->setContentHolderText(
 			$contentFormatter->getText( $content->getText(), $schema, $errors )
 		);
 


### PR DESCRIPTION
setText was deprecated in MW 1.42 and replaced with setContentHolderText.

Fixes a deprecation warning.

Bug: Issue #6255