### PR TITLE
Replace "Xml::check" with "Html::check"

### DIFF
--- a/src/MediaWiki/Specials/Ask/ParameterInput.php
+++ b/src/MediaWiki/Specials/Ask/ParameterInput.php
@@ -3,7 +3,6 @@
 namespace SMW\MediaWiki\Specials\Ask;
 
 use MediaWiki\Html\Html;
-use MediaWiki\Xml\Xml;
 use ParamProcessor\ParamDefinition;
 
 /**
@@ -224,7 +223,7 @@ class ParameterInput {
 			$attributes = $this->attributes;
 		}
 
-		return Xml::check(
+		return Html::check(
 			$this->inputName,
 			$this->getValueToUse(),
 			$attributes


### PR DESCRIPTION
Xml::check was deprecated in MW 1.42 and removed in MW 1.45.

Fixes #6292