### PR TITLE
refactor: constructor promotion + readonly for MediaWiki

### DIFF
--- a/src/MediaWiki/Api/ApiQueryResultFormatter.php
+++ b/src/MediaWiki/Api/ApiQueryResultFormatter.php
@@ -33,20 +33,14 @@ class ApiQueryResultFormatter {
 	 */
 	protected $isRawMode = false;
 
-	/**
-	 * @var QueryResult
-	 */
-	protected $queryResult = null;
-
 	protected array $result;
 
 	/**
 	 * @since 1.9
-	 *
-	 * @param QueryResult $queryResult
 	 */
-	public function __construct( QueryResult $queryResult ) {
-		$this->queryResult = $queryResult;
+	public function __construct(
+		protected readonly QueryResult $queryResult,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/ApiRequestParameterFormatter.php
+++ b/src/MediaWiki/Api/ApiRequestParameterFormatter.php
@@ -17,22 +17,16 @@ use SMW\Query\PrintRequest;
 final class ApiRequestParameterFormatter {
 
 	/**
-	 * @var array
-	 */
-	protected $requestParameters = [];
-
-	/**
 	 * @var ObjectDictionary
 	 */
 	protected $results = null;
 
 	/**
 	 * @since 1.9
-	 *
-	 * @param array $requestParameters
 	 */
-	public function __construct( array $requestParameters ) {
-		$this->requestParameters = $requestParameters;
+	public function __construct(
+		protected array $requestParameters,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Browse/ArticleAugmentor.php
+++ b/src/MediaWiki/Api/Browse/ArticleAugmentor.php
@@ -13,17 +13,11 @@ use SMW\MediaWiki\TitleFactory;
 class ArticleAugmentor {
 
 	/**
-	 * @var TitleFactory
-	 */
-	private $titleFactory;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param TitleFactory $titleFactory
 	 */
-	public function __construct( TitleFactory $titleFactory ) {
-		$this->titleFactory = $titleFactory;
+	public function __construct(
+		private readonly TitleFactory $titleFactory,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Browse/ArticleLookup.php
+++ b/src/MediaWiki/Api/Browse/ArticleLookup.php
@@ -16,24 +16,12 @@ class ArticleLookup extends Lookup {
 	const VERSION = 1;
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
-	 * @var ArticleAugmentor
-	 */
-	private $articleAugmentor;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param Database $connection
-	 * @param ArticleAugmentor $articleAugmentor
 	 */
-	public function __construct( Database $connection, ArticleAugmentor $articleAugmentor ) {
-		$this->connection = $connection;
-		$this->articleAugmentor = $articleAugmentor;
+	public function __construct(
+		private readonly Database $connection,
+		private readonly ArticleAugmentor $articleAugmentor,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Browse/CachingLookup.php
+++ b/src/MediaWiki/Api/Browse/CachingLookup.php
@@ -22,26 +22,17 @@ class CachingLookup {
 	private $store;
 
 	/**
-	 * @var Lookup
-	 */
-	private $lookup;
-
-	/**
 	 * @var int|bool
 	 */
 	private $cacheTTL;
 
-	private Cache $cache;
-
 	/**
 	 * @since 3.0
-	 *
-	 * @param Cache $cache
-	 * @param Lookup $lookup
 	 */
-	public function __construct( Cache $cache, Lookup $lookup ) {
-		$this->cache = $cache;
-		$this->lookup = $lookup;
+	public function __construct(
+		private readonly Cache $cache,
+		private readonly Lookup $lookup,
+	) {
 		$this->cacheTTL = self::CACHE_TTL;
 	}
 

--- a/src/MediaWiki/Api/Browse/ListAugmentor.php
+++ b/src/MediaWiki/Api/Browse/ListAugmentor.php
@@ -16,17 +16,11 @@ use SMW\Store;
 class ListAugmentor {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Browse/ListLookup.php
+++ b/src/MediaWiki/Api/Browse/ListLookup.php
@@ -20,23 +20,12 @@ class ListLookup extends Lookup {
 	const VERSION = 1;
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var ListAugmentor
-	 */
-	private $listAugmentor;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store, ListAugmentor $listAugmentor ) {
-		$this->store = $store;
-		$this->listAugmentor = $listAugmentor;
+	public function __construct(
+		private readonly Store $store,
+		private readonly ListAugmentor $listAugmentor,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Browse/PSubjectLookup.php
+++ b/src/MediaWiki/Api/Browse/PSubjectLookup.php
@@ -21,17 +21,11 @@ class PSubjectLookup extends Lookup {
 	const VERSION = 1;
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Browse/PValueLookup.php
+++ b/src/MediaWiki/Api/Browse/PValueLookup.php
@@ -18,17 +18,11 @@ class PValueLookup extends Lookup {
 	const VERSION = 1;
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Browse/SubjectLookup.php
+++ b/src/MediaWiki/Api/Browse/SubjectLookup.php
@@ -19,17 +19,11 @@ use SMW\Store;
 class SubjectLookup extends Lookup {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/PropertyListByApiRequest.php
+++ b/src/MediaWiki/Api/PropertyListByApiRequest.php
@@ -19,16 +19,6 @@ use SMW\StringCondition;
 class PropertyListByApiRequest {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var SpecificationLookup
-	 */
-	private $propertySpecificationLookup;
-
-	/**
 	 * @var RequestOptions
 	 */
 	private $requestOptions = null;
@@ -70,13 +60,11 @@ class PropertyListByApiRequest {
 
 	/**
 	 * @since 2.4
-	 *
-	 * @param Store $store
-	 * @param SpecificationLookup $propertySpecificationLookup
 	 */
-	public function __construct( Store $store, SpecificationLookup $propertySpecificationLookup ) {
-		$this->store = $store;
-		$this->propertySpecificationLookup = $propertySpecificationLookup;
+	public function __construct(
+		private readonly Store $store,
+		private readonly SpecificationLookup $propertySpecificationLookup,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Tasks/CheckQueryTask.php
+++ b/src/MediaWiki/Api/Tasks/CheckQueryTask.php
@@ -16,17 +16,11 @@ use SMWQueryProcessor as QueryProcessor;
 class CheckQueryTask extends Task {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Tasks/DuplicateLookupTask.php
+++ b/src/MediaWiki/Api/Tasks/DuplicateLookupTask.php
@@ -15,26 +15,17 @@ use SMW\Store;
 class DuplicateLookupTask extends Task {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var
 	 */
 	private $cacheUsage;
 
-	private Cache $cache;
-
 	/**
 	 * @since 3.1
-	 *
-	 * @param Store $store
-	 * @param Cache $cache
 	 */
-	public function __construct( Store $store, Cache $cache ) {
-		$this->store = $store;
-		$this->cache = $cache;
+	public function __construct(
+		private readonly Store $store,
+		private readonly Cache $cache,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Tasks/EntityExaminerTask.php
+++ b/src/MediaWiki/Api/Tasks/EntityExaminerTask.php
@@ -17,29 +17,17 @@ use SMW\Store;
 class EntityExaminerTask extends Task implements PermissionExaminerAware {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var EntityExaminerIndicatorsFactory
-	 */
-	private $entityExaminerIndicatorsFactory;
-
-	/**
 	 * @var PermissionExaminer
 	 */
 	private $permissionExaminer;
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param Store $store
-	 * @param EntityExaminerIndicatorsFactory $entityExaminerIndicatorsFactory
 	 */
-	public function __construct( Store $store, EntityExaminerIndicatorsFactory $entityExaminerIndicatorsFactory ) {
-		$this->store = $store;
-		$this->entityExaminerIndicatorsFactory = $entityExaminerIndicatorsFactory;
+	public function __construct(
+		private readonly Store $store,
+		private readonly EntityExaminerIndicatorsFactory $entityExaminerIndicatorsFactory,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Tasks/InsertJobTask.php
+++ b/src/MediaWiki/Api/Tasks/InsertJobTask.php
@@ -14,17 +14,11 @@ use SMW\MediaWiki\JobFactory;
 class InsertJobTask extends Task {
 
 	/**
-	 * @var JobFactory
-	 */
-	private $jobFactory;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param JobFactory $jobFactory
 	 */
-	public function __construct( JobFactory $jobFactory ) {
-		$this->jobFactory = $jobFactory;
+	public function __construct(
+		private readonly JobFactory $jobFactory,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Tasks/JobListTask.php
+++ b/src/MediaWiki/Api/Tasks/JobListTask.php
@@ -14,17 +14,11 @@ use SMW\MediaWiki\JobQueue;
 class JobListTask extends Task {
 
 	/**
-	 * @var JobQueue
-	 */
-	private $jobQueue;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param JobQueue $jobQueue
 	 */
-	public function __construct( JobQueue $jobQueue ) {
-		$this->jobQueue = $jobQueue;
+	public function __construct(
+		private readonly JobQueue $jobQueue,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Tasks/TableStatisticsTask.php
+++ b/src/MediaWiki/Api/Tasks/TableStatisticsTask.php
@@ -16,26 +16,17 @@ class TableStatisticsTask extends Task {
 	const CACHE_KEY = 'table-statistics';
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var
 	 */
 	private $cacheUsage;
 
-	private Cache $cache;
-
 	/**
 	 * @since 3.1
-	 *
-	 * @param Store $store
-	 * @param Cache $cache
 	 */
-	public function __construct( Store $store, Cache $cache ) {
-		$this->store = $store;
-		$this->cache = $cache;
+	public function __construct(
+		private readonly Store $store,
+		private readonly Cache $cache,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Api/Tasks/UpdateTask.php
+++ b/src/MediaWiki/Api/Tasks/UpdateTask.php
@@ -16,17 +16,11 @@ use SMW\MediaWiki\Jobs\UpdateJob;
 class UpdateTask extends Task {
 
 	/**
-	 * @var JobFactory
-	 */
-	private $jobFactory;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param JobFactory $jobFactory
 	 */
-	public function __construct( JobFactory $jobFactory ) {
-		$this->jobFactory = $jobFactory;
+	public function __construct(
+		private readonly JobFactory $jobFactory,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Collator.php
+++ b/src/MediaWiki/Collator.php
@@ -25,26 +25,14 @@ class Collator {
 	private static $instance = [];
 
 	/**
-	 * @var Collation
-	 */
-	private $collation;
-
-	/**
-	 * @var string
-	 */
-	private $collationName;
-
-	/**
 	 * @private
 	 *
 	 * @since 3.0
-	 *
-	 * @param Collation $collation
-	 * @param string $collationName
 	 */
-	public function __construct( Collation $collation, $collationName = '' ) {
-		$this->collation = $collation;
-		$this->collationName = $collationName;
+	public function __construct(
+		private readonly Collation $collation,
+		private $collationName = '',
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Connection/CleanUpTables.php
+++ b/src/MediaWiki/Connection/CleanUpTables.php
@@ -17,21 +17,16 @@ use Wikimedia\Rdbms\Platform\ISQLPlatform;
 class CleanUpTables {
 
 	/**
-	 * @var Database|IDatabase
-	 */
-	private $connection;
-
-	/**
 	 * @since 3.1
 	 */
-	public function __construct( $connection ) {
+	public function __construct(
+		private $connection,
+	) {
 		if (
 			!$connection instanceof Database &&
 			!$connection instanceof IDatabase ) {
 			throw new RuntimeException( "Invalid connection instance!" );
 		}
-
-		$this->connection = $connection;
 	}
 
 	/**

--- a/src/MediaWiki/Connection/ConnectionProvider.php
+++ b/src/MediaWiki/Connection/ConnectionProvider.php
@@ -19,11 +19,6 @@ class ConnectionProvider implements IConnectionProvider {
 	use LoggerAwareTrait;
 
 	/**
-	 * @var string
-	 */
-	private $provider;
-
-	/**
 	 * @var Database
 	 */
 	private $connection;
@@ -35,11 +30,10 @@ class ConnectionProvider implements IConnectionProvider {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param string|null $provider
 	 */
-	public function __construct( $provider = null ) {
-		$this->provider = $provider;
+	public function __construct(
+		private $provider = null,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -45,16 +45,6 @@ class Database {
 	const LIST_COMMA = ISQLPlatform::LIST_COMMA;
 
 	/**
-	 * @var ConnRef
-	 */
-	private $connRef;
-
-	/**
-	 * @var TransactionHandler
-	 */
-	private $transactionHandler;
-
-	/**
 	 * @var int
 	 */
 	private $flags = 0;
@@ -71,13 +61,11 @@ class Database {
 
 	/**
 	 * @since 1.9
-	 *
-	 * @param ConnRef $connRef
-	 * @param TransactionHandler $transactionHandler
 	 */
-	public function __construct( ConnRef $connRef, TransactionHandler $transactionHandler ) {
-		$this->connRef = $connRef;
-		$this->transactionHandler = $transactionHandler;
+	public function __construct(
+		private readonly ConnRef $connRef,
+		private readonly TransactionHandler $transactionHandler,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
+++ b/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
@@ -25,36 +25,18 @@ class LoadBalancerConnectionProvider implements IConnectionProvider {
 	private $connection;
 
 	/**
-	 * @var int
-	 */
-	private $id;
-
-	/**
-	 * @var string|array
-	 */
-	private $groups;
-
-	/**
-	 * @var string|bool
-	 */
-	private $wiki;
-
-	/**
 	 * @var ILoadBalancer
 	 */
 	private $loadBalancer;
 
 	/**
 	 * @since 1.9
-	 *
-	 * @param int $id
-	 * @param string|array $groups
-	 * @param string|bool $wiki Wiki ID, or false for the current wiki
 	 */
-	public function __construct( $id, $groups = [], $wiki = false ) {
-		$this->id = $id;
-		$this->groups = $groups;
-		$this->wiki = $wiki;
+	public function __construct(
+		private $id,
+		private $groups = [],
+		private $wiki = false,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Connection/Query.php
+++ b/src/MediaWiki/Connection/Query.php
@@ -21,11 +21,6 @@ class Query {
 	const TYPE_SELECT = 'SELECT';
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
 	 * @var string
 	 */
 	protected $type = '';
@@ -72,11 +67,10 @@ class Query {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Database $connection
 	 */
-	public function __construct( Database $connection ) {
-		$this->connection = $connection;
+	public function __construct(
+		private readonly Database $connection,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Connection/Sequence.php
+++ b/src/MediaWiki/Connection/Sequence.php
@@ -15,11 +15,6 @@ use Wikimedia\Rdbms\Platform\ISQLPlatform;
 class Sequence {
 
 	/**
-	 * @var Database|IDatabase
-	 */
-	private $connection;
-
-	/**
 	 * @var string
 	 */
 	private $tablePrefix;
@@ -27,14 +22,14 @@ class Sequence {
 	/**
 	 * @since 3.0
 	 */
-	public function __construct( $connection ) {
+	public function __construct(
+		private $connection,
+	) {
 		if (
 			!$connection instanceof Database &&
 			!$connection instanceof IDatabase ) {
 			throw new RuntimeException( "Invalid connection instance!" );
 		}
-
-		$this->connection = $connection;
 	}
 
 	/**

--- a/src/MediaWiki/Connection/TransactionHandler.php
+++ b/src/MediaWiki/Connection/TransactionHandler.php
@@ -16,11 +16,6 @@ use Wikimedia\ScopedCallback;
 class TransactionHandler {
 
 	/**
-	 * @var ILBFactory
-	 */
-	private $loadBalancerFactory;
-
-	/**
 	 * @var string|null
 	 */
 	private $sectionTransaction;
@@ -35,8 +30,9 @@ class TransactionHandler {
 	/**
 	 * @since 3.1
 	 */
-	public function __construct( ILBFactory $loadBalancerFactory ) {
-		$this->loadBalancerFactory = $loadBalancerFactory;
+	public function __construct(
+		private readonly ILBFactory $loadBalancerFactory,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Content/SchemaContentFormatter.php
+++ b/src/MediaWiki/Content/SchemaContentFormatter.php
@@ -24,11 +24,6 @@ use Traversable;
 class SchemaContentFormatter {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var HtmlBuilder
 	 */
 	private $htmlBuilder;
@@ -50,11 +45,10 @@ class SchemaContentFormatter {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 		$this->htmlBuilder = new HtmlBuilder();
 	}
 

--- a/src/MediaWiki/DeepRedirectTargetResolver.php
+++ b/src/MediaWiki/DeepRedirectTargetResolver.php
@@ -14,11 +14,6 @@ use RuntimeException;
 class DeepRedirectTargetResolver {
 
 	/**
-	 * @var PageCreator
-	 */
-	private $pageCreator = null;
-
-	/**
 	 * Track titles to prevent circular references caused by double redirects
 	 * on the same title
 	 *
@@ -28,11 +23,10 @@ class DeepRedirectTargetResolver {
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param PageCreator $pageCreator
 	 */
-	public function __construct( PageCreator $pageCreator ) {
-		$this->pageCreator = $pageCreator;
+	public function __construct(
+		private readonly PageCreator $pageCreator,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Deferred/ChangeTitleUpdate.php
+++ b/src/MediaWiki/Deferred/ChangeTitleUpdate.php
@@ -22,24 +22,12 @@ use SMW\Site;
 class ChangeTitleUpdate implements DeferrableUpdate {
 
 	/**
-	 * @var Title|null
-	 */
-	private $oldTitle;
-
-	/**
-	 * @var Title|null
-	 */
-	private $newTitle;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param Title|null $oldTitle
-	 * @param Title|null $newTitle
 	 */
-	public function __construct( ?Title $oldTitle = null, ?Title $newTitle = null ) {
-		$this->oldTitle = $oldTitle;
-		$this->newTitle = $newTitle;
+	public function __construct(
+		private readonly ?Title $oldTitle = null,
+		private readonly ?Title $newTitle = null,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Deferred/HashFieldUpdate.php
+++ b/src/MediaWiki/Deferred/HashFieldUpdate.php
@@ -23,36 +23,18 @@ class HashFieldUpdate implements DeferrableUpdate {
 	use LoggerAwareTrait;
 
 	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
-	 * @var int
-	 */
-	private $id;
-
-	/**
-	 * @var string
-	 */
-	private $hash;
-
-	/**
 	 * @var bool
 	 */
 	public static $isCommandLineMode;
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param Database $connection
-	 * @param int $id
-	 * @param string $hash
 	 */
-	public function __construct( Database $connection, $id, $hash ) {
-		$this->connection = $connection;
-		$this->id = $id;
-		$this->hash = $hash;
+	public function __construct(
+		private readonly Database $connection,
+		private $id,
+		private $hash,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Deferred/TransactionalCallableUpdate.php
+++ b/src/MediaWiki/Deferred/TransactionalCallableUpdate.php
@@ -20,11 +20,6 @@ use SMW\Site;
 class TransactionalCallableUpdate extends CallableUpdate {
 
 	/**
-	 * @var Database|null
-	 */
-	private $connection;
-
-	/**
 	 * @var bool
 	 */
 	private $onTransactionIdle = false;
@@ -69,11 +64,12 @@ class TransactionalCallableUpdate extends CallableUpdate {
 	 * @since 3.0
 	 *
 	 * @param callable|null $callback
-	 * @param Database|null $connection
 	 */
-	public function __construct( ?callable $callback = null, ?Database $connection = null ) {
+	public function __construct(
+		?callable $callback = null,
+		private readonly ?Database $connection = null,
+	) {
 		parent::__construct( $callback );
-		$this->connection = $connection;
 		$this->connection->onTransactionResolution( [ $this, 'cancelOnRollback' ], __METHOD__ );
 	}
 

--- a/src/MediaWiki/EditInfo.php
+++ b/src/MediaWiki/EditInfo.php
@@ -21,21 +21,6 @@ class EditInfo {
 	use RevisionGuardAwareTrait;
 
 	/**
-	 * @var WikiPage
-	 */
-	private $page;
-
-	/**
-	 * @var RevisionRecord|null
-	 */
-	private $revision;
-
-	/**
-	 * @var User
-	 */
-	private $user;
-
-	/**
 	 * @var ParserOutput
 	 */
 	private $parserOutput;
@@ -43,10 +28,11 @@ class EditInfo {
 	/**
 	 * @since 1.9
 	 */
-	public function __construct( WikiPage $page, ?RevisionRecord $revision, User $user ) {
-		$this->page = $page;
-		$this->revision = $revision;
-		$this->user = $user;
+	public function __construct(
+		private readonly WikiPage $page,
+		private ?RevisionRecord $revision,
+		private readonly User $user,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/FileRepoFinder.php
+++ b/src/MediaWiki/FileRepoFinder.php
@@ -15,17 +15,11 @@ use RepoGroup;
 class FileRepoFinder {
 
 	/**
-	 * @var RepoGroup
-	 */
-	private $repoGroup;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param RepoGroup $repoGroup
 	 */
-	public function __construct( RepoGroup $repoGroup ) {
-		$this->repoGroup = $repoGroup;
+	public function __construct(
+		private readonly RepoGroup $repoGroup,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -24,22 +24,16 @@ class ArticleDelete implements HookListener {
 	use EventDispatcherAwareTrait;
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var string
 	 */
 	private $origin = 'ArticleDelete';
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/ArticleFromTitle.php
+++ b/src/MediaWiki/Hooks/ArticleFromTitle.php
@@ -22,17 +22,11 @@ use SMW\Store;
 class ArticleFromTitle implements HookListener {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 2.0
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/ArticleProtectComplete.php
+++ b/src/MediaWiki/Hooks/ArticleProtectComplete.php
@@ -34,24 +34,12 @@ class ArticleProtectComplete implements HookListener {
 	const RESTRICTED_UPDATE = 'articleprotectcomplete.restricted.update';
 
 	/**
-	 * @var Title
-	 */
-	private $title;
-
-	/**
-	 * @var EditInfo
-	 */
-	private $editInfo;
-
-	/**
 	 * @since  2.5
-	 *
-	 * @param Title $title
-	 * @param EditInfo $editInfo
 	 */
-	public function __construct( Title $title, EditInfo $editInfo ) {
-		$this->title = $title;
-		$this->editInfo = $editInfo;
+	public function __construct(
+		private readonly Title $title,
+		private readonly EditInfo $editInfo,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/ArticleViewHeader.php
+++ b/src/MediaWiki/Hooks/ArticleViewHeader.php
@@ -30,31 +30,13 @@ class ArticleViewHeader implements HookListener {
 	use OptionsAwareTrait;
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var NamespaceExaminer
-	 */
-	private $namespaceExaminer;
-
-	/**
-	 * @var DependencyValidator
-	 */
-	private $dependencyValidator;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
-	 * @param NamespaceExaminer $namespaceExaminer
-	 * @param DependencyValidator $dependencyValidator
 	 */
-	public function __construct( Store $store, NamespaceExaminer $namespaceExaminer, DependencyValidator $dependencyValidator ) {
-		$this->store = $store;
-		$this->namespaceExaminer = $namespaceExaminer;
-		$this->dependencyValidator = $dependencyValidator;
+	public function __construct(
+		private readonly Store $store,
+		private readonly NamespaceExaminer $namespaceExaminer,
+		private readonly DependencyValidator $dependencyValidator,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/BeforeDisplayNoArticleText.php
+++ b/src/MediaWiki/Hooks/BeforeDisplayNoArticleText.php
@@ -18,17 +18,11 @@ use SMW\MediaWiki\HookListener;
 class BeforeDisplayNoArticleText implements HookListener {
 
 	/**
-	 * @var Page
-	 */
-	private $article;
-
-	/**
 	 * @since  2.0
-	 *
-	 * @param Page $article
 	 */
-	public function __construct( $article ) {
-		$this->article = $article;
+	public function __construct(
+		private $article,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/DeleteAccount.php
+++ b/src/MediaWiki/Hooks/DeleteAccount.php
@@ -18,24 +18,12 @@ use SMW\NamespaceExaminer;
 class DeleteAccount implements HookListener {
 
 	/**
-	 * @var NamespaceExaminer
-	 */
-	private $namespaceExaminer;
-
-	/**
-	 * @var ArticleDelete
-	 */
-	private $articleDelete;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param NamespaceExaminer $namespaceExaminer
-	 * @param ArticleDelete $articleDelete
 	 */
-	public function __construct( NamespaceExaminer $namespaceExaminer, ArticleDelete $articleDelete ) {
-		$this->namespaceExaminer = $namespaceExaminer;
-		$this->articleDelete = $articleDelete;
+	public function __construct(
+		private readonly NamespaceExaminer $namespaceExaminer,
+		private readonly ArticleDelete $articleDelete,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/EditPageForm.php
+++ b/src/MediaWiki/Hooks/EditPageForm.php
@@ -28,31 +28,13 @@ class EditPageForm implements HookListener {
 	use OptionsAwareTrait;
 
 	/**
-	 * @var NamespaceExaminer
-	 */
-	private $namespaceExaminer;
-
-	/**
-	 * @var PermissionExaminer
-	 */
-	private $permissionExaminer;
-
-	/**
-	 * @var PreferenceExaminer
-	 */
-	private $preferenceExaminer;
-
-	/**
 	 * @since 2.5
-	 *
-	 * @param NamespaceExaminer $namespaceExaminer
-	 * @param PermissionExaminer $permissionExaminer
-	 * @param PreferenceExaminer $preferenceExaminer
 	 */
-	public function __construct( NamespaceExaminer $namespaceExaminer, PermissionExaminer $permissionExaminer, PreferenceExaminer $preferenceExaminer ) {
-		$this->namespaceExaminer = $namespaceExaminer;
-		$this->permissionExaminer = $permissionExaminer;
-		$this->preferenceExaminer = $preferenceExaminer;
+	public function __construct(
+		private readonly NamespaceExaminer $namespaceExaminer,
+		private readonly PermissionExaminer $permissionExaminer,
+		private readonly PreferenceExaminer $preferenceExaminer,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
+++ b/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
@@ -24,17 +24,11 @@ use SMW\Store;
 class ExtensionSchemaUpdates implements HookListener {
 
 	/**
-	 * @var DatabaseUpdater
-	 */
-	protected $updater = null;
-
-	/**
 	 * @since  2.0
-	 *
-	 * @param DatabaseUpdater|null $updater = null
 	 */
-	public function __construct( ?DatabaseUpdater $updater = null ) {
-		$this->updater = $updater;
+	public function __construct(
+		protected readonly ?DatabaseUpdater $updater = null,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/FileUpload.php
+++ b/src/MediaWiki/Hooks/FileUpload.php
@@ -23,22 +23,10 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
  */
 class FileUpload implements HookListener {
 
-	/**
-	 * @var NamespaceExaminer
-	 */
-	private $namespaceExaminer;
-
-	/**
-	 * @var HookContainer
-	 */
-	private $hookContainer;
-
 	public function __construct(
-		NamespaceExaminer $namespaceExaminer,
-		HookContainer $hookContainer
+		private readonly NamespaceExaminer $namespaceExaminer,
+		private readonly HookContainer $hookContainer,
 	) {
-		$this->namespaceExaminer = $namespaceExaminer;
-		$this->hookContainer = $hookContainer;
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/GetPreferences.php
+++ b/src/MediaWiki/Hooks/GetPreferences.php
@@ -62,23 +62,12 @@ class GetPreferences implements HookListener {
 	const SHOW_ENTITY_ISSUE_PANEL = 'smw-prefs-general-options-show-entity-issue-panel';
 
 	/**
-	 * @var PermissionExaminer
-	 */
-	private $permissionExaminer;
-
-	/**
-	 * @var SchemaFactory
-	 */
-	private $schemaFactory;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param PermissionExaminer $permissionExaminer
 	 */
-	public function __construct( PermissionExaminer $permissionExaminer, SchemaFactory $schemaFactory ) {
-		$this->permissionExaminer = $permissionExaminer;
-		$this->schemaFactory = $schemaFactory;
+	public function __construct(
+		private readonly PermissionExaminer $permissionExaminer,
+		private readonly SchemaFactory $schemaFactory,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/LinksUpdateComplete.php
+++ b/src/MediaWiki/Hooks/LinksUpdateComplete.php
@@ -26,11 +26,6 @@ class LinksUpdateComplete implements HookListener {
 	use LoggerAwareTrait;
 
 	/**
-	 * @var NamespaceExaminer
-	 */
-	private $namespaceExaminer;
-
-	/**
 	 * @var bool
 	 */
 	private $enabledDeferredUpdate = true;
@@ -42,11 +37,10 @@ class LinksUpdateComplete implements HookListener {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param NamespaceExaminer $namespaceExaminer
 	 */
-	public function __construct( NamespaceExaminer $namespaceExaminer ) {
-		$this->namespaceExaminer = $namespaceExaminer;
+	public function __construct(
+		private readonly NamespaceExaminer $namespaceExaminer,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -32,33 +32,18 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 class OutputPageParserOutput implements HookListener {
 
 	/**
-	 * @var NamespaceExaminer
-	 */
-	private $namespaceExaminer;
-
-	/**
-	 * @var PermissionExaminer
-	 */
-	private $permissionExaminer;
-
-	/**
 	 * @var IndicatorRegistry
 	 */
 	private $indicatorRegistry;
-
-	private FactboxText $factboxText;
 
 	/**
 	 * @since 1.9
 	 */
 	public function __construct(
-		NamespaceExaminer $namespaceExaminer,
-		PermissionExaminer $permissionExaminer,
-		FactboxText $factboxText
+		private readonly NamespaceExaminer $namespaceExaminer,
+		private readonly PermissionExaminer $permissionExaminer,
+		private readonly FactboxText $factboxText,
 	) {
-		$this->namespaceExaminer = $namespaceExaminer;
-		$this->permissionExaminer = $permissionExaminer;
-		$this->factboxText = $factboxText;
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/PageMoveComplete.php
+++ b/src/MediaWiki/Hooks/PageMoveComplete.php
@@ -28,17 +28,11 @@ class PageMoveComplete implements HookListener {
 	use EventDispatcherAwareTrait;
 
 	/**
-	 * @var NamespaceExaminer
-	 */
-	private $namespaceExaminer;
-
-	/**
 	 * @since  1.9
-	 *
-	 * @param NamespaceExaminer $namespaceExaminer
 	 */
-	public function __construct( NamespaceExaminer $namespaceExaminer ) {
-		$this->namespaceExaminer = $namespaceExaminer;
+	public function __construct(
+		private readonly NamespaceExaminer $namespaceExaminer,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -40,16 +40,6 @@ class ParserAfterTidy implements HookListener {
 	private $parser;
 
 	/**
-	 * @var NamespaceExaminer
-	 */
-	private $namespaceExaminer;
-
-	/**
-	 * @var Cache
-	 */
-	private $cache;
-
-	/**
 	 * @var bool
 	 */
 	private $isCommandLineMode = false;
@@ -63,13 +53,13 @@ class ParserAfterTidy implements HookListener {
 	 * @since  1.9
 	 *
 	 * @param Parser &$parser
-	 * @param NamespaceExaminer $namespaceExaminer
-	 * @param Cache $cache
 	 */
-	public function __construct( Parser &$parser, NamespaceExaminer $namespaceExaminer, Cache $cache ) {
+	public function __construct(
+		Parser &$parser,
+		private readonly NamespaceExaminer $namespaceExaminer,
+		private readonly Cache $cache,
+	) {
 		$this->parser = $parser;
-		$this->namespaceExaminer = $namespaceExaminer;
-		$this->cache = $cache;
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/PersonalUrls.php
+++ b/src/MediaWiki/Hooks/PersonalUrls.php
@@ -23,38 +23,14 @@ class PersonalUrls implements HookListener {
 	use OptionsAwareTrait;
 
 	/**
-	 * @var SkinTemplate
-	 */
-	private $skin;
-
-	/**
-	 * @var JobQueue
-	 */
-	private $jobQueue;
-
-	/**
-	 * @var PermissionExaminer
-	 */
-	private $permissionExaminer;
-
-	/**
-	 * @var PreferenceExaminer
-	 */
-	private $preferenceExaminer;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param SkinTemplate $skin
-	 * @param JobQueue $jobQueue
-	 * @param PermissionExaminer $permissionExaminer
-	 * @param PreferenceExaminer $preferenceExaminer
 	 */
-	public function __construct( SkinTemplate $skin, JobQueue $jobQueue, PermissionExaminer $permissionExaminer, PreferenceExaminer $preferenceExaminer ) {
-		$this->skin = $skin;
-		$this->jobQueue = $jobQueue;
-		$this->permissionExaminer = $permissionExaminer;
-		$this->preferenceExaminer = $preferenceExaminer;
+	public function __construct(
+		private readonly SkinTemplate $skin,
+		private readonly JobQueue $jobQueue,
+		private readonly PermissionExaminer $permissionExaminer,
+		private readonly PreferenceExaminer $preferenceExaminer,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/RejectParserCacheValue.php
+++ b/src/MediaWiki/Hooks/RejectParserCacheValue.php
@@ -22,24 +22,12 @@ class RejectParserCacheValue implements HookListener {
 	use LoggerAwareTrait;
 
 	/**
-	 * @var NamespaceExaminer
-	 */
-	private $namespaceExaminer;
-
-	/**
-	 * @var DependencyValidator
-	 */
-	private $dependencyValidator;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param NamespaceExaminer $namespaceExaminer
-	 * @param DependencyValidator $dependencyValidator
 	 */
-	public function __construct( NamespaceExaminer $namespaceExaminer, DependencyValidator $dependencyValidator ) {
-		$this->namespaceExaminer = $namespaceExaminer;
-		$this->dependencyValidator = $dependencyValidator;
+	public function __construct(
+		private readonly NamespaceExaminer $namespaceExaminer,
+		private readonly DependencyValidator $dependencyValidator,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/ResourceLoaderGetConfigVars.php
+++ b/src/MediaWiki/Hooks/ResourceLoaderGetConfigVars.php
@@ -32,17 +32,11 @@ class ResourceLoaderGetConfigVars implements HookListener {
 	];
 
 	/**
-	 * @var NamespaceInfo
-	 */
-	private $namespaceInfo;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param NamespaceInfo $namespaceInfo
 	 */
-	public function __construct( NamespaceInfo $namespaceInfo ) {
-		$this->namespaceInfo = $namespaceInfo;
+	public function __construct(
+		private readonly NamespaceInfo $namespaceInfo,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/RevisionFromEditComplete.php
+++ b/src/MediaWiki/Hooks/RevisionFromEditComplete.php
@@ -39,38 +39,14 @@ class RevisionFromEditComplete implements HookListener {
 	use EventDispatcherAwareTrait;
 
 	/**
-	 * @var EditInfo
-	 */
-	private $editInfo;
-
-	/**
-	 * @var PageInfoProvider
-	 */
-	private $pageInfoProvider;
-
-	/**
-	 * @var PropertyAnnotatorFactory
-	 */
-	private $propertyAnnotatorFactory;
-
-	/**
-	 * @var SchemaFactory
-	 */
-	private $schemaFactory;
-
-	/**
 	 * @since 1.9
-	 *
-	 * @param EditInfo $editInfo
-	 * @param PageInfoProvider $pageInfoProvider
-	 * @param PropertyAnnotatorFactory $propertyAnnotatorFactory
-	 * @param SchemaFactory $schemaFactory
 	 */
-	public function __construct( EditInfo $editInfo, PageInfoProvider $pageInfoProvider, PropertyAnnotatorFactory $propertyAnnotatorFactory, SchemaFactory $schemaFactory ) {
-		$this->editInfo = $editInfo;
-		$this->pageInfoProvider = $pageInfoProvider;
-		$this->propertyAnnotatorFactory = $propertyAnnotatorFactory;
-		$this->schemaFactory = $schemaFactory;
+	public function __construct(
+		private readonly EditInfo $editInfo,
+		private readonly PageInfoProvider $pageInfoProvider,
+		private readonly PropertyAnnotatorFactory $propertyAnnotatorFactory,
+		private readonly SchemaFactory $schemaFactory,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/SidebarBeforeOutput.php
+++ b/src/MediaWiki/Hooks/SidebarBeforeOutput.php
@@ -23,16 +23,9 @@ class SidebarBeforeOutput implements HookListener {
 
 	use OptionsAwareTrait;
 
-	/**
-	 * @var NamespaceExaminer
-	 */
-	private $namespaceExaminer;
-
-	/**
-	 * @param NamespaceExaminer $namespaceExaminer
-	 */
-	public function __construct( NamespaceExaminer $namespaceExaminer ) {
-		$this->namespaceExaminer = $namespaceExaminer;
+	public function __construct(
+		private readonly NamespaceExaminer $namespaceExaminer,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/SkinAfterContent.php
+++ b/src/MediaWiki/Hooks/SkinAfterContent.php
@@ -23,17 +23,11 @@ class SkinAfterContent implements HookListener {
 	use OptionsAwareTrait;
 
 	/**
-	 * @var Skin
-	 */
-	private $skin = null;
-
-	/**
 	 * @since  1.9
-	 *
-	 * @param Skin|null $skin
 	 */
-	public function __construct( ?Skin $skin = null ) {
-		$this->skin = $skin;
+	public function __construct(
+		private readonly ?Skin $skin = null,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/SpecialSearchResultsPrepend.php
+++ b/src/MediaWiki/Hooks/SpecialSearchResultsPrepend.php
@@ -27,31 +27,13 @@ class SpecialSearchResultsPrepend implements HookListener {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var PreferenceExaminer
-	 */
-	private $preferenceExaminer;
-
-	/**
-	 * @var SpecialSearch
-	 */
-	private $specialSearch;
-
-	/**
-	 * @var OutputPage
-	 */
-	private $outputPage;
-
-	/**
 	 * @since  3.0
-	 *
-	 * @param PreferenceExaminer $preferenceExaminer
-	 * @param SpecialSearch $specialSearch
-	 * @param OutputPage $outputPage
 	 */
-	public function __construct( PreferenceExaminer $preferenceExaminer, SpecialSearch $specialSearch, OutputPage $outputPage ) {
-		$this->preferenceExaminer = $preferenceExaminer;
-		$this->specialSearch = $specialSearch;
-		$this->outputPage = $outputPage;
+	public function __construct(
+		private readonly PreferenceExaminer $preferenceExaminer,
+		private readonly SpecialSearch $specialSearch,
+		private readonly OutputPage $outputPage,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/SpecialStatsAddExtra.php
+++ b/src/MediaWiki/Hooks/SpecialStatsAddExtra.php
@@ -28,11 +28,6 @@ class SpecialStatsAddExtra implements HookListener {
 	const CRITICAL_DELETECOUNT = 5000;
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var Language|string
 	 */
 	private $language;
@@ -62,11 +57,10 @@ class SpecialStatsAddExtra implements HookListener {
 
 	/**
 	 * @since  1.9
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/TitleIsAlwaysKnown.php
+++ b/src/MediaWiki/Hooks/TitleIsAlwaysKnown.php
@@ -19,23 +19,17 @@ use SMW\MediaWiki\HookListener;
 class TitleIsAlwaysKnown implements HookListener {
 
 	/**
-	 * @var Title
-	 */
-	private $title;
-
-	/**
 	 * @var mixed
 	 */
 	private $result;
 
 	/**
 	 * @since  2.0
-	 *
-	 * @param Title $title
-	 * @param mixed &$result
 	 */
-	public function __construct( Title $title, &$result ) {
-		$this->title = $title;
+	public function __construct(
+		private readonly Title $title,
+		&$result,
+	) {
 		$this->result =& $result;
 	}
 

--- a/src/MediaWiki/Hooks/TitleIsMovable.php
+++ b/src/MediaWiki/Hooks/TitleIsMovable.php
@@ -17,17 +17,11 @@ use SMW\MediaWiki\HookListener;
 class TitleIsMovable implements HookListener {
 
 	/**
-	 * @var Title
-	 */
-	private $title;
-
-	/**
 	 * @since  2.1
-	 *
-	 * @param Title $title
 	 */
-	public function __construct( Title $title ) {
-		$this->title = $title;
+	public function __construct(
+		private readonly Title $title,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/TitleQuickPermissions.php
+++ b/src/MediaWiki/Hooks/TitleQuickPermissions.php
@@ -18,24 +18,12 @@ use SMW\NamespaceExaminer;
 class TitleQuickPermissions implements HookListener {
 
 	/**
-	 * @var NamespaceExaminer
-	 */
-	private $namespaceExaminer;
-
-	/**
-	 * @var TitlePermissions
-	 */
-	private $titlePermissions;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param NamespaceExaminer $namespaceExaminer
-	 * @param TitlePermissions $titlePermissions
 	 */
-	public function __construct( NamespaceExaminer $namespaceExaminer, TitlePermissions $titlePermissions ) {
-		$this->namespaceExaminer = $namespaceExaminer;
-		$this->titlePermissions = $titlePermissions;
+	public function __construct(
+		private readonly NamespaceExaminer $namespaceExaminer,
+		private readonly TitlePermissions $titlePermissions,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Hooks/UserChange.php
+++ b/src/MediaWiki/Hooks/UserChange.php
@@ -25,22 +25,16 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 class UserChange implements HookListener {
 
 	/**
-	 * @var NamespaceExaminer
-	 */
-	private $namespaceExaminer;
-
-	/**
 	 * @var string
 	 */
 	private $origin = '';
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param NamespaceExaminer $namespaceExaminer
 	 */
-	public function __construct( NamespaceExaminer $namespaceExaminer ) {
-		$this->namespaceExaminer = $namespaceExaminer;
+	public function __construct(
+		private readonly NamespaceExaminer $namespaceExaminer,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/JobQueue.php
+++ b/src/MediaWiki/JobQueue.php
@@ -17,22 +17,16 @@ use JobQueueGroup;
 class JobQueue {
 
 	/**
-	 * @var JobQueueGroup
-	 */
-	private $jobQueueGroup;
-
-	/**
 	 * @var bool
 	 */
 	private $disableCache = false;
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param JobQueueGroup $jobQueueGroup
 	 */
-	public function __construct( JobQueueGroup $jobQueueGroup ) {
-		$this->jobQueueGroup = $jobQueueGroup;
+	public function __construct(
+		private readonly JobQueueGroup $jobQueueGroup,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/LinkBatch.php
+++ b/src/MediaWiki/LinkBatch.php
@@ -33,17 +33,11 @@ class LinkBatch {
 	private $batch = [];
 
 	/**
-	 * @var MwLinkBatch|null
-	 */
-	private $linkBatch;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param MwLinkBatch|null $linkBatch
 	 */
-	public function __construct( ?MwLinkBatch $linkBatch = null ) {
-		$this->linkBatch = $linkBatch;
+	public function __construct(
+		private ?MwLinkBatch $linkBatch = null,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/MagicWordsFinder.php
+++ b/src/MediaWiki/MagicWordsFinder.php
@@ -15,24 +15,12 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 class MagicWordsFinder {
 
 	/**
-	 * @var ParserOutput
-	 */
-	private $parserOutput;
-
-	/**
-	 * @var MagicWordFactory
-	 */
-	private $magicWordFactory;
-
-	/**
 	 * @since 2.0
-	 *
-	 * @param ParserOutput|null $parserOutput
-	 * @param MagicWordFactory|null $magicWordFactory
 	 */
-	public function __construct( ?ParserOutput $parserOutput = null, ?MagicWordFactory $magicWordFactory = null ) {
-		$this->parserOutput = $parserOutput;
-		$this->magicWordFactory = $magicWordFactory;
+	public function __construct(
+		private ?ParserOutput $parserOutput = null,
+		private readonly ?MagicWordFactory $magicWordFactory = null,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/ManualEntryLogger.php
+++ b/src/MediaWiki/ManualEntryLogger.php
@@ -16,22 +16,16 @@ use MediaWiki\User\User;
 class ManualEntryLogger {
 
 	/**
-	 * @var logEntry
-	 */
-	private $logEntry = null;
-
-	/**
 	 * @var array
 	 */
 	private $eventTypes = [];
 
 	/**
 	 * @since 2.4
-	 *
-	 * @param LogEntry|null $logEntry
 	 */
-	public function __construct( ?LogEntry $logEntry = null ) {
-		$this->logEntry = $logEntry;
+	public function __construct(
+		private readonly ?LogEntry $logEntry = null,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/MessageBuilder.php
+++ b/src/MediaWiki/MessageBuilder.php
@@ -23,17 +23,11 @@ use RuntimeException;
 class MessageBuilder {
 
 	/**
-	 * @var Language
-	 */
-	private $language = null;
-
-	/**
 	 * @since 2.1
-	 *
-	 * @param Language|null $language
 	 */
-	public function __construct( ?Language $language = null ) {
-		$this->language = $language;
+	public function __construct(
+		private ?Language $language = null,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -28,17 +28,11 @@ use WikiPage;
 class MwCollaboratorFactory {
 
 	/**
-	 * @var ApplicationFactory
-	 */
-	private $applicationFactory;
-
-	/**
 	 * @since 2.1
-	 *
-	 * @param ApplicationFactory $applicationFactory
 	 */
-	public function __construct( ApplicationFactory $applicationFactory ) {
-		$this->applicationFactory = $applicationFactory;
+	public function __construct(
+		private readonly ApplicationFactory $applicationFactory,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Page/ListBuilder.php
+++ b/src/MediaWiki/Page/ListBuilder.php
@@ -20,16 +20,6 @@ use SMWInfolink as Infolink;
 class ListBuilder {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var Collator
-	 */
-	private $collator;
-
-	/**
 	 * @var callable
 	 */
 	private $itemFormatter;
@@ -61,13 +51,11 @@ class ListBuilder {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
-	 * @param Collator|null $collator
 	 */
-	public function __construct( Store $store, ?Collator $collator = null ) {
-		$this->store = $store;
-		$this->collator = $collator;
+	public function __construct(
+		private readonly Store $store,
+		private ?Collator $collator = null,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Page/ListBuilder/ItemListBuilder.php
+++ b/src/MediaWiki/Page/ListBuilder/ItemListBuilder.php
@@ -21,11 +21,6 @@ use SMWDataItem as DataItem;
 class ItemListBuilder {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var string
 	 */
 	private $languageCode = 'en';
@@ -62,11 +57,10 @@ class ItemListBuilder {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Page/ListBuilder/ValueListBuilder.php
+++ b/src/MediaWiki/Page/ListBuilder/ValueListBuilder.php
@@ -30,11 +30,6 @@ use Traversable;
 class ValueListBuilder {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var int
 	 */
 	private $pagingLimit = 0;
@@ -66,11 +61,10 @@ class ValueListBuilder {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Page/PropertyPage.php
+++ b/src/MediaWiki/Page/PropertyPage.php
@@ -34,16 +34,6 @@ use SMWDataValue;
 class PropertyPage extends Page {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var DeclarationExaminerFactory
-	 */
-	private $declarationExaminerFactory;
-
-	/**
 	 * @var DIProperty
 	 */
 	private $property;
@@ -72,13 +62,13 @@ class PropertyPage extends Page {
 	 * @see 3.0
 	 *
 	 * @param Title $title
-	 * @param Store $store
-	 * @param DeclarationExaminerFactory $declarationExaminerFactory
 	 */
-	public function __construct( Title $title, Store $store, DeclarationExaminerFactory $declarationExaminerFactory ) {
+	public function __construct(
+		Title $title,
+		private readonly Store $store,
+		private readonly DeclarationExaminerFactory $declarationExaminerFactory,
+	) {
 		parent::__construct( $title );
-		$this->store = $store;
-		$this->declarationExaminerFactory = $declarationExaminerFactory;
 	}
 
 	/**

--- a/src/MediaWiki/PageFactory.php
+++ b/src/MediaWiki/PageFactory.php
@@ -19,17 +19,11 @@ use SMW\Store;
 class PageFactory {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/PageInfoProvider.php
+++ b/src/MediaWiki/PageInfoProvider.php
@@ -28,48 +28,19 @@ class PageInfoProvider implements PageInfo {
 	use RevisionGuardAwareTrait;
 
 	/**
-	 * @var WikiPage
-	 */
-	private $wikiPage = null;
-
-	/**
-	 * @var RevisionRecord
-	 */
-	private $revision = null;
-
-	/**
-	 * @var User
-	 */
-	private $user = null;
-
-	/**
 	 * @var RevisionLookup
 	 */
 	private $revisionLookup;
 
 	/**
-	 * @var ?bool
-	 */
-	private $isReUpload = null;
-
-	/**
 	 * @since 1.9
-	 *
-	 * @param WikiPage $wikiPage
-	 * @param ?RevisionRecord $revision
-	 * @param ?User $user
-	 * @param ?bool $isReUpload
 	 */
 	public function __construct(
-		WikiPage $wikiPage,
-		?RevisionRecord $revision = null,
-		?User $user = null,
-		?bool $isReUpload = null
+		private readonly WikiPage $wikiPage,
+		private readonly ?RevisionRecord $revision = null,
+		private readonly ?User $user = null,
+		private readonly ?bool $isReUpload = null,
 	) {
-		$this->wikiPage = $wikiPage;
-		$this->revision = $revision;
-		$this->user = $user;
-		$this->isReUpload = $isReUpload;
 	}
 
 	/**

--- a/src/MediaWiki/PageUpdater.php
+++ b/src/MediaWiki/PageUpdater.php
@@ -21,16 +21,6 @@ class PageUpdater implements DeferrableUpdate {
 	use LoggerAwareTrait;
 
 	/**
-	 * @var TransactionalCallableUpdate
-	 */
-	private $transactionalCallableUpdate;
-
-	/**
-	 * @var Database
-	 */
-	private $connection;
-
-	/**
 	 * @var Title[]
 	 */
 	private $titles = [];
@@ -72,13 +62,11 @@ class PageUpdater implements DeferrableUpdate {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Database|null $connection
-	 * @param TransactionalCallableUpdate|null $transactionalCallableUpdate
 	 */
-	public function __construct( ?Database $connection = null, ?TransactionalCallableUpdate $transactionalCallableUpdate = null ) {
-		$this->connection = $connection;
-		$this->transactionalCallableUpdate = $transactionalCallableUpdate;
+	public function __construct(
+		private readonly ?Database $connection = null,
+		private ?TransactionalCallableUpdate $transactionalCallableUpdate = null,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Permission/PermissionExaminer.php
+++ b/src/MediaWiki/Permission/PermissionExaminer.php
@@ -14,24 +14,12 @@ use SMW\MediaWiki\PermissionManager;
 class PermissionExaminer {
 
 	/**
-	 * @var PermissionManager
-	 */
-	private $permissionManager;
-
-	/**
-	 * @var User
-	 */
-	private $user;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param PermissionManager $permissionManager
-	 * @param User|null $user
 	 */
-	public function __construct( PermissionManager $permissionManager, ?User $user = null ) {
-		$this->permissionManager = $permissionManager;
-		$this->user = $user;
+	public function __construct(
+		private readonly PermissionManager $permissionManager,
+		private ?User $user = null,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Permission/TitlePermissions.php
+++ b/src/MediaWiki/Permission/TitlePermissions.php
@@ -17,29 +17,17 @@ use SMW\Protection\ProtectionValidator;
 class TitlePermissions {
 
 	/**
-	 * @var ProtectionValidator
-	 */
-	private $protectionValidator;
-
-	/**
-	 * @var PermissionManager
-	 */
-	private $permissionManager;
-
-	/**
 	 * @var
 	 */
 	private $errors = [];
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param ProtectionValidator $protectionValidator
-	 * @param permissionManager $permissionManager
 	 */
-	public function __construct( ProtectionValidator $protectionValidator, PermissionManager $permissionManager ) {
-		$this->protectionValidator = $protectionValidator;
-		$this->permissionManager = $permissionManager;
+	public function __construct(
+		private readonly ProtectionValidator $protectionValidator,
+		private readonly PermissionManager $permissionManager,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/PermissionManager.php
+++ b/src/MediaWiki/PermissionManager.php
@@ -16,17 +16,11 @@ use MediaWiki\User\User;
 class PermissionManager {
 
 	/**
-	 * @var MwPermissionManager
-	 */
-	private $permissionManager;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param MwPermissionManager $permissionManager
 	 */
-	public function __construct( MwPermissionManager $permissionManager ) {
-		$this->permissionManager = $permissionManager;
+	public function __construct(
+		private readonly MwPermissionManager $permissionManager,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Preference/PreferenceExaminer.php
+++ b/src/MediaWiki/Preference/PreferenceExaminer.php
@@ -14,23 +14,12 @@ use MediaWiki\User\User;
 class PreferenceExaminer {
 
 	/**
-	 * @var User
-	 */
-	private $user;
-
-	/**
-	 * @var ?UserOptionsLookup
-	 */
-	private $userOptionsLookup;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param User|null $user
 	 */
-	public function __construct( ?User $user = null, ?UserOptionsLookup $userOptionsLookup = null ) {
-		$this->user = $user;
-		$this->userOptionsLookup = $userOptionsLookup;
+	public function __construct(
+		private ?User $user = null,
+		private ?UserOptionsLookup $userOptionsLookup = null,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Renderer/HtmlFormRenderer.php
+++ b/src/MediaWiki/Renderer/HtmlFormRenderer.php
@@ -31,16 +31,6 @@ use SMW\MediaWiki\MessageBuilder;
 class HtmlFormRenderer {
 
 	/**
-	 * @var Title
-	 */
-	private $title = null;
-
-	/**
-	 * @var MessageBuilder
-	 */
-	private $messageBuilder = null;
-
-	/**
 	 * @var array
 	 */
 	private $queryParameters = [];
@@ -77,13 +67,11 @@ class HtmlFormRenderer {
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param Title $title
-	 * @param MessageBuilder $messageBuilder
 	 */
-	public function __construct( Title $title, MessageBuilder $messageBuilder ) {
-		$this->title = $title;
-		$this->messageBuilder = $messageBuilder;
+	public function __construct(
+		private readonly Title $title,
+		private readonly MessageBuilder $messageBuilder,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Renderer/HtmlTableRenderer.php
+++ b/src/MediaWiki/Renderer/HtmlTableRenderer.php
@@ -47,8 +47,6 @@ class HtmlTableRenderer {
 	 */
 	private $transpose = false;
 
-	private bool $htmlContext;
-
 	/**
 	 * @par Example:
 	 * @code
@@ -65,11 +63,10 @@ class HtmlTableRenderer {
 	 * @endcode
 	 *
 	 * @since 1.9
-	 *
-	 * @param bool $htmlContext
 	 */
-	public function __construct( $htmlContext = false ) {
-		$this->htmlContext = $htmlContext;
+	public function __construct(
+		private bool $htmlContext = false,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Renderer/HtmlTemplateRenderer.php
+++ b/src/MediaWiki/Renderer/HtmlTemplateRenderer.php
@@ -13,24 +13,12 @@ use MediaWiki\Parser\Parser;
 class HtmlTemplateRenderer {
 
 	/**
-	 * @var WikitextTemplateRenderer
-	 */
-	private $wikitextTemplateRenderer;
-
-	/**
-	 * @var Parser
-	 */
-	private $parser;
-
-	/**
 	 * @since 2.2
-	 *
-	 * @param WikitextTemplateRenderer $wikitextTemplateRenderer
-	 * @param Parser $parser
 	 */
-	public function __construct( WikitextTemplateRenderer $wikitextTemplateRenderer, Parser $parser ) {
-		$this->wikitextTemplateRenderer = $wikitextTemplateRenderer;
-		$this->parser = $parser;
+	public function __construct(
+		private readonly WikitextTemplateRenderer $wikitextTemplateRenderer,
+		private readonly Parser $parser,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/RevisionGuard.php
+++ b/src/MediaWiki/RevisionGuard.php
@@ -27,17 +27,11 @@ class RevisionGuard {
 	use HookDispatcherAwareTrait;
 
 	/**
-	 * @var RevisionLookup
-	 */
-	private $revisionLookup;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param RevisionLookup $revisionLookup
 	 */
-	public function __construct( RevisionLookup $revisionLookup ) {
-		$this->revisionLookup = $revisionLookup;
+	public function __construct(
+		private readonly RevisionLookup $revisionLookup,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Search/ExtendedSearch.php
+++ b/src/MediaWiki/Search/ExtendedSearch.php
@@ -27,16 +27,6 @@ class ExtendedSearch {
 	const COMPLETION_SEARCH_EXTRA_SEARCH_SIZE = 10;
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var SearchEngine
-	 */
-	private $fallbackSearchEngine;
-
-	/**
 	 * @var array
 	 */
 	private $errors = [];
@@ -93,13 +83,11 @@ class ExtendedSearch {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param Store $store
-	 * @param SearchEngine $fallbackSearchEngine
 	 */
-	public function __construct( Store $store, SearchEngine $fallbackSearchEngine ) {
-		$this->store = $store;
-		$this->fallbackSearchEngine = $fallbackSearchEngine;
+	public function __construct(
+		private readonly Store $store,
+		private readonly SearchEngine $fallbackSearchEngine,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Search/ProfileForm/Forms/CustomForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/CustomForm.php
@@ -17,11 +17,6 @@ use SMW\MediaWiki\Search\ProfileForm\FormsBuilder;
 class CustomForm {
 
 	/**
-	 * @var WebRequest
-	 */
-	private $request;
-
-	/**
 	 * @var Field
 	 */
 	private $field;
@@ -55,11 +50,10 @@ class CustomForm {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param WebRequest $request
 	 */
-	public function __construct( WebRequest $request ) {
-		$this->request = $request;
+	public function __construct(
+		private readonly WebRequest $request,
+	) {
 		$this->field = new Field();
 	}
 

--- a/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/NamespaceForm.php
@@ -24,16 +24,6 @@ class NamespaceForm {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var NamespaceInfo
-	 */
-	private $namespaceInfo;
-
-	/**
-	 * @var Localizer
-	 */
-	private $localizer;
-
-	/**
 	 * @var
 	 */
 	private $activeNamespaces = [];
@@ -60,13 +50,11 @@ class NamespaceForm {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param NamespaceInfo $namespaceInfo
-	 * @param Localizer $localizer
 	 */
-	public function __construct( NamespaceInfo $namespaceInfo, Localizer $localizer ) {
-		$this->namespaceInfo = $namespaceInfo;
-		$this->localizer = $localizer;
+	public function __construct(
+		private readonly NamespaceInfo $namespaceInfo,
+		private readonly Localizer $localizer,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Search/ProfileForm/Forms/OpenForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/OpenForm.php
@@ -16,11 +16,6 @@ use MediaWiki\Request\WebRequest;
 class OpenForm {
 
 	/**
-	 * @var WebRequest
-	 */
-	private $request;
-
-	/**
 	 * @var Field
 	 */
 	private $field;
@@ -37,11 +32,10 @@ class OpenForm {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param WebRequest $request
 	 */
-	public function __construct( WebRequest $request ) {
-		$this->request = $request;
+	public function __construct(
+		private readonly WebRequest $request,
+	) {
 		$this->field = new Field();
 	}
 

--- a/src/MediaWiki/Search/ProfileForm/Forms/SortForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/SortForm.php
@@ -17,11 +17,6 @@ use SMW\Localizer\Message;
 class SortForm {
 
 	/**
-	 * @var WebRequest
-	 */
-	private $request;
-
-	/**
 	 * @var Field
 	 */
 	private $field;
@@ -33,11 +28,10 @@ class SortForm {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param WebRequest $request
 	 */
-	public function __construct( WebRequest $request ) {
-		$this->request = $request;
+	public function __construct(
+		private readonly WebRequest $request,
+	) {
 		$this->field = new Field();
 	}
 

--- a/src/MediaWiki/Search/ProfileForm/FormsBuilder.php
+++ b/src/MediaWiki/Search/ProfileForm/FormsBuilder.php
@@ -18,16 +18,6 @@ use SMW\Localizer\Message;
 class FormsBuilder {
 
 	/**
-	 * @var WebRequest
-	 */
-	private $request;
-
-	/**
-	 * @var FormsFactory
-	 */
-	private $formsFactory;
-
-	/**
 	 * @var OpenForm
 	 */
 	private $openForm;
@@ -69,13 +59,11 @@ class FormsBuilder {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param WebRequest $request
-	 * @param FormsFactory $formsFactory
 	 */
-	public function __construct( WebRequest $request, FormsFactory $formsFactory ) {
-		$this->request = $request;
-		$this->formsFactory = $formsFactory;
+	public function __construct(
+		private readonly WebRequest $request,
+		private readonly FormsFactory $formsFactory,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Search/ProfileForm/ProfileForm.php
+++ b/src/MediaWiki/Search/ProfileForm/ProfileForm.php
@@ -28,16 +28,6 @@ class ProfileForm {
 	const SCHEMA_TYPE = 'SEARCH_FORM_SCHEMA';
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var SpecialSearch
-	 */
-	private $specialSearch;
-
-	/**
 	 * @var FormsFactory
 	 */
 	private $formsFactory;
@@ -49,13 +39,11 @@ class ProfileForm {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Store $store
-	 * @param SpecialSearch $specialSearch
 	 */
-	public function __construct( Store $store, SpecialSearch $specialSearch ) {
-		$this->store = $store;
-		$this->specialSearch = $specialSearch;
+	public function __construct(
+		private readonly Store $store,
+		private readonly SpecialSearch $specialSearch,
+	) {
 		$this->formsFactory = new FormsFactory();
 	}
 

--- a/src/MediaWiki/Search/QueryBuilder.php
+++ b/src/MediaWiki/Search/QueryBuilder.php
@@ -25,30 +25,17 @@ use SMWQueryProcessor as QueryProcessor;
 class QueryBuilder {
 
 	/**
-	 * @var WebRequest
-	 */
-	private $request;
-
-	/**
-	 * @var array
-	 */
-	private $data = [];
-
-	/**
 	 * @var array
 	 */
 	private $queryCache = [];
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param WebRequest|null $request
-	 * @param array|null $data
 	 */
-	public function __construct( ?WebRequest $request = null, array $data = [] ) {
-		$this->request = $request;
-		$this->data = $data;
-
+	public function __construct(
+		private ?WebRequest $request = null,
+		private array $data = [],
+	) {
 		if ( $this->request === null ) {
 			$this->request = $GLOBALS['wgRequest'];
 		}

--- a/src/MediaWiki/Search/SearchResultSet.php
+++ b/src/MediaWiki/Search/SearchResultSet.php
@@ -33,13 +33,13 @@ class SearchResultSet extends \SearchResultSet {
 	 */
 	private $excerpts;
 
-	private $count = null;
-
-	public function __construct( QueryResult $result, $count = null ) {
+	public function __construct(
+		QueryResult $result,
+		private $count = null,
+	) {
 		$this->pages = $result->getResults();
 		$this->queryToken = $result->getQuery()->getQueryToken();
 		$this->excerpts = $result->getExcerpts();
-		$this->count = $count;
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Alerts/ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Alerts/ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler.php
@@ -17,22 +17,16 @@ use SMW\Store;
 class ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler extends TaskHandler {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var array
 	 */
 	private $namespacesWithSemanticLinks = [];
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Alerts/DeprecationNoticeTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Alerts/DeprecationNoticeTaskHandler.php
@@ -16,24 +16,12 @@ use SMW\MediaWiki\Specials\Admin\TaskHandler;
 class DeprecationNoticeTaskHandler extends TaskHandler {
 
 	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
-	 * @var array
-	 */
-	private $deprecationNoticeList = [];
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param OutputFormatter $outputFormatter
-	 * @param array $deprecationNoticeList
 	 */
-	public function __construct( OutputFormatter $outputFormatter, array $deprecationNoticeList = [] ) {
-		$this->outputFormatter = $outputFormatter;
-		$this->deprecationNoticeList = $deprecationNoticeList;
+	public function __construct(
+		private readonly OutputFormatter $outputFormatter,
+		private readonly array $deprecationNoticeList = [],
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Alerts/LastOptimizationRunMaintenanceAlertTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Alerts/LastOptimizationRunMaintenanceAlertTaskHandler.php
@@ -23,17 +23,11 @@ class LastOptimizationRunMaintenanceAlertTaskHandler extends TaskHandler {
 	const DAYS_THRESHOLD = 90; // 3 Month;
 
 	/**
-	 * @var SetupFile
-	 */
-	private $setupFile;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param SetupFile $setupFile
 	 */
-	public function __construct( SetupFile $setupFile ) {
-		$this->setupFile = $setupFile;
+	public function __construct(
+		private readonly SetupFile $setupFile,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Alerts/MaintenanceAlertsTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Alerts/MaintenanceAlertsTaskHandler.php
@@ -14,17 +14,11 @@ use SMW\MediaWiki\Specials\Admin\TaskHandler;
 class MaintenanceAlertsTaskHandler extends TaskHandler {
 
 	/**
-	 * @var TaskHandler[]
-	 */
-	private $taskHandlers = [];
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param TaskHandler[] $taskHandlers
 	 */
-	public function __construct( array $taskHandlers = [] ) {
-		$this->taskHandlers = $taskHandlers;
+	public function __construct(
+		private readonly array $taskHandlers = [],
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Alerts/OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Alerts/OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandler.php
@@ -23,17 +23,11 @@ class OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandler extends TaskH
 	const MAXCOUNT_THRESHOLD = 20000;
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/AlertsTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/AlertsTaskHandler.php
@@ -15,24 +15,12 @@ use SMW\Utils\HtmlTabs;
 class AlertsTaskHandler extends TaskHandler {
 
 	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
-	 * @var TaskHandler[]
-	 */
-	private $taskHandlers = [];
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param OutputFormatter $outputFormatter
-	 * @param TaskHandler[] $taskHandlers
 	 */
-	public function __construct( OutputFormatter $outputFormatter, array $taskHandlers = [] ) {
-		$this->outputFormatter = $outputFormatter;
-		$this->taskHandlers = $taskHandlers;
+	public function __construct(
+		private readonly OutputFormatter $outputFormatter,
+		private readonly array $taskHandlers = [],
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Maintenance/DataRefreshJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/DataRefreshJobTaskHandler.php
@@ -21,29 +21,17 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 class DataRefreshJobTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
-	 * @var HtmlFormRenderer
-	 */
-	private $htmlFormRenderer;
-
-	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
 	 * @var null|Job
 	 */
 	private $refreshjob = null;
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param HtmlFormRenderer $htmlFormRenderer
-	 * @param OutputFormatter $outputFormatter
 	 */
-	public function __construct( HtmlFormRenderer $htmlFormRenderer, OutputFormatter $outputFormatter ) {
-		$this->htmlFormRenderer = $htmlFormRenderer;
-		$this->outputFormatter = $outputFormatter;
+	public function __construct(
+		private readonly HtmlFormRenderer $htmlFormRenderer,
+		private readonly OutputFormatter $outputFormatter,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Maintenance/DisposeJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/DisposeJobTaskHandler.php
@@ -22,16 +22,6 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 class DisposeJobTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
-	 * @var HtmlFormRenderer
-	 */
-	private $htmlFormRenderer;
-
-	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
 	 * @var null|Job
 	 */
 	private $refreshjob = null;
@@ -43,13 +33,11 @@ class DisposeJobTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param HtmlFormRenderer $htmlFormRenderer
-	 * @param OutputFormatter $outputFormatter
 	 */
-	public function __construct( HtmlFormRenderer $htmlFormRenderer, OutputFormatter $outputFormatter ) {
-		$this->htmlFormRenderer = $htmlFormRenderer;
-		$this->outputFormatter = $outputFormatter;
+	public function __construct(
+		private readonly HtmlFormRenderer $htmlFormRenderer,
+		private readonly OutputFormatter $outputFormatter,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Maintenance/FulltextSearchTableRebuildJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/FulltextSearchTableRebuildJobTaskHandler.php
@@ -22,29 +22,17 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 class FulltextSearchTableRebuildJobTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
-	 * @var HtmlFormRenderer
-	 */
-	private $htmlFormRenderer;
-
-	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
 	 * @var bool
 	 */
 	public $isApiTask = true;
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param HtmlFormRenderer $htmlFormRenderer
-	 * @param OutputFormatter $outputFormatter
 	 */
-	public function __construct( HtmlFormRenderer $htmlFormRenderer, OutputFormatter $outputFormatter ) {
-		$this->htmlFormRenderer = $htmlFormRenderer;
-		$this->outputFormatter = $outputFormatter;
+	public function __construct(
+		private readonly HtmlFormRenderer $htmlFormRenderer,
+		private readonly OutputFormatter $outputFormatter,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Maintenance/PropertyStatsRebuildJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/PropertyStatsRebuildJobTaskHandler.php
@@ -22,29 +22,17 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 class PropertyStatsRebuildJobTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
-	 * @var HtmlFormRenderer
-	 */
-	private $htmlFormRenderer;
-
-	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
 	 * @var bool
 	 */
 	public $isApiTask = true;
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param HtmlFormRenderer $htmlFormRenderer
-	 * @param OutputFormatter $outputFormatter
 	 */
-	public function __construct( HtmlFormRenderer $htmlFormRenderer, OutputFormatter $outputFormatter ) {
-		$this->htmlFormRenderer = $htmlFormRenderer;
-		$this->outputFormatter = $outputFormatter;
+	public function __construct(
+		private readonly HtmlFormRenderer $htmlFormRenderer,
+		private readonly OutputFormatter $outputFormatter,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Maintenance/TableSchemaTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/TableSchemaTaskHandler.php
@@ -20,31 +20,13 @@ use SMW\Store;
 class TableSchemaTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var HtmlFormRenderer
-	 */
-	private $htmlFormRenderer;
-
-	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
 	 * @since 2.5
-	 *
-	 * @param Store $store
-	 * @param HtmlFormRenderer $htmlFormRenderer
-	 * @param OutputFormatter $outputFormatter
 	 */
-	public function __construct( Store $store, HtmlFormRenderer $htmlFormRenderer, OutputFormatter $outputFormatter ) {
-		$this->store = $store;
-		$this->htmlFormRenderer = $htmlFormRenderer;
-		$this->outputFormatter = $outputFormatter;
+	public function __construct(
+		private readonly Store $store,
+		private readonly HtmlFormRenderer $htmlFormRenderer,
+		private readonly OutputFormatter $outputFormatter,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/MaintenanceTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/MaintenanceTaskHandler.php
@@ -18,31 +18,13 @@ use SMW\Utils\HtmlTabs;
 class MaintenanceTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
-	 * @var FileFetcher
-	 */
-	private $fileFetcher;
-
-	/**
-	 * @var TaskHandler[]
-	 */
-	private $taskHandlers = [];
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param OutputFormatter $outputFormatter
-	 * @param FileFetcher $fileFetcher
-	 * @param TaskHandler[] $taskHandlers
 	 */
-	public function __construct( OutputFormatter $outputFormatter, FileFetcher $fileFetcher, array $taskHandlers = [] ) {
-		$this->outputFormatter = $outputFormatter;
-		$this->fileFetcher = $fileFetcher;
-		$this->taskHandlers = $taskHandlers;
+	public function __construct(
+		private readonly OutputFormatter $outputFormatter,
+		private readonly FileFetcher $fileFetcher,
+		private readonly array $taskHandlers = [],
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/OutputFormatter.php
+++ b/src/MediaWiki/Specials/Admin/OutputFormatter.php
@@ -18,17 +18,11 @@ use SMW\Localizer\Message;
 class OutputFormatter {
 
 	/**
-	 * @var OutputPage
-	 */
-	private $outputPage;
-
-	/**
 	 * @since 2.5
-	 *
-	 * @param OutputPage $outputPage
 	 */
-	public function __construct( OutputPage $outputPage ) {
-		$this->outputPage = $outputPage;
+	public function __construct(
+		private readonly OutputPage $outputPage,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Supplement/CacheStatisticsListTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/CacheStatisticsListTaskHandler.php
@@ -21,17 +21,11 @@ use SMW\Utils\JsonView;
 class CacheStatisticsListTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param OutputFormatter $outputFormatter
 	 */
-	public function __construct( OutputFormatter $outputFormatter ) {
-		$this->outputFormatter = $outputFormatter;
+	public function __construct(
+		private readonly OutputFormatter $outputFormatter,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Supplement/ConfigurationListTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/ConfigurationListTaskHandler.php
@@ -22,17 +22,11 @@ use SMW\Utils\JsonView;
 class ConfigurationListTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
 	 * @since 2.5
-	 *
-	 * @param OutputFormatter $outputFormatter
 	 */
-	public function __construct( OutputFormatter $outputFormatter ) {
-		$this->outputFormatter = $outputFormatter;
+	public function __construct(
+		private readonly OutputFormatter $outputFormatter,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Supplement/DuplicateLookupTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/DuplicateLookupTaskHandler.php
@@ -18,17 +18,11 @@ use SMW\MediaWiki\Specials\Admin\TaskHandler;
 class DuplicateLookupTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param OutputFormatter $outputFormatter
 	 */
-	public function __construct( OutputFormatter $outputFormatter ) {
-		$this->outputFormatter = $outputFormatter;
+	public function __construct(
+		private readonly OutputFormatter $outputFormatter,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
@@ -23,36 +23,18 @@ use SMW\Store;
 class EntityLookupTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var HtmlFormRenderer
-	 */
-	private $htmlFormRenderer;
-
-	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
 	 * @var User|null
 	 */
 	private $user;
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Store $store
-	 * @param HtmlFormRenderer $htmlFormRenderer
-	 * @param OutputFormatter $outputFormatter
 	 */
-	public function __construct( Store $store, HtmlFormRenderer $htmlFormRenderer, OutputFormatter $outputFormatter ) {
-		$this->store = $store;
-		$this->htmlFormRenderer = $htmlFormRenderer;
-		$this->outputFormatter = $outputFormatter;
+	public function __construct(
+		private readonly Store $store,
+		private readonly HtmlFormRenderer $htmlFormRenderer,
+		private readonly OutputFormatter $outputFormatter,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Supplement/OperationalStatisticsListTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/OperationalStatisticsListTaskHandler.php
@@ -19,24 +19,12 @@ use SMW\Utils\HtmlTabs;
 class OperationalStatisticsListTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
-	 * @var TaskHandler[]
-	 */
-	private $taskHandlers = [];
-
-	/**
 	 * @since 2.5
-	 *
-	 * @param OutputFormatter $outputFormatter
-	 * @param TaskHandler[] $taskHandlers
 	 */
-	public function __construct( OutputFormatter $outputFormatter, array $taskHandlers = [] ) {
-		$this->outputFormatter = $outputFormatter;
-		$this->taskHandlers = $taskHandlers;
+	public function __construct(
+		private readonly OutputFormatter $outputFormatter,
+		private readonly array $taskHandlers = [],
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/Supplement/TableStatisticsTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/TableStatisticsTaskHandler.php
@@ -22,24 +22,12 @@ use SMW\Utils\HtmlTabs;
 class TableStatisticsTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
-	 * @var EntityCache
-	 */
-	private $entityCache;
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param OutputFormatter $outputFormatter
-	 * @param EntityCache $entityCache
 	 */
-	public function __construct( OutputFormatter $outputFormatter, EntityCache $entityCache ) {
-		$this->outputFormatter = $outputFormatter;
-		$this->entityCache = $entityCache;
+	public function __construct(
+		private readonly OutputFormatter $outputFormatter,
+		private readonly EntityCache $entityCache,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/SupplementTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/SupplementTaskHandler.php
@@ -15,24 +15,12 @@ use SMW\Localizer\Message;
 class SupplementTaskHandler extends TaskHandler implements ActionableTask {
 
 	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
-	 * @var TaskHandler[]
-	 */
-	private $taskHandlers = [];
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param OutputFormatter $outputFormatter
-	 * @param TaskHandler[] $taskHandlers
 	 */
-	public function __construct( OutputFormatter $outputFormatter, array $taskHandlers = [] ) {
-		$this->outputFormatter = $outputFormatter;
-		$this->taskHandlers = $taskHandlers;
+	public function __construct(
+		private readonly OutputFormatter $outputFormatter,
+		private readonly array $taskHandlers = [],
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/SupportListTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/SupportListTaskHandler.php
@@ -14,17 +14,11 @@ use SMW\MediaWiki\Renderer\HtmlFormRenderer;
 class SupportListTaskHandler extends TaskHandler {
 
 	/**
-	 * @var HtmlFormRenderer
-	 */
-	private $htmlFormRenderer;
-
-	/**
 	 * @since 2.5
-	 *
-	 * @param HtmlFormRenderer $htmlFormRenderer
 	 */
-	public function __construct( HtmlFormRenderer $htmlFormRenderer ) {
-		$this->htmlFormRenderer = $htmlFormRenderer;
+	public function __construct(
+		private readonly HtmlFormRenderer $htmlFormRenderer,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/TaskHandlerFactory.php
+++ b/src/MediaWiki/Specials/Admin/TaskHandlerFactory.php
@@ -37,31 +37,13 @@ class TaskHandlerFactory {
 	use HookDispatcherAwareTrait;
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var HtmlFormRenderer
-	 */
-	private $htmlFormRenderer;
-
-	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
 	 * @since 2.5
-	 *
-	 * @param Store $store
-	 * @param HtmlFormRenderer $htmlFormRenderer
-	 * @param OutputFormatter $outputFormatter
 	 */
-	public function __construct( Store $store, HtmlFormRenderer $htmlFormRenderer, OutputFormatter $outputFormatter ) {
-		$this->store = $store;
-		$this->htmlFormRenderer = $htmlFormRenderer;
-		$this->outputFormatter = $outputFormatter;
+	public function __construct(
+		private readonly Store $store,
+		private readonly HtmlFormRenderer $htmlFormRenderer,
+		private readonly OutputFormatter $outputFormatter,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Admin/TaskHandlerRegistry.php
+++ b/src/MediaWiki/Specials/Admin/TaskHandlerRegistry.php
@@ -17,16 +17,6 @@ class TaskHandlerRegistry {
 	use HookDispatcherAwareTrait;
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var OutputFormatter
-	 */
-	private $outputFormatter;
-
-	/**
 	 * @var
 	 */
 	private $taskHandlers = [];
@@ -43,13 +33,11 @@ class TaskHandlerRegistry {
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param Store $store
-	 * @param OutputFormatter $outputFormatter
 	 */
-	public function __construct( Store $store, OutputFormatter $outputFormatter ) {
-		$this->store = $store;
-		$this->outputFormatter = $outputFormatter;
+	public function __construct(
+		private readonly Store $store,
+		private readonly OutputFormatter $outputFormatter,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Ask/HtmlForm.php
+++ b/src/MediaWiki/Specials/Ask/HtmlForm.php
@@ -19,11 +19,6 @@ use SMWQuery as Query;
 class HtmlForm {
 
 	/**
-	 * @var Title
-	 */
-	private $title;
-
-	/**
 	 * @var array
 	 */
 	private $parameters = [];
@@ -60,11 +55,10 @@ class HtmlForm {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Title $title
 	 */
-	public function __construct( Title $title ) {
-		$this->title = $title;
+	public function __construct(
+		private readonly Title $title,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Ask/ParameterInput.php
+++ b/src/MediaWiki/Specials/Ask/ParameterInput.php
@@ -23,26 +23,6 @@ use ParamProcessor\ParamDefinition;
 class ParameterInput {
 
 	/**
-	 * The parameter to print an input for.
-	 *
-	 * @since 1.9
-	 *
-	 * @var ParamDefinition
-	 */
-	protected $param;
-
-	/**
-	 * The current value for the parameter. When provided,
-	 * it'll be used as value for the input, otherwise the
-	 * parameters default value will be used.
-	 *
-	 * @since 1.9
-	 *
-	 * @var mixed string or false
-	 */
-	protected $currentValue;
-
-	/**
 	 * Name for the input.
 	 *
 	 * @since 1.9
@@ -60,14 +40,12 @@ class ParameterInput {
 	 * Constructor.
 	 *
 	 * @since 1.9
-	 *
-	 * @param ParamDefinition $param
-	 * @param mixed $currentValue
 	 */
-	public function __construct( ParamDefinition $param, $currentValue = false ) {
-		$this->currentValue = $currentValue;
+	public function __construct(
+		protected readonly ParamDefinition $param,
+		protected $currentValue = false,
+	) {
 		$this->inputName = $param->getName();
-		$this->param = $param;
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Browse/GroupFormatter.php
+++ b/src/MediaWiki/Specials/Browse/GroupFormatter.php
@@ -30,16 +30,6 @@ class GroupFormatter {
 	const MESSAGE_GROUP_DESCRIPTION = 'smw-property-group-description-';
 
 	/**
-	 * @var SpecificationLookup
-	 */
-	private $propertySpecificationLookup;
-
-	/**
-	 * @var SchemaFinder
-	 */
-	private $schemaFinder;
-
-	/**
 	 * @var bool
 	 */
 	private $showGroup = true;
@@ -56,12 +46,11 @@ class GroupFormatter {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param SpecificationLookup $propertySpecificationLookup
 	 */
-	public function __construct( SpecificationLookup $propertySpecificationLookup, SchemaFinder $schemaFinder ) {
-		$this->propertySpecificationLookup = $propertySpecificationLookup;
-		$this->schemaFinder = $schemaFinder;
+	public function __construct(
+		private readonly SpecificationLookup $propertySpecificationLookup,
+		private readonly SchemaFinder $schemaFinder,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/Browse/HtmlBuilder.php
+++ b/src/MediaWiki/Specials/Browse/HtmlBuilder.php
@@ -26,16 +26,6 @@ use SMWDataValue;
 class HtmlBuilder {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
-	 * @var DIWikiPage
-	 */
-	private $subject;
-
-	/**
 	 * @var bool
 	 */
 	private $showoutgoing = true;
@@ -96,13 +86,11 @@ class HtmlBuilder {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Store $store
-	 * @param DIWikiPage $subject
 	 */
-	public function __construct( Store $store, DIWikiPage $subject ) {
-		$this->store = $store;
-		$this->subject = $subject;
+	public function __construct(
+		private readonly Store $store,
+		private readonly DIWikiPage $subject,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/ExploreListBuilder.php
+++ b/src/MediaWiki/Specials/FacetedSearch/ExploreListBuilder.php
@@ -19,17 +19,11 @@ class ExploreListBuilder {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var Profile
-	 */
-	private $profile;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param Profile $profile
 	 */
-	public function __construct( Profile $profile ) {
-		$this->profile = $profile;
+	public function __construct(
+		private readonly Profile $profile,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/ExtraFieldBuilder.php
+++ b/src/MediaWiki/Specials/FacetedSearch/ExtraFieldBuilder.php
@@ -17,24 +17,12 @@ class ExtraFieldBuilder {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var Profile
-	 */
-	private $profile;
-
-	/**
-	 * @var TemplateParser
-	 */
-	private $templateParser;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param Profile $profile
-	 * @param TemplateParser $templateParser
 	 */
-	public function __construct( Profile $profile, TemplateParser $templateParser ) {
-		$this->profile = $profile;
-		$this->templateParser = $templateParser;
+	public function __construct(
+		private readonly Profile $profile,
+		private readonly TemplateParser $templateParser,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/FacetBuilder.php
+++ b/src/MediaWiki/Specials/FacetedSearch/FacetBuilder.php
@@ -18,38 +18,14 @@ class FacetBuilder {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var FilterFactory
-	 */
-	private $filterFactory;
-
-	/**
-	 * @var TemplateParser
-	 */
-	private $templateParser;
-
-	/**
-	 * @var ResultFetcher
-	 */
-	private $resultFetcher;
-
-	/**
-	 * @var Profile
-	 */
-	private $profile;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param Profile $profile
-	 * @param TemplateParser $templateParser
-	 * @param FilterFactory $filterFactory
-	 * @param ResultFetcher $resultFetcher
 	 */
-	public function __construct( Profile $profile, TemplateParser $templateParser, FilterFactory $filterFactory, ResultFetcher $resultFetcher ) {
-		$this->profile = $profile;
-		$this->templateParser = $templateParser;
-		$this->filterFactory = $filterFactory;
-		$this->resultFetcher = $resultFetcher;
+	public function __construct(
+		private readonly Profile $profile,
+		private readonly TemplateParser $templateParser,
+		private readonly FilterFactory $filterFactory,
+		private readonly ResultFetcher $resultFetcher,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/FilterFactory.php
+++ b/src/MediaWiki/Specials/FacetedSearch/FilterFactory.php
@@ -18,31 +18,13 @@ use SMW\Schema\SchemaFactory;
 class FilterFactory {
 
 	/**
-	 * @var TemplateParser
-	 */
-	private $templateParser;
-
-	/**
-	 * @var TreeBuilder
-	 */
-	private $treeBuilder;
-
-	/**
-	 * @var SchemaFactory
-	 */
-	private $schemaFactory;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param TemplateParser $templateParser
-	 * @param TreeBuilder $treeBuilder
-	 * @param SchemaFactory $schemaFactory
 	 */
-	public function __construct( TemplateParser $templateParser, TreeBuilder $treeBuilder, SchemaFactory $schemaFactory ) {
-		$this->templateParser = $templateParser;
-		$this->treeBuilder = $treeBuilder;
-		$this->schemaFactory = $schemaFactory;
+	public function __construct(
+		private readonly TemplateParser $templateParser,
+		private readonly TreeBuilder $treeBuilder,
+		private readonly SchemaFactory $schemaFactory,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/Filters/CategoryFilter.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Filters/CategoryFilter.php
@@ -19,31 +19,13 @@ class CategoryFilter {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var TemplateParser
-	 */
-	private $templateParser;
-
-	/**
-	 * @var TreeBuilder
-	 */
-	private $treeBuilder;
-
-	/**
-	 * @var
-	 */
-	private $params;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param TemplateParser $templateParser
-	 * @param TreeBuilder $treeBuilder
-	 * @param array $params
 	 */
-	public function __construct( TemplateParser $templateParser, TreeBuilder $treeBuilder, array $params ) {
-		$this->templateParser = $templateParser;
-		$this->treeBuilder = $treeBuilder;
-		$this->params = $params;
+	public function __construct(
+		private readonly TemplateParser $templateParser,
+		private readonly TreeBuilder $treeBuilder,
+		private array $params,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/Filters/PropertyFilter.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Filters/PropertyFilter.php
@@ -20,36 +20,18 @@ class PropertyFilter {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var TemplateParser
-	 */
-	private $templateParser;
-
-	/**
-	 * @var TreeBuilder
-	 */
-	private $treeBuilder;
-
-	/**
-	 * @var
-	 */
-	private $params;
-
-	/**
 	 * @var UrlArgs
 	 */
 	private $urlArgs;
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param TemplateParser $templateParser
-	 * @param TreeBuilder $treeBuilder
-	 * @param array $params
 	 */
-	public function __construct( TemplateParser $templateParser, TreeBuilder $treeBuilder, array $params ) {
-		$this->templateParser = $templateParser;
-		$this->treeBuilder = $treeBuilder;
-		$this->params = $params;
+	public function __construct(
+		private readonly TemplateParser $templateParser,
+		private readonly TreeBuilder $treeBuilder,
+		private array $params,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilter.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilter.php
@@ -22,43 +22,19 @@ class ValueFilter {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var TemplateParser
-	 */
-	private $templateParser;
-
-	/**
-	 * @var ValueFilterFactory
-	 */
-	private $valueFilterFactory;
-
-	/**
-	 * @var SchemaFinder
-	 */
-	private $schemaFinder;
-
-	/**
 	 * @var UrlArgs
 	 */
 	private $urlArgs;
 
 	/**
-	 * @var
-	 */
-	private $params;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param TemplateParser $templateParser
-	 * @param ValueFilterFactory $valueFilterFactory
-	 * @param SchemaFinder $schemaFinder
-	 * @param array $params
 	 */
-	public function __construct( TemplateParser $templateParser, ValueFilterFactory $valueFilterFactory, SchemaFinder $schemaFinder, array $params ) {
-		$this->templateParser = $templateParser;
-		$this->valueFilterFactory = $valueFilterFactory;
-		$this->schemaFinder = $schemaFinder;
-		$this->params = $params;
+	public function __construct(
+		private readonly TemplateParser $templateParser,
+		private readonly ValueFilterFactory $valueFilterFactory,
+		private readonly SchemaFinder $schemaFinder,
+		private array $params,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilterFactory.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilterFactory.php
@@ -18,17 +18,11 @@ use SMW\Schema\CompartmentIterator;
 class ValueFilterFactory {
 
 	/**
-	 * @var TemplateParser
-	 */
-	private $templateParser;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param TemplateParser $templateParser
 	 */
-	public function __construct( TemplateParser $templateParser ) {
-		$this->templateParser = $templateParser;
+	public function __construct(
+		private readonly TemplateParser $templateParser,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/CheckboxRangeGroupValueFilter.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/CheckboxRangeGroupValueFilter.php
@@ -22,36 +22,18 @@ class CheckboxRangeGroupValueFilter {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var TemplateParser
-	 */
-	private $templateParser;
-
-	/**
-	 * @var CompartmentIterator
-	 */
-	private $compartmentIterator;
-
-	/**
 	 * @var UrlArgs
 	 */
 	private $urlArgs;
 
 	/**
-	 * @var
-	 */
-	private $params;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param TemplateParser $templateParser
-	 * @param CompartmentIterator $compartmentIterator
-	 * @param array $params
 	 */
-	public function __construct( TemplateParser $templateParser, CompartmentIterator $compartmentIterator, array $params ) {
-		$this->templateParser = $templateParser;
-		$this->compartmentIterator = $compartmentIterator;
-		$this->params = $params;
+	public function __construct(
+		private readonly TemplateParser $templateParser,
+		private readonly CompartmentIterator $compartmentIterator,
+		private array $params,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/CheckboxValueFilter.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/CheckboxValueFilter.php
@@ -20,29 +20,17 @@ class CheckboxValueFilter {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var TemplateParser
-	 */
-	private $templateParser;
-
-	/**
 	 * @var UrlArgs
 	 */
 	private $urlArgs;
 
 	/**
-	 * @var
-	 */
-	private $params;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param TemplateParser $templateParser
-	 * @param array $params
 	 */
-	public function __construct( TemplateParser $templateParser, array $params ) {
-		$this->templateParser = $templateParser;
-		$this->params = $params;
+	public function __construct(
+		private readonly TemplateParser $templateParser,
+		private array $params,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/ListValueFilter.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/ListValueFilter.php
@@ -20,29 +20,17 @@ class ListValueFilter {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var TemplateParser
-	 */
-	private $templateParser;
-
-	/**
 	 * @var UrlArgs
 	 */
 	private $urlArgs;
 
 	/**
-	 * @var
-	 */
-	private $params;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param TemplateParser $templateParser
-	 * @param array $params
 	 */
-	public function __construct( TemplateParser $templateParser, array $params ) {
-		$this->templateParser = $templateParser;
-		$this->params = $params;
+	public function __construct(
+		private readonly TemplateParser $templateParser,
+		private array $params,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/RangeValueFilter.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/RangeValueFilter.php
@@ -19,36 +19,18 @@ class RangeValueFilter {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var TemplateParser
-	 */
-	private $templateParser;
-
-	/**
-	 * @var CompartmentIterator
-	 */
-	private $compartmentIterator;
-
-	/**
 	 * @var UrlArgs
 	 */
 	private $urlArgs;
 
 	/**
-	 * @var
-	 */
-	private $params;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param TemplateParser $templateParser
-	 * @param CompartmentIterator $compartmentIterator
-	 * @param array $params
 	 */
-	public function __construct( TemplateParser $templateParser, CompartmentIterator $compartmentIterator, array $params ) {
-		$this->templateParser = $templateParser;
-		$this->compartmentIterator = $compartmentIterator;
-		$this->params = $params;
+	public function __construct(
+		private readonly TemplateParser $templateParser,
+		private readonly CompartmentIterator $compartmentIterator,
+		private readonly array $params,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/HtmlBuilder.php
+++ b/src/MediaWiki/Specials/FacetedSearch/HtmlBuilder.php
@@ -19,59 +19,17 @@ class HtmlBuilder {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var Profile
-	 */
-	private $profile;
-
-	/**
-	 * @var TemplateParser
-	 */
-	private $templateParser;
-
-	/**
-	 * @var OptionsBuilder
-	 */
-	private $optionsBuilder;
-
-	/**
-	 * @var ExtraFieldBuilder
-	 */
-	private $extraFieldBuilder;
-
-	/**
-	 * @var FacetBuilder
-	 */
-	private $facetBuilder;
-
-	/**
-	 * @var ResultFetcher
-	 */
-	private $resultFetcher;
-
-	/**
-	 * @var ExploreListBuilder
-	 */
-	private $exploreListBuilder;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param Profile $profile
-	 * @param TemplateParser $templateParser
-	 * @param OptionsBuilder $optionsBuilder
-	 * @param ExtraFieldBuilder $extraFieldBuilder
-	 * @param FacetBuilder $facetBuilder
-	 * @param ResultFetcher $resultFetcher
-	 * @param ExploreListBuilder $exploreListBuilder
 	 */
-	public function __construct( Profile $profile, TemplateParser $templateParser, OptionsBuilder $optionsBuilder, ExtraFieldBuilder $extraFieldBuilder, FacetBuilder $facetBuilder, ResultFetcher $resultFetcher, ExploreListBuilder $exploreListBuilder ) {
-		$this->profile = $profile;
-		$this->templateParser = $templateParser;
-		$this->optionsBuilder = $optionsBuilder;
-		$this->extraFieldBuilder = $extraFieldBuilder;
-		$this->facetBuilder = $facetBuilder;
-		$this->resultFetcher = $resultFetcher;
-		$this->exploreListBuilder = $exploreListBuilder;
+	public function __construct(
+		private readonly Profile $profile,
+		private readonly TemplateParser $templateParser,
+		private readonly OptionsBuilder $optionsBuilder,
+		private readonly ExtraFieldBuilder $extraFieldBuilder,
+		private readonly FacetBuilder $facetBuilder,
+		private readonly ResultFetcher $resultFetcher,
+		private readonly ExploreListBuilder $exploreListBuilder,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/OptionsBuilder.php
+++ b/src/MediaWiki/Specials/FacetedSearch/OptionsBuilder.php
@@ -16,17 +16,11 @@ class OptionsBuilder {
 	use MessageLocalizerTrait;
 
 	/**
-	 * @var Profile
-	 */
-	private $profile;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param Profile $profile
 	 */
-	public function __construct( Profile $profile ) {
-		$this->profile = $profile;
+	public function __construct(
+		private readonly Profile $profile,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/ParametersProcessor.php
+++ b/src/MediaWiki/Specials/FacetedSearch/ParametersProcessor.php
@@ -30,11 +30,6 @@ class ParametersProcessor {
 	// RequestParameters
 
 	/**
-	 * @var Profile
-	 */
-	private $profile;
-
-	/**
 	 * @var string
 	 */
 	private $queryString = '';
@@ -66,11 +61,10 @@ class ParametersProcessor {
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param Profile $profile
 	 */
-	public function __construct( Profile $profile ) {
-		$this->profile = $profile;
+	public function __construct(
+		private readonly Profile $profile,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/Profile.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Profile.php
@@ -22,11 +22,6 @@ class Profile {
 	const SCHEMA_TYPE = 'FACETEDSEARCH_PROFILE_SCHEMA';
 
 	/**
-	 * @var SchemaFactory
-	 */
-	private $schemaFactory;
-
-	/**
 	 * @var Compartment
 	 */
 	private $profile;
@@ -48,12 +43,11 @@ class Profile {
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param SchemaFactory $schemaFactory
-	 * @param string $profileName
 	 */
-	public function __construct( SchemaFactory $schemaFactory, string $profileName = '' ) {
-		$this->schemaFactory = $schemaFactory;
+	public function __construct(
+		private readonly SchemaFactory $schemaFactory,
+		string $profileName = '',
+	) {
 		$this->profileName = str_replace( '_profile', '', $profileName );
 	}
 

--- a/src/MediaWiki/Specials/FacetedSearch/ResultFetcher.php
+++ b/src/MediaWiki/Specials/FacetedSearch/ResultFetcher.php
@@ -21,11 +21,6 @@ use SMWQueryProcessor as QueryProcessor;
 class ResultFetcher {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var int
 	 */
 	private $totalCount = 0;
@@ -87,11 +82,10 @@ class ResultFetcher {
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/FacetedSearch/TreeBuilder.php
+++ b/src/MediaWiki/Specials/FacetedSearch/TreeBuilder.php
@@ -26,22 +26,16 @@ class TreeBuilder {
 	const TYPE_CATEGORY = 'type/category';
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @var
 	 */
 	private $nodes;
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/PageProperty/PageBuilder.php
+++ b/src/MediaWiki/Specials/PageProperty/PageBuilder.php
@@ -19,29 +19,17 @@ use SMWInfolink as Infolink;
 class PageBuilder {
 
 	/**
-	 * @var HtmlFormRenderer
-	 */
-	private $htmlFormRenderer;
-
-	/**
-	 * @var Options
-	 */
-	private $options;
-
-	/**
 	 * @var Linker
 	 */
 	private $linker;
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param HtmlFormRenderer $htmlFormRenderer
-	 * @param Options $options
 	 */
-	public function __construct( HtmlFormRenderer $htmlFormRenderer, Options $options ) {
-		$this->htmlFormRenderer = $htmlFormRenderer;
-		$this->options = $options;
+	public function __construct(
+		private readonly HtmlFormRenderer $htmlFormRenderer,
+		private readonly Options $options,
+	) {
 		$this->linker = smwfGetLinker();
 	}
 

--- a/src/MediaWiki/Specials/PendingTasks/IncompleteSetupTasks.php
+++ b/src/MediaWiki/Specials/PendingTasks/IncompleteSetupTasks.php
@@ -15,18 +15,11 @@ use SMW\SetupFile;
 class IncompleteSetupTasks {
 
 	/**
-	 * @var SetupFile
-	 */
-	private $setupFile;
-
-	/**
 	 * @since 3.2
-	 *
-	 * @param SetupFile|null $setupFile
 	 */
-	public function __construct( ?SetupFile $setupFile = null ) {
-		$this->setupFile = $setupFile;
-
+	public function __construct(
+		private ?SetupFile $setupFile = null,
+	) {
 		if ( $this->setupFile === null ) {
 			$this->setupFile = new SetupFile();
 		}

--- a/src/MediaWiki/Specials/PropertyLabelSimilarity/ContentsBuilder.php
+++ b/src/MediaWiki/Specials/PropertyLabelSimilarity/ContentsBuilder.php
@@ -17,24 +17,12 @@ use SMW\SQLStore\Lookup\PropertyLabelSimilarityLookup;
 class ContentsBuilder {
 
 	/**
-	 * @var PropertyLabelSimilarityLookup
-	 */
-	private $propertyLabelSimilarityLookup;
-
-	/**
-	 * @var HtmlFormRenderer
-	 */
-	private $htmlFormRenderer;
-
-	/**
 	 * @since 2.5
-	 *
-	 * @param PropertyLabelSimilarityLookup $propertyLabelSimilarityLookup
-	 * @param HtmlFormRenderer $htmlFormRenderer
 	 */
-	public function __construct( PropertyLabelSimilarityLookup $propertyLabelSimilarityLookup, HtmlFormRenderer $htmlFormRenderer ) {
-		$this->propertyLabelSimilarityLookup = $propertyLabelSimilarityLookup;
-		$this->htmlFormRenderer = $htmlFormRenderer;
+	public function __construct(
+		private readonly PropertyLabelSimilarityLookup $propertyLabelSimilarityLookup,
+		private readonly HtmlFormRenderer $htmlFormRenderer,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Specials/SearchByProperty/PageBuilder.php
+++ b/src/MediaWiki/Specials/SearchByProperty/PageBuilder.php
@@ -28,21 +28,6 @@ use SMWInfolink as Infolink;
 class PageBuilder {
 
 	/**
-	 * @var HtmlFormRenderer
-	 */
-	private $htmlFormRenderer;
-
-	/**
-	 * @var PageRequestOptions
-	 */
-	private $pageRequestOptions;
-
-	/**
-	 * @var QueryResultLookup
-	 */
-	private $queryResultLookup;
-
-	/**
 	 * @var MessageBuilder
 	 */
 	private $messageBuilder;
@@ -54,15 +39,12 @@ class PageBuilder {
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param HtmlFormRenderer $htmlFormRenderer
-	 * @param PageRequestOptions $pageRequestOptions
-	 * @param QueryResultLookup $queryResultLookup
 	 */
-	public function __construct( HtmlFormRenderer $htmlFormRenderer, PageRequestOptions $pageRequestOptions, QueryResultLookup $queryResultLookup ) {
-		$this->htmlFormRenderer = $htmlFormRenderer;
-		$this->pageRequestOptions = $pageRequestOptions;
-		$this->queryResultLookup = $queryResultLookup;
+	public function __construct(
+		private readonly HtmlFormRenderer $htmlFormRenderer,
+		private readonly PageRequestOptions $pageRequestOptions,
+		private readonly QueryResultLookup $queryResultLookup,
+	) {
 		$this->linker = smwfGetLinker();
 	}
 

--- a/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
+++ b/src/MediaWiki/Specials/SearchByProperty/PageRequestOptions.php
@@ -18,16 +18,6 @@ use SMWNumberValue as NumberValue;
 class PageRequestOptions {
 
 	/**
-	 * @var string
-	 */
-	private $queryString;
-
-	/**
-	 * @var array
-	 */
-	private $requestOptions;
-
-	/**
 	 * @var Encoder
 	 */
 	private $urlEncoder;
@@ -69,13 +59,11 @@ class PageRequestOptions {
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param string $queryString
-	 * @param array $requestOptions
 	 */
-	public function __construct( $queryString, array $requestOptions ) {
-		$this->queryString = $queryString;
-		$this->requestOptions = $requestOptions;
+	public function __construct(
+		private $queryString,
+		private array $requestOptions,
+	) {
 		$this->urlEncoder = new Encoder();
 	}
 

--- a/src/MediaWiki/Specials/SearchByProperty/QueryResultLookup.php
+++ b/src/MediaWiki/Specials/SearchByProperty/QueryResultLookup.php
@@ -29,15 +29,11 @@ use SMWQuery as Query;
 class QueryResultLookup {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 2.1
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct(
+		private readonly Store $store,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/StripMarkerDecoder.php
+++ b/src/MediaWiki/StripMarkerDecoder.php
@@ -14,22 +14,16 @@ use MediaWiki\Parser\StripState;
 class StripMarkerDecoder {
 
 	/**
-	 * @var StripState
-	 */
-	private $stripState;
-
-	/**
 	 * @var bool
 	 */
 	private $isSupported = false;
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param StripState $stripState
 	 */
-	public function __construct( StripState $stripState ) {
-		$this->stripState = $stripState;
+	public function __construct(
+		private readonly StripState $stripState,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Template/Template.php
+++ b/src/MediaWiki/Template/Template.php
@@ -11,22 +11,16 @@ namespace SMW\MediaWiki\Template;
 class Template {
 
 	/**
-	 * @var string
-	 */
-	private $name;
-
-	/**
 	 * @var
 	 */
 	private $fields = [];
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param string $name
 	 */
-	public function __construct( $name ) {
-		$this->name = $name;
+	public function __construct(
+		private $name,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Template/TemplateExpander.php
+++ b/src/MediaWiki/Template/TemplateExpander.php
@@ -25,22 +25,16 @@ class TemplateExpander {
 	const MAX_INCLUDE_SIZE = 50000000;
 
 	/**
-	 * @var Parser
-	 */
-	private $parser;
-
-	/**
 	 * @var Title
 	 */
 	private $title;
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param Parser $parser
 	 */
-	public function __construct( $parser ) {
-		$this->parser = $parser;
+	public function __construct(
+		private $parser,
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/Template/TemplateSet.php
+++ b/src/MediaWiki/Template/TemplateSet.php
@@ -11,17 +11,11 @@ namespace SMW\MediaWiki\Template;
 class TemplateSet {
 
 	/**
-	 * @var
-	 */
-	private $templates = [];
-
-	/**
 	 * @since 3.1
-	 *
-	 * @param array $templates
 	 */
-	public function __construct( array $templates = [] ) {
-		$this->templates = $templates;
+	public function __construct(
+		private array $templates = [],
+	) {
 	}
 
 	/**

--- a/src/MediaWiki/TitleLookup.php
+++ b/src/MediaWiki/TitleLookup.php
@@ -21,22 +21,16 @@ use SMW\MediaWiki\Connection\Database;
 class TitleLookup {
 
 	/**
-	 * @var Database
-	 */
-	private $connection = null;
-
-	/**
 	 * @var int
 	 */
 	private $namespace = null;
 
 	/**
 	 * @since 1.9.2
-	 *
-	 * @param Database $connection
 	 */
-	public function __construct( Database $connection ) {
-		$this->connection = $connection;
+	public function __construct(
+		private readonly Database $connection,
+	) {
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Apply PHP 8.1 constructor promotion to 145 files in `src/MediaWiki/`
- Add `readonly` to promoted properties that are never reassigned and have a type declaration
- Remove redundant property declarations, `@var` phpdoc, and constructor `@param` phpdoc
- Net reduction of ~1,477 lines

## Test plan

- [ ] PHPCS passes clean
- [ ] Unit tests pass
- [ ] Integration tests pass