### PR TITLE
Replace deprecated InterwikiLoadPrefix hook with InterwikiCache

### DIFF
--- a/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
+++ b/tests/phpunit/Integration/InterwikiDBIntegrationTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\Integration;
 
+use MediaWiki\Interwiki\ClassicInterwikiLookup;
 use MediaWiki\MediaWikiServices;
 use SMW\DIWikiPage;
 use SMW\Exporter\ExporterFactory;
@@ -31,6 +32,7 @@ class InterwikiDBIntegrationTest extends SMWIntegrationTestCase {
 	private $queryParser;
 	private $semanticDataFactory;
 	private $pageCreator;
+	private $oldInterwikiCache;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -49,31 +51,25 @@ class InterwikiDBIntegrationTest extends SMWIntegrationTestCase {
 			->deregisterListedHooks()
 			->invokeHooksFromRegistry();
 
-		// Manipulate the interwiki prefix on-the-fly
-		MediaWikiServices::getInstance()->getHookContainer()->register(
-			'InterwikiLoadPrefix',
-			static function ( $prefix, &$interwiki ) {
-				if ( $prefix !== 'iw-test' ) {
-					return true;
-				}
-
-				$interwiki = [
-					'iw_prefix' => 'iw-test',
-					'iw_url' => 'http://www.example.org/$1',
-					'iw_api' => false,
-					'iw_wikiid' => 'foo',
-					'iw_local' => true,
-					'iw_trans' => false,
-				];
-
-				return false;
-			}
-		);
+		// Register a test interwiki prefix via the interwiki cache.
+		// Must be set after deregisterListedHooks()/invokeHooksFromRegistry()
+		// which call resetGlobalInstance() and disable the old service container,
+		// making overrideConfigValue() unusable.
+		$this->oldInterwikiCache = $GLOBALS['wgInterwikiCache'] ?? false;
+		$GLOBALS['wgInterwikiCache'] = ClassicInterwikiLookup::buildCdbHash( [
+			[
+				'iw_prefix' => 'iw-test',
+				'iw_url' => 'http://www.example.org/$1',
+				'iw_api' => '',
+				'iw_wikiid' => 'foo',
+				'iw_local' => 1,
+			],
+		] );
+		MediaWikiServices::getInstance()->resetServiceForTesting( 'InterwikiLookup' );
 	}
 
 	protected function tearDown(): void {
-		MediaWikiServices::getInstance()->getHookContainer()->clear( 'InterwikiLoadPrefix' );
-
+		$GLOBALS['wgInterwikiCache'] = $this->oldInterwikiCache;
 		parent::tearDown();
 	}
 


### PR DESCRIPTION
## Summary

Replace the deprecated `InterwikiLoadPrefix` hook (deprecated since MW 1.36) with `$wgInterwikiCache` configuration using `ClassicInterwikiLookup::buildCdbHash()` in `InterwikiDBIntegrationTest`.

## Changes

- Replace `InterwikiLoadPrefix` hook registration with `$wgInterwikiCache` global set via `ClassicInterwikiLookup::buildCdbHash()`
- Set the interwiki cache config after `deregisterListedHooks()`/`invokeHooksFromRegistry()` to avoid `ContainerDisabledException` (these methods call `resetGlobalInstance()` which disables the old service container, making `overrideConfigValue()` unusable)
- Reset `InterwikiLookup` service so it picks up the new config
- Add `tearDown()` to restore original `$wgInterwikiCache` value

## Test plan

- [x] Verified locally on MW 1.44 Docker container: all 3 tests pass (1 skipped for MW >= 1.40 RDF test, as before)
- [ ] CI passes on MW 1.43, 1.44, 1.45
