### PR TITLE
Implement abstract SearchResult methods for MW 1.45 compat

### DIFF
--- a/src/MediaWiki/Search/SearchResult.php
+++ b/src/MediaWiki/Search/SearchResult.php
@@ -18,6 +18,16 @@ use SMW\DIWikiPage;
 class SearchResult extends \SearchResult {
 
 	/**
+	 * @var Title|null
+	 */
+	protected $mTitle;
+
+	/**
+	 * @var string|null
+	 */
+	protected $mText;
+
+	/**
 	 * @var bool
 	 */
 	private $hasHighlight = false;
@@ -28,24 +38,38 @@ class SearchResult extends \SearchResult {
 	 * @param Title|null $title
 	 */
 	public function __construct( $title ) {
-		$this->initFromTitle( $title );
+		$this->mTitle = $title;
+	}
+
+	/**
+	 * @return Title|null
+	 */
+	public function getTitle() {
+		return $this->mTitle;
+	}
+
+	/**
+	 * @return \File|null
+	 */
+	public function getFile() {
+		return null;
 	}
 
 	/**
 	 * @see SearchResult::getTextSnippet
 	 */
-	function getTextSnippet( $terms = [] ) {
+	public function getTextSnippet( $terms = [] ) {
 		if ( $this->hasHighlight ) {
 			return str_replace( [ '<em>', '</em>' ], [ "<span class='searchmatch'>", '</span>' ], $this->mText );
 		}
 
-		return parent::getTextSnippet( $terms );
+		return $this->mText ?? '';
 	}
 
 	/**
 	 * @see SearchResult::getSectionTitle
 	 */
-	function getSectionTitle() {
+	public function getSectionTitle() {
 		if ( !isset( $this->mTitle ) || $this->mTitle->getFragment() === '' ) {
 			return null;
 		}
@@ -56,14 +80,14 @@ class SearchResult extends \SearchResult {
 	/**
 	 * @see SearchResult::isBrokenTitle
 	 */
-	function isBrokenTitle() {
+	public function isBrokenTitle() {
 		return $this->mTitle === null;
 	}
 
 	/**
 	 * @see SearchResult::isMissingRevision
 	 */
-	function isMissingRevision() {
+	public function isMissingRevision() {
 		if ( $this->mTitle == null ) {
 			return true;
 		}
@@ -114,6 +138,76 @@ class SearchResult extends \SearchResult {
 
 		// Will return the DISPLAYTITLE, if available
 		return $dataValue->getPreferredCaption();
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getRedirectSnippet() {
+		return '';
+	}
+
+	/**
+	 * @return Title|null
+	 */
+	public function getRedirectTitle() {
+		return null;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getSectionSnippet() {
+		return '';
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getCategorySnippet() {
+		return '';
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getTimestamp() {
+		return '';
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getWordCount() {
+		return 0;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getByteSize() {
+		return 0;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getInterwikiPrefix() {
+		return '';
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getInterwikiNamespaceText() {
+		return '';
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function isFileMatch() {
+		return false;
 	}
 
 }


### PR DESCRIPTION
This PR unblocks the 1.45 CI, so it can actually run the test suite.

## Summary
- MW 1.45 made `\SearchResult` abstract with 17 abstract methods. SMW's `SearchResult` only implemented 5 of them, causing a **fatal error** that crashed the entire unit test suite on MW 1.45 CI.
- Implements the 12 missing abstract methods with sensible defaults matching `RevisionSearchResult`.
- Replaces `initFromTitle()` (moved to `RevisionSearchResult` in MW 1.45) with direct property assignment.
- Declares `$mTitle` and `$mText` properties directly (previously inherited via trait, removed in MW 1.45).
- Fixes `getTextSnippet()` to return non-highlighted excerpt text when available instead of discarding it (per code review feedback).

## Backward compatibility
- Tested on MW 1.44: full unit suite (6888 tests) — no regressions
- The property redeclarations and method implementations safely shadow the trait-provided ones on MW 1.43/1.44

## Test plan
- [x] MW 1.45: Fatal error resolved, full suite completes (6888 tests, 13 errors — all pre-existing alias/EditPage issues from other PRs)
- [x] MW 1.44: No regressions (same 19 errors as before this change)
- [ ] CI passes on MW 1.43, 1.44, and 1.45