### PR TITLE
Remove version check for MW 1.42 in SMW_ExportController

### DIFF
--- a/includes/export/SMW_ExportController.php
+++ b/includes/export/SMW_ExportController.php
@@ -494,11 +494,7 @@ class SMWExportController {
 	 * @return \Wikimedia\Rdbms\IDatabase|\Wikimedia\Rdbms\IReadableDatabase
 	 */
 	public static function getDBHandle() {
-		if ( version_compare( MW_VERSION, '1.42', '>=' ) ) {
-			return MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
-		} else {
-			return MediaWikiServices::getInstance()->getDBLoadBalancer()->getConnection( DB_REPLICA );
-		}
+		return MediaWikiServices::getInstance()->getConnectionProvider()->getReplicaDatabase();
 	}
 
 	/**


### PR DESCRIPTION
Simplified getDBHandle method to always return the replica database connection.