### PR TITLE
Fix flaky lock wait timeout in integration test tearDown

### DIFF
--- a/tests/phpunit/SMWIntegrationTestCase.php
+++ b/tests/phpunit/SMWIntegrationTestCase.php
@@ -155,10 +155,18 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 			}
 		} finally {
 			try {
-				// Ensure all transactions are closed before ending the test
+				// Roll back all open database transactions to prevent lock
+				// contention when MediaWikiIntegrationTestCase::tearDown()
+				// truncates tables. Without this, page deletions from
+				// flushPages() can hold row locks that block TRUNCATE,
+				// causing "Lock wait timeout" errors.
 				if ( $this->testDatabaseTableBuilder !== null ) {
 					$this->getDBConnection()?->rollback();
 				}
+
+				MediaWikiServices::getInstance()
+					->getDBLoadBalancerFactory()
+					->rollbackPrimaryChanges( __METHOD__ );
 			} finally {
 				parent::tearDown();
 			}


### PR DESCRIPTION
This fixes the flaky tests in the JSONScriptTestCaseRunnerTest in 1.43 that fails the workflow occasionally.

Sample error:
```
1) SMW\Tests\Integration\JSONScript\JSONScriptTestCaseRunnerTest::testCaseFile with data set "format-category-0005.json" ('/var/www/html/extensions/Sema...5.json')
Wikimedia\Rdbms\DBQueryError: Error 1205: Lock wait timeout exceeded; try restarting transaction
Function: MediaWikiIntegrationTestCase::truncateTables
Query: TRUNCATE TABLE `unittest_ip_changes`


/var/www/html/includes/libs/rdbms/database/Database.php:1198
/var/www/html/includes/libs/rdbms/database/Database.php:1182
/var/www/html/includes/libs/rdbms/database/Database.php:1156
/var/www/html/includes/libs/rdbms/database/Database.php:647
/var/www/html/includes/libs/rdbms/database/Database.php:2991
/var/www/html/tests/phpunit/MediaWikiIntegrationTestCase.php:2153
/var/www/html/tests/phpunit/MediaWikiIntegrationTestCase.php:2135
/var/www/html/tests/phpunit/MediaWikiIntegrationTestCase.php:797
/var/www/html/extensions/SemanticMediaWiki/tests/phpunit/SMWIntegrationTestCase.php:192
```

## Summary
- Fixes intermittent `DBQueryError: Error 1205: Lock wait timeout exceeded` during `TRUNCATE TABLE unittest_ip_changes` in integration test tearDown
- Root cause: `flushPages()` deletes pages during tearDown, opening DB transactions with row locks. When `MediaWikiIntegrationTestCase::tearDown()` then runs `TRUNCATE TABLE`, it needs an exclusive table lock but gets blocked by those uncommitted transactions
- Fix: call `LBFactory::rollbackPrimaryChanges()` before `parent::tearDown()` to ensure all connections (both MW's and SMW's) have their transactions rolled back before table truncation

## Test plan
- [x] Integration tests pass locally (LinksUpdateTest, InterwikiDBIntegrationTest, JSONScript tests)
- [x] CI passes — the fix is inherently about reducing flakiness, so it needs multiple CI runs to confirm