### PR TITLE
Mark MW 1.44 and 1.45 CI jobs as non-experimental

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,19 +43,19 @@ jobs:
             database_type: mysql
             database_image: "mariadb:11.2"
             coverage: false
-            experimental: true
+            experimental: false
           - mediawiki_version: '1.44'
             php_version: 8.3
             database_type: mysql
             database_image: "mariadb:11.8"
             coverage: false
-            experimental: true
+            experimental: false
           - mediawiki_version: '1.45'
             php_version: 8.4
             database_type: mysql
             database_image: "mariadb:11.8"
             coverage: false
-            experimental: true
+            experimental: false
 
     env:
       MW_VERSION: ${{ matrix.mediawiki_version }}


### PR DESCRIPTION
The whole CI is passing now 🎉

## Summary

- Set `experimental: false` on the MW 1.44 and 1.45 matrix entries

These jobs are now passing consistently, so their failures should block PRs rather than being silently ignored via `continue-on-error`.

## Test plan

- [x] All 6 CI jobs pass (including the previously experimental ones)