### PR TITLE
Clean up JSON script test runner classes

### DIFF
--- a/tests/phpunit/Benchmark/BenchmarkJsonScriptRunnerTest.php
+++ b/tests/phpunit/Benchmark/BenchmarkJsonScriptRunnerTest.php
@@ -55,7 +55,7 @@ class BenchmarkJsonScriptRunnerTest extends JSONScriptTestCaseRunner {
 	/**
 	 * @see JSONScriptTestCaseRunner::$deletePagesOnTearDown
 	 */
-	protected $deletePagesOnTearDown = true;
+	protected bool $deletePagesOnTearDown = true;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -113,21 +113,21 @@ class BenchmarkJsonScriptRunnerTest extends JSONScriptTestCaseRunner {
 	/**
 	 * @see JSONScriptTestCaseRunner::getTestCaseLocation
 	 */
-	protected function getTestCaseLocation() {
+	protected function getTestCaseLocation(): string {
 		return __DIR__ . '/TestCases';
 	}
 
 	/**
 	 * @see JSONScriptTestCaseRunner::getTestCaseLocation
 	 */
-	protected function getRequiredJsonTestCaseMinVersion() {
+	protected function getRequiredJsonTestCaseMinVersion(): string {
 		return '1';
 	}
 
 	/**
 	 * @see JSONScriptTestCaseRunner::getAllowedTestCaseFiles
 	 */
-	protected function getAllowedTestCaseFiles() {
+	protected function getAllowedTestCaseFiles(): array {
 		return [];
 	}
 
@@ -136,7 +136,7 @@ class BenchmarkJsonScriptRunnerTest extends JSONScriptTestCaseRunner {
 	 *
 	 * @param JsonTestCaseFileHandler $jsonTestCaseFileHandler
 	 */
-	protected function runTestCaseFile( JsonTestCaseFileHandler $jsonTestCaseFileHandler ) {
+	protected function runTestCaseFile( JsonTestCaseFileHandler $jsonTestCaseFileHandler ): void {
 		$this->pageImportBenchmarkRunner->setTestCaseLocation(
 			$this->getTestCaseLocation()
 		);
@@ -163,7 +163,7 @@ class BenchmarkJsonScriptRunnerTest extends JSONScriptTestCaseRunner {
 			CliOutputFormatter::FORMAT_JSON
 		);
 
-		return print "\n\n" . $cliOutputFormatter->format( $report );
+		print "\n\n" . $cliOutputFormatter->format( $report );
 	}
 
 	private function doRunImportBenchmarks( $jsonTestCaseFileHandler ) {

--- a/tests/phpunit/Integration/JSONScript/JSONScriptTestCaseRunnerTest.php
+++ b/tests/phpunit/Integration/JSONScript/JSONScriptTestCaseRunnerTest.php
@@ -36,21 +36,21 @@ class JSONScriptTestCaseRunnerTest extends JSONScriptServicesTestCaseRunner {
 	/**
 	 * @see JSONScriptTestCaseRunner::getTestCaseLocation
 	 */
-	protected function getTestCaseLocation() {
+	protected function getTestCaseLocation(): string {
 		return __DIR__ . '/TestCases';
 	}
 
 	/**
 	 * @see JSONScriptTestCaseRunner::getTestCaseLocation
 	 */
-	protected function getRequiredJsonTestCaseMinVersion() {
+	protected function getRequiredJsonTestCaseMinVersion(): string {
 		return '2';
 	}
 
 	/**
 	 * @see JSONScriptTestCaseRunner::getDependencyDefinitions
 	 */
-	protected function getDependencyDefinitions() {
+	protected function getDependencyDefinitions(): array {
 		return [
 			'Maps' => static function ( $val, &$reason ) {
 				if ( !ExtensionRegistry::getInstance()->isLoaded( 'Maps' ) ) {

--- a/tests/phpunit/JSONScriptServicesTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptServicesTestCaseRunner.php
@@ -15,6 +15,9 @@ use SMW\Tests\Utils\JSONScript\QueryTestCaseInterpreter;
 use SMW\Tests\Utils\JSONScript\QueryTestCaseProcessor;
 use SMW\Tests\Utils\JSONScript\RdfTestCaseProcessor;
 use SMW\Tests\Utils\JSONScript\SpecialPageTestCaseProcessor;
+use SMW\Tests\Utils\MwApiFactory;
+use SMW\Tests\Utils\Runners\RunnerFactory;
+use SMW\Tests\Utils\Validators\ValidatorFactory;
 
 /**
  * It is provided for external extensions that seek a simple way of creating tests
@@ -31,30 +34,19 @@ use SMW\Tests\Utils\JSONScript\SpecialPageTestCaseProcessor;
  */
 abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner {
 
-	/**
-	 * @var ValidatorFactory
-	 */
-	protected $validatorFactory;
-
-	/**
-	 * @var RunnerFactory
-	 */
-	protected $runnerFactory;
-
-	/**
-	 * @var ApiFactory
-	 */
-	private $apiFactory;
+	protected ValidatorFactory $validatorFactory;
+	protected RunnerFactory $runnerFactory;
+	private MwApiFactory $apiFactory;
 
 	/**
 	 * @see JSONScriptTestCaseRunner::$deletePagesOnTearDown
 	 */
-	protected $deletePagesOnTearDown = true;
+	protected bool $deletePagesOnTearDown = true;
 
 	/**
 	 * Defines set of assertation services to be available by the runner
 	 */
-	protected $defaultAssertionTypes = [
+	protected array $defaultAssertionTypes = [
 		'parser',
 		'parser-html',
 		'special'
@@ -92,21 +84,14 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 		);
 	}
 
-	/**
-	 * @param string $type
-	 *
-	 * @return bool
-	 */
 	protected function runTestAssertionForType( string $type ): bool {
 		return in_array( $type, $this->defaultAssertionTypes );
 	}
 
 	/**
 	 * @see JSONScriptTestCaseRunner::runTestCaseFile
-	 *
-	 * @param JsonTestCaseFileHandler $jsonTestCaseFileHandler
 	 */
-	protected function runTestCaseFile( JsonTestCaseFileHandler $jsonTestCaseFileHandler ) {
+	protected function runTestCaseFile( JsonTestCaseFileHandler $jsonTestCaseFileHandler ): void {
 		$this->checkEnvironmentToSkipCurrentTest( $jsonTestCaseFileHandler );
 
 		// Setup
@@ -152,7 +137,7 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 	/**
 	 * @see JSONScriptTestCaseRunner::getPermittedSettings
 	 */
-	protected function getPermittedSettings() {
+	protected function getPermittedSettings(): array {
 		parent::getPermittedSettings();
 
 		$elasticsearchConfig = function ( $val ) {
@@ -437,7 +422,7 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 		}
 	}
 
-	private function doRunQueryTests( $jsonTestCaseFileHandler, $queryParser, &$i, &$count ) {
+	private function doRunQueryTests( JsonTestCaseFileHandler $jsonTestCaseFileHandler, $queryParser, &$i, &$count ) {
 		$testCases = $jsonTestCaseFileHandler->findTestCasesByType( 'query' );
 		$count += count( $testCases );
 
@@ -445,20 +430,7 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 			return;
 		}
 
-		$queryTestCaseProcessor = new QueryTestCaseProcessor(
-			$this->getStore(),
-			$this->validatorFactory->newQueryResultValidator(),
-			$this->validatorFactory->newStringValidator(),
-			$this->validatorFactory->newNumberValidator()
-		);
-
-		$queryTestCaseProcessor->setQueryParser(
-			$queryParser
-		);
-
-		$queryTestCaseProcessor->setDebugMode(
-			$jsonTestCaseFileHandler->getDebugMode()
-		);
+		$queryTestCaseProcessor = $this->newQueryTestCaseProcessor( $queryParser, $jsonTestCaseFileHandler );
 
 		foreach ( $testCases as $case ) {
 
@@ -471,7 +443,7 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 		}
 	}
 
-	private function doRunConceptTests( $jsonTestCaseFileHandler, $queryParser, &$i, &$count ) {
+	private function doRunConceptTests( JsonTestCaseFileHandler $jsonTestCaseFileHandler, $queryParser, &$i, &$count ) {
 		$testCases = $jsonTestCaseFileHandler->findTestCasesByType( 'concept' );
 		$count += count( $testCases );
 
@@ -479,20 +451,7 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 			return;
 		}
 
-		$queryTestCaseProcessor = new QueryTestCaseProcessor(
-			$this->getStore(),
-			$this->validatorFactory->newQueryResultValidator(),
-			$this->validatorFactory->newStringValidator(),
-			$this->validatorFactory->newNumberValidator()
-		);
-
-		$queryTestCaseProcessor->setQueryParser(
-			$queryParser
-		);
-
-		$queryTestCaseProcessor->setDebugMode(
-			$jsonTestCaseFileHandler->getDebugMode()
-		);
+		$queryTestCaseProcessor = $this->newQueryTestCaseProcessor( $queryParser, $jsonTestCaseFileHandler );
 
 		foreach ( $testCases as $case ) {
 			$queryTestCaseProcessor->processConceptCase( new QueryTestCaseInterpreter( $case ) );
@@ -500,7 +459,7 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 		}
 	}
 
-	private function doRunFormatTests( $jsonTestCaseFileHandler, $queryParser, &$i, &$count ) {
+	private function doRunFormatTests( JsonTestCaseFileHandler $jsonTestCaseFileHandler, $queryParser, &$i, &$count ) {
 		$testCases = $jsonTestCaseFileHandler->findTestCasesByType( 'format' );
 		$count += count( $testCases );
 
@@ -508,20 +467,7 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 			return;
 		}
 
-		$queryTestCaseProcessor = new QueryTestCaseProcessor(
-			$this->getStore(),
-			$this->validatorFactory->newQueryResultValidator(),
-			$this->validatorFactory->newStringValidator(),
-			$this->validatorFactory->newNumberValidator()
-		);
-
-		$queryTestCaseProcessor->setQueryParser(
-			$queryParser
-		);
-
-		$queryTestCaseProcessor->setDebugMode(
-			$jsonTestCaseFileHandler->getDebugMode()
-		);
+		$queryTestCaseProcessor = $this->newQueryTestCaseProcessor( $queryParser, $jsonTestCaseFileHandler );
 
 		foreach ( $testCases as $case ) {
 
@@ -532,6 +478,23 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 			$queryTestCaseProcessor->processFormatCase( new QueryTestCaseInterpreter( $case ) );
 			$i++;
 		}
+	}
+
+	private function newQueryTestCaseProcessor(
+		$queryParser,
+		JsonTestCaseFileHandler $jsonTestCaseFileHandler
+	): QueryTestCaseProcessor {
+		$queryTestCaseProcessor = new QueryTestCaseProcessor(
+			$this->getStore(),
+			$this->validatorFactory->newQueryResultValidator(),
+			$this->validatorFactory->newStringValidator(),
+			$this->validatorFactory->newNumberValidator()
+		);
+
+		$queryTestCaseProcessor->setQueryParser( $queryParser );
+		$queryTestCaseProcessor->setDebugMode( $jsonTestCaseFileHandler->getDebugMode() );
+
+		return $queryTestCaseProcessor;
 	}
 
 	private function doRunApiTests( JsonTestCaseFileHandler $jsonTestCaseFileHandler ) {

--- a/tests/phpunit/JSONScriptTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptTestCaseRunner.php
@@ -34,40 +34,13 @@ use SMW\Tests\Utils\UtilityFactory;
  */
 abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
 
-	/**
-	 * @var JsonFileReader
-	 */
-	private $fileReader;
-
-	/**
-	 * @var JsonTestCaseContentHandler
-	 */
-	private $jsonTestCaseContentHandler;
-
-	/**
-	 * @var array
-	 */
-	private $itemsMarkedForDeletion = [];
-
-	/**
-	 * @var array
-	 */
-	private $configValueCallback = [];
-
-	/**
-	 * @var bool
-	 */
-	protected $deletePagesOnTearDown = true;
-
-	/**
-	 * @var string
-	 */
-	protected $searchByFileExtension = 'json';
-
-	/**
-	 * @var string
-	 */
-	protected $connectorId = '';
+	private JsonFileReader $fileReader;
+	private JsonTestCaseContentHandler $jsonTestCaseContentHandler;
+	private array $itemsMarkedForDeletion = [];
+	private array $configValueCallback = [];
+	protected bool $deletePagesOnTearDown = true;
+	protected string $searchByFileExtension = 'json';
+	protected string $connectorId = '';
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -113,36 +86,22 @@ abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
 		}
 	}
 
-	/**
-	 * @return string
-	 */
-	abstract protected function getTestCaseLocation();
+	abstract protected function getTestCaseLocation(): string;
 
-	/**
-	 * @param JsonTestCaseFileHandler $jsonTestCaseFileHandler
-	 */
-	abstract protected function runTestCaseFile( JsonTestCaseFileHandler $jsonTestCaseFileHandler );
+	abstract protected function runTestCaseFile( JsonTestCaseFileHandler $jsonTestCaseFileHandler ): void;
 
-	/**
-	 * @return string
-	 */
-	protected function getRequiredJsonTestCaseMinVersion() {
+	protected function getRequiredJsonTestCaseMinVersion(): string {
 		return '0.1';
 	}
 
-	/**
-	 * @return array
-	 */
-	protected function getAllowedTestCaseFiles() {
+	protected function getAllowedTestCaseFiles(): array {
 		return [];
 	}
 
 	/**
 	 * @since 3.0
-	 *
-	 * @return
 	 */
-	protected function getDependencyDefinitions() {
+	protected function getDependencyDefinitions(): array {
 		return [];
 	}
 
@@ -153,10 +112,8 @@ abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
 	 * For a configuration that requires special treatment (i.e. where a simple
 	 * assignment isn't sufficient), a callback can be assigned to a settings
 	 * key in order to sort out required manipulation (constants etc.).
-	 *
-	 * @return array
 	 */
-	protected function getPermittedSettings() {
+	protected function getPermittedSettings(): array {
 		// Ensure that the context is set for a selected language
 		// and dependent objects are reset
 		$this->registerConfigValueCallback( 'wgContLang', function ( $val ) {
@@ -192,19 +149,12 @@ abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
 		return [];
 	}
 
-	/**
-	 * @param string $key
-	 * @param Closure $callback
-	 */
-	protected function registerConfigValueCallback( $key, Closure $callback ) {
+	protected function registerConfigValueCallback( string $key, Closure $callback ): void {
 		$this->configValueCallback[$key] = $callback;
 	}
 
-	/**
-	 * @return callable|null
-	 */
-	protected function getConfigValueCallback( $key ) {
-		return isset( $this->configValueCallback[$key] ) ? $this->configValueCallback[$key] : null;
+	protected function getConfigValueCallback( string $key ): ?callable {
+		return $this->configValueCallback[$key] ?? null;
 	}
 
 	/**
@@ -212,12 +162,8 @@ abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
 	 * JsonTestCaseScriptRunner::getAllowedTestCaseFiles (or hereof) to filter
 	 * selected files and help fine tune a setup or debug a potential issue
 	 * without having to run all test files at once.
-	 *
-	 * @param string $file
-	 *
-	 * @return bool
 	 */
-	protected function canTestCaseFile( $file ) {
+	protected function canTestCaseFile( string $file ): bool {
 		// Filter specific files on-the-fly
 		$allowedTestCaseFiles = $this->getAllowedTestCaseFiles();
 
@@ -238,7 +184,7 @@ abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
 	/**
 	 * @dataProvider jsonFileProvider
 	 */
-	public function testCaseFile( $file ) {
+	public function testCaseFile( string $file ): void {
 		if ( !$this->canTestCaseFile( $file ) ) {
 			$this->markTestSkipped( $file . ' excluded from the test run' );
 		}
@@ -247,10 +193,7 @@ abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
 		$this->runTestCaseFile( new JsonTestCaseFileHandler( $this->fileReader ) );
 	}
 
-	/**
-	 * @return array
-	 */
-	public function jsonFileProvider() {
+	public function jsonFileProvider(): array {
 		$provider = [];
 
 		$bulkFileProvider = UtilityFactory::getInstance()->newBulkFileProvider(
@@ -268,20 +211,15 @@ abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
 
 	/**
 	 * @since 2.2
-	 *
-	 * @param mixed $key
-	 * @param mixed $value
 	 */
-	protected function changeGlobalSettingTo( $key, $value ) {
+	protected function changeGlobalSettingTo( string $key, $value ): void {
 		$this->testEnvironment->addConfiguration( $key, $value );
 	}
 
 	/**
 	 * @since 2.2
-	 *
-	 * @param JsonTestCaseFileHandler $jsonTestCaseFileHandler
 	 */
-	protected function checkEnvironmentToSkipCurrentTest( JsonTestCaseFileHandler $jsonTestCaseFileHandler ) {
+	protected function checkEnvironmentToSkipCurrentTest( JsonTestCaseFileHandler $jsonTestCaseFileHandler ): void {
 		if ( $jsonTestCaseFileHandler->isIncomplete() ) {
 			$this->markTestIncomplete( $jsonTestCaseFileHandler->getReasonForSkip() );
 		}
@@ -309,11 +247,8 @@ abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param array $pages
-	 * @param int $defaultNamespace
 	 */
-	protected function createPagesFrom( array $pages, $defaultNamespace = NS_MAIN ) {
+	protected function createPagesFrom( array $pages, int $defaultNamespace = NS_MAIN ): void {
 		$this->jsonTestCaseContentHandler->skipOn(
 			$this->connectorId
 		);


### PR DESCRIPTION
## Summary

Two commits cleaning up `JSONScriptTestCaseRunner` and `JSONScriptServicesTestCaseRunner`:

**Commit 1: Remove dead code, fix imports**
- Remove duplicate `requiredToSkipForConnector` call in `checkEnvironmentToSkipCurrentTest`
- Remove deprecated `createPagesFor` method (zero callers, deprecated since 2.5)
- Add `use Closure` and `use SMW\Elastic\ElasticStore` — replace inline `\` references

**Commit 2: Add native types, extract helper**
- Add native type declarations to properties and method signatures across both runner classes
- Update subclasses (`JSONScriptTestCaseRunnerTest`, `BenchmarkJsonScriptRunnerTest`) for signature compatibility
- Extract `newQueryTestCaseProcessor` helper to deduplicate identical construction in `doRunQueryTests`, `doRunConceptTests`, `doRunFormatTests`
- Replace `isset() ? : null` with null coalescing operator

## Test plan

- [x] CI passes on all MW versions