### PR TITLE
Remove obsolete version check for MW 1.42 in ContentParser

### DIFF
--- a/includes/ContentParser.php
+++ b/includes/ContentParser.php
@@ -162,10 +162,6 @@ class ContentParser {
 		// Avoid "The content model 'xyz' is not registered on this wiki."
 		try {
 			$services = MediaWikiServices::getInstance();
-			// MW 1.42+
-			if ( version_compare( MW_VERSION, '1.42', '<' ) ) {
-				$revision = $revision->getId();
-			}
 			$contentRenderer = $services->getContentRenderer();
 			$this->parserOutput = $contentRenderer->getParserOutput(
 				$content,


### PR DESCRIPTION
Removed version check for MediaWiki version 1.42.