### PR TITLE
Drop psr/log from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
 		"php": ">=8.1",
 		"ext-mbstring": "*",
 		"composer/installers": "^2.2.0|^1.0.1",
-		"psr/log": "1.1.4",
 		"mediawiki/parser-hooks": "~1.4",
 		"param-processor/param-processor": "~1.2",
 		"serialization/serialization": "~3.2|~4.0",


### PR DESCRIPTION
## Summary

- Remove `psr/log` from `require` in `composer.json`

MediaWiki core already requires `psr/log` at the same version (1.1.4). Since SMW always runs as a MW extension, the dependency is guaranteed to be available at runtime and the explicit requirement is redundant.

## Test plan

- [ ] CI passes