### PR TITLE
refactor: constructor promotion + readonly for SQLStore

### DIFF
--- a/src/SQLStore/ChangeOp/ChangeDiff.php
+++ b/src/SQLStore/ChangeOp/ChangeDiff.php
@@ -30,31 +30,6 @@ class ChangeDiff {
 	private $time;
 
 	/**
-	 * @var DIWikiPage
-	 */
-	private $subject;
-
-	/**
-	 * @var array
-	 */
-	private $tableChangeOps = [];
-
-	/**
-	 * @var array
-	 */
-	private $dataOps = [];
-
-	/**
-	 * @var array
-	 */
-	private $propertyList = [];
-
-	/**
-	 * @var array
-	 */
-	private $textItems = [];
-
-	/**
 	 * @var array
 	 */
 	private $changeList = [];
@@ -66,20 +41,15 @@ class ChangeDiff {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param DIWikiPage $subject
-	 * @param array $tableChangeOps
-	 * @param array $dataOps
-	 * @param array $propertyList
-	 * @param array $textItems
 	 */
-	public function __construct( DIWikiPage $subject, array $tableChangeOps, array $dataOps, array $propertyList, array $textItems = [] ) {
+	public function __construct(
+		private readonly DIWikiPage $subject,
+		private readonly array $tableChangeOps,
+		private readonly array $dataOps,
+		private readonly array $propertyList,
+		private readonly array $textItems = [],
+	) {
 		$this->time = time();
-		$this->subject = $subject;
-		$this->tableChangeOps = $tableChangeOps;
-		$this->dataOps = $dataOps;
-		$this->propertyList = $propertyList;
-		$this->textItems = $textItems;
 	}
 
 	/**

--- a/src/SQLStore/ChangeOp/ChangeOp.php
+++ b/src/SQLStore/ChangeOp/ChangeOp.php
@@ -23,11 +23,6 @@ class ChangeOp implements IteratorAggregate {
 	/**
 	 * @var array
 	 */
-	private $diff = [];
-
-	/**
-	 * @var array
-	 */
 	private $data = [];
 
 	/**
@@ -39,11 +34,6 @@ class ChangeOp implements IteratorAggregate {
 	 * @var array
 	 */
 	private $orderedDiff = [];
-
-	/**
-	 * @var DIWikiPage
-	 */
-	private $subject;
 
 	/**
 	 * @var array
@@ -62,13 +52,11 @@ class ChangeOp implements IteratorAggregate {
 
 	/**
 	 * @since 2.3
-	 *
-	 * @param DIWikiPage|null $subject
-	 * @param array $diff
 	 */
-	public function __construct( ?DIWikiPage $subject = null, array $diff = [] ) {
-		$this->subject = $subject;
-		$this->diff = $diff;
+	public function __construct(
+		private readonly ?DIWikiPage $subject = null,
+		private array $diff = [],
+	) {
 	}
 
 	/**

--- a/src/SQLStore/ChangeOp/FieldChangeOp.php
+++ b/src/SQLStore/ChangeOp/FieldChangeOp.php
@@ -13,24 +13,12 @@ use InvalidArgumentException;
 class FieldChangeOp {
 
 	/**
-	 * @var array
-	 */
-	private $changeOp = [];
-
-	/**
-	 * @var string
-	 */
-	private $type;
-
-	/**
 	 * @since 2.4
-	 *
-	 * @param array $changeOp
-	 * @param string|null $type
 	 */
-	public function __construct( array $changeOp = [], $type = null ) {
-		$this->changeOp = $changeOp;
-		$this->type = $type;
+	public function __construct(
+		private array $changeOp = [],
+		private $type = null,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/ChangeOp/TableChangeOp.php
+++ b/src/SQLStore/ChangeOp/TableChangeOp.php
@@ -14,24 +14,12 @@ class TableChangeOp {
 	const OP_DELETE = 'delete';
 
 	/**
-	 * @var string
-	 */
-	private $tableName;
-
-	/**
-	 * @var array
-	 */
-	private $changeOps;
-
-	/**
 	 * @since 2.4
-	 *
-	 * @param string $tableName
-	 * @param array $changeOps
 	 */
-	public function __construct( $tableName, array $changeOps ) {
-		$this->tableName = $tableName;
-		$this->changeOps = $changeOps;
+	public function __construct(
+		private $tableName,
+		private array $changeOps,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/ConceptCache.php
+++ b/src/SQLStore/ConceptCache.php
@@ -20,29 +20,17 @@ use Wikimedia\Rdbms\Platform\ISQLPlatform;
 class ConceptCache {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
-	 * @var ConceptQuerySegmentBuilder
-	 */
-	private $conceptQuerySegmentBuilder;
-
-	/**
 	 * @var int
 	 */
 	private $upperLimit = 50;
 
 	/**
 	 * @since 2.2
-	 *
-	 * @param SQLStore $store
-	 * @param ConceptQuerySegmentBuilder $conceptQuerySegmentBuilder
 	 */
-	public function __construct( SQLStore $store, ConceptQuerySegmentBuilder $conceptQuerySegmentBuilder ) {
-		$this->store = $store;
-		$this->conceptQuerySegmentBuilder = $conceptQuerySegmentBuilder;
+	public function __construct(
+		private readonly SQLStore $store,
+		private readonly ConceptQuerySegmentBuilder $conceptQuerySegmentBuilder,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/AuxiliaryFields.php
+++ b/src/SQLStore/EntityStore/AuxiliaryFields.php
@@ -19,24 +19,12 @@ class AuxiliaryFields {
 	const COUNTMAP_CACHE_ID = 'count.map';
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
-	 * @var IdCacheManager
-	 */
-	private $idCacheManager;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param Database $connection
-	 * @param IdCacheManager $idCacheManager
 	 */
-	public function __construct( Database $connection, IdCacheManager $idCacheManager ) {
-		$this->connection = $connection;
-		$this->idCacheManager = $idCacheManager;
+	public function __construct(
+		private readonly Database $connection,
+		private readonly IdCacheManager $idCacheManager,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/CacheWarmer.php
+++ b/src/SQLStore/EntityStore/CacheWarmer.php
@@ -21,16 +21,6 @@ use SMW\SQLStore\SQLStore;
 class CacheWarmer {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
-	 * @var IdCacheManager
-	 */
-	private $idCacheManager;
-
-	/**
 	 * @var DisplayTitleFinder
 	 */
 	private $displayTitleFinder;
@@ -42,13 +32,11 @@ class CacheWarmer {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param SQLStore $store
-	 * @param IdCacheManager $idCacheManager
 	 */
-	public function __construct( SQLStore $store, IdCacheManager $idCacheManager ) {
-		$this->store = $store;
-		$this->idCacheManager = $idCacheManager;
+	public function __construct(
+		private readonly SQLStore $store,
+		private readonly IdCacheManager $idCacheManager,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/CachingSemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/CachingSemanticDataLookup.php
@@ -24,16 +24,6 @@ class CachingSemanticDataLookup {
 	use LoggerAwareTrait;
 
 	/**
-	 * @var SemanticDataLookup
-	 */
-	private $semanticDataLookup;
-
-	/**
-	 * @var Cache
-	 */
-	private $cache;
-
-	/**
 	 * Cache for SemanticData dataItems, indexed by SMW ID.
 	 *
 	 * @var array
@@ -63,14 +53,11 @@ class CachingSemanticDataLookup {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param SemanticDataLookup $semanticDataLookup
-	 * @param Cache|null $cache
 	 */
-	public function __construct( SemanticDataLookup $semanticDataLookup, ?Cache $cache = null ) {
-		$this->semanticDataLookup = $semanticDataLookup;
-		$this->cache = $cache;
-
+	public function __construct(
+		private SemanticDataLookup $semanticDataLookup,
+		private ?Cache $cache = null,
+	) {
 		if ( $this->cache === null ) {
 			$this->cache = new NullCache();
 		}

--- a/src/SQLStore/EntityStore/DataItemHandlerFactory.php
+++ b/src/SQLStore/EntityStore/DataItemHandlerFactory.php
@@ -24,11 +24,6 @@ use SMWDataItem as DataItem;
 class DataItemHandlerFactory {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @var array
 	 */
 	private $handlers = [];
@@ -40,11 +35,8 @@ class DataItemHandlerFactory {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private readonly SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/DuplicateFinder.php
+++ b/src/SQLStore/EntityStore/DuplicateFinder.php
@@ -19,24 +19,12 @@ use SMWDataItem as DataItem;
 class DuplicateFinder {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var IteratorFactory
-	 */
-	private $iteratorFactory;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
-	 * @param IteratorFactory $iteratorFactory
 	 */
-	public function __construct( Store $store, IteratorFactory $iteratorFactory ) {
-		$this->store = $store;
-		$this->iteratorFactory = $iteratorFactory;
+	public function __construct(
+		private readonly Store $store,
+		private readonly IteratorFactory $iteratorFactory,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/EntityIdFinder.php
+++ b/src/SQLStore/EntityStore/EntityIdFinder.php
@@ -19,36 +19,18 @@ use SMW\SQLStore\SQLStore;
 class EntityIdFinder {
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
-	 * @var PropertyTableHashes
-	 */
-	private $propertyTableHashes;
-
-	/**
-	 * @var IdCacheManager
-	 */
-	private $idCacheManager;
-
-	/**
 	 * @var bool
 	 */
 	private $fetchPropertyTableHashes = false;
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param Database $connection
-	 * @param PropertyTableHashes $propertyTableHashes
-	 * @param IdCacheManager $idCacheManager
 	 */
-	public function __construct( Database $connection, PropertyTableHashes $propertyTableHashes, IdCacheManager $idCacheManager ) {
-		$this->connection = $connection;
-		$this->propertyTableHashes = $propertyTableHashes;
-		$this->idCacheManager = $idCacheManager;
+	public function __construct(
+		private readonly Database $connection,
+		private readonly PropertyTableHashes $propertyTableHashes,
+		private readonly IdCacheManager $idCacheManager,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -72,11 +72,6 @@ class EntityIdManager {
 	public $store;
 
 	/**
-	 * @var SQLStoreFactory
-	 */
-	private $factory;
-
-	/**
 	 * @var IdToDataItemMatchFinder
 	 */
 	private $idMatchFinder;
@@ -148,12 +143,12 @@ class EntityIdManager {
 
 	/**
 	 * @since 1.8
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store, SQLStoreFactory $factory ) {
+	public function __construct(
+		SQLStore $store,
+		private readonly SQLStoreFactory $factory,
+	) {
 		$this->store = $store;
-		$this->factory = $factory;
 		$this->initCache();
 
 		$this->idEntityFinder = $this->factory->newIdEntityFinder(

--- a/src/SQLStore/EntityStore/EntityLookup.php
+++ b/src/SQLStore/EntityStore/EntityLookup.php
@@ -24,11 +24,6 @@ use SMWDIBlob as DIBlob;
 class EntityLookup implements IEntityLookup {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @var TraversalPropertyLookup
 	 */
 	private $traversalPropertyLookup;
@@ -50,12 +45,11 @@ class EntityLookup implements IEntityLookup {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param SQLStore $store
-	 * @param SQLStoreFactory $factory
 	 */
-	public function __construct( SQLStore $store, SQLStoreFactory $factory ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly SQLStore $store,
+		SQLStoreFactory $factory,
+	) {
 		$this->traversalPropertyLookup = $factory->newTraversalPropertyLookup();
 		$this->propertySubjectsLookup = $factory->newPropertySubjectsLookup();
 		$this->propertiesLookup = $factory->newPropertiesLookup();

--- a/src/SQLStore/EntityStore/FieldList.php
+++ b/src/SQLStore/EntityStore/FieldList.php
@@ -23,17 +23,9 @@ class FieldList {
 	const CATEGORY_LIST = 'list/category';
 
 	/**
-	 * @var
-	 */
-	private $countMaps = [];
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param iterable $countMaps
 	 */
-	public function __construct( iterable $countMaps = [] ) {
-		$this->countMaps = $countMaps;
+	public function __construct( private readonly iterable $countMaps = [] ) {
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/IdCacheManager.php
+++ b/src/SQLStore/EntityStore/IdCacheManager.php
@@ -22,18 +22,9 @@ class IdCacheManager {
 	const REDIRECT_TARGET = 'redirect.target.lookup';
 
 	/**
-	 * @var
-	 */
-	private $caches;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param array $caches
 	 */
-	public function __construct( array $caches ) {
-		$this->caches = $caches;
-
+	public function __construct( private array $caches ) {
 		if ( !isset( $this->caches['entity.id'] ) ) {
 			throw new RuntimeException( "Missing 'entity.id' instance." );
 		}

--- a/src/SQLStore/EntityStore/IdChanger.php
+++ b/src/SQLStore/EntityStore/IdChanger.php
@@ -17,25 +17,12 @@ use SMW\SQLStore\TableBuilder\FieldType;
 class IdChanger {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
-	 * @var JobFactory
-	 */
-	private $jobFactory;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param SQLStore $store
-	 * @param JobFactory|null $jobFactory
 	 */
-	public function __construct( SQLStore $store, ?JobFactory $jobFactory = null ) {
-		$this->store = $store;
-		$this->jobFactory = $jobFactory;
-
+	public function __construct(
+		private readonly SQLStore $store,
+		private ?JobFactory $jobFactory = null,
+	) {
 		if ( $this->jobFactory === null ) {
 			$this->jobFactory = new JobFactory();
 		}

--- a/src/SQLStore/EntityStore/IdEntityFinder.php
+++ b/src/SQLStore/EntityStore/IdEntityFinder.php
@@ -17,31 +17,13 @@ use SMW\Store;
 class IdEntityFinder {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var IteratorFactory
-	 */
-	private $iteratorFactory;
-
-	/**
-	 * @var IdCacheManager
-	 */
-	private $idCacheManager;
-
-	/**
 	 * @since 2.1
-	 *
-	 * @param Store $store
-	 * @param IteratorFactory $iteratorFactory
-	 * @param IdCacheManager $idCacheManager
 	 */
-	public function __construct( Store $store, IteratorFactory $iteratorFactory, IdCacheManager $idCacheManager ) {
-		$this->store = $store;
-		$this->iteratorFactory = $iteratorFactory;
-		$this->idCacheManager = $idCacheManager;
+	public function __construct(
+		private readonly Store $store,
+		private readonly IteratorFactory $iteratorFactory,
+		private readonly IdCacheManager $idCacheManager,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -16,16 +16,6 @@ use SMW\SQLStore\SQLStore;
 class PrefetchCache {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
-	 * @var PrefetchItemLookup
-	 */
-	private $prefetchItemLookup;
-
-	/**
 	 * @var
 	 */
 	private $cache = [];
@@ -37,13 +27,11 @@ class PrefetchCache {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param SQLStore $store
-	 * @param PrefetchItemLookup $prefetchItemLookup
 	 */
-	public function __construct( SQLStore $store, PrefetchItemLookup $prefetchItemLookup ) {
-		$this->store = $store;
-		$this->prefetchItemLookup = $prefetchItemLookup;
+	public function __construct(
+		private readonly SQLStore $store,
+		private readonly PrefetchItemLookup $prefetchItemLookup,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/PrefetchItemLookup.php
+++ b/src/SQLStore/EntityStore/PrefetchItemLookup.php
@@ -37,46 +37,15 @@ class PrefetchItemLookup {
 	const HASH_INDEX = 'hash.index';
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var SemanticDataLookup
-	 */
-	private $semanticDataLookup;
-
-	/**
-	 * @var PropertySubjectsLookup
-	 */
-	private $propertySubjectsLookup;
-
-	/**
-	 * @var LinkBatch
-	 */
-	private $linkBatch;
-
-	/**
-	 * @var SequenceMap
-	 */
-	private $sequenceMap;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param Store $store
-	 * @param CachingSemanticDataLookup $semanticDataLookup
-	 * @param PropertySubjectsLookup $propertySubjectsLookup
-	 * @param LinkBatch|null $linkBatch
-	 * @param SequenceMap|null $sequenceMap
 	 */
-	public function __construct( Store $store, CachingSemanticDataLookup $semanticDataLookup, PropertySubjectsLookup $propertySubjectsLookup, ?LinkBatch $linkBatch = null, ?SequenceMap $sequenceMap = null ) {
-		$this->store = $store;
-		$this->semanticDataLookup = $semanticDataLookup;
-		$this->propertySubjectsLookup = $propertySubjectsLookup;
-		$this->linkBatch = $linkBatch;
-		$this->sequenceMap = $sequenceMap;
-
+	public function __construct(
+		private readonly Store $store,
+		private readonly CachingSemanticDataLookup $semanticDataLookup,
+		private readonly PropertySubjectsLookup $propertySubjectsLookup,
+		private ?LinkBatch $linkBatch = null,
+		private ?SequenceMap $sequenceMap = null,
+	) {
 		// Help reduce the amount of queries by allowing to prefetch those
 		// links we know will be used for the display
 		if ( $this->linkBatch === null ) {

--- a/src/SQLStore/EntityStore/PropertiesLookup.php
+++ b/src/SQLStore/EntityStore/PropertiesLookup.php
@@ -16,17 +16,9 @@ use SMW\SQLStore\SQLStore;
 class PropertiesLookup {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private readonly SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -20,11 +20,6 @@ use SMWDIContainer;
 class PropertySubjectsLookup {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @var IteratorFactory
 	 */
 	private $iteratorFactory;
@@ -51,11 +46,8 @@ class PropertySubjectsLookup {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private readonly SQLStore $store ) {
 		$this->iteratorFactory = ApplicationFactory::getInstance()->getIteratorFactory();
 	}
 

--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -26,22 +26,14 @@ class SemanticDataLookup {
 	use LoggerAwareTrait;
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @var string
 	 */
 	private $caller = '';
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/SequenceMapFinder.php
+++ b/src/SQLStore/EntityStore/SequenceMapFinder.php
@@ -17,29 +17,17 @@ use SMW\Utils\HmacSerializer;
 class SequenceMapFinder {
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
-	 * @var IdCacheManager
-	 */
-	private $idCacheManager;
-
-	/**
 	 * @var
 	 */
 	private $preloaded = [];
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param Database $connection
-	 * @param IdCacheManager $idCacheManager
 	 */
-	public function __construct( Database $connection, IdCacheManager $idCacheManager ) {
-		$this->connection = $connection;
-		$this->idCacheManager = $idCacheManager;
+	public function __construct(
+		private readonly Database $connection,
+		private readonly IdCacheManager $idCacheManager,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/SubobjectListFinder.php
+++ b/src/SQLStore/EntityStore/SubobjectListFinder.php
@@ -18,16 +18,6 @@ use SMW\SQLStore\SQLStore;
 class SubobjectListFinder {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
-	 * @var IteratorFactory
-	 */
-	private $iteratorFactory;
-
-	/**
 	 * @var DIWikiPage
 	 */
 	private $subject;
@@ -44,13 +34,11 @@ class SubobjectListFinder {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param SQLStore $store
-	 * @param IteratorFactory $iteratorFactory
 	 */
-	public function __construct( SQLStore $store, IteratorFactory $iteratorFactory ) {
-		$this->store = $store;
-		$this->iteratorFactory = $iteratorFactory;
+	public function __construct(
+		private readonly SQLStore $store,
+		private readonly IteratorFactory $iteratorFactory,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/TraversalPropertyLookup.php
+++ b/src/SQLStore/EntityStore/TraversalPropertyLookup.php
@@ -21,17 +21,9 @@ use Wikimedia\Rdbms\Subquery;
 class TraversalPropertyLookup {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private readonly SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -53,31 +53,6 @@ class Installer implements MessageReporter {
 	const POPULATE_HASH_FIELD_COMPLETE = 'populate.smw_hash_field_complete';
 
 	/**
-	 * @var TableSchemaManager
-	 */
-	private $tableSchemaManager;
-
-	/**
-	 * @var TableBuilder
-	 */
-	private $tableBuilder;
-
-	/**
-	 * @var TableBuildExaminer
-	 */
-	private $tableBuildExaminer;
-
-	/**
-	 * @var VersionExaminer
-	 */
-	private $versionExaminer;
-
-	/**
-	 * @var TableOptimizer
-	 */
-	private $tableOptimizer;
-
-	/**
 	 * @var Options
 	 */
 	private $options;
@@ -94,19 +69,14 @@ class Installer implements MessageReporter {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param TableSchemaManager $tableSchemaManager
-	 * @param TableBuilder $tableBuilder
-	 * @param TableBuildExaminer $tableBuildExaminer
-	 * @param VersionExaminer VersionExaminer
-	 * @param TableOptimizer $tableOptimizer
 	 */
-	public function __construct( TableSchemaManager $tableSchemaManager, TableBuilder $tableBuilder, TableBuildExaminer $tableBuildExaminer, VersionExaminer $versionExaminer, TableOptimizer $tableOptimizer ) {
-		$this->tableSchemaManager = $tableSchemaManager;
-		$this->tableBuilder = $tableBuilder;
-		$this->tableBuildExaminer = $tableBuildExaminer;
-		$this->versionExaminer = $versionExaminer;
-		$this->tableOptimizer = $tableOptimizer;
+	public function __construct(
+		private TableSchemaManager $tableSchemaManager,
+		private TableBuilder $tableBuilder,
+		private TableBuildExaminer $tableBuildExaminer,
+		private VersionExaminer $versionExaminer,
+		private TableOptimizer $tableOptimizer,
+	) {
 		$this->options = new Options();
 		$this->setupFile = new SetupFile();
 	}

--- a/src/SQLStore/Installer/TableOptimizer.php
+++ b/src/SQLStore/Installer/TableOptimizer.php
@@ -22,22 +22,14 @@ class TableOptimizer {
 	use MessageReporterAwareTrait;
 
 	/**
-	 * @var TableBuilder
-	 */
-	private $tableBuilder;
-
-	/**
 	 * @var SetupFile
 	 */
 	private $setupFile;
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param TableBuilder $tableBuilder
 	 */
-	public function __construct( TableBuilder $tableBuilder ) {
-		$this->tableBuilder = $tableBuilder;
+	public function __construct( private TableBuilder $tableBuilder ) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/ByGroupPropertyValuesLookup.php
+++ b/src/SQLStore/Lookup/ByGroupPropertyValuesLookup.php
@@ -20,22 +20,14 @@ use SMWDataItem as DataItem;
 class ByGroupPropertyValuesLookup {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @var
 	 */
 	private $cache = [];
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private readonly SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/CachedListLookup.php
+++ b/src/SQLStore/Lookup/CachedListLookup.php
@@ -16,21 +16,6 @@ class CachedListLookup implements ListLookup {
 	const VERSION = '0.2';
 
 	/**
-	 * @var ListLookup
-	 */
-	private $listLookup;
-
-	/**
-	 * @var Cache
-	 */
-	private $cache;
-
-	/**
-	 * @var stdClass
-	 */
-	private $cacheOptions;
-
-	/**
 	 * @var bool
 	 */
 	private $isFromCache = false;
@@ -47,15 +32,12 @@ class CachedListLookup implements ListLookup {
 
 	/**
 	 * @since 2.2
-	 *
-	 * @param ListLookup $listLookup
-	 * @param Cache $cache
-	 * @param stdClass $cacheOptions
 	 */
-	public function __construct( ListLookup $listLookup, Cache $cache, stdClass $cacheOptions ) {
-		$this->listLookup = $listLookup;
-		$this->cache = $cache;
-		$this->cacheOptions = $cacheOptions;
+	public function __construct(
+		private readonly ListLookup $listLookup,
+		private readonly Cache $cache,
+		private readonly stdClass $cacheOptions,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/ChangePropagationEntityLookup.php
+++ b/src/SQLStore/Lookup/ChangePropagationEntityLookup.php
@@ -20,29 +20,17 @@ use SMW\Store;
 class ChangePropagationEntityLookup {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var IteratorFactory
-	 */
-	private $iteratorFactory;
-
-	/**
 	 * @var bool
 	 */
 	private $isTypePropagation = false;
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
-	 * @param IteratorFactory $iteratorFactory
 	 */
-	public function __construct( Store $store, IteratorFactory $iteratorFactory ) {
-		$this->store = $store;
-		$this->iteratorFactory = $iteratorFactory;
+	public function __construct(
+		private readonly Store $store,
+		private readonly IteratorFactory $iteratorFactory,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/DisplayTitleLookup.php
+++ b/src/SQLStore/Lookup/DisplayTitleLookup.php
@@ -17,17 +17,9 @@ class DisplayTitleLookup {
 	private const MAX_ITEMS_PER_QUERY = 2000;
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct( private readonly Store $store ) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/EntityUniquenessLookup.php
+++ b/src/SQLStore/Lookup/EntityUniquenessLookup.php
@@ -21,24 +21,12 @@ use Wikimedia\Rdbms\Platform\ISQLPlatform;
 class EntityUniquenessLookup {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
-	 * @var IteratorFactory
-	 */
-	private $iteratorFactory;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param SQLStore $store
-	 * @param IteratorFactory $iteratorFactory
 	 */
-	public function __construct( Store $store, IteratorFactory $iteratorFactory ) {
-		$this->store = $store;
-		$this->iteratorFactory = $iteratorFactory;
+	public function __construct(
+		private readonly Store $store,
+		private readonly IteratorFactory $iteratorFactory,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/ErrorLookup.php
+++ b/src/SQLStore/Lookup/ErrorLookup.php
@@ -19,17 +19,9 @@ use Traversable;
 class ErrorLookup {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct( private readonly Store $store ) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/MissingRedirectLookup.php
+++ b/src/SQLStore/Lookup/MissingRedirectLookup.php
@@ -14,11 +14,6 @@ use SMW\Store;
 class MissingRedirectLookup {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var array
 	 */
 	private $namespaces;
@@ -30,11 +25,8 @@ class MissingRedirectLookup {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct( private readonly Store $store ) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/MonolingualTextLookup.php
+++ b/src/SQLStore/Lookup/MonolingualTextLookup.php
@@ -21,11 +21,6 @@ use SMWDIContainer as DIContainer;
 class MonolingualTextLookup {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var string
 	 */
 	private $caller = '';
@@ -37,11 +32,8 @@ class MonolingualTextLookup {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct( private readonly Store $store ) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/PropertyLabelSimilarityLookup.php
+++ b/src/SQLStore/Lookup/PropertyLabelSimilarityLookup.php
@@ -20,16 +20,6 @@ use SMW\Store;
 class PropertyLabelSimilarityLookup {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var SpecificationLookup
-	 */
-	private $propertySpecificationLookup;
-
-	/**
 	 * @var integer/float
 	 */
 	private $threshold = 50;
@@ -46,14 +36,11 @@ class PropertyLabelSimilarityLookup {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Store $store
-	 * @param SpecificationLookup|null $propertySpecificationLookup
 	 */
-	public function __construct( Store $store, ?SpecificationLookup $propertySpecificationLookup = null ) {
-		$this->store = $store;
-		$this->propertySpecificationLookup = $propertySpecificationLookup;
-
+	public function __construct(
+		private readonly Store $store,
+		private ?SpecificationLookup $propertySpecificationLookup = null,
+	) {
 		if ( $this->propertySpecificationLookup === null ) {
 			$this->propertySpecificationLookup = ApplicationFactory::getInstance()->getPropertySpecificationLookup();
 		}

--- a/src/SQLStore/Lookup/PropertyUsageListLookup.php
+++ b/src/SQLStore/Lookup/PropertyUsageListLookup.php
@@ -21,31 +21,13 @@ use SMWDIError as DIError;
 class PropertyUsageListLookup implements ListLookup {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var PropertyStatisticsStore
-	 */
-	private $propertyStatisticsStore;
-
-	/**
-	 * @var RequestOptions
-	 */
-	private $requestOptions;
-
-	/**
 	 * @since 2.2
-	 *
-	 * @param Store $store
-	 * @param PropertyStatisticsStore $propertyStatisticsStore
-	 * @param RequestOptions|null $requestOptions
 	 */
-	public function __construct( Store $store, PropertyStatisticsStore $propertyStatisticsStore, ?RequestOptions $requestOptions = null ) {
-		$this->store = $store;
-		$this->propertyStatisticsStore = $propertyStatisticsStore;
-		$this->requestOptions = $requestOptions;
+	public function __construct(
+		private readonly Store $store,
+		private readonly PropertyStatisticsStore $propertyStatisticsStore,
+		private readonly ?RequestOptions $requestOptions = null,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/ProximityPropertyValueLookup.php
+++ b/src/SQLStore/Lookup/ProximityPropertyValueLookup.php
@@ -21,17 +21,9 @@ use Wikimedia\Rdbms\Platform\ISQLPlatform;
 class ProximityPropertyValueLookup {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct( private readonly Store $store ) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/RedirectTargetLookup.php
+++ b/src/SQLStore/Lookup/RedirectTargetLookup.php
@@ -26,23 +26,17 @@ class RedirectTargetLookup {
 	const CACHE_ONLY = 'cache/only';
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var InMemoryCacheManager
 	 */
 	private $inMemoryCacheManager;
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Store $store
-	 * @param IdCacheManager $inMemoryCacheManager
 	 */
-	public function __construct( Store $store, IdCacheManager $inMemoryCacheManager ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+		IdCacheManager $inMemoryCacheManager,
+	) {
 		$this->inMemoryCacheManager = $inMemoryCacheManager;
 	}
 

--- a/src/SQLStore/Lookup/SingleEntityQueryLookup.php
+++ b/src/SQLStore/Lookup/SingleEntityQueryLookup.php
@@ -23,17 +23,9 @@ use SMWQuery as Query;
 class SingleEntityQueryLookup implements QueryEngine {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct( private readonly Store $store ) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/TableStatisticsLookup.php
+++ b/src/SQLStore/Lookup/TableStatisticsLookup.php
@@ -16,17 +16,9 @@ use SMWQuery as Query;
 class TableStatisticsLookup {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private readonly SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/UndeclaredPropertyListLookup.php
+++ b/src/SQLStore/Lookup/UndeclaredPropertyListLookup.php
@@ -21,31 +21,13 @@ use SMWDIError as DIError;
 class UndeclaredPropertyListLookup implements ListLookup {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var string
-	 */
-	private $defaultPropertyType;
-
-	/**
-	 * @var RequestOptions
-	 */
-	private $requestOptions;
-
-	/**
 	 * @since 2.2
-	 *
-	 * @param Store $store
-	 * @param string $defaultPropertyType
-	 * @param RequestOptions|null $requestOptions
 	 */
-	public function __construct( Store $store, $defaultPropertyType, ?RequestOptions $requestOptions = null ) {
-		$this->store = $store;
-		$this->defaultPropertyType = $defaultPropertyType;
-		$this->requestOptions = $requestOptions;
+	public function __construct(
+		private readonly Store $store,
+		private $defaultPropertyType,
+		private readonly ?RequestOptions $requestOptions = null,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/UnusedPropertyListLookup.php
+++ b/src/SQLStore/Lookup/UnusedPropertyListLookup.php
@@ -22,31 +22,13 @@ use SMWDIError as DIError;
 class UnusedPropertyListLookup implements ListLookup {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var PropertyStatisticsStore
-	 */
-	private $propertyStatisticsStore;
-
-	/**
-	 * @var RequestOptions
-	 */
-	private $requestOptions;
-
-	/**
 	 * @since 2.2
-	 *
-	 * @param Store $store
-	 * @param PropertyStatisticsStore $propertyStatisticsStore
-	 * @param RequestOptions|null $requestOptions
 	 */
-	public function __construct( Store $store, PropertyStatisticsStore $propertyStatisticsStore, ?RequestOptions $requestOptions = null ) {
-		$this->store = $store;
-		$this->propertyStatisticsStore = $propertyStatisticsStore;
-		$this->requestOptions = $requestOptions;
+	public function __construct(
+		private readonly Store $store,
+		private readonly PropertyStatisticsStore $propertyStatisticsStore,
+		private readonly ?RequestOptions $requestOptions = null,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/Lookup/UsageStatisticsListLookup.php
+++ b/src/SQLStore/Lookup/UsageStatisticsListLookup.php
@@ -17,24 +17,12 @@ use SMW\Store;
 class UsageStatisticsListLookup implements ListLookup {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var PropertyStatisticsStore
-	 */
-	private $propertyStatisticsStore;
-
-	/**
 	 * @since 2.2
-	 *
-	 * @param Store $store
-	 * @param PropertyStatisticsStore $propertyStatisticsStore
 	 */
-	public function __construct( Store $store, PropertyStatisticsStore $propertyStatisticsStore ) {
-		$this->store = $store;
-		$this->propertyStatisticsStore = $propertyStatisticsStore;
+	public function __construct(
+		private readonly Store $store,
+		private readonly PropertyStatisticsStore $propertyStatisticsStore,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/PropertyStatisticsStore.php
+++ b/src/SQLStore/PropertyStatisticsStore.php
@@ -21,11 +21,6 @@ class PropertyStatisticsStore {
 	use LoggerAwareTrait;
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
 	 * @var bool
 	 */
 	private $isCommandLineMode = false;
@@ -37,11 +32,8 @@ class PropertyStatisticsStore {
 
 	/**
 	 * @since 1.9
-	 *
-	 * @param Database $connection
 	 */
-	public function __construct( Database $connection ) {
-		$this->connection = $connection;
+	public function __construct( private Database $connection ) {
 	}
 
 	/**

--- a/src/SQLStore/PropertyTable/PropertyTableHashes.php
+++ b/src/SQLStore/PropertyTable/PropertyTableHashes.php
@@ -18,24 +18,12 @@ use SMW\SQLStore\SQLStore;
 class PropertyTableHashes {
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
-	 * @var IdCacheManager
-	 */
-	private $idCacheManager;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param Database $connection
-	 * @param IdCacheManager $idCacheManager
 	 */
-	public function __construct( Database $connection, IdCacheManager $idCacheManager ) {
-		$this->connection = $connection;
-		$this->idCacheManager = $idCacheManager;
+	public function __construct(
+		private readonly Database $connection,
+		private readonly IdCacheManager $idCacheManager,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/PropertyTableDefinition.php
+++ b/src/SQLStore/PropertyTableDefinition.php
@@ -32,37 +32,6 @@ class PropertyTableDefinition {
 	const TYPE_CUSTOM = 'type/custom';
 
 	/**
-	 * Name of the table in the DB.
-	 *
-	 * @since 1.8
-	 * @var string
-	 */
-	protected $name;
-
-	/**
-	 * DIType of this table.
-	 *
-	 * @since 1.8
-	 * @var int
-	 */
-	protected $diType;
-
-	/**
-	 * If the table is only for one property, this field holds its key.
-	 * Empty otherwise. Tables without a fixed property have a column "p_id"
-	 * for storing the SMW page id of the property.
-	 *
-	 * @note It is important that this is the DB key form or special
-	 * property key, not the label. This is not checked eagerly in SMW but
-	 * can lead to spurious errors when properties are compared to each
-	 * other or to the contents of the store.
-	 *
-	 * @since 1.8
-	 * @var string|bool false
-	 */
-	protected $fixedProperty;
-
-	/**
 	 * Boolean that states how subjects are stored. If true, a column "s_id"
 	 * with an SMW page id is used. If false, two columns "s_title" and
 	 * "s_namespace" are used. The latter de-normalized form cannot store
@@ -84,15 +53,12 @@ class PropertyTableDefinition {
 	 * DI type and the given table name.
 	 *
 	 * @since 1.8
-	 *
-	 * @param int $DIType constant
-	 * @param string $tableName logocal table name (not the DB version)
-	 * @param string|false $fixedProperty property key if any
 	 */
-	public function __construct( $DIType, $tableName, $fixedProperty = false ) {
-		$this->name = $tableName;
-		$this->fixedProperty = $fixedProperty;
-		$this->diType = $DIType;
+	public function __construct(
+		protected $diType,
+		protected $name,
+		protected $fixedProperty = false,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/PropertyTableDefinitionBuilder.php
+++ b/src/SQLStore/PropertyTableDefinitionBuilder.php
@@ -23,11 +23,6 @@ class PropertyTableDefinitionBuilder {
 	const PROPERTY_TABLE_PREFIX = 'smw_fpt';
 
 	/**
-	 * @var PropertyTypeFinder
-	 */
-	private $propertyTypeFinder;
-
-	/**
 	 * @var PropertyTableDefinition[]
 	 */
 	protected $propertyTables = [];
@@ -39,11 +34,8 @@ class PropertyTableDefinitionBuilder {
 
 	/**
 	 * @since 1.9
-	 *
-	 * @param PropertyTypeFinder $propertyTypeFinder
 	 */
-	public function __construct( PropertyTypeFinder $propertyTypeFinder ) {
-		$this->propertyTypeFinder = $propertyTypeFinder;
+	public function __construct( private readonly PropertyTypeFinder $propertyTypeFinder ) {
 	}
 
 	/**

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -27,11 +27,6 @@ class PropertyTableIdReferenceDisposer {
 	use EventDispatcherAwareTrait;
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store = null;
-
-	/**
 	 * @var Database
 	 */
 	private $connection = null;
@@ -58,11 +53,8 @@ class PropertyTableIdReferenceDisposer {
 
 	/**
 	 * @since 2.4
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private SQLStore $store ) {
 		$this->connection = $this->store->getConnection( 'mw.db' );
 	}
 

--- a/src/SQLStore/PropertyTableIdReferenceFinder.php
+++ b/src/SQLStore/PropertyTableIdReferenceFinder.php
@@ -15,11 +15,6 @@ use SMWDataItem as DataItem;
 class PropertyTableIdReferenceFinder {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @var Database
 	 */
 	private $connection;
@@ -36,11 +31,8 @@ class PropertyTableIdReferenceFinder {
 
 	/**
 	 * @since 2.4
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private readonly SQLStore $store ) {
 		$this->connection = $this->store->getConnection( 'mw.db' );
 		$this->namespaceExaminer = ApplicationFactory::getInstance()->getNamespaceExaminer();
 	}

--- a/src/SQLStore/PropertyTableInfoFetcher.php
+++ b/src/SQLStore/PropertyTableInfoFetcher.php
@@ -16,11 +16,6 @@ use SMWDataItem as DataItem;
 class PropertyTableInfoFetcher {
 
 	/**
-	 * @var PropertyTypeFinder
-	 */
-	private $propertyTypeFinder;
-
-	/**
 	 * Array for keeping property table table data, indexed by table id.
 	 * Access this only by calling getPropertyTables().
 	 *
@@ -65,11 +60,8 @@ class PropertyTableInfoFetcher {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param PropertyTypeFinder $propertyTypeFinder
 	 */
-	public function __construct( PropertyTypeFinder $propertyTypeFinder ) {
-		$this->propertyTypeFinder = $propertyTypeFinder;
+	public function __construct( private readonly PropertyTypeFinder $propertyTypeFinder ) {
 	}
 
 	/**

--- a/src/SQLStore/PropertyTableRowDiffer.php
+++ b/src/SQLStore/PropertyTableRowDiffer.php
@@ -23,16 +23,6 @@ use SMWDataItem as DataItem;
 class PropertyTableRowDiffer {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var PropertyTableRowMapper
-	 */
-	private $propertyTableRowMapper;
-
-	/**
 	 * @var ChangeOp
 	 */
 	private $changeOp;
@@ -44,13 +34,11 @@ class PropertyTableRowDiffer {
 
 	/**
 	 * @since 2.3
-	 *
-	 * @param Store $store
-	 * @param PropertyTableRowMapper $propertyTableRowMapper
 	 */
-	public function __construct( Store $store, PropertyTableRowMapper $propertyTableRowMapper ) {
-		$this->store = $store;
-		$this->propertyTableRowMapper = $propertyTableRowMapper;
+	public function __construct(
+		private readonly Store $store,
+		private readonly PropertyTableRowMapper $propertyTableRowMapper,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/PropertyTableRowMapper.php
+++ b/src/SQLStore/PropertyTableRowMapper.php
@@ -20,17 +20,9 @@ use SMWDIError as DIError;
 class PropertyTableRowMapper {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 2.3
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct( private readonly Store $store ) {
 	}
 
 	/**

--- a/src/SQLStore/PropertyTableUpdater.php
+++ b/src/SQLStore/PropertyTableUpdater.php
@@ -19,16 +19,6 @@ use SMW\Store;
 class PropertyTableUpdater {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var PropertyStatisticsStore
-	 */
-	private $propertyStatisticsStore;
-
-	/**
 	 * @var PropertyChangeListener
 	 */
 	private $propertyChangeListener;
@@ -40,13 +30,11 @@ class PropertyTableUpdater {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
-	 * @param PropertyStatisticsStore $propertyStatisticsStore
 	 */
-	public function __construct( Store $store, PropertyStatisticsStore $propertyStatisticsStore ) {
-		$this->store = $store;
-		$this->propertyStatisticsStore = $propertyStatisticsStore;
+	public function __construct(
+		private readonly Store $store,
+		private readonly PropertyStatisticsStore $propertyStatisticsStore,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/PropertyTypeFinder.php
+++ b/src/SQLStore/PropertyTypeFinder.php
@@ -18,22 +18,14 @@ use SMW\MediaWiki\Connection\Database;
 class PropertyTypeFinder {
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
 	 * @var string
 	 */
 	private $typeTableName = '';
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Database $connection
 	 */
-	public function __construct( Database $connection ) {
-		$this->connection = $connection;
+	public function __construct( private readonly Database $connection ) {
 	}
 
 	/**

--- a/src/SQLStore/QueryDependency/DependencyLinksTableUpdater.php
+++ b/src/SQLStore/QueryDependency/DependencyLinksTableUpdater.php
@@ -23,17 +23,9 @@ class DependencyLinksTableUpdater {
 	private static $updateList = [];
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 2.4
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct( private Store $store ) {
 	}
 
 	/**

--- a/src/SQLStore/QueryDependency/DependencyLinksValidator.php
+++ b/src/SQLStore/QueryDependency/DependencyLinksValidator.php
@@ -19,11 +19,6 @@ class DependencyLinksValidator {
 	use LoggerAwareTrait;
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var bool
 	 */
 	private $checkDependencies = false;
@@ -35,11 +30,8 @@ class DependencyLinksValidator {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct( private Store $store ) {
 	}
 
 	/**

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -30,16 +30,6 @@ class QueryDependencyLinksStore {
 	private $store;
 
 	/**
-	 * @var DependencyLinksTableUpdater
-	 */
-	private $dependencyLinksTableUpdater;
-
-	/**
-	 * @var QueryResultDependencyListResolver
-	 */
-	private $queryResultDependencyListResolver;
-
-	/**
 	 * @var NamespaceExaminer
 	 */
 	private $namespaceExaminer;
@@ -66,13 +56,11 @@ class QueryDependencyLinksStore {
 
 	/**
 	 * @since 2.3
-	 *
-	 * @param QueryResultDependencyListResolver $queryResultDependencyListResolver
-	 * @param DependencyLinksTableUpdater $dependencyLinksTableUpdater
 	 */
-	public function __construct( QueryResultDependencyListResolver $queryResultDependencyListResolver, DependencyLinksTableUpdater $dependencyLinksTableUpdater ) {
-		$this->queryResultDependencyListResolver = $queryResultDependencyListResolver;
-		$this->dependencyLinksTableUpdater = $dependencyLinksTableUpdater;
+	public function __construct(
+		private QueryResultDependencyListResolver $queryResultDependencyListResolver,
+		private DependencyLinksTableUpdater $dependencyLinksTableUpdater,
+	) {
 		$this->store = $this->dependencyLinksTableUpdater->getStore();
 		$this->namespaceExaminer = ApplicationFactory::getInstance()->getNamespaceExaminer();
 	}

--- a/src/SQLStore/QueryDependency/QueryLinksTableDisposer.php
+++ b/src/SQLStore/QueryDependency/QueryLinksTableDisposer.php
@@ -17,16 +17,6 @@ use SMW\Store;
 class QueryLinksTableDisposer {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
-	 * @var IteratorFactory
-	 */
-	private $iteratorFactory;
-
-	/**
 	 * @var Database
 	 */
 	private $connection;
@@ -43,13 +33,11 @@ class QueryLinksTableDisposer {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param Store $store
-	 * @param IteratorFactory $iteratorFactory
 	 */
-	public function __construct( Store $store, IteratorFactory $iteratorFactory ) {
-		$this->store = $store;
-		$this->iteratorFactory = $iteratorFactory;
+	public function __construct(
+		private readonly Store $store,
+		private readonly IteratorFactory $iteratorFactory,
+	) {
 		$this->connection = $this->store->getConnection( 'mw.db' );
 	}
 

--- a/src/SQLStore/QueryDependency/QueryReferenceBacklinks.php
+++ b/src/SQLStore/QueryDependency/QueryReferenceBacklinks.php
@@ -19,17 +19,9 @@ use SMW\SemanticData;
 class QueryReferenceBacklinks {
 
 	/**
-	 * @var QueryDependencyLinksStore
-	 */
-	private $queryDependencyLinksStore = null;
-
-	/**
 	 * @since 2.5
-	 *
-	 * @param QueryDependencyLinksStore $queryDependencyLinksStore
 	 */
-	public function __construct( QueryDependencyLinksStore $queryDependencyLinksStore ) {
-		$this->queryDependencyLinksStore = $queryDependencyLinksStore;
+	public function __construct( private readonly QueryDependencyLinksStore $queryDependencyLinksStore ) {
 	}
 
 	/**

--- a/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
+++ b/src/SQLStore/QueryDependency/QueryResultDependencyListResolver.php
@@ -26,11 +26,6 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 class QueryResultDependencyListResolver {
 
 	/**
-	 * @var HierarchyLookup
-	 */
-	private $hierarchyLookup;
-
-	/**
 	 * Specifies a list of property keys to be excluded from the detection
 	 * process.
 	 *
@@ -40,11 +35,8 @@ class QueryResultDependencyListResolver {
 
 	/**
 	 * @since 2.3
-	 *
-	 * @param HierarchyLookup $hierarchyLookup
 	 */
-	public function __construct( HierarchyLookup $hierarchyLookup ) {
-		$this->hierarchyLookup = $hierarchyLookup;
+	public function __construct( private readonly HierarchyLookup $hierarchyLookup ) {
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/ConceptQuerySegmentBuilder.php
+++ b/src/SQLStore/QueryEngine/ConceptQuerySegmentBuilder.php
@@ -15,29 +15,17 @@ use SMWQuery as Query;
 class ConceptQuerySegmentBuilder {
 
 	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
-	 * @var QuerySegmentListProcessor
-	 */
-	private $querySegmentListProcessor;
-
-	/**
 	 * @var QueryParser
 	 */
 	private $queryParser;
 
 	/**
 	 * @since 2.2
-	 *
-	 * @param ConditionBuilder $conditionBuilder
-	 * @param QuerySegmentListProcessor $querySegmentListProcessor
 	 */
-	public function __construct( ConditionBuilder $conditionBuilder, QuerySegmentListProcessor $querySegmentListProcessor ) {
-		$this->conditionBuilder = $conditionBuilder;
-		$this->querySegmentListProcessor = $querySegmentListProcessor;
+	public function __construct(
+		private readonly ConditionBuilder $conditionBuilder,
+		private readonly QuerySegmentListProcessor $querySegmentListProcessor,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/ConditionBuilder.php
+++ b/src/SQLStore/QueryEngine/ConditionBuilder.php
@@ -22,16 +22,6 @@ use SMWQuery as Query;
 class ConditionBuilder {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var OrderCondition
-	 */
-	private $orderCondition;
-
-	/**
 	 * @var DispatchingDescriptionInterpreter
 	 */
 	private $dispatchingDescriptionInterpreter;
@@ -67,20 +57,15 @@ class ConditionBuilder {
 	 */
 	private $lastQuerySegmentId = -1;
 
-	private CircularReferenceGuard $circularReferenceGuard;
-
 	/**
 	 * @since 2.2
-	 *
-	 * @param Store $store
-	 * @param OrderCondition $orderCondition
-	 * @param DescriptionInterpreterFactory $descriptionInterpreterFactory
-	 * @param CircularReferenceGuard $circularReferenceGuard
 	 */
-	public function __construct( Store $store, OrderCondition $orderCondition, DescriptionInterpreterFactory $descriptionInterpreterFactory, CircularReferenceGuard $circularReferenceGuard ) {
-		$this->store = $store;
-		$this->orderCondition = $orderCondition;
-		$this->circularReferenceGuard = $circularReferenceGuard;
+	public function __construct(
+		private readonly Store $store,
+		private readonly OrderCondition $orderCondition,
+		DescriptionInterpreterFactory $descriptionInterpreterFactory,
+		private readonly CircularReferenceGuard $circularReferenceGuard,
+	) {
 		$this->dispatchingDescriptionInterpreter = $descriptionInterpreterFactory->newDispatchingDescriptionInterpreter( $this );
 		QuerySegment::$qnum = 0;
 	}

--- a/src/SQLStore/QueryEngine/DescriptionInterpreterFactory.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreterFactory.php
@@ -23,23 +23,12 @@ use SMW\Utils\CircularReferenceGuard;
 class DescriptionInterpreterFactory {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var CircularReferenceGuard
-	 */
-	private $circularReferenceGuard;
-
-	/**
 	 * @since 2.4
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( Store $store, CircularReferenceGuard $circularReferenceGuard ) {
-		$this->store = $store;
-		$this->circularReferenceGuard = $circularReferenceGuard;
+	public function __construct(
+		private readonly Store $store,
+		private readonly CircularReferenceGuard $circularReferenceGuard,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreter.php
@@ -21,24 +21,12 @@ use SMW\Store;
 class ClassDescriptionInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
 	 * @since 2.2
-	 *
-	 * @param Store $store
-	 * @param ConditionBuilder $conditionBuilder
 	 */
-	public function __construct( Store $store, ConditionBuilder $conditionBuilder ) {
-		$this->store = $store;
-		$this->conditionBuilder = $conditionBuilder;
+	public function __construct(
+		private readonly Store $store,
+		private readonly ConditionBuilder $conditionBuilder,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreter.php
@@ -26,36 +26,18 @@ use SMW\Utils\CircularReferenceGuard;
 class ConceptDescriptionInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
-	 * @var CircularReferenceGuard
-	 */
-	private $circularReferenceGuard;
-
-	/**
 	 * @var QueryParser
 	 */
 	private $queryParser;
 
 	/**
 	 * @since 2.2
-	 *
-	 * @param Store $store
-	 * @param ConditionBuilder $conditionBuilder
-	 * @param CircularReferenceGuard $circularReferenceGuard
 	 */
-	public function __construct( Store $store, ConditionBuilder $conditionBuilder, CircularReferenceGuard $circularReferenceGuard ) {
-		$this->store = $store;
-		$this->conditionBuilder = $conditionBuilder;
-		$this->circularReferenceGuard = $circularReferenceGuard;
+	public function __construct(
+		private readonly Store $store,
+		private readonly ConditionBuilder $conditionBuilder,
+		private readonly CircularReferenceGuard $circularReferenceGuard,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/DisjunctionConjunctionInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/DisjunctionConjunctionInterpreter.php
@@ -19,20 +19,10 @@ use SMW\SQLStore\QueryEngine\QuerySegment;
  */
 class DisjunctionConjunctionInterpreter implements DescriptionInterpreter {
 
-	// DisjunctionConjunctionInterpreter -> CompoundInterpreter
-
-	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
 	/**
 	 * @since 2.2
-	 *
-	 * @param ConditionBuilder $conditionBuilder
 	 */
-	public function __construct( ConditionBuilder $conditionBuilder ) {
-		$this->conditionBuilder = $conditionBuilder;
+	public function __construct( private readonly ConditionBuilder $conditionBuilder ) {
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/NamespaceDescriptionInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/NamespaceDescriptionInterpreter.php
@@ -21,24 +21,12 @@ use SMW\Store;
 class NamespaceDescriptionInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
 	 * @since 2.2
-	 *
-	 * @param Store $store
-	 * @param ConditionBuilder $conditionBuilder
 	 */
-	public function __construct( Store $store, ConditionBuilder $conditionBuilder ) {
-		$this->store = $store;
-		$this->conditionBuilder = $conditionBuilder;
+	public function __construct(
+		private readonly Store $store,
+		private readonly ConditionBuilder $conditionBuilder,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -32,21 +32,6 @@ use SMWDataItem as DataItem;
 class SomePropertyInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
-	 * @var ValueMatchConditionBuilder
-	 */
-	private $valueMatchConditionBuilder;
-
-	/**
 	 * @var ComparatorMapper
 	 */
 	private $comparatorMapper;
@@ -58,14 +43,12 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 
 	/**
 	 * @since 2.2
-	 *
-	 * @param Store $store
-	 * @param ConditionBuilder $conditionBuilder
 	 */
-	public function __construct( Store $store, ConditionBuilder $conditionBuilder, ValueMatchConditionBuilder $valueMatchConditionBuilder ) {
-		$this->store = $store;
-		$this->conditionBuilder = $conditionBuilder;
-		$this->valueMatchConditionBuilder = $valueMatchConditionBuilder;
+	public function __construct(
+		private readonly Store $store,
+		private readonly ConditionBuilder $conditionBuilder,
+		private readonly ValueMatchConditionBuilder $valueMatchConditionBuilder,
+	) {
 		$this->comparatorMapper = new ComparatorMapper();
 	}
 

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ThingDescriptionInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ThingDescriptionInterpreter.php
@@ -17,17 +17,9 @@ use SMW\SQLStore\QueryEngine\QuerySegment;
 class ThingDescriptionInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
 	 * @since 2.2
-	 *
-	 * @param ConditionBuilder $conditionBuilder
 	 */
-	public function __construct( ConditionBuilder $conditionBuilder ) {
-		$this->conditionBuilder = $conditionBuilder;
+	public function __construct( private readonly ConditionBuilder $conditionBuilder ) {
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
@@ -24,16 +24,6 @@ use SMWDIBlob as DIBlob;
 class ValueDescriptionInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
 	 * @var ComparatorMapper
 	 */
 	private $comparatorMapper;
@@ -45,13 +35,11 @@ class ValueDescriptionInterpreter implements DescriptionInterpreter {
 
 	/**
 	 * @since 2.2
-	 *
-	 * @param Store $store
-	 * @param ConditionBuilder $conditionBuilder
 	 */
-	public function __construct( Store $store, ConditionBuilder $conditionBuilder ) {
-		$this->store = $store;
-		$this->conditionBuilder = $conditionBuilder;
+	public function __construct(
+		private readonly Store $store,
+		private readonly ConditionBuilder $conditionBuilder,
+	) {
 		$this->comparatorMapper = new ComparatorMapper();
 		$this->fulltextSearchTableFactory = new FulltextSearchTableFactory();
 	}

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
@@ -18,16 +18,6 @@ use SMWDataItem as DataItem;
 class SearchTableRebuilder {
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
-	 * @var SearchTableUpdater
-	 */
-	private $searchTableUpdater;
-
-	/**
 	 * @var MessageReporter
 	 */
 	private $messageReporter;
@@ -49,13 +39,11 @@ class SearchTableRebuilder {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Database $connection
-	 * @param SearchTableUpdater $searchTableUpdater
 	 */
-	public function __construct( Database $connection, SearchTableUpdater $searchTableUpdater ) {
-		$this->connection = $connection;
-		$this->searchTableUpdater = $searchTableUpdater;
+	public function __construct(
+		private readonly Database $connection,
+		private readonly SearchTableUpdater $searchTableUpdater,
+	) {
 		$this->messageReporter = MessageReporterFactory::getInstance()->newNullMessageReporter();
 	}
 

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
@@ -14,31 +14,13 @@ use Wikimedia\Rdbms\Platform\ISQLPlatform;
 class SearchTableUpdater {
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
-	 * @var SearchTable
-	 */
-	private $searchTable;
-
-	/**
-	 * @var TextSanitizer
-	 */
-	private $textSanitizer;
-
-	/**
 	 * @since 2.5
-	 *
-	 * @param Database $connection
-	 * @param SearchTable $searchTable
-	 * @param TextSanitizer $textSanitizer
 	 */
-	public function __construct( Database $connection, SearchTable $searchTable, TextSanitizer $textSanitizer ) {
-		$this->connection = $connection;
-		$this->searchTable = $searchTable;
-		$this->textSanitizer = $textSanitizer;
+	public function __construct(
+		private readonly Database $connection,
+		private readonly SearchTable $searchTable,
+		private readonly TextSanitizer $textSanitizer,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/Fulltext/TextChangeUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextChangeUpdater.php
@@ -23,21 +23,6 @@ class TextChangeUpdater {
 	use LoggerAwareTrait;
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
-	 * @var Cache
-	 */
-	private $cache;
-
-	/**
-	 * @var SearchTableUpdater
-	 */
-	private $searchTableUpdater;
-
-	/**
 	 * @var bool
 	 */
 	private $asDeferredUpdate = true;
@@ -54,15 +39,12 @@ class TextChangeUpdater {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Database $connection
-	 * @param Cache $cache
-	 * @param SearchTableUpdater $searchTableUpdater
 	 */
-	public function __construct( Database $connection, Cache $cache, SearchTableUpdater $searchTableUpdater ) {
-		$this->connection = $connection;
-		$this->cache = $cache;
-		$this->searchTableUpdater = $searchTableUpdater;
+	public function __construct(
+		private Database $connection,
+		private Cache $cache,
+		private SearchTableUpdater $searchTableUpdater,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
+++ b/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
@@ -17,16 +17,6 @@ use Wikimedia\Rdbms\Platform\ISQLPlatform;
 class HierarchyTempTableBuilder {
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
-	 * @var TemporaryTableBuilder
-	 */
-	private $temporaryTableBuilder;
-
-	/**
 	 * Cache of computed hierarchy queries for reuse ("catetgory/property value
 	 * string" => "tablename").
 	 *
@@ -41,13 +31,11 @@ class HierarchyTempTableBuilder {
 
 	/**
 	 * @since 2.3
-	 *
-	 * @param Database $connection
-	 * @param TemporaryTableBuilder $temporaryTableBuilder
 	 */
-	public function __construct( Database $connection, TemporaryTableBuilder $temporaryTableBuilder ) {
-		$this->connection = $connection;
-		$this->temporaryTableBuilder = $temporaryTableBuilder;
+	public function __construct(
+		private readonly Database $connection,
+		private readonly TemporaryTableBuilder $temporaryTableBuilder,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -31,11 +31,6 @@ use Wikimedia\Rdbms\Platform\ISQLPlatform;
 class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @var LoggerInterface
 	 */
 	private $logger;
@@ -72,38 +67,19 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 	private $errors = [];
 
 	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
-	 * @var QuerySegmentListProcessor
-	 */
-	private $querySegmentListProcessor;
-
-	/**
-	 * @var EngineOptions
-	 */
-	private $engineOptions;
-
-	/**
 	 * @var QueryFactory
 	 */
 	private $queryFactory;
 
 	/**
 	 * @since 2.2
-	 *
-	 * @param SQLStore $store
-	 * @param ConditionBuilder $conditionBuilder
-	 * @param QuerySegmentListProcessor $querySegmentListProcessor
-	 * @param EngineOptions $engineOptions
 	 */
-	public function __construct( SQLStore $store, ConditionBuilder $conditionBuilder, QuerySegmentListProcessor $querySegmentListProcessor, EngineOptions $engineOptions ) {
-		$this->store = $store;
-		$this->conditionBuilder = $conditionBuilder;
-		$this->querySegmentListProcessor = $querySegmentListProcessor;
-		$this->engineOptions = $engineOptions;
+	public function __construct(
+		private readonly SQLStore $store,
+		private readonly ConditionBuilder $conditionBuilder,
+		private readonly QuerySegmentListProcessor $querySegmentListProcessor,
+		private readonly EngineOptions $engineOptions,
+	) {
 		$this->queryFactory = new QueryFactory();
 	}
 

--- a/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
+++ b/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
@@ -18,23 +18,6 @@ use Wikimedia\Rdbms\Platform\ISQLPlatform;
  */
 class QuerySegmentListProcessor {
 
-	// ConditionTreeProcessor
-
-	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
-	 * @var TemporaryTableBuilder
-	 */
-	private $temporaryTableBuilder;
-
-	/**
-	 * @var HierarchyTempTableBuilder
-	 */
-	private $hierarchyTempTableBuilder;
-
 	/**
 	 * Array of arrays of executed queries, indexed by the temporary table names
 	 * results were fed into.
@@ -56,15 +39,11 @@ class QuerySegmentListProcessor {
 	 */
 	private $querySegmentList = [];
 
-	/**
-	 * @param Database $connection
-	 * @param TemporaryTableBuilder $temporaryTableBuilder
-	 * @param HierarchyTempTableBuilder $hierarchyTempTableBuilder
-	 */
-	public function __construct( Database $connection, TemporaryTableBuilder $temporaryTableBuilder, HierarchyTempTableBuilder $hierarchyTempTableBuilder ) {
-		$this->connection = $connection;
-		$this->temporaryTableBuilder = $temporaryTableBuilder;
-		$this->hierarchyTempTableBuilder = $hierarchyTempTableBuilder;
+	public function __construct(
+		private readonly Database $connection,
+		private readonly TemporaryTableBuilder $temporaryTableBuilder,
+		private readonly HierarchyTempTableBuilder $hierarchyTempTableBuilder,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/QueryEngineFactory.php
+++ b/src/SQLStore/QueryEngineFactory.php
@@ -24,17 +24,9 @@ use SMW\Utils\CircularReferenceGuard;
 class QueryEngineFactory {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @since 2.4
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private readonly SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/Rebuilder/EntityValidator.php
+++ b/src/SQLStore/Rebuilder/EntityValidator.php
@@ -21,16 +21,6 @@ class EntityValidator {
 	use RevisionGuardAwareTrait;
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
-	 * @var NamespaceExaminer
-	 */
-	private $namespaceExaminer;
-
-	/**
 	 * @var array
 	 */
 	private $propertyInvalidCharacterList = [];
@@ -47,13 +37,11 @@ class EntityValidator {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param SQLStore $store
-	 * @param NamespaceExaminer $namespaceExaminer
 	 */
-	public function __construct( SQLStore $store, NamespaceExaminer $namespaceExaminer ) {
-		$this->store = $store;
-		$this->namespaceExaminer = $namespaceExaminer;
+	public function __construct(
+		private SQLStore $store,
+		private NamespaceExaminer $namespaceExaminer,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/Rebuilder/Rebuilder.php
+++ b/src/SQLStore/Rebuilder/Rebuilder.php
@@ -27,26 +27,6 @@ use SMW\Utils\Lru;
 class Rebuilder {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
-	 * @var TitleFactory
-	 */
-	private $titleFactory;
-
-	/**
-	 * @var EntityValidator
-	 */
-	private $entityValidator;
-
-	/**
-	 * @var PropertyTableIdReferenceDisposer
-	 */
-	private $propertyTableIdReferenceDisposer;
-
-	/**
 	 * @var JobFactory
 	 */
 	private $jobFactory;
@@ -98,17 +78,13 @@ class Rebuilder {
 
 	/**
 	 * @since 2.3
-	 *
-	 * @param SQLStore $store
-	 * @param TitleFactory $titleFactory
-	 * @param EntityValidator $entityValidator
-	 * @param PropertyTableIdReferenceDisposer $propertyTableIdReferenceDisposer
 	 */
-	public function __construct( SQLStore $store, TitleFactory $titleFactory, EntityValidator $entityValidator, PropertyTableIdReferenceDisposer $propertyTableIdReferenceDisposer ) {
-		$this->store = $store;
-		$this->titleFactory = $titleFactory;
-		$this->entityValidator = $entityValidator;
-		$this->propertyTableIdReferenceDisposer = $propertyTableIdReferenceDisposer;
+	public function __construct(
+		private readonly SQLStore $store,
+		private readonly TitleFactory $titleFactory,
+		private readonly EntityValidator $entityValidator,
+		private readonly PropertyTableIdReferenceDisposer $propertyTableIdReferenceDisposer,
+	) {
 		$this->jobFactory = ApplicationFactory::getInstance()->newJobFactory();
 		$this->hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 		$this->lru = new Lru( 10000 );

--- a/src/SQLStore/RedirectStore.php
+++ b/src/SQLStore/RedirectStore.php
@@ -22,16 +22,6 @@ class RedirectStore {
 	const TABLE_NAME = 'smw_fpt_redi';
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var Cache
-	 */
-	private $cache;
-
-	/**
 	 * @var int
 	 */
 	private $equalitySupport = 0;
@@ -43,14 +33,11 @@ class RedirectStore {
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param Store $store
-	 * @param Cache|null $cache
 	 */
-	public function __construct( Store $store, ?Cache $cache = null ) {
-		$this->store = $store;
-		$this->cache = $cache;
-
+	public function __construct(
+		private readonly Store $store,
+		private ?Cache $cache = null,
+	) {
 		if ( $this->cache === null ) {
 			$this->cache = InMemoryPoolCache::getInstance()->getPoolCacheById( 'sql.store.redirect.infostore' );
 		}

--- a/src/SQLStore/RedirectUpdater.php
+++ b/src/SQLStore/RedirectUpdater.php
@@ -22,26 +22,6 @@ use Wikimedia\Rdbms\Platform\ISQLPlatform;
 class RedirectUpdater {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var IdChanger
-	 */
-	private $idChanger;
-
-	/**
-	 * @var TableFieldUpdater
-	 */
-	private $tableFieldUpdater;
-
-	/**
-	 * @var PropertyStatisticsStore
-	 */
-	private $propertyStatisticsStore;
-
-	/**
 	 * @var
 	 */
 	private $lookupCache = [];
@@ -53,17 +33,13 @@ class RedirectUpdater {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param Store $store
-	 * @param IdChanger $idChanger
-	 * @param TableFieldUpdater $tableFieldUpdater
-	 * @param PropertyStatisticsStore $propertyStatisticsStore
 	 */
-	public function __construct( Store $store, IdChanger $idChanger, TableFieldUpdater $tableFieldUpdater, PropertyStatisticsStore $propertyStatisticsStore ) {
-		$this->store = $store;
-		$this->idChanger = $idChanger;
-		$this->tableFieldUpdater = $tableFieldUpdater;
-		$this->propertyStatisticsStore = $propertyStatisticsStore;
+	public function __construct(
+		private readonly Store $store,
+		private readonly IdChanger $idChanger,
+		private readonly TableFieldUpdater $tableFieldUpdater,
+		private readonly PropertyStatisticsStore $propertyStatisticsStore,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -69,35 +69,22 @@ use SMW\SQLStore\TableBuilder\TableSchemaManager;
 class SQLStoreFactory {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
-	 * @var MessageReporter
-	 */
-	private $messageReporter;
-
-	/**
 	 * @var QueryEngineFactory
 	 */
 	private $queryEngineFactory;
 
 	/**
 	 * @since 2.2
-	 *
-	 * @param SQLStore $store
-	 * @param MessageReporter|null $messageReporter
 	 */
-	public function __construct( SQLStore $store, ?MessageReporter $messageReporter = null ) {
-		$this->store = $store;
-		$this->messageReporter = $messageReporter;
-
+	public function __construct(
+		private readonly SQLStore $store,
+		private ?MessageReporter $messageReporter = null,
+	) {
 		if ( $this->messageReporter === null ) {
 			$this->messageReporter = new NullMessageReporter();
 		}
 
-		$this->queryEngineFactory = new QueryEngineFactory( $store );
+		$this->queryEngineFactory = new QueryEngineFactory( $this->store );
 	}
 
 	/**

--- a/src/SQLStore/SQLStoreUpdater.php
+++ b/src/SQLStore/SQLStoreUpdater.php
@@ -29,19 +29,6 @@ use SMWDIBlob as DIBlob;
 class SQLStoreUpdater {
 
 	/**
-	 * The store used by this store writer.
-	 *
-	 * @since 1.8
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
-	 * @var SQLStoreFactory
-	 */
-	private $factory;
-
-	/**
 	 * @var PropertyTableRowDiffer
 	 */
 	private $propertyTableRowDiffer;
@@ -73,13 +60,11 @@ class SQLStoreUpdater {
 
 	/**
 	 * @since 1.8
-	 *
-	 * @param SQLStore $store
-	 * @param SQLStoreFactory $factory
 	 */
-	public function __construct( SQLStore $store, $factory ) {
-		$this->store = $store;
-		$this->factory = $factory;
+	public function __construct(
+		private readonly SQLStore $store,
+		private $factory,
+	) {
 		$this->propertyTableRowDiffer = $this->factory->newPropertyTableRowDiffer();
 		$this->propertyTableUpdater = $this->factory->newPropertyTableUpdater();
 		$this->semanticDataLookup = $this->factory->newSemanticDataLookup();

--- a/src/SQLStore/TableBuilder/Examiner/CountMapField.php
+++ b/src/SQLStore/TableBuilder/Examiner/CountMapField.php
@@ -20,22 +20,14 @@ class CountMapField {
 	use MessageReporterAwareTrait;
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @var SetupFile
 	 */
 	private $setupFile;
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/Examiner/EntityCollation.php
+++ b/src/SQLStore/TableBuilder/Examiner/EntityCollation.php
@@ -19,11 +19,6 @@ class EntityCollation {
 	use MessageReporterAwareTrait;
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @var SetupFile
 	 */
 	private $setupFile;
@@ -35,11 +30,8 @@ class EntityCollation {
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/Examiner/FixedProperties.php
+++ b/src/SQLStore/TableBuilder/Examiner/FixedProperties.php
@@ -17,11 +17,6 @@ class FixedProperties {
 	use MessageReporterAwareTrait;
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @var
 	 */
 	private $fixedProperties = [];
@@ -33,11 +28,8 @@ class FixedProperties {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/Examiner/HashField.php
+++ b/src/SQLStore/TableBuilder/Examiner/HashField.php
@@ -18,23 +18,17 @@ class HashField {
 	use MessageReporterAwareTrait;
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @var PopulateHashField
 	 */
 	private $populateHashField;
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param SQLStore $store
-	 * @param PopulateHashField|null $populateHashField
 	 */
-	public function __construct( SQLStore $store, ?PopulateHashField $populateHashField = null ) {
-		$this->store = $store;
+	public function __construct(
+		private SQLStore $store,
+		?PopulateHashField $populateHashField = null,
+	) {
 		$this->populateHashField = $populateHashField;
 	}
 

--- a/src/SQLStore/TableBuilder/Examiner/IdBorder.php
+++ b/src/SQLStore/TableBuilder/Examiner/IdBorder.php
@@ -28,17 +28,9 @@ class IdBorder {
 	const UPPER_BOUND = 'upper.bound';
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
+++ b/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
@@ -19,22 +19,14 @@ class PredefinedProperties {
 	use MessageReporterAwareTrait;
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @var
 	 */
 	private $predefinedPropertyList = [];
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/Examiner/TouchedField.php
+++ b/src/SQLStore/TableBuilder/Examiner/TouchedField.php
@@ -16,17 +16,9 @@ class TouchedField {
 	use MessageReporterAwareTrait;
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/Table.php
+++ b/src/SQLStore/TableBuilder/Table.php
@@ -19,29 +19,17 @@ class Table {
 	const TYPE_DEFAULTS = 'defaults';
 
 	/**
-	 * @var string
-	 */
-	private $name;
-
-	/**
-	 * @var bool
-	 */
-	private $isCoreTable = true;
-
-	/**
 	 * @var array
 	 */
 	private $attributes = [];
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param string $name
-	 * @param bool $isCoreTable
 	 */
-	public function __construct( $name, bool $isCoreTable = true ) {
-		$this->name = $name;
-		$this->isCoreTable = $isCoreTable;
+	public function __construct(
+		private $name,
+		private readonly bool $isCoreTable = true,
+	) {
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/TableBuildExaminer.php
+++ b/src/SQLStore/TableBuilder/TableBuildExaminer.php
@@ -26,29 +26,17 @@ class TableBuildExaminer {
 	use MessageReporterAwareTrait;
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
-	 * @var TableBuildExaminerFactory
-	 */
-	private $tableBuildExaminerFactory;
-
-	/**
 	 * @var array
 	 */
 	private $predefinedPropertyList = [];
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param SQLStore $store
-	 * @param TableBuildExaminerFactory $tableBuildExaminerFactory
 	 */
-	public function __construct( SQLStore $store, TableBuildExaminerFactory $tableBuildExaminerFactory ) {
-		$this->store = $store;
-		$this->tableBuildExaminerFactory = $tableBuildExaminerFactory;
+	public function __construct(
+		private SQLStore $store,
+		private TableBuildExaminerFactory $tableBuildExaminerFactory,
+	) {
 		$this->messageReporter = new NullMessageReporter();
 		$this->setPredefinedPropertyList( PropertyRegistry::getInstance()->getPropertyList() );
 	}

--- a/src/SQLStore/TableBuilder/TableBuilder.php
+++ b/src/SQLStore/TableBuilder/TableBuilder.php
@@ -18,11 +18,6 @@ use Wikimedia\Rdbms\IDatabase;
 abstract class TableBuilder implements TableBuilderInterface, MessageReporterAware, MessageReporter {
 
 	/**
-	 * @var IDatabase
-	 */
-	protected $connection;
-
-	/**
 	 * @var MessageReporter
 	 */
 	private $messageReporter;
@@ -41,11 +36,8 @@ abstract class TableBuilder implements TableBuilderInterface, MessageReporterAwa
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param IDatabase $connection
 	 */
-	protected function __construct( $connection ) {
-		$this->connection = $connection;
+	protected function __construct( protected $connection ) {
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/TableSchemaManager.php
+++ b/src/SQLStore/TableBuilder/TableSchemaManager.php
@@ -19,11 +19,6 @@ use SMWDataItem as DataItem;
 class TableSchemaManager {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
 	 * @var MessageReporter
 	 */
 	private $messageReporter;
@@ -45,11 +40,8 @@ class TableSchemaManager {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param SQLStore $store
 	 */
-	public function __construct( SQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private readonly SQLStore $store ) {
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/TemporaryTableBuilder.php
+++ b/src/SQLStore/TableBuilder/TemporaryTableBuilder.php
@@ -15,22 +15,14 @@ use Wikimedia\Rdbms\Platform\ISQLPlatform;
 class TemporaryTableBuilder {
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
 	 * @var bool
 	 */
 	private $autoCommitFlag = false;
 
 	/**
 	 * @since 2.3
-	 *
-	 * @param Database $connection
 	 */
-	public function __construct( Database $connection ) {
-		$this->connection = $connection;
+	public function __construct( private readonly Database $connection ) {
 	}
 
 	/**

--- a/src/SQLStore/TableFieldUpdater.php
+++ b/src/SQLStore/TableFieldUpdater.php
@@ -13,24 +13,12 @@ use SMW\MediaWiki\Collator;
 class TableFieldUpdater {
 
 	/**
-	 * @var SQLStore
-	 */
-	private $store;
-
-	/**
-	 * @var Collator
-	 */
-	private $collator;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param SQLStore $store
-	 * @param Collator|null $collator
 	 */
-	public function __construct( SQLStore $store, ?Collator $collator = null ) {
-		$this->store = $store;
-		$this->collator = $collator;
+	public function __construct(
+		private readonly SQLStore $store,
+		private ?Collator $collator = null,
+	) {
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Apply PHP 8.1 constructor promotion to files in ``src/SQLStore/``
- Add `readonly` to promoted properties that are never reassigned and have a type declaration
- Remove redundant property declarations, `@var` phpdoc, and constructor `@param` phpdoc

## Test plan

- [x] PHPCS passes clean
- [x] Unit tests pass
- [x] Integration tests pass