### PR TITLE
Fix fill content namespaces config numeric array

### DIFF
--- a/src/NamespaceManager.php
+++ b/src/NamespaceManager.php
@@ -273,10 +273,10 @@ class NamespaceManager {
 		 *
 		 * @see https://www.mediawiki.org/wiki/Manual:$wgContentNamespaces
 		 */
-		$vars['wgContentNamespaces'] = $vars['wgContentNamespaces'] + [
+		$vars['wgContentNamespaces'] = array_merge( $vars['wgContentNamespaces'], [
 			SMW_NS_PROPERTY,
 			SMW_NS_CONCEPT
-		];
+		] );
 
 		/**
 		 * To indicate which namespaces are enabled for searching by default


### PR DESCRIPTION
With the current implementation and using the union operator on the arrays, `SMW_NS_PROPERTY` and `SMW_NS_CONCEPT` will only be added if `$vars['wgContentNamespaces']` is empty.
Its working on the other config arrays, because they are indexed arrays.