### PR TITLE
Remove createDummyPage from test database setup

### DIFF
--- a/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php
+++ b/tests/phpunit/Utils/Connection/TestDatabaseTableBuilder.php
@@ -3,11 +3,9 @@
 namespace SMW\Tests\Utils\Connection;
 
 use CloneDatabase;
-use MediaWiki\MediaWikiServices;
 use RuntimeException;
 use SMW\Connection\ConnectionProvider;
 use SMW\Store;
-use SMW\Tests\Utils\PageCreator;
 use Wikimedia\Rdbms\IDatabase;
 
 /**
@@ -196,7 +194,6 @@ class TestDatabaseTableBuilder {
 
 		$this->cloneDatabaseTables();
 		$this->store->setup( false );
-		$this->createDummyPage();
 
 		$this->dbSetup = true;
 	}
@@ -236,13 +233,6 @@ class TestDatabaseTableBuilder {
 			// @see https://github.com/wikimedia/mediawiki/commit/6badc7415684df54d6672098834359223b859507
 			CloneDatabase::changePrefix( self::$UTDB_PREFIX );
 		}
-	}
-
-	private function createDummyPage() {
-		$pageCreator = new PageCreator();
-		$pageCreator
-			->createPage( MediaWikiServices::getInstance()->getTitleFactory()->newFromText( 'SMWUTDummyPage' ) )
-			->doEdit( 'SMW dummy page' );
 	}
 
 	private function destroyDatabaseTables() {


### PR DESCRIPTION
## Summary

- Remove unused `createDummyPage()` from `TestDatabaseTableBuilder::setupDatabaseTables()` which causes a fatal "Uncancelable atomic section canceled" error on MW 1.44+
- The dummy page (`SMWUTDummyPage`) is unreferenced by any test — it's dead code from 2014

## Context

On MW 1.44, `PageUpdater::saveRevision()` (called via `createDummyPage()`) conflicts with the stricter atomic section handling introduced after DDL operations from table cloning. This causes PHPUnit to crash at ~test 173 with no visible error output.

With this fix, all 6888 tests complete successfully. The 19 remaining errors are pre-existing MW 1.44 compatibility issues (mocking changes, deprecated APIs) unrelated to this change.

## Test plan

- [x] MW 1.43 CI continues to pass (no regression)
- [x] MW 1.44 CI completes all tests without crashing
- [x] Grep for `SMWUTDummyPage` confirms zero references outside creation site