### PR TITLE
Use MediaWiki namespaced EditPage class in tests

### DIFF
--- a/tests/phpunit/MediaWiki/Hooks/EditPageFormTest.php
+++ b/tests/phpunit/MediaWiki/Hooks/EditPageFormTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\MediaWiki\Hooks;
 
+use MediaWiki\EditPage\EditPage;
 use MediaWiki\Title\Title;
 use SMW\MediaWiki\Hooks\EditPageForm;
 use SMW\Tests\PHPUnitCompat;
@@ -52,7 +53,7 @@ class EditPageFormTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testDisabledHelp() {
-		$editPage = $this->getMockBuilder( '\EditPage' )
+		$editPage = $this->getMockBuilder( EditPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -83,7 +84,7 @@ class EditPageFormTest extends \PHPUnit\Framework\TestCase {
 			->with( 'smw-prefs-general-options-disable-editpage-info' )
 			->willReturn( true );
 
-		$editPage = $this->getMockBuilder( '\EditPage' )
+		$editPage = $this->getMockBuilder( EditPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -126,7 +127,7 @@ class EditPageFormTest extends \PHPUnit\Framework\TestCase {
 			->with( $namespaces )
 			->willReturn( $isSemanticEnabled );
 
-		$editPage = $this->getMockBuilder( '\EditPage' )
+		$editPage = $this->getMockBuilder( EditPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/MediaWiki/HooksTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\MediaWiki;
 use MediaWiki\Block\Block;
 use MediaWiki\Deferred\LinksUpdate\LinksUpdate;
 use MediaWiki\Edit\PreparedEdit;
+use MediaWiki\EditPage\EditPage;
 use MediaWiki\Parser\ParserOptions;
 use MediaWiki\Title\Title;
 use MediaWiki\User\UserIdentity;
@@ -1206,7 +1207,7 @@ class HooksTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$editPage = $this->getMockBuilder( '\EditPage' )
+		$editPage = $this->getMockBuilder( EditPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 


### PR DESCRIPTION
## Summary
- MW 1.44 removed the global `\EditPage` class alias. Tests mocking `\EditPage` fail with `TypeError` because the mock doesn't match the `MediaWiki\EditPage\EditPage` type hint, and `getTitle()` can't be configured on a mock of a non-existent class.
- Updated `EditPageFormTest` and `HooksTest` to mock `MediaWiki\EditPage\EditPage` via `use` import and `::class` constant.
- Fixes 9 errors (7 in EditPageFormTest + 2 cascading in HooksTest).

## Files changed
- `EditPageFormTest` — `'\EditPage'` → `EditPage::class`
- `HooksTest` — `'\EditPage'` → `EditPage::class`

## Test plan
- [x] Verified all 67 tests in affected classes pass on MW 1.44 (0 errors, 0 failures)
- [x] Full unit suite (6888 tests) passes with 0 errors and 0 failures on MW 1.44
- [x] CI passes on MW 1.43 and 1.44