### PR TITLE
Skip SchemaContentHandler serialization test on MW 1.45+

### DIFF
--- a/tests/phpunit/MediaWiki/Content/SchemaContentHandlerTest.php
+++ b/tests/phpunit/MediaWiki/Content/SchemaContentHandlerTest.php
@@ -134,6 +134,10 @@ class SchemaContentHandlerTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function testSerializationOfClassInstance() {
+		if ( version_compare( MW_VERSION, '1.45', '>=' ) ) {
+			$this->markTestSkipped( 'ContentHandler is not serializable in MW 1.45+' );
+		}
+
 		$title = $this->createMock( Title::class );
 
 		$title->expects( $this->any() )


### PR DESCRIPTION
## Summary

- Skip `testSerializationOfClassInstance` on MW 1.45+ where `ContentHandler` is no longer serializable

In MW 1.45, `ContentHandler` stores a `MediaWikiServices` reference which uses `NonSerializableTrait`, making all `ContentHandler` subclasses non-serializable by design. This causes `testSerializationOfClassInstance` to fail with:

```
LogicException: Instances of MediaWiki\MediaWikiServices are not serializable!
```

This is an upstream change, not an SMW issue — `SchemaContentHandler` has no instance properties that could leak database state. The test remains active on MW 1.43 and 1.44 where `ContentHandler` is still serializable.

## Test plan

- [x] CI passes on MW 1.45 (the failing test is now skipped)
- [x] CI still passes on MW 1.43 and 1.44 (the test still runs there)