### PR TITLE
Stats: Update makeCacheKey to use array for parameters

### DIFF
--- a/src/Utils/Stats.php
+++ b/src/Utils/Stats.php
@@ -85,7 +85,7 @@ class Stats {
 	 * @since 3.1
 	 */
 	public function makeCacheKey( $id ) {
-		return smwfCacheKey( self::CACHE_NAMESPACE, $id, self::VERSION );
+		return smwfCacheKey( self::CACHE_NAMESPACE, [ $id, self::VERSION ] );
 	}
 
 	/**


### PR DESCRIPTION
smwfCacheKey doesn't take 3 args, it only takes 2. The 2nd one can be an array, so we will fix this by using an array.