### PR TITLE
ParserOutput::setText() was deprecated in MW 1.42

### DIFF
--- a/tests/phpunit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -387,7 +387,7 @@ class OutputPageParserOutputTest extends \PHPUnit\Framework\TestCase {
 	protected function makeParserOutput( $data ) {
 		$parserOutput = new ParserOutput();
 		$parserOutput->setExtensionData( 'smwdata', $data );
-		$parserOutput->setText( 'test' );
+		$parserOutput->setContentHolderText( 'test' );
 		return $parserOutput;
 	}
 


### PR DESCRIPTION
Since it causes noise in the output while running tests and SMW doesn't support MW that old any more, replacing.

Fixes #6278