### PR TITLE
Fix integration test failures on MariaDB 11.8+

### DIFF
--- a/tests/phpunit/SMWIntegrationTestCase.php
+++ b/tests/phpunit/SMWIntegrationTestCase.php
@@ -110,6 +110,7 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 
 		$this->testEnvironment = new TestEnvironment();
 		$this->testEnvironment->addConfiguration( 'smwgEnabledDeferredUpdate', false );
+		$this->testEnvironment->disableSoftwareChangeTags();
 		$this->testEnvironment->registerObject( 'Store', $this->getStore() );
 		$this->testEnvironment->registerObject( 'Cache', $fixedInMemoryLruCache );
 		$this->testEnvironment->resetDBLoadBalancer();

--- a/tests/phpunit/TestEnvironment.php
+++ b/tests/phpunit/TestEnvironment.php
@@ -62,6 +62,30 @@ class TestEnvironment {
 	}
 
 	/**
+	 * Disable MediaWiki software change tags (mw-new-redirect, mw-blank,
+	 * etc.) to avoid MariaDB 11.8+ error 1020 ("Record has changed since
+	 * last read") caused by ChangeTagsStore::updateTags reading and then
+	 * updating change_tag_def within the same transaction.
+	 *
+	 * @since 6.1.0
+	 */
+	public function disableSoftwareChangeTags() {
+		$GLOBALS['wgSoftwareTags'] = [
+			'mw-contentmodelchange' => false,
+			'mw-new-redirect' => false,
+			'mw-removed-redirect' => false,
+			'mw-changed-redirect-target' => false,
+			'mw-blank' => false,
+			'mw-replace' => false,
+			'mw-rollback' => false,
+			'mw-undo' => false,
+			'mw-manual-revert' => false,
+			'mw-reverted' => false,
+			'mw-server-side-upload' => false,
+		];
+	}
+
+	/**
 	 * @since 3.2
 	 *
 	 * @param array $defaultSettingKeys


### PR DESCRIPTION
It is a workaround to get the tests running. The issue seems to come from MW core.

Might be related to https://phabricator.wikimedia.org/T388337

## Summary

- Disable MW software change tags in the test environment to fix MariaDB 11.8+ error 1020 ("Record has changed since last read in table 'change_tag_def'")
- Add `TestEnvironment::disableSoftwareChangeTags()` method and call it during integration test setup

## Problem

MariaDB 11.8 introduced stricter row-versioning checks that reject `UPDATE` statements on rows already read in the same transaction. During integration tests, `PageUpdater::saveRevision()` triggers `ChangeTagsStore::updateTags` which reads `change_tag_def` (to resolve the tag ID) then updates it (to increment `ctd_count`) — all within the same transaction. This causes 29 integration test failures on the MW 1.44 + MariaDB 11.8 CI matrix entry.

The same tests pass on MariaDB 11.2 because the older version does not enforce this check.

## Fix

Software change tags (`mw-new-redirect`, `mw-blank`, etc.) are not relevant to SMW's test assertions. Disabling them in the test environment avoids the problematic `UPDATE` entirely.

## Test plan

- [ ] CI passes on MW 1.44 + PHP 8.3 + MariaDB 11.8
- [ ] CI passes on all other matrix entries (no regressions)