### PR TITLE
JobQueueRunner: Remove unused $offset variable

### DIFF
--- a/tests/phpunit/Utils/Runners/JobQueueRunner.php
+++ b/tests/phpunit/Utils/Runners/JobQueueRunner.php
@@ -131,7 +131,6 @@ class JobQueueRunner {
 	 * @see https://gerrit.wikimedia.org/r/#/c/162009/
 	 */
 	private function pop() {
-		$offset = 0;
 		return MediaWikiServices::getInstance()->getJobQueueGroup()->pop();
 	}
 


### PR DESCRIPTION
## Summary

- Remove unused `$offset` variable in `JobQueueRunner::pop()`

Split out from #6414 to keep that PR focused on the DB lifecycle fix.