### PR TITLE
Remove Reflection(Property|Method|Class)::setAccessible()

### DIFF
--- a/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
+++ b/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
@@ -118,13 +118,11 @@ class ExtensionSchemaUpdates implements HookListener {
 		// Check required due to missing property in MW 1.29-
 		if ( property_exists( $this->updater, 'maintenance' ) ) {
 			$reflectionProperty = new ReflectionProperty( $this->updater, 'maintenance' );
-			$reflectionProperty->setAccessible( true );
 			$maintenance = $reflectionProperty->getValue( $this->updater );
 		}
 
 		if ( $maintenance instanceof Maintenance ) {
 			$reflectionProperty = new ReflectionProperty( $maintenance, 'mOptions' );
-			$reflectionProperty->setAccessible( true );
 			$options = $reflectionProperty->getValue( $maintenance );
 			return isset( $options[$key] );
 		}

--- a/tests/phpunit/Factbox/FactboxMagicWordsTest.php
+++ b/tests/phpunit/Factbox/FactboxMagicWordsTest.php
@@ -121,7 +121,6 @@ class FactboxMagicWordsTest extends \PHPUnit\Framework\TestCase {
 		$reflector = new ReflectionClass( '\SMW\Factbox\Factbox' );
 
 		$magic = $reflector->getMethod( 'getMagicWords' );
-		$magic->setAccessible( true );
 
 		$result = $magic->invoke( $instance );
 

--- a/tests/phpunit/Factbox/FactboxTest.php
+++ b/tests/phpunit/Factbox/FactboxTest.php
@@ -78,7 +78,6 @@ class FactboxTest extends \PHPUnit\Framework\TestCase {
 
 		$reflector = new ReflectionClass( '\SMW\Factbox\Factbox' );
 		$buildHTML  = $reflector->getMethod( 'buildHTML' );
-		$buildHTML->setAccessible( true );
 
 		$this->assertIsString(
 			$buildHTML->invoke( $instance, $parserData->getSemanticData() )
@@ -119,7 +118,6 @@ class FactboxTest extends \PHPUnit\Framework\TestCase {
 		$reflector = new ReflectionClass( '\SMW\Factbox\Factbox' );
 
 		$fetchContent = $reflector->getMethod( 'fetchContent' );
-		$fetchContent->setAccessible( true );
 
 		$this->assertIsString(
 			$fetchContent->invoke( $instance, SMW_FACTBOX_NONEMPTY )
@@ -198,7 +196,6 @@ class FactboxTest extends \PHPUnit\Framework\TestCase {
 
 		$reflector = new ReflectionClass( '\SMW\Factbox\Factbox' );
 		$fetchContent = $reflector->getMethod( 'fetchContent' );
-		$fetchContent->setAccessible( true );
 
 		$this->assertIsString(
 			$fetchContent->invoke( $factbox )

--- a/tests/phpunit/Integration/SemanticDataSerializerDeserializerRoundtripTest.php
+++ b/tests/phpunit/Integration/SemanticDataSerializerDeserializerRoundtripTest.php
@@ -71,7 +71,6 @@ class SemanticDataSerializerDeserializerRoundtripTest extends \PHPUnit\Framework
 		// etc.)
 		$reflector = new ReflectionClass( '\SMW\Deserializers\SemanticDataDeserializer' );
 		$property  = $reflector->getProperty( 'dataItemTypeIdCache' );
-		$property->setAccessible( true );
 		$property->setValue( $deserializer, [ $type => 2 ] );
 
 		$deserialized = $deserializer->deserialize( $serialized );

--- a/tests/phpunit/MediaWiki/Api/ApiQueryResultFormatterTest.php
+++ b/tests/phpunit/MediaWiki/Api/ApiQueryResultFormatterTest.php
@@ -41,7 +41,6 @@ class ApiQueryResultFormatterTest extends \PHPUnit\Framework\TestCase {
 		// method public to test the exception without reflection
 		// $reflector = new ReflectionClass( 'SMW\MediaWiki\Api\ApiQueryResultFormatter' );
 		// $method = $reflector->getMethod( 'setIndexedTagName' );
-		// $method->setAccessible( true );
 		// $method->invoke( $instance, $arr, null )
 
 		$arr = [];

--- a/tests/phpunit/MediaWiki/Api/QueryTest.php
+++ b/tests/phpunit/MediaWiki/Api/QueryTest.php
@@ -54,7 +54,6 @@ class QueryTest extends \PHPUnit\Framework\TestCase {
 
 		$reflector = new ReflectionClass( '\SMW\MediaWiki\Api\Query' );
 		$getQuery  = $reflector->getMethod( 'getQuery' );
-		$getQuery->setAccessible( true );
 		$query = $getQuery->invoke( $instance, '[[Modification date::+]]', [], [] );
 
 		$this->assertInstanceOf(
@@ -63,7 +62,6 @@ class QueryTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$getQueryResult = $reflector->getMethod( 'getQueryResult' );
-		$getQueryResult->setAccessible( true );
 
 		$this->assertInstanceOf(
 			'\SMW\Query\QueryResult',
@@ -104,7 +102,6 @@ class QueryTest extends \PHPUnit\Framework\TestCase {
 
 		$reflector = new ReflectionClass( '\SMW\MediaWiki\Api\Query' );
 		$method = $reflector->getMethod( 'addQueryResult' );
-		$method->setAccessible( true );
 
 		$instance = $this->getMockBuilder( '\SMW\MediaWiki\Api\Query' )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Parser/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Parser/InTextAnnotationParserTest.php
@@ -350,7 +350,6 @@ class InTextAnnotationParserTest extends \PHPUnit\Framework\TestCase {
 		$reflector = new ReflectionClass( '\SMW\Parser\InTextAnnotationParser' );
 
 		$method = $reflector->getMethod( 'process' );
-		$method->setAccessible( true );
 
 		$result = $method->invoke( $instance, [] );
 		$this->assertEmpty( $result );

--- a/tests/phpunit/ParserFunctions/AskParserFunctionTest.php
+++ b/tests/phpunit/ParserFunctions/AskParserFunctionTest.php
@@ -185,7 +185,6 @@ class AskParserFunctionTest extends \PHPUnit\Framework\TestCase {
 
 		$reflector = new ReflectionClass( '\SMW\ParserFunctions\AskParserFunction' );
 		$showMode = $reflector->getProperty( 'showMode' );
-		$showMode->setAccessible( true );
 
 		$this->assertFalse( $showMode->getValue( $instance ) );
 		$instance->setShowMode( true );

--- a/tests/phpunit/Query/ResultPrinters/AggregatablePrinterTest.php
+++ b/tests/phpunit/Query/ResultPrinters/AggregatablePrinterTest.php
@@ -95,7 +95,6 @@ class AggregatablePrinterTest extends \PHPUnit\Framework\TestCase {
 
 		$reflector = new ReflectionClass( $this->aggregatablePrinter );
 		$method = $reflector->getMethod( 'addNumbersForDataItem' );
-		$method->setAccessible( true );
 
 		for ( $i = 1; $i <= 10; $i++ ) {
 
@@ -137,7 +136,6 @@ class AggregatablePrinterTest extends \PHPUnit\Framework\TestCase {
 
 		$reflector = new ReflectionClass( $this->aggregatablePrinter );
 		$method = $reflector->getMethod( 'getNumericResults' );
-		$method->setAccessible( true );
 
 		$result = $method->invoke(
 			$this->aggregatablePrinter,

--- a/tests/phpunit/Query/ResultPrinters/FeedExportPrinterTest.php
+++ b/tests/phpunit/Query/ResultPrinters/FeedExportPrinterTest.php
@@ -30,7 +30,6 @@ class FeedExportPrinterTest extends \PHPUnit\Framework\TestCase {
 
 		$reflector = new ReflectionClass( '\SMW\Query\ResultPrinters\FeedExportPrinter' );
 		$method = $reflector->getMethod( 'feedItemDescription' );
-		$method->setAccessible( true );
 
 		$this->assertEquals(
 			$expected['text'],

--- a/tests/phpunit/QueryPrinterTestCase.php
+++ b/tests/phpunit/QueryPrinterTestCase.php
@@ -36,18 +36,15 @@ abstract class QueryPrinterTestCase extends \PHPUnit\Framework\TestCase {
 	protected function setParameters( ResultPrinter $instance, array $parameters ) {
 		$reflector = new ReflectionClass( $this->getClass() );
 		$params = $reflector->getProperty( 'params' );
-		$params->setAccessible( true );
 		$params->setValue( $instance, $parameters );
 
 		if ( isset( $parameters['searchlabel'] ) ) {
 			$searchlabel = $reflector->getProperty( 'mSearchlabel' );
-			$searchlabel->setAccessible( true );
 			$searchlabel->setValue( $instance, $parameters['searchlabel'] );
 		}
 
 		if ( isset( $parameters['headers'] ) ) {
 			$searchlabel = $reflector->getProperty( 'mShowHeaders' );
-			$searchlabel->setAccessible( true );
 			$searchlabel->setValue( $instance, $parameters['headers'] );
 		}
 

--- a/tests/phpunit/Utils/ResultPrinterReflector.php
+++ b/tests/phpunit/Utils/ResultPrinterReflector.php
@@ -24,18 +24,15 @@ class ResultPrinterReflector {
 	public function addParameters( ResultPrinter $instance, array $parameters ) {
 		$reflector = new ReflectionClass( $instance );
 		$params = $reflector->getProperty( 'params' );
-		$params->setAccessible( true );
 		$params->setValue( $instance, $parameters );
 
 		if ( isset( $parameters['searchlabel'] ) ) {
 			$searchlabel = $reflector->getProperty( 'mSearchlabel' );
-			$searchlabel->setAccessible( true );
 			$searchlabel->setValue( $instance, $parameters['searchlabel'] );
 		}
 
 		if ( isset( $parameters['headers'] ) ) {
 			$searchlabel = $reflector->getProperty( 'mShowHeaders' );
-			$searchlabel->setAccessible( true );
 			$searchlabel->setValue( $instance, $parameters['headers'] );
 		}
 
@@ -45,7 +42,6 @@ class ResultPrinterReflector {
 	public function invoke( ResultPrinter $instance, $queryResult, $outputMode ) {
 		$reflector = new ReflectionClass( $instance );
 		$method = $reflector->getMethod( 'getResultText' );
-		$method->setAccessible( true );
 
 		return $method->invoke( $instance, $queryResult, $outputMode );
 	}

--- a/tests/phpunit/includes/formatters/MessageFormatterTest.php
+++ b/tests/phpunit/includes/formatters/MessageFormatterTest.php
@@ -153,7 +153,6 @@ class MessageFormatterTest extends SemanticMediaWikiTestCase {
 		// Access protected method
 		$reflection = new ReflectionClass( $this->getClass() );
 		$method = $reflection->getMethod( 'doFormat' );
-		$method->setAccessible( true );
 
 		// Test array normalization and deletion of duplicates
 		$result = $method->invoke( $instance, $instance->getMessages() );

--- a/tests/phpunit/includes/querypages/QueryPageTest.php
+++ b/tests/phpunit/includes/querypages/QueryPageTest.php
@@ -81,7 +81,6 @@ class QueryPageTest extends \PHPUnit\Framework\TestCase {
 
 		$reflector = new ReflectionClass( '\SMW\QueryPage' );
 		$selectOptions = $reflector->getProperty( 'selectOptions' );
-		$selectOptions->setAccessible( true );
 		$selectOptions->setValue( $instance, [
 			'offset' => 1,
 			'limit'  => 2,


### PR DESCRIPTION
It is a no-op for PHP > 8.1 and it is deprecated in PHP 8.5

Related: [T406744](https://phabricator.wikimedia.org/T406744)
Resolves: #6248