### PR TITLE
XmlResponseParser: Remove destructor and xml_parser_free() call

### DIFF
--- a/src/SPARQLStore/QueryEngine/XmlResponseParser.php
+++ b/src/SPARQLStore/QueryEngine/XmlResponseParser.php
@@ -85,13 +85,6 @@ class XmlResponseParser implements HttpResponseParser {
 	}
 
 	/**
-	 * @since 2.0
-	 */
-	public function __destruct() {
-		xml_parser_free( $this->parser );
-	}
-
-	/**
 	 * Parse the given XML result and return an RepositoryResult for
 	 * the contained data.
 	 *


### PR DESCRIPTION
xml_parser_free() is a noop in PHP 8.0+, and deprecated in PHP 8.5

https://php.watch/versions/8.5/xml_parser_free-deprecated

https://phabricator.wikimedia.org/T410934