### PR TITLE
remove bullet-point styling from FacetedSearch list

### DIFF
--- a/res/smw/special/smw.special.facetedsearch.css
+++ b/res/smw/special/smw.special.facetedsearch.css
@@ -276,17 +276,18 @@
 }
 
 .filter-items {
-    max-height: 200px;
+	max-height: 200px;
     overflow-y: scroll;
 }
 
 .filter-items.no-result {
-	 overflow-y: unset;
+	overflow-y: unset;
 }
 
 .filter-items ul {
-	margin: 0.3em 0 0 1.6em;
-    padding: 0;
+	margin: 0.3em 0 0 0;
+	list-style: none;
+	padding: 0;
 }
 
 .filter-items li {


### PR DESCRIPTION
Just a patch to remove unnecessary bullet points from facets in Special:FacetedSearch in favour of a plainer, space-saving style.