### PR TITLE
Change key parameter type in smwfCacheKey function to string|aray

### DIFF
--- a/includes/GlobalFunctions.php
+++ b/includes/GlobalFunctions.php
@@ -162,7 +162,7 @@ function &smwfGetStore() {
  * @since 3.0
  *
  * @param string $namespace
- * @param string $key
+ * @param string|array $key
  *
  * @return string
  */


### PR DESCRIPTION
Updated parameter type for key to accept string or array.