### PR TITLE
Add escape character to fputcsv in Csv.php

### DIFF
--- a/src/Utils/Csv.php
+++ b/src/Utils/Csv.php
@@ -60,11 +60,11 @@ class Csv {
 		}
 
 		if ( $header !== [] ) {
-			fputcsv( $handle, $header, $sep, '\\' );
+			fputcsv( $handle, $header, $sep, '"', '\\' );
 		}
 
 		foreach ( $rows as $row ) {
-			fputcsv( $handle, $row, $sep, '\\' );
+			fputcsv( $handle, $row, $sep, '"', '\\' );
 		}
 
 		rewind( $handle );


### PR DESCRIPTION
> As of PHP 8.4.0, depending on the default value of escape is deprecated. It needs to be provided explicitly either positionally or by the use of named arguments.