### PR TITLE
refactor: constructor promotion + readonly for DataValues + SPARQLStore

### DIFF
--- a/src/DataValues/ConstraintSchemaValue.php
+++ b/src/DataValues/ConstraintSchemaValue.php
@@ -21,17 +21,11 @@ class ConstraintSchemaValue extends WikiPageValue {
 	 */
 	const TYPE_ID = '__cschema';
 
-	/**
-	 * @var SpecificationLookup
-	 */
-	private $specificationLookup;
-
-	/**
-	 * @param string $typeid
-	 */
-	public function __construct( $typeid, SpecificationLookup $specificationLookup ) {
+	public function __construct(
+		$typeid,
+		private readonly SpecificationLookup $specificationLookup,
+	) {
 		parent::__construct( self::TYPE_ID );
-		$this->specificationLookup = $specificationLookup;
 		$this->m_fixNamespace = SMW_NS_SCHEMA;
 	}
 

--- a/src/DataValues/ImportValue.php
+++ b/src/DataValues/ImportValue.php
@@ -78,7 +78,7 @@ class ImportValue extends DataValue {
 
 	private array $declarativeNames = [];
 
-	private MediaWikiNsContentReader $mediaWikiNsContentReader;
+	private readonly MediaWikiNsContentReader $mediaWikiNsContentReader;
 
 	/**
 	 * @param string $typeid

--- a/src/DataValues/InfoLinksProvider.php
+++ b/src/DataValues/InfoLinksProvider.php
@@ -22,16 +22,6 @@ use SMWWikiPageValue as WikiPageValue;
 class InfoLinksProvider {
 
 	/**
-	 * @var DataValue
-	 */
-	private $dataValue;
-
-	/**
-	 * @var SpecificationLookup
-	 */
-	private $propertySpecificationLookup;
-
-	/**
 	 * @var Infolink[]
 	 */
 	protected $infoLinks = [];
@@ -72,13 +62,11 @@ class InfoLinksProvider {
 
 	/**
 	 * @since 2.4
-	 *
-	 * @param DataValue $dataValue
-	 * @param SpecificationLookup $propertySpecificationLookup
 	 */
-	public function __construct( DataValue $dataValue, SpecificationLookup $propertySpecificationLookup ) {
-		$this->dataValue = $dataValue;
-		$this->propertySpecificationLookup = $propertySpecificationLookup;
+	public function __construct(
+		private readonly DataValue $dataValue,
+		private readonly SpecificationLookup $propertySpecificationLookup,
+	) {
 	}
 
 	/**

--- a/src/DataValues/Number/IntlNumberFormatter.php
+++ b/src/DataValues/Number/IntlNumberFormatter.php
@@ -48,20 +48,12 @@ class IntlNumberFormatter {
 	/**
 	 * @var int
 	 */
-	private $maxNonExpNumber = null;
-
-	/**
-	 * @var int
-	 */
 	private $defaultPrecision = 3;
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param int $maxNonExpNumber
 	 */
-	public function __construct( $maxNonExpNumber ) {
-		$this->maxNonExpNumber = $maxNonExpNumber;
+	public function __construct( private $maxNonExpNumber ) {
 		$this->options = new Options();
 	}
 

--- a/src/DataValues/Number/UnitConverter.php
+++ b/src/DataValues/Number/UnitConverter.php
@@ -23,16 +23,6 @@ use SMWNumberValue as NumberValue;
 class UnitConverter {
 
 	/**
-	 * @var SpecificationLookup
-	 */
-	private $propertySpecificationLookup;
-
-	/**
-	 * @var EntityCache
-	 */
-	private $entityCache;
-
-	/**
 	 * @var array
 	 */
 	private $errors = [];
@@ -59,13 +49,11 @@ class UnitConverter {
 
 	/**
 	 * @since 2.4
-	 *
-	 * @param SpecificationLookup $propertySpecificationLookup
-	 * @param EntityCache $entityCache
 	 */
-	public function __construct( SpecificationLookup $propertySpecificationLookup, EntityCache $entityCache ) {
-		$this->propertySpecificationLookup = $propertySpecificationLookup;
-		$this->entityCache = $entityCache;
+	public function __construct(
+		private readonly SpecificationLookup $propertySpecificationLookup,
+		private readonly EntityCache $entityCache,
+	) {
 	}
 
 	/**

--- a/src/DataValues/Time/Components.php
+++ b/src/DataValues/Time/Components.php
@@ -49,17 +49,9 @@ class Components {
 	];
 
 	/**
-	 * @var
-	 */
-	private $components = [];
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param array $components
 	 */
-	public function __construct( array $components = [] ) {
-		$this->components = $components;
+	public function __construct( private array $components = [] ) {
 	}
 
 	/**

--- a/src/DataValues/Time/IntlTimeFormatter.php
+++ b/src/DataValues/Time/IntlTimeFormatter.php
@@ -19,30 +19,17 @@ class IntlTimeFormatter {
 	const LOCL_TIMEOFFSET = 0x4;
 
 	/**
-	 * @var DITime
-	 */
-	private $dataItem;
-
-	/**
-	 * @var Language
-	 */
-	private $language;
-
-	/**
 	 * @var bool
 	 */
 	private $hasLocalTimeCorrection = false;
 
 	/**
 	 * @since 2.4
-	 *
-	 * @param DITime $dataItem
-	 * @param Language|null $language
 	 */
-	public function __construct( DITime $dataItem, ?Language $language = null ) {
-		$this->dataItem = $dataItem;
-		$this->language = $language;
-
+	public function __construct(
+		private readonly DITime $dataItem,
+		private ?Language $language = null,
+	) {
 		if ( $this->language === null ) {
 			$this->language = Localizer::getInstance()->getContentLanguage();
 		}

--- a/src/DataValues/ValueFormatters/PropertyValueFormatter.php
+++ b/src/DataValues/ValueFormatters/PropertyValueFormatter.php
@@ -21,17 +21,9 @@ use SMWDataValue as DataValue;
 class PropertyValueFormatter extends DataValueFormatter {
 
 	/**
-	 * @var SpecificationLookup
-	 */
-	private $propertySpecificationLookup;
-
-	/**
 	 * @since 3.0
-	 *
-	 * @param SpecificationLookup $propertySpecificationLookup
 	 */
-	public function __construct( SpecificationLookup $propertySpecificationLookup ) {
-		$this->propertySpecificationLookup = $propertySpecificationLookup;
+	public function __construct( private readonly SpecificationLookup $propertySpecificationLookup ) {
 	}
 
 	/**

--- a/src/DataValues/ValueParsers/AllowsListValueParser.php
+++ b/src/DataValues/ValueParsers/AllowsListValueParser.php
@@ -16,11 +16,6 @@ use SMW\MediaWiki\MediaWikiNsContentReader;
 class AllowsListValueParser implements ValueParser {
 
 	/**
-	 * @var MediaWikiNsContentReader
-	 */
-	private $mediaWikiNsContentReader;
-
-	/**
 	 * @var array
 	 */
 	private $errors = [];
@@ -32,11 +27,8 @@ class AllowsListValueParser implements ValueParser {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param MediaWikiNsContentReader $mediaWikiNsContentReader
 	 */
-	public function __construct( MediaWikiNsContentReader $mediaWikiNsContentReader ) {
-		$this->mediaWikiNsContentReader = $mediaWikiNsContentReader;
+	public function __construct( private readonly MediaWikiNsContentReader $mediaWikiNsContentReader ) {
 	}
 
 	/**

--- a/src/DataValues/ValueParsers/AllowsPatternValueParser.php
+++ b/src/DataValues/ValueParsers/AllowsPatternValueParser.php
@@ -16,22 +16,14 @@ use SMW\MediaWiki\MediaWikiNsContentReader;
 class AllowsPatternValueParser implements ValueParser {
 
 	/**
-	 * @var MediaWikiNsContentReader
-	 */
-	private $mediaWikiNsContentReader;
-
-	/**
 	 * @var array
 	 */
 	private $errors = [];
 
 	/**
 	 * @since 2.4
-	 *
-	 * @param MediaWikiNsContentReader $mediaWikiNsContentReader
 	 */
-	public function __construct( MediaWikiNsContentReader $mediaWikiNsContentReader ) {
-		$this->mediaWikiNsContentReader = $mediaWikiNsContentReader;
+	public function __construct( private readonly MediaWikiNsContentReader $mediaWikiNsContentReader ) {
 	}
 
 	/**

--- a/src/DataValues/ValueParsers/ImportValueParser.php
+++ b/src/DataValues/ValueParsers/ImportValueParser.php
@@ -16,22 +16,14 @@ use SMW\MediaWiki\MediaWikiNsContentReader;
 class ImportValueParser implements ValueParser {
 
 	/**
-	 * @var MediaWikiNsContentReader
-	 */
-	private $mediaWikiNsContentReader;
-
-	/**
 	 * @var array
 	 */
 	private $errors = [];
 
 	/**
 	 * @since 2.2
-	 *
-	 * @param MediaWikiNsContentReader $mediaWikiNsContentReader
 	 */
-	public function __construct( MediaWikiNsContentReader $mediaWikiNsContentReader ) {
-		$this->mediaWikiNsContentReader = $mediaWikiNsContentReader;
+	public function __construct( private readonly MediaWikiNsContentReader $mediaWikiNsContentReader ) {
 	}
 
 	/**

--- a/src/DataValues/ValueValidators/ConstraintSchemaValueValidator.php
+++ b/src/DataValues/ValueValidators/ConstraintSchemaValueValidator.php
@@ -20,16 +20,6 @@ use SMWDataValue as DataValue;
 class ConstraintSchemaValueValidator implements ConstraintValueValidator {
 
 	/**
-	 * @var ConstraintCheckRunner
-	 */
-	private $constraintCheckRunner;
-
-	/**
-	 * @var SchemaFinder
-	 */
-	private $schemaFinder;
-
-	/**
 	 * @var
 	 */
 	private $schemaLists = [];
@@ -56,13 +46,11 @@ class ConstraintSchemaValueValidator implements ConstraintValueValidator {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param ConstraintCheckRunner $constraintCheckRunner
-	 * @param SchemaFinder $schemaFinder
 	 */
-	public function __construct( ConstraintCheckRunner $constraintCheckRunner, SchemaFinder $schemaFinder ) {
-		$this->constraintCheckRunner = $constraintCheckRunner;
-		$this->schemaFinder = $schemaFinder;
+	public function __construct(
+		private readonly ConstraintCheckRunner $constraintCheckRunner,
+		private readonly SchemaFinder $schemaFinder,
+	) {
 	}
 
 	/**

--- a/src/DataValues/ValueValidators/UniquenessConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/UniquenessConstraintValueValidator.php
@@ -24,29 +24,17 @@ use SMWDataValue as DataValue;
 class UniquenessConstraintValueValidator implements ConstraintValueValidator {
 
 	/**
-	 * @var UniqueValueConstraint
-	 */
-	private $uniqueValueConstraint;
-
-	/**
-	 * @var SpecificationLookup
-	 */
-	private $propertySpecificationLookup;
-
-	/**
 	 * @var bool
 	 */
 	private $hasConstraintViolation = false;
 
 	/**
 	 * @since 2.4
-	 *
-	 * @param UniqueValueConstraint $uniqueValueConstraint
-	 * @param SpecificationLookup $propertySpecificationLookup
 	 */
-	public function __construct( UniqueValueConstraint $uniqueValueConstraint, SpecificationLookup $propertySpecificationLookup ) {
-		$this->uniqueValueConstraint = $uniqueValueConstraint;
-		$this->propertySpecificationLookup = $propertySpecificationLookup;
+	public function __construct(
+		private readonly UniqueValueConstraint $uniqueValueConstraint,
+		private readonly SpecificationLookup $propertySpecificationLookup,
+	) {
 	}
 
 	/**

--- a/src/SPARQLStore/HttpResponseErrorMapper.php
+++ b/src/SPARQLStore/HttpResponseErrorMapper.php
@@ -20,15 +20,10 @@ use SMW\SPARQLStore\Exception\HttpEndpointConnectionException;
  */
 class HttpResponseErrorMapper {
 
-	private $httpRequest = null;
-
 	/**
 	 * @since  2.0
-	 *
-	 * @param HttpRequest $httpRequest
 	 */
-	public function __construct( HttpRequest $httpRequest ) {
-		$this->httpRequest = $httpRequest;
+	public function __construct( private readonly HttpRequest $httpRequest ) {
 	}
 
 	/**

--- a/src/SPARQLStore/QueryEngine/Condition/FilterCondition.php
+++ b/src/SPARQLStore/QueryEngine/Condition/FilterCondition.php
@@ -15,16 +15,10 @@ namespace SMW\SPARQLStore\QueryEngine\Condition;
  */
 class FilterCondition extends Condition {
 
-	/**
-	 * Additional filter condition, i.e. a string that could be placed in
-	 * "FILTER( ... )".
-	 *
-	 * @var string
-	 */
-	public $filter;
-
-	public function __construct( $filter, $namespaces = [] ) {
-		$this->filter = $filter;
+	public function __construct(
+		public $filter,
+		$namespaces = [],
+	) {
 		$this->namespaces = $namespaces;
 	}
 

--- a/src/SPARQLStore/QueryEngine/Condition/SingletonCondition.php
+++ b/src/SPARQLStore/QueryEngine/Condition/SingletonCondition.php
@@ -17,33 +17,19 @@ use SMW\Exporter\Element\ExpElement;
 class SingletonCondition extends Condition {
 
 	/**
-	 * Pattern string. Anything that can be used as a WHERE condition
-	 * when put between "{" and "}". Can be empty if the result
-	 * unconditionally is the given element.
-	 *
-	 * @var string
-	 */
-	public $condition;
-
-	/**
 	 * The single element that this condition may possibly match.
 	 *
 	 * @var ExpElement
 	 */
 	public $matchElement;
 
-	/**
-	 * Whether this condition is safe.
-	 *
-	 * @see SMWSparqlCondition::isSafe().
-	 * @var bool
-	 */
-	public $isSafe;
-
-	public function __construct( ExpElement $matchElement, $condition = '', $isSafe = false, $namespaces = [] ) {
+	public function __construct(
+		ExpElement $matchElement,
+		public $condition = '',
+		public $isSafe = false,
+		$namespaces = [],
+	) {
 		$this->matchElement = $matchElement;
-		$this->condition  = $condition;
-		$this->isSafe     = $isSafe;
 		$this->namespaces = $namespaces;
 	}
 

--- a/src/SPARQLStore/QueryEngine/Condition/WhereCondition.php
+++ b/src/SPARQLStore/QueryEngine/Condition/WhereCondition.php
@@ -15,23 +15,11 @@ namespace SMW\SPARQLStore\QueryEngine\Condition;
  */
 class WhereCondition extends Condition {
 
-	/**
-	 * The pattern string. Anything that can be used as a WHERE condition
-	 * when put between "{" and "}".
-	 * @var string
-	 */
-	public $condition;
-
-	/**
-	 * Whether this condition is safe.
-	 * @see SMWSparqlCondition::isSafe().
-	 * @var bool
-	 */
-	public $isSafe;
-
-	public function __construct( $condition, $isSafe, $namespaces = [] ) {
-		$this->condition  = $condition;
-		$this->isSafe     = $isSafe;
+	public function __construct(
+		public $condition,
+		public $isSafe,
+		$namespaces = [],
+	) {
 		$this->namespaces = $namespaces;
 	}
 

--- a/src/SPARQLStore/QueryEngine/ConditionBuilder.php
+++ b/src/SPARQLStore/QueryEngine/ConditionBuilder.php
@@ -34,11 +34,6 @@ use SMWExporter as Exporter;
 class ConditionBuilder {
 
 	/**
-	 * @var EngineOptions
-	 */
-	private $engineOptions;
-
-	/**
 	 * @var DispatchingDescriptionInterpreter
 	 */
 	private $dispatchingDescriptionInterpreter;
@@ -101,13 +96,12 @@ class ConditionBuilder {
 
 	/**
 	 * @since 2.2
-	 *
-	 * @param DescriptionInterpreterFactory $descriptionInterpreterFactory
-	 * @param EngineOptions|null $engineOptions
 	 */
-	public function __construct( DescriptionInterpreterFactory $descriptionInterpreterFactory, ?EngineOptions $engineOptions = null ) {
+	public function __construct(
+		DescriptionInterpreterFactory $descriptionInterpreterFactory,
+		private ?EngineOptions $engineOptions = null,
+	) {
 		$this->dispatchingDescriptionInterpreter = $descriptionInterpreterFactory->newDispatchingDescriptionInterpreter( $this );
-		$this->engineOptions = $engineOptions;
 
 		if ( $this->engineOptions === null ) {
 			$this->engineOptions = new EngineOptions();

--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ClassDescriptionInterpreter.php
@@ -22,22 +22,14 @@ use SMWExporter as Exporter;
 class ClassDescriptionInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
 	 * @var Exporter
 	 */
 	private $exporter;
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param ConditionBuilder|null $conditionBuilder
 	 */
-	public function __construct( ?ConditionBuilder $conditionBuilder = null ) {
-		$this->conditionBuilder = $conditionBuilder;
+	public function __construct( private readonly ?ConditionBuilder $conditionBuilder = null ) {
 		$this->exporter = Exporter::getInstance();
 	}
 

--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreter.php
@@ -24,22 +24,14 @@ use SMWExporter as Exporter;
 class ConceptDescriptionInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
 	 * @var Exporter
 	 */
 	private $exporter;
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param ConditionBuilder|null $conditionBuilder
 	 */
-	public function __construct( ?ConditionBuilder $conditionBuilder = null ) {
-		$this->conditionBuilder = $conditionBuilder;
+	public function __construct( private readonly ?ConditionBuilder $conditionBuilder = null ) {
 		$this->exporter = Exporter::getInstance();
 	}
 

--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ConjunctionInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ConjunctionInterpreter.php
@@ -27,22 +27,14 @@ use stdClass;
 class ConjunctionInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
 	 * @var Exporter
 	 */
 	private $exporter;
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param ConditionBuilder|null $conditionBuilder
 	 */
-	public function __construct( ?ConditionBuilder $conditionBuilder = null ) {
-		$this->conditionBuilder = $conditionBuilder;
+	public function __construct( private readonly ?ConditionBuilder $conditionBuilder = null ) {
 		$this->exporter = Exporter::getInstance();
 	}
 

--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/DisjunctionInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/DisjunctionInterpreter.php
@@ -27,22 +27,14 @@ use stdClass;
 class DisjunctionInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
 	 * @var Exporter
 	 */
 	private $exporter;
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param ConditionBuilder|null $conditionBuilder
 	 */
-	public function __construct( ?ConditionBuilder $conditionBuilder = null ) {
-		$this->conditionBuilder = $conditionBuilder;
+	public function __construct( private readonly ?ConditionBuilder $conditionBuilder = null ) {
 		$this->exporter = Exporter::getInstance();
 	}
 

--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/NamespaceDescriptionInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/NamespaceDescriptionInterpreter.php
@@ -22,22 +22,14 @@ use SMWExporter as Exporter;
 class NamespaceDescriptionInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
 	 * @var Exporter
 	 */
 	private $exporter;
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param ConditionBuilder|null $conditionBuilder
 	 */
-	public function __construct( ?ConditionBuilder $conditionBuilder = null ) {
-		$this->conditionBuilder = $conditionBuilder;
+	public function __construct( private readonly ?ConditionBuilder $conditionBuilder = null ) {
 		$this->exporter = Exporter::getInstance();
 	}
 

--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -27,22 +27,14 @@ use SMWExporter as Exporter;
 class SomePropertyInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
 	 * @var Exporter
 	 */
 	private $exporter;
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param ConditionBuilder|null $conditionBuilder
 	 */
-	public function __construct( ?ConditionBuilder $conditionBuilder = null ) {
-		$this->conditionBuilder = $conditionBuilder;
+	public function __construct( private readonly ?ConditionBuilder $conditionBuilder = null ) {
 		$this->exporter = Exporter::getInstance();
 	}
 

--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ThingDescriptionInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ThingDescriptionInterpreter.php
@@ -18,22 +18,14 @@ use SMWExporter as Exporter;
 class ThingDescriptionInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
 	 * @var Exporter
 	 */
 	private $exporter;
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param ConditionBuilder|null $conditionBuilder
 	 */
-	public function __construct( ?ConditionBuilder $conditionBuilder = null ) {
-		$this->conditionBuilder = $conditionBuilder;
+	public function __construct( private readonly ?ConditionBuilder $conditionBuilder = null ) {
 		$this->exporter = Exporter::getInstance();
 	}
 

--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/ValueDescriptionInterpreter.php
@@ -27,22 +27,14 @@ use SMWExporter as Exporter;
 class ValueDescriptionInterpreter implements DescriptionInterpreter {
 
 	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
 	 * @var Exporter
 	 */
 	private $exporter;
 
 	/**
 	 * @since 2.1
-	 *
-	 * @param ConditionBuilder|null $conditionBuilder
 	 */
-	public function __construct( ?ConditionBuilder $conditionBuilder = null ) {
-		$this->conditionBuilder = $conditionBuilder;
+	public function __construct( private readonly ?ConditionBuilder $conditionBuilder = null ) {
 		$this->exporter = Exporter::getInstance();
 	}
 

--- a/src/SPARQLStore/QueryEngine/QueryEngine.php
+++ b/src/SPARQLStore/QueryEngine/QueryEngine.php
@@ -32,26 +32,6 @@ class QueryEngine implements QueryEngineInterface {
 	const RESULT_VARIABLE = 'result';
 
 	/**
-	 * @var RepositoryConnection
-	 */
-	private $connection;
-
-	/**
-	 * @var ConditionBuilder
-	 */
-	private $conditionBuilder;
-
-	/**
-	 * @var QueryResultFactory
-	 */
-	private $queryResultFactory;
-
-	/**
-	 * @var EngineOptions
-	 */
-	private $engineOptions;
-
-	/**
 	 * @var array
 	 */
 	private $sortKeys = [];
@@ -65,14 +45,13 @@ class QueryEngine implements QueryEngineInterface {
 	 * @param EngineOptions|null $EngineOptions
 	 */
 	// @codingStandardsIgnoreStart phpcs, ignore --sniffs=Generic.Files.LineLength
-	public function __construct( RepositoryConnection $connection, ConditionBuilder $conditionBuilder, QueryResultFactory $queryResultFactory, ?EngineOptions $engineOptions = null ) {
-	// @codingStandardsIgnoreEnd
-		$this->connection = $connection;
-		$this->conditionBuilder = $conditionBuilder;
-		$this->queryResultFactory = $queryResultFactory;
-		$this->engineOptions = $engineOptions;
-
-		if ( $this->engineOptions === null ) {
+	public function __construct(
+		private readonly RepositoryConnection $connection,
+		private readonly ConditionBuilder $conditionBuilder,
+		private readonly QueryResultFactory $queryResultFactory,
+		private ?EngineOptions $engineOptions = null,
+	) {
+	if ( $this->engineOptions === null ) {
 			$this->engineOptions = new EngineOptions();
 		}
 

--- a/src/SPARQLStore/QueryEngine/QueryResultFactory.php
+++ b/src/SPARQLStore/QueryEngine/QueryResultFactory.php
@@ -18,17 +18,9 @@ use SMWQuery as Query;
 class QueryResultFactory {
 
 	/**
-	 * @var Store
-	 */
-	private $store;
-
-	/**
 	 * @since 2.0
-	 *
-	 * @param Store $store
 	 */
-	public function __construct( Store $store ) {
-		$this->store = $store;
+	public function __construct( private readonly Store $store ) {
 	}
 
 	/**

--- a/src/SPARQLStore/QueryEngine/RepositoryResult.php
+++ b/src/SPARQLStore/QueryEngine/RepositoryResult.php
@@ -54,25 +54,17 @@ class RepositoryResult implements Iterator {
 	protected $comments;
 
 	/**
-	 * Error code.
-	 *
-	 * @var int
-	 */
-	protected $errorCode;
-
-	/**
 	 * Initialise a result set from a result string in SPARQL XML format.
-	 *
-	 * @param $header array mapping SPARQL variable names to column indices
-	 * @param $data array of array of (ExpElement or null)
-	 * @param $comments array of string comments if the result contained any
-	 * @param $errorCode integer an error code
 	 */
-	public function __construct( array $header = [], array $data = [], array $comments = [], $errorCode = self::ERROR_NOERROR ) {
+	public function __construct(
+		array $header = [],
+		array $data = [],
+		array $comments = [],
+		protected $errorCode = self::ERROR_NOERROR,
+	) {
 		$this->header    = $header;
 		$this->data      = $data;
 		$this->comments  = $comments;
-		$this->errorCode = $errorCode;
 		reset( $this->data );
 	}
 

--- a/src/SPARQLStore/RepositoryClient.php
+++ b/src/SPARQLStore/RepositoryClient.php
@@ -16,38 +16,6 @@ use SMW\Utils\Flag;
 class RepositoryClient {
 
 	/**
-	 * The URI of the default graph that is used to store data.
-	 * Can be the empty string to omit this information in all requests
-	 * (not supported by all stores).
-	 *
-	 * @var string
-	 */
-	private $defaultGraph = '';
-
-	/**
-	 * The URL of the endpoint for executing read queries.
-	 *
-	 * @var string
-	 */
-	private $queryEndpoint = '';
-
-	/**
-	 * The URL of the endpoint for executing update queries, or empty if
-	 * update is not allowed/supported.
-	 *
-	 * @var string
-	 */
-	private $updateEndpoint = '';
-
-	/**
-	 * The URL of the endpoint for using the SPARQL Graph Store HTTP
-	 * Protocol with, or empty if this method is not allowed/supported.
-	 *
-	 * @var string
-	 */
-	private $dataEndpoint = '';
-
-	/**
 	 * @var string
 	 */
 	private $name = '';
@@ -59,17 +27,13 @@ class RepositoryClient {
 
 	/**
 	 * @since 2.2
-	 *
-	 * @param string $defaultGraph
-	 * @param string $queryEndpoint
-	 * @param string $updateEndpoint
-	 * @param string $dataEndpoint
 	 */
-	public function __construct( $defaultGraph, $queryEndpoint, $updateEndpoint = '', $dataEndpoint = '' ) {
-		$this->defaultGraph = $defaultGraph;
-		$this->queryEndpoint = $queryEndpoint;
-		$this->updateEndpoint = $updateEndpoint;
-		$this->dataEndpoint = $dataEndpoint;
+	public function __construct(
+		private $defaultGraph,
+		private $queryEndpoint,
+		private $updateEndpoint = '',
+		private $dataEndpoint = '',
+	) {
 	}
 
 	/**

--- a/src/SPARQLStore/RepositoryConnectionProvider.php
+++ b/src/SPARQLStore/RepositoryConnectionProvider.php
@@ -42,31 +42,6 @@ class RepositoryConnectionProvider implements ConnectionProvider {
 	private $connection = null;
 
 	/**
-	 * @var string|null
-	 */
-	private $connectorId = null;
-
-	/**
-	 * @var string|null
-	 */
-	private $defaultGraph = null;
-
-	/**
-	 * @var string|null
-	 */
-	private $queryEndpoint = null;
-
-	/**
-	 * @var string|null
-	 */
-	private $updateEndpoint = null;
-
-	/**
-	 * @var string|null
-	 */
-	private $dataEndpoint = null;
-
-	/**
 	 * @var HttpRequest
 	 */
 	private $httpRequest;
@@ -83,20 +58,14 @@ class RepositoryConnectionProvider implements ConnectionProvider {
 
 	/**
 	 * @since 2.0
-	 *
-	 * @param string|null $connectorId
-	 * @param string|null $defaultGraph
-	 * @param string|null $queryEndpoint
-	 * @param string|null $updateEndpoint
-	 * @param string|null $dataEndpoint
 	 */
-	public function __construct( $connectorId = null, $defaultGraph = null, $queryEndpoint = null, $updateEndpoint = null, $dataEndpoint = null ) {
-		$this->connectorId = $connectorId;
-		$this->defaultGraph = $defaultGraph;
-		$this->queryEndpoint = $queryEndpoint;
-		$this->updateEndpoint = $updateEndpoint;
-		$this->dataEndpoint = $dataEndpoint;
-
+	public function __construct(
+		private $connectorId = null,
+		private $defaultGraph = null,
+		private $queryEndpoint = null,
+		private $updateEndpoint = null,
+		private $dataEndpoint = null,
+	) {
 		if ( $this->connectorId === null ) {
 			$this->connectorId = $GLOBALS['smwgSparqlRepositoryConnector'];
 		}

--- a/src/SPARQLStore/RepositoryRedirectLookup.php
+++ b/src/SPARQLStore/RepositoryRedirectLookup.php
@@ -25,17 +25,9 @@ class RepositoryRedirectLookup {
 	const POOLCACHE_ID = 'sparql.repository.redirectLookup';
 
 	/**
-	 * @var RepositoryConnection
-	 */
-	private $repositoryConnection;
-
-	/**
 	 * @since 2.0
-	 *
-	 * @param RepositoryConnection $repositoryConnection
 	 */
-	public function __construct( RepositoryConnection $repositoryConnection ) {
-		$this->repositoryConnection = $repositoryConnection;
+	public function __construct( private readonly RepositoryConnection $repositoryConnection ) {
 	}
 
 	/**

--- a/src/SPARQLStore/SPARQLStoreFactory.php
+++ b/src/SPARQLStore/SPARQLStoreFactory.php
@@ -22,17 +22,9 @@ use SMW\Utils\CircularReferenceGuard;
 class SPARQLStoreFactory {
 
 	/**
-	 * @var SPARQLStore
-	 */
-	private $store;
-
-	/**
 	 * @since 2.2
-	 *
-	 * @param SPARQLStore $store
 	 */
-	public function __construct( SPARQLStore $store ) {
-		$this->store = $store;
+	public function __construct( private readonly SPARQLStore $store ) {
 	}
 
 	/**

--- a/src/SPARQLStore/TurtleTriplesBuilder.php
+++ b/src/SPARQLStore/TurtleTriplesBuilder.php
@@ -33,11 +33,6 @@ class TurtleTriplesBuilder {
 	private $semanticData = null;
 
 	/**
-	 * @var RepositoryRedirectLookup
-	 */
-	private $repositoryRedirectLookup = null;
-
-	/**
 	 * @var null|string
 	 */
 	private $triples = null;
@@ -58,19 +53,12 @@ class TurtleTriplesBuilder {
 	private $triplesChunkSize = 80;
 
 	/**
-	 * @var Cache
-	 */
-	private $cache;
-
-	/**
 	 * @since 2.0
-	 *
-	 * @param RepositoryRedirectLookup $repositoryRedirectLookup
-	 * @param Cache|null $cache
 	 */
-	public function __construct( RepositoryRedirectLookup $repositoryRedirectLookup, ?Cache $cache = null ) {
-		$this->repositoryRedirectLookup = $repositoryRedirectLookup;
-		$this->cache = $cache;
+	public function __construct(
+		private readonly RepositoryRedirectLookup $repositoryRedirectLookup,
+		private readonly ?Cache $cache = null,
+	) {
 	}
 
 	/**


### PR DESCRIPTION
## Summary

- Apply PHP 8.1 constructor promotion to files in ``src/DataValues/` and `src/SPARQLStore/``
- Add `readonly` to promoted properties that are never reassigned and have a type declaration
- Remove redundant property declarations, `@var` phpdoc, and constructor `@param` phpdoc

## Test plan

- [x] PHPCS passes clean
- [x] Unit tests pass
- [x] Integration tests pass