### PR TITLE
Add development environment guide

### DIFF
--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,195 @@
+# Development environment
+
+Set up a local development environment for Semantic MediaWiki (SMW) using Docker. The environment is powered by [docker-compose-ci](https://github.com/gesinn-it-pub/docker-compose-ci) (included as a Git submodule in `build/`) and mirrors the GitHub Actions CI pipeline — tests that pass locally will pass in CI.
+
+## Prerequisites
+
+- [Git](https://git-scm.com/)
+- [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://docs.docker.com/compose/install/)
+
+## Quick start
+
+```sh
+git clone --recurse-submodules https://github.com/SemanticMediaWiki/SemanticMediaWiki.git
+cd SemanticMediaWiki
+make install
+```
+
+This builds the Docker containers, installs MediaWiki (MW 1.43, PHP 8.1, MariaDB 11.2 by default), and runs `composer update` inside the extension.
+
+Verify the setup:
+
+```sh
+make composer-test
+```
+
+This runs lint, PHPCS, and all PHPUnit test suites — the same sequence as CI.
+
+## Browsing the wiki
+
+`make install` does not expose any ports by default. To access the wiki in a browser, create a compose override file and reinstall:
+
+```sh
+cat > build/docker-compose.override.yml <<'EOF'
+services:
+  wiki:
+    ports:
+      - 8080:8080
+EOF
+make destroy install
+```
+
+The wiki is then available at [http://localhost:8080](http://localhost:8080) (credentials: **WikiSysop** / **wiki4everyone**). The override file only needs to be created once.
+
+## Seeding demo data
+
+The dev wiki starts empty. To populate it with sample pages that exercise SMW features, run the seeder script:
+
+```sh
+docker exec semanticmediawiki-mysql-wiki-1 php /var/www/html/maintenance/run.php \
+  SemanticMediaWiki:seedDemoData --force
+```
+
+This creates ~147 pages tracked in `Category:Seed data`. To remove them:
+
+```sh
+docker exec semanticmediawiki-mysql-wiki-1 php /var/www/html/maintenance/run.php \
+  SemanticMediaWiki:seedDemoData --force --clear-only
+```
+
+## Syncing local changes
+
+The extension is copied into the container at build time, not bind-mounted. Local edits are **not** reflected automatically. Copy files in before testing and copy fixes back after auto-formatting:
+
+```sh
+# Copy a local file into the container
+docker cp path/to/file.php \
+  semanticmediawiki-mysql-wiki-1:/var/www/html/extensions/SemanticMediaWiki/path/to/file.php
+
+# Copy a file back from the container
+docker cp semanticmediawiki-mysql-wiki-1:/var/www/html/extensions/SemanticMediaWiki/path/to/file.php \
+  path/to/file.php
+```
+
+## Configuration
+
+The Makefile accepts these variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `MW_VERSION` | `1.43` | MediaWiki version |
+| `PHP_VERSION` | `8.1` | PHP version |
+| `DB_TYPE` | `mysql` | Database type |
+| `DB_IMAGE` | `mariadb:11.2` | Database Docker image |
+
+Override on the command line or in a `.env` file at the project root:
+
+```sh
+# Command line
+make install MW_VERSION=1.44 PHP_VERSION=8.3
+
+# Or via .env file
+echo 'MW_VERSION=1.44' >> .env
+echo 'PHP_VERSION=8.3' >> .env
+make install
+```
+
+To switch versions, destroy and reinstall:
+
+```sh
+make destroy install MW_VERSION=1.45 PHP_VERSION=8.4 DB_IMAGE="mariadb:11.8"
+```
+
+## Running tests
+
+### Inside the container
+
+From a shell inside the container (`make bash`), run tests directly:
+
+```sh
+cd /var/www/html/extensions/SemanticMediaWiki
+
+# Full test suite (lint + PHPCS + PHPUnit)
+composer test
+
+# Unit tests only
+composer phpunit:unit
+
+# Integration tests only
+composer phpunit:integration
+```
+
+### Via Make
+
+```sh
+# Full test suite (lint + PHPCS + PHPUnit)
+make composer-test
+
+# Unit tests only
+make composer-test COMPOSER_PARAMS="-- --testsuite=semantic-mediawiki-unit"
+```
+
+### Via docker exec
+
+To run individual test suites or classes from your host machine (the container name follows the pattern `semanticmediawiki-<DB_TYPE>-wiki-1`):
+
+```sh
+# Unit tests
+docker exec semanticmediawiki-mysql-wiki-1 php /var/www/html/tests/phpunit/phpunit.php \
+  -c /var/www/html/extensions/SemanticMediaWiki/phpunit.xml.dist \
+  --testsuite=semantic-mediawiki-unit --no-coverage
+
+# Integration tests
+docker exec semanticmediawiki-mysql-wiki-1 php /var/www/html/tests/phpunit/phpunit.php \
+  -c /var/www/html/extensions/SemanticMediaWiki/phpunit.xml.dist \
+  --testsuite=semantic-mediawiki-integration --no-coverage
+
+# Single test class
+docker exec semanticmediawiki-mysql-wiki-1 php /var/www/html/tests/phpunit/phpunit.php \
+  -c /var/www/html/extensions/SemanticMediaWiki/phpunit.xml.dist \
+  --no-coverage --filter 'TestClassName'
+```
+
+## PHPCS
+
+Run analysis (lint + code style):
+
+```sh
+docker exec semanticmediawiki-mysql-wiki-1 bash -c \
+  "cd /var/www/html/extensions/SemanticMediaWiki && composer analyze"
+```
+
+Auto-fix code style violations:
+
+```sh
+docker exec semanticmediawiki-mysql-wiki-1 bash -c \
+  "cd /var/www/html/extensions/SemanticMediaWiki && composer fix"
+```
+
+After running `composer fix`, remember to [copy fixed files back](#syncing-local-changes) to your local checkout.
+
+**Caution:** `composer analyze` exits 0 even with warnings. Read the full output — warnings must also be fixed.
+
+## Interactive shell
+
+```sh
+make bash
+# or:
+docker exec -it semanticmediawiki-mysql-wiki-1 bash
+```
+
+## CI
+
+CI runs on [GitHub Actions](https://github.com/SemanticMediaWiki/SemanticMediaWiki/actions) using the same Docker and Makefile setup. The workflow is defined in [`.github/workflows/main.yml`](../.github/workflows/main.yml).
+
+### Test matrix
+
+| MediaWiki | PHP | Database | Status |
+|---|---|---|---|
+| 1.43 | 8.2 | MariaDB 11.2 | Stable (+ coverage) |
+| 1.43 | 8.3 | MariaDB 11.2 | Stable |
+| 1.44 | 8.3 | MariaDB 11.2 | Experimental |
+| 1.44 | 8.3 | MariaDB 11.8 | Experimental |
+| 1.45 | 8.4 | MariaDB 11.8 | Experimental |
+
+CI runs `make ci`, which calls `make install` followed by `composer test` and `npm test`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,5 +16,6 @@ View [all release notes](releasenotes/README.md)
 
 ## For developers
 
+* [Development environment](DEVELOPMENT.md) — setting up and running tests locally
 * [Developing Semantic MediaWiki](architecture/README.md)
 * [Technical documentation](technical/README.md)

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -70,32 +70,31 @@ Some conventions to help developers and the project to maintain a consistent pro
 
 ## Testing
 
-The `Semantic MediaWiki` software alone deploys ~7400 tests (as of July 2019) which are __required to pass__ before changes can be merged into the repository.
+All tests are __required to pass__ before changes can be merged into the repository.
 
-Tests are commonly divided into [unit][glossary] and [integration tests][glossary] where unit tests represent an isolated unit (or component) to be tested and normally doesn't require a database or other repository connection (e.g. triple store etc.). Integration tests on the other hand provide the means to test the interplay with other components by directly interacting with MediaWiki and its services. For example, about 80% of the CI running time is spend on executing integration tests as they normally run a full integration cycle (parsing, storing, reading, HTML generating etc.).
+Tests are commonly divided into [unit][glossary] and [integration tests][glossary]. Unit tests cover an isolated unit (or component) and normally don't require a database or other repository connection (e.g. triple store). Integration tests verify the interplay between components by interacting with MediaWiki and its services directly. About 80% of CI running time is spent on integration tests as they run a full cycle (parsing, storing, reading, HTML generation, etc.).
 
 For an introduction on "How to use `PHPUnit`" and "How to write integration tests using `JSONScript`" see the relevant section in this [document](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/tests/README.md).
 
 ### Continuous integration (CI)
 
-The project uses [Travis-CI](https://travis-ci.org/SemanticMediaWiki/SemanticMediaWiki) to run its tests on different platforms with different services enabled to provide a wide range of  environments including MySQL, SQLite, and Postgres.
+The project uses [GitHub Actions](https://github.com/SemanticMediaWiki/SemanticMediaWiki/actions) to run its tests across multiple MediaWiki and PHP versions. CI uses the same Docker-based setup as local development.
 
-- [`.travis.yml`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/.travis.yml) testing matrix
-- Settings and [configurations](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/tests/travis/README.md) to tune the Travis-CI setup
+- [`.github/workflows/main.yml`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/.github/workflows/main.yml) — workflow and testing matrix
+- See the [development environment guide](../DEVELOPMENT.md) for how to set up and run tests locally
 
 ## Create a pull request
 
 Before creating a pull request it is recommended to:
 
 - Read this document
-- Install [git](https://www.semantic-mediawiki.org/wiki/Help:Using_Git)
-- Install/clone `Semantic MediaWiki` with `@dev` (with development happening against the master branch)
-- Run `composer test` locally (see the test section) and verify that your installation and test environment are setup correctly
+- Set up the [development environment](../DEVELOPMENT.md)
+- Run `make composer-test` locally and verify that tests pass
 
 ### First PR
 
 - Send a PR with subject [first pr] to the [`Semantic MediaWiki`](https://github.com/SemanticMediaWiki/SemanticMediaWiki/) repository and verify that your git setup works and you are able to replicate changes against the master branch
-- Get yourself familiar with the [Travis-CI](https://travis-ci.org/SemanticMediaWiki/SemanticMediaWiki) environment and observe how a PR triggers CI jobs and review the output of those jobs (important when a job doesn't pass and you need to find the cause for a failure)
+- Observe how a PR triggers [CI jobs](https://github.com/SemanticMediaWiki/SemanticMediaWiki/actions) and review the output of those jobs (important when a job doesn't pass and you need to find the cause for a failure)
 
 ### Preparing a PR
 


### PR DESCRIPTION
## Motivation

In response to #6339 and also making it easier for other developers.

The project had no documentation for how to set up a local dev environment or run CI locally. The existing architecture README referenced Travis CI (no longer used) and a `.travis.yml` that no longer exists.

## Summary

- Add `docs/DEVELOPMENT.md` covering:
  - Quick start with `make install`
  - Browsing the wiki via `docker-compose.override.yml` port mapping
  - Seeding demo data with `seedDemoData` maintenance script
  - Syncing local changes with `docker cp` (code is copied, not mounted)
  - Configuration variables (MW/PHP/DB versions)
  - Running tests (inside container, via Make, via `docker exec`)
  - PHPCS analysis and auto-fix
  - CI test matrix (GitHub Actions)
- Update `docs/architecture/README.md` — replace stale Travis CI references with GitHub Actions, fix grammar, link to new guide
- Update `docs/README.md` — add link to new guide

## Test plan

- [x] Verified `make install` with `docker-compose.override.yml` serves wiki at localhost:8080
- [x] Review rendered markdown on GitHub
- [x] Verify all relative links resolve correctly