### PR TITLE
Clean up SMWIntegrationTestCase class

### DIFF
--- a/tests/phpunit/SMWIntegrationTestCase.php
+++ b/tests/phpunit/SMWIntegrationTestCase.php
@@ -30,25 +30,13 @@ use Wikimedia\ObjectCache\HashBagOStuff;
  */
 abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 
-	/**
-	 * @var TestEnvironment
-	 */
-	protected $testEnvironment;
+	protected ?TestEnvironment $testEnvironment = null;
 
-	/**
-	 * @var TestDatabaseTableBuilder
-	 */
-	protected $testDatabaseTableBuilder;
+	protected ?TestDatabaseTableBuilder $testDatabaseTableBuilder = null;
 
-	/**
-	 * @var bool
-	 */
-	protected $destroyDatabaseTablesBeforeRun = false;
+	protected bool $destroyDatabaseTablesBeforeRun = false;
 
-	/**
-	 * @var bool
-	 */
-	protected $isUsableUnitTestDatabase = true;
+	protected bool $isUsableUnitTestDatabase = true;
 
 	/**
 	 * Setup configuration required for SMW integration tests.
@@ -177,7 +165,7 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		return StoreFactory::getStore();
 	}
 
-	protected function skipTestForMediaWikiVersionLowerThan( $version, $message = '' ) {
+	protected function skipTestForMediaWikiVersionLowerThan( string $version, string $message = '' ): void {
 		if ( $message === '' ) {
 			$message = "This test is skipped for MediaWiki version " . MW_VERSION;
 		}
@@ -187,7 +175,7 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		}
 	}
 
-	protected function skipTestForDatabase( $excludedDatabase, $message = '' ) {
+	protected function skipTestForDatabase( string|array $excludedDatabase, string $message = '' ): void {
 		if ( is_string( $excludedDatabase ) ) {
 			$excludedDatabase = [ $excludedDatabase ];
 		}
@@ -209,7 +197,7 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		return $this->testDatabaseTableBuilder->getConnectionProvider();
 	}
 
-	private function destroyDatabaseTables( $destroyDatabaseTables ) {
+	private function destroyDatabaseTables( bool $destroyDatabaseTables ): void {
 		if ( $this->isUsableUnitTestDatabase && $destroyDatabaseTables ) {
 			try {
 				$this->testDatabaseTableBuilder->doDestroy();


### PR DESCRIPTION
## Summary

Two commits cleaning up the `SMWIntegrationTestCase` base test class:

**Commit 1: Remove dead code, fix imports**
- Remove 7 dead methods with zero callers across 70 subclasses: `removeDatabaseTypeFromTest`, `destroyDatabaseTablesAfterRun`, `setStoresToBeExcluded`, `skipTestForStore`, `isUsableUnitTestDatabase`, `checkIfDatabaseCanBeUsedOtherwiseSkipTest`, `checkIfStoreCanBeUsedOtherwiseSkipTest`
- Remove 3 dead properties: `$databaseToBeExcluded`, `$storesToBeExcluded`, `$destroyDatabaseTablesAfterRun`
- Remove dead code in `run()`: `removeAvailableDatabaseType` call (always null), `destroyDatabaseTables` after-run call (always false)
- Remove commented-out code and trivial `clearPendingDeferredUpdates` wrapper (inlined)
- Replace inline `\Exception` with `use` import
- Remove outdated `@codingStandardsIgnoreStart/End` comments

**Commit 2: Add native type declarations**
- Replace PHPDoc-only type hints with native PHP type declarations for properties and method signatures

80 lines of dead code removed.

## Test plan

- [ ] CI passes on all MW versions — no subclass uses the removed methods