### PR TITLE
Remove use of E_STRICT as deprecated in PHP 8.4

### DIFF
--- a/data/config/developer.php
+++ b/data/config/developer.php
@@ -7,7 +7,7 @@
  * @since 3.2
  */
 
-error_reporting( E_STRICT | E_ALL );
+error_reporting( E_ALL );
 ini_set( "display_errors", 1 );
 
 return [


### PR DESCRIPTION
https://phabricator.wikimedia.org/T375707

> Deprecated: Constant E_STRICT is deprecated in /var/www/html/extensions/SemanticMediaWiki/data/config/developer.php on line 10