### PR TITLE
ServicesFactory: Fix containerBuilder type

### DIFF
--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -67,7 +67,7 @@ class ServicesFactory {
 	private static $instance = null;
 
 	/**
-	 * @var CallbackContainerBuilder
+	 * @var CallbackContainerBuilder|null
 	 */
 	private $callbackContainerBuilder;
 
@@ -79,10 +79,10 @@ class ServicesFactory {
 	/**
 	 * @since 2.0
 	 *
-	 * @param CallbackContainerBuilder $callbackContainerBuilder
+	 * @param CallbackContainerBuilder|null $callbackContainerBuilder
 	 * @param string $servicesFileDir
 	 */
-	public function __construct( CallbackContainerBuilder $callbackContainerBuilder, $servicesFileDir = '' ) {
+	public function __construct( ?CallbackContainerBuilder $callbackContainerBuilder = null, $servicesFileDir = '' ) {
 		$this->callbackContainerBuilder = $callbackContainerBuilder;
 		$this->servicesFileDir = $servicesFileDir;
 	}


### PR DESCRIPTION
We have to use CallbackContainerBuilder because well we use that already but use the wrong type. Thus create() is a single parameter under ContainerBuilder but multiple under CallbackContainerBuilder.