### PR TITLE
Fix LinksUpdateTest for MW 1.44+ ParserOutput caching change

### DIFF
--- a/tests/phpunit/Integration/MediaWiki/LinksUpdateTest.php
+++ b/tests/phpunit/Integration/MediaWiki/LinksUpdateTest.php
@@ -101,10 +101,21 @@ class LinksUpdateTest extends SMWIntegrationTestCase {
 			$contentParser->getOutput()
 		);
 
-		$this->assertCount(
-			4,
-			$parserData->getSemanticData()->getProperties()
-		);
+		// The predefined _MDAT property is added by DataUpdater during the store
+		// update phase, not during parsing. On MW 1.43, prepareContentForEdit()
+		// returns a cached ParserOutput that includes _MDAT from the store update.
+		// On MW 1.44+, it returns a fresh parse without _MDAT.
+		if ( version_compare( MW_VERSION, '1.44', '>=' ) ) {
+			$this->assertCount(
+				3,
+				$parserData->getSemanticData()->getProperties()
+			);
+		} else {
+			$this->assertCount(
+				4,
+				$parserData->getSemanticData()->getProperties()
+			);
+		}
 
 		$this->assertCount(
 			4,


### PR DESCRIPTION
## Summary

Fix `LinksUpdateTest::testDoUpdateUsingUserdefinedAnnotations` failing on MW 1.44 with "Failed asserting that actual size 3 matches expected size 4".

## Root cause

The `_MDAT` predefined property is added by `DataUpdater` during the **store update phase** (via `LinksUpdateComplete` hook), not during parsing. On MW 1.43, `WikiPage::prepareContentForEdit()` returns a cached `ParserOutput` that includes `_MDAT` from the store update. On MW 1.44+, it returns a fresh parse without `_MDAT`, so the `ParserOutput` only contains 3 properties (`_SKEY` + 2 user-defined) instead of 4.

## Changes

- Add version check for MW 1.44+: expect 3 properties from `ParserOutput` (without `_MDAT`) vs 4 on MW 1.43 (with `_MDAT`)
- Store assertions (which correctly verify all 4 properties including `_MDAT`) are unchanged

## Test plan

- [x] Verified locally on MW 1.44 Docker: all tests pass
- [ ] CI passes on MW 1.43, 1.44, 1.45