### PR TITLE
Clean up autoloading: use extension.json conventions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,12 +81,7 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"SMW\\": "src/",
-			"SMW\\Maintenance\\": "maintenance/",
 			"Onoi\\Tesa\\": "Tesa/src/"
-		},
-		"psr-0": {
-			"SemanticMediaWiki": "includes/SemanticMediaWiki.php"
 		},
 		"files": [
 			"includes/GlobalFunctions.php"

--- a/extension.json
+++ b/extension.json
@@ -23,7 +23,7 @@
 	},
 	"AutoloadNamespaces": {
 		"SMW\\": "src/",
-		"SMW\\Maintenance": "maintenance/",
+		"SMW\\Maintenance\\": "maintenance/",
 		"Onoi\\Tesa\\": "Tesa/src/"
 	},
 	"TestAutoloadNamespaces": {


### PR DESCRIPTION
## Summary

Two commits cleaning up autoloading to align with modern MediaWiki extension conventions:

**Commit 1: Move test autoloading to extension.json**
- Move `SMW\Tests\` from `composer.json` `autoload.psr-4` to `extension.json` `TestAutoloadNamespaces`
- Test classes are now only autoloaded during test runs, not in production

**Commit 2: Remove duplicate autoload entries from composer.json**
- Remove `SMW\` and `SMW\Maintenance\` psr-4 entries (already in `extension.json` `AutoloadNamespaces`)
- Remove `SemanticMediaWiki` psr-0 entry (already in `extension.json` `AutoloadClasses`)
- Keep `Onoi\Tesa\` in `composer.json` — it's a bundled library with its own test suite that runs outside MW
- Keep `files` and `classmap` entries — these serve purposes not covered by `extension.json`

Verified locally: lint, PHPCS, 6,885 unit tests pass, wiki loads correctly in browser.

## Test plan

- [x] CI passes on all MW versions
- [x] Tesa test suite passes