### PR TITLE
Remove version check for MW 1.41 in FileRepoFinderTest

### DIFF
--- a/tests/phpunit/MediaWiki/FileRepoFinderTest.php
+++ b/tests/phpunit/MediaWiki/FileRepoFinderTest.php
@@ -58,16 +58,10 @@ class FileRepoFinderTest extends \PHPUnit\Framework\TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		if ( version_compare( MW_VERSION, '1.41', '>=' ) ) {
-			// Mock the IReadableDatabase interface
-			$db = $this->getMockBuilder( \Wikimedia\Rdbms\IReadableDatabase::class )
+		// Mock the IReadableDatabase interface
+		$db = $this->getMockBuilder( \Wikimedia\Rdbms\IReadableDatabase::class )
 			->disableOriginalConstructor()
 			->getMock();
-		} else {
-			$db = $this->getMockBuilder( '\Database' )
-			->disableOriginalConstructor()
-			->getMock();
-		}
 
 		$localRepo = $this->getMockBuilder( '\LocalRepo' )
 			->disableOriginalConstructor()


### PR DESCRIPTION
Removed conditional logic for database mock based on MW_VERSION.