### PR TITLE
Cancel in-progress CI runs when new commits are pushed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Adds a concurrency group to the CI workflow so that new pushes to a PR branch automatically cancel any in-progress CI runs for that branch
- Cancellation is limited to PR branches only — master pushes always run to completion

## Test plan
- [x] Push to a PR branch, then force push again before CI finishes — verify the first run is cancelled
- [x] Merge a PR to master — verify the CI run is not cancelled by subsequent merges