### PR TITLE
Fix format-embedded test assertions for MW 1.44 heading markup change

### DIFF
--- a/tests/phpunit/Integration/JSONScript/TestCases/format-embedded-0001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/format-embedded-0001.json
@@ -106,13 +106,13 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<h1><span id=\"Format/Embedded/A/1\"></span><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA.2F1\">",
-					"<h1><span id=\"Format/Embedded/A/2\"></span><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA.2F2\">",
+					"id=\"Format.2FEmbedded.2FA.2F1\"",
+					"id=\"Format.2FEmbedded.2FA.2F2\"",
 					"ABC",
 					"DEF"
 				],
 				"not-contain": [
-					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FA\">.*selflink\">Format/Embedded/A.*</h1>"
+					"selflink\">Format/Embedded/A.*</h1>"
 				]
 			}
 		},
@@ -137,13 +137,13 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<h1>.*<span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F1\">",
-					"<h1>.*<span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F2\">",
+					"id=\"Format.2FEmbedded.2FB.2F1\"",
+					"id=\"Format.2FEmbedded.2FB.2F2\"",
 					"ABC",
 					"DEF"
 				],
 				"not-contain": [
-					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB\">.*selflink\">Format/Embedded/B.*</h1>"
+					"selflink\">Format/Embedded/B.*</h1>"
 				]
 			}
 		},
@@ -191,14 +191,14 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<h1>.*<span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F1\">",
-					"<h1>.*<span class=\"mw-headline\" id=\"Format.2FEmbedded.2FB.2F2\">",
+					"id=\"Format.2FEmbedded.2FB.2F1\"",
+					"id=\"Format.2FEmbedded.2FB.2F2\"",
 					"A123",
 					"ABC",
 					"DEF"
 				],
 				"not-contain": [
-					"<h1><span class=\"mw-headline\" id=\"Format.2FEmbedded.2FD\">.*selflink\">Format/Embedded/D.*</h1>"
+					"selflink\">Format/Embedded/D.*</h1>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/format-embedded-0002.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/format-embedded-0002.json
@@ -50,8 +50,8 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<span class=\"mw-headline\" id=\"Example.2FFE0002.2F1\"><a href=.* title=\"Example/FE0002/1\">Example/FE0002/1</a></span>",
-					"<span class=\"mw-headline\" id=\"Example.2FFE0002.2F2\"><a href=.* title=\"Example/FE0002/2\">Example/FE0002/2</a></span>"
+					"id=\"Example.2FFE0002.2F1\".*Example/FE0002/1",
+					"id=\"Example.2FFE0002.2F2\".*Example/FE0002/2"
 				]
 			}
 		},
@@ -61,8 +61,8 @@
 			"subject": "Example/FE0002/Q.2",
 			"assert-output": {
 				"to-contain": [
-					"<span class=\"mw-headline\" id=\"Example.2FFE0002.2F3\"><a href=.* title=\"Example/FE0002/3\">Example/FE0002/3</a></span>",
-					"<span class=\"mw-headline\" id=\"Example.2FFE0002.2F2\"><a href=.* title=\"Example/FE0002/2\">Example/FE0002/2</a></span>"
+					"id=\"Example.2FFE0002.2F3\".*Example/FE0002/3",
+					"id=\"Example.2FFE0002.2F2\".*Example/FE0002/2"
 				]
 			}
 		}


### PR DESCRIPTION
1 error to go for MW 1.44.

## Summary

- Fix `format-embedded-0001` and `format-embedded-0002` test failures on MW 1.44
- MW 1.44 changed heading HTML from `<span class="mw-headline" id="...">` to `<div class="mw-heading"><h1 id="...">`
- Update assertions to match on heading IDs (`id="Format.2FEmbedded.2FA.2F1"`) rather than specific HTML structure, making them compatible with both MW 1.43 and 1.44+

## Changes

- `tests/phpunit/Integration/JSONScript/TestCases/format-embedded-0001.json` — updated `to-contain` and `not-contain` assertions in tests #0.x, #1, #3
- `tests/phpunit/Integration/JSONScript/TestCases/format-embedded-0002.json` — updated `to-contain` assertions in tests #0, #1

## Test plan

- [x] CI passes on MW 1.43 (assertions still match old heading format)
- [x] CI passes on MW 1.44 (assertions now match new heading format)
