### PR TITLE
HtmlColumns: Fix phan errors

### DIFF
--- a/src/Utils/HtmlColumns.php
+++ b/src/Utils/HtmlColumns.php
@@ -269,7 +269,7 @@ class HtmlColumns {
 			);
 		}
 
-		if ( !$usedColumnCloser && !$result ) {
+		if ( !$usedColumnCloser && $result ) {
 			$result .= "</{$this->listType}></div> <!-- end column -->";
 		}
 


### PR DESCRIPTION
```
src/Utils/HtmlColumns.php:244 PhanTypeMismatchPropertyProbablyReal Assigning "width:{$width}%;columns:{$maxColumns} 20em;" of type string to property but \SMW\Utils\HtmlColumns->columnStyle is int (no real type) (the inferred real assigned type has nothing in common with the declared phpdoc property type)
src/Utils/HtmlColumns.php:250 PhanTypeMismatchProperty Assigning "width:{$width}%;columns:{$maxColumns} 20em;" of type string to property but \SMW\Utils\HtmlColumns->columnStyle is int
src/Utils/HtmlColumns.php:253 PhanTypeMismatchProperty Assigning "width:{$width}%;" of type string to property but \SMW\Utils\HtmlColumns->columnStyle is int
src/Utils/HtmlColumns.php:273 MediaWikiNoEmptyIfDefined Found usage of empty() on expression $result that appears to be always set. empty() should only be used to suppress errors. See https://w.wiki/6paE
src/Utils/HtmlColumns.php:287 PhanUnusedPrivateMethodParameter Parameter $columns is never used
src/Utils/HtmlColumns.php:304 PhanTypeInvalidModuloOperand Operand $rowsPerColumn of type float|int to modulo (%) operator is implicitly converted to int (deprecated in PHP 8.1)
src/Utils/HtmlColumns.php:328 PhanTypeInvalidModuloOperand Operand $rowsPerColumn of type float|int to modulo (%) operator is implicitly converted to int (deprecated in PHP 8.1)
src/Utils/HtmlColumns.php:336 PhanTypeInvalidModuloOperand Operand $rowsPerColumn of type float|int to modulo (%) operator is implicitly converted to int (deprecated in PHP 8.1)
```