### PR TITLE
HtmlFormRenderer: Fix "Error: Call to undefined method MediaWiki\Xml\Xml::submitButton()"

### DIFF
--- a/src/MediaWiki/Renderer/HtmlFormRenderer.php
+++ b/src/MediaWiki/Renderer/HtmlFormRenderer.php
@@ -256,7 +256,7 @@ class HtmlFormRenderer {
 	 * @return HtmlFormRenderer
 	 */
 	public function addSubmitButton( $text, $attributes = [] ) {
-		$this->content[] = Xml::submitButton( $text, $attributes );
+		$this->content[] = Html::submitButton( $text, $attributes );
 		return $this;
 	}
 


### PR DESCRIPTION
Replace Xml::submitButton with Html::submitButton.

In newer MW versions this is removed and in others it is deprecated.