### PR TITLE
Tests: Add coverage for Onoi\HttpRequest-based HTTP layer

### DIFF
--- a/tests/phpunit/Query/RemoteRequestTest.php
+++ b/tests/phpunit/Query/RemoteRequestTest.php
@@ -58,6 +58,155 @@ class RemoteRequestTest extends TestCase {
 		);
 	}
 
+	public function testGetQueryResultSetsCorrectCurlOptionsAndPostParams() {
+		$output = 'Result' . RemoteRequest::REQUEST_ID;
+		$capturedOptions = [];
+
+		$this->httpRequest->expects( $this->once() )
+			->method( 'ping' )
+			->willReturn( true );
+
+		$this->httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$this->httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( $output );
+
+		$this->httpRequest->method( 'getLastError' )
+			->willReturn( '' );
+
+		$this->query->method( 'toArray' )
+			->willReturn( [
+				'conditions' => '[[Category:Foo]]',
+				'printouts' => [ '?Bar', '?Baz' ],
+				'parameters' => [ 'limit' => '10' ]
+			] );
+
+		$this->query->method( 'getOption' )
+			->with( 'query.params' )
+			->willReturn( [ 'format' => 'table' ] );
+
+		$this->query->method( 'isEmbedded' )
+			->willReturn( false );
+
+		$this->query->method( 'getQueryMode' )
+			->willReturn( 0 );
+
+		$parameters = [
+			'url' => 'http://example.org/wiki',
+			'smwgRemoteReqFeatures' => 0
+		];
+
+		$instance = new RemoteRequest( $parameters, $this->httpRequest );
+		$instance->clear();
+		$instance->getQueryResult( $this->query );
+
+		$this->assertFalse( $capturedOptions[CURLOPT_SSL_VERIFYPEER] );
+		$this->assertTrue( $capturedOptions[CURLOPT_POST] );
+		$this->assertSame( 1, $capturedOptions[CURLOPT_RETURNTRANSFER] );
+
+		$postFields = $capturedOptions[CURLOPT_POSTFIELDS];
+		$this->assertStringContainsString( 'q=' . urlencode( '[[Category:Foo]]' ), $postFields );
+		$this->assertStringContainsString( 'po=' . urlencode( '?Bar|?Baz' ), $postFields );
+	}
+
+	public function testCanConnectCachesPingResult() {
+		$output = 'Result' . RemoteRequest::REQUEST_ID;
+
+		$this->httpRequest->expects( $this->once() )
+			->method( 'ping' )
+			->willReturn( true );
+
+		$this->httpRequest->method( 'setOption' )->willReturn( true );
+
+		$this->httpRequest->method( 'execute' )
+			->willReturn( $output );
+
+		$this->httpRequest->method( 'getLastError' )
+			->willReturn( '' );
+
+		$this->query->method( 'toArray' )->willReturn( [] );
+		$this->query->method( 'getOption' )->willReturn( [] );
+		$this->query->method( 'isEmbedded' )->willReturn( false );
+		$this->query->method( 'getQueryMode' )->willReturn( 0 );
+
+		$parameters = [ 'url' => 'http://example.org/wiki' ];
+
+		$instance = new RemoteRequest( $parameters, $this->httpRequest );
+		$instance->clear();
+
+		// First call pings, second call uses cached result
+		$instance->getQueryResult( $this->query );
+		$instance->getQueryResult( $this->query );
+	}
+
+	public function testGetQueryResultWithMissingRequestId() {
+		$this->httpRequest->expects( $this->once() )
+			->method( 'ping' )
+			->willReturn( true );
+
+		$this->httpRequest->method( 'setOption' )->willReturn( true );
+
+		$this->httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( 'Some random output without the magic ID' );
+
+		$this->httpRequest->method( 'getLastError' )
+			->willReturn( '' );
+
+		$this->query->method( 'toArray' )->willReturn( [] );
+		$this->query->method( 'getOption' )->willReturn( [] );
+		$this->query->method( 'isEmbedded' )->willReturn( false );
+		$this->query->method( 'getQueryMode' )->willReturn( 0 );
+		$this->query->method( 'getQuerySource' )->willReturn( 'remote-wiki' );
+
+		$parameters = [ 'url' => 'http://example.org/wiki' ];
+
+		$instance = new RemoteRequest( $parameters, $this->httpRequest );
+		$instance->clear();
+
+		$result = $instance->getQueryResult( $this->query );
+
+		$this->assertInstanceOf( StringResult::class, $result );
+		$this->assertStringContainsString( 'smw-remote-source-unmatched-id', $result->getResults() );
+	}
+
+	public function testGetQueryResultWithFetchError() {
+		$this->httpRequest->expects( $this->once() )
+			->method( 'ping' )
+			->willReturn( true );
+
+		$this->httpRequest->method( 'setOption' )->willReturn( true );
+
+		$this->httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( '' );
+
+		$this->httpRequest->method( 'getLastError' )
+			->willReturn( 'Connection timed out' );
+
+		$this->query->method( 'toArray' )->willReturn( [] );
+		$this->query->method( 'getOption' )->willReturn( [] );
+		$this->query->method( 'isEmbedded' )->willReturn( false );
+		$this->query->method( 'getQueryMode' )->willReturn( 0 );
+		$this->query->method( 'getQuerySource' )->willReturn( 'remote-wiki' );
+
+		$parameters = [ 'url' => 'http://example.org/wiki' ];
+
+		$instance = new RemoteRequest( $parameters, $this->httpRequest );
+		$instance->clear();
+
+		$result = $instance->getQueryResult( $this->query );
+
+		$this->assertInstanceOf( StringResult::class, $result );
+		$this->assertStringContainsString( 'smw-remote-source-unmatched-id', $result->getResults() );
+	}
+
 	public function testGetQueryResult_Connect() {
 		$output = 'Foobar <!--COUNT:42--><!--FURTHERRESULTS:1-->' . RemoteRequest::REQUEST_ID;
 

--- a/tests/phpunit/SPARQLStore/HttpResponseErrorMapperTest.php
+++ b/tests/phpunit/SPARQLStore/HttpResponseErrorMapperTest.php
@@ -107,6 +107,7 @@ class HttpResponseErrorMapperTest extends TestCase {
 
 	public function curlErrorCodeThatNotThrowsExceptionProvider() {
 		$provider = [
+			[ 52 ],
 			[ CURLE_GOT_NOTHING ],
 			[ CURLE_COULDNT_CONNECT ]
 		];
@@ -117,7 +118,8 @@ class HttpResponseErrorMapperTest extends TestCase {
 	public function httpCodeThatThrowsExceptionProvider() {
 		$provider = [
 			[ 400 ],
-			[ 500 ]
+			[ 500 ],
+			[ 503 ]
 		];
 
 		return $provider;

--- a/tests/phpunit/SPARQLStore/RepositoryConnectors/FourstoreRepositoryConnectorTest.php
+++ b/tests/phpunit/SPARQLStore/RepositoryConnectors/FourstoreRepositoryConnectorTest.php
@@ -2,16 +2,16 @@
 
 namespace SMW\Tests\SPARQLStore\RepositoryConnectors;
 
+use Onoi\HttpRequest\HttpRequest;
+use SMW\SPARQLStore\RepositoryClient;
 use SMW\SPARQLStore\RepositoryConnectors\FourstoreRepositoryConnector;
+use SMW\Tests\Utils\Fixtures\Results\FakeRawResultProvider;
 
 /**
  * @covers \SMW\SPARQLStore\RepositoryConnectors\FourstoreRepositoryConnector
  * @group semantic-mediawiki
  *
  * @license GPL-2.0-or-later
- * @since 3.0
- *
- * @author mwjames
  */
 class FourstoreRepositoryConnectorTest extends ElementaryRepositoryConnectorTest {
 
@@ -19,6 +19,101 @@ class FourstoreRepositoryConnectorTest extends ElementaryRepositoryConnectorTest
 		return [
 			FourstoreRepositoryConnector::class
 		];
+	}
+
+	public function testDoQueryAddsRestrictedParameter() {
+		$rawResultProvider = new FakeRawResultProvider();
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->method( 'execute' )
+			->willReturn( $rawResultProvider->getEmptySparqlResultXml() );
+
+		$httpRequest->method( 'getLastErrorCode' )
+			->willReturn( 0 );
+
+		$instance = new FourstoreRepositoryConnector(
+			new RepositoryClient( 'http://foo/graph', 'http://localhost/query' ),
+			$httpRequest
+		);
+
+		$instance->doQuery( 'ASK { ?s ?p ?o }' );
+
+		$this->assertStringContainsString( '&restricted=1', $capturedOptions[CURLOPT_POSTFIELDS] );
+	}
+
+	public function testDoHttpPostUsesFormEncodedParams() {
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->method( 'getLastErrorCode' )->willReturn( 0 );
+
+		$instance = new FourstoreRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/graph',
+				'http://localhost/query',
+				'http://localhost/update',
+				'http://localhost/data'
+			),
+			$httpRequest
+		);
+
+		$instance->doHttpPost( '<s> <p> <o> .' );
+
+		// Fourstore uses form-encoded data= param, not CURLOPT_INFILE
+		$this->assertStringContainsString( 'data=', $capturedOptions[CURLOPT_POSTFIELDS] );
+		$this->assertStringContainsString( 'mime-type=application/x-turtle', $capturedOptions[CURLOPT_POSTFIELDS] );
+		$this->assertArrayNotHasKey( CURLOPT_INFILE, $capturedOptions );
+	}
+
+	public function testDoUpdateOmitsCharsetFromContentType() {
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->method( 'getLastErrorCode' )->willReturn( 0 );
+
+		$instance = new FourstoreRepositoryConnector(
+			new RepositoryClient( '', 'http://localhost/query', 'http://localhost/update' ),
+			$httpRequest
+		);
+
+		$instance->doUpdate( 'INSERT DATA { <s> <p> <o> }' );
+
+		// 4Store breaks when charset is included
+		$this->assertSame(
+			[ 'Content-Type: application/x-www-form-urlencoded' ],
+			$capturedOptions[CURLOPT_HTTPHEADER]
+		);
 	}
 
 }

--- a/tests/phpunit/SPARQLStore/RepositoryConnectors/FusekiRepositoryConnectorTest.php
+++ b/tests/phpunit/SPARQLStore/RepositoryConnectors/FusekiRepositoryConnectorTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\SPARQLStore\RepositoryConnectors;
 use Onoi\HttpRequest\HttpRequest;
 use SMW\SPARQLStore\RepositoryClient;
 use SMW\SPARQLStore\RepositoryConnectors\FusekiRepositoryConnector;
+use SMW\Tests\Utils\Fixtures\Results\FakeRawResultProvider;
 
 /**
  * @covers \SMW\SPARQLStore\RepositoryConnectors\FusekiRepositoryConnector
@@ -51,6 +52,37 @@ class FusekiRepositoryConnectorTest extends ElementaryRepositoryConnectorTest {
 			'3.2',
 			$instance->getVersion()
 		);
+	}
+
+	public function testDoQueryAddsOutputXmlParameter() {
+		$rawResultProvider = new FakeRawResultProvider();
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->method( 'execute' )
+			->willReturn( $rawResultProvider->getEmptySparqlResultXml() );
+
+		$httpRequest->method( 'getLastErrorCode' )
+			->willReturn( 0 );
+
+		$instance = new FusekiRepositoryConnector(
+			new RepositoryClient( 'http://foo/graph', 'http://localhost/query' ),
+			$httpRequest
+		);
+
+		$instance->doQuery( 'SELECT ?s WHERE { ?s ?p ?o }' );
+
+		$this->assertStringContainsString( '&output=xml', $capturedOptions[CURLOPT_POSTFIELDS] );
 	}
 
 }

--- a/tests/phpunit/SPARQLStore/RepositoryConnectors/GenericRepositoryConnectorTest.php
+++ b/tests/phpunit/SPARQLStore/RepositoryConnectors/GenericRepositoryConnectorTest.php
@@ -3,8 +3,10 @@
 namespace SMW\Tests\SPARQLStore\RepositoryConnectors;
 
 use Onoi\HttpRequest\HttpRequest;
+use SMW\SPARQLStore\QueryEngine\RepositoryResult;
 use SMW\SPARQLStore\RepositoryClient;
 use SMW\SPARQLStore\RepositoryConnectors\GenericRepositoryConnector;
+use SMW\Tests\Utils\Fixtures\Results\FakeRawResultProvider;
 
 /**
  * @covers \SMW\SPARQLStore\RepositoryConnectors\GenericRepositoryConnector
@@ -93,6 +95,626 @@ class GenericRepositoryConnectorTest extends ElementaryRepositoryConnectorTest {
 			42,
 			$instance->getLastErrorCode()
 		);
+	}
+
+	public function testConstructorSetsCurlOptions() {
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost:9999/query'
+			),
+			$httpRequest
+		);
+
+		$this->assertFalse( $capturedOptions[CURLOPT_FORBID_REUSE] );
+		$this->assertFalse( $capturedOptions[CURLOPT_FRESH_CONNECT] );
+		$this->assertTrue( $capturedOptions[CURLOPT_RETURNTRANSFER] );
+		$this->assertTrue( $capturedOptions[CURLOPT_FAILONERROR] );
+		$this->assertEquals( 10, $capturedOptions[CURLOPT_CONNECTTIMEOUT] );
+	}
+
+	public function testPingQueryEndpointSuccess() {
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( '' );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastErrorCode' )
+			->willReturn( 0 );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost/query'
+			),
+			$httpRequest
+		);
+
+		$this->assertTrue( $instance->ping( GenericRepositoryConnector::ENDP_QUERY ) );
+		$this->assertEquals( 'http://localhost/query', $capturedOptions[CURLOPT_URL] );
+		$this->assertTrue( $capturedOptions[CURLOPT_NOBODY] );
+		$this->assertTrue( $capturedOptions[CURLOPT_POST] );
+	}
+
+	public function testPingQueryEndpointHttp500IsAlive() {
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->any() )
+			->method( 'setOption' )
+			->willReturn( true );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( '' );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastErrorCode' )
+			->willReturn( 22 );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastTransferInfo' )
+			->with( CURLINFO_HTTP_CODE )
+			->willReturn( 500 );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost/query'
+			),
+			$httpRequest
+		);
+
+		$this->assertTrue( $instance->ping( GenericRepositoryConnector::ENDP_QUERY ) );
+	}
+
+	public function testPingQueryEndpointHttp400IsAlive() {
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->any() )
+			->method( 'setOption' )
+			->willReturn( true );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( '' );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastErrorCode' )
+			->willReturn( 22 );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastTransferInfo' )
+			->with( CURLINFO_HTTP_CODE )
+			->willReturn( 400 );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost/query'
+			),
+			$httpRequest
+		);
+
+		$this->assertTrue( $instance->ping( GenericRepositoryConnector::ENDP_QUERY ) );
+	}
+
+	public function testPingQueryEndpointOtherHttpCodeIsNotAlive() {
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->any() )
+			->method( 'setOption' )
+			->willReturn( true );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( '' );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastErrorCode' )
+			->willReturn( 22 );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastTransferInfo' )
+			->with( CURLINFO_HTTP_CODE )
+			->willReturn( 403 );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost/query'
+			),
+			$httpRequest
+		);
+
+		$this->assertFalse( $instance->ping( GenericRepositoryConnector::ENDP_QUERY ) );
+	}
+
+	public function testPingUpdateEndpointSuccess() {
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( '' );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastErrorCode' )
+			->willReturn( 0 );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost/query',
+				'http://localhost/update'
+			),
+			$httpRequest
+		);
+
+		$this->assertTrue( $instance->ping( GenericRepositoryConnector::ENDP_UPDATE ) );
+		$this->assertEquals( 'http://localhost/update', $capturedOptions[CURLOPT_URL] );
+		$this->assertFalse( $capturedOptions[CURLOPT_NOBODY] );
+	}
+
+	public function testPingUpdateEndpointEmptyReturnsFalse() {
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->any() )
+			->method( 'setOption' )
+			->willReturn( true );
+
+		$httpRequest->expects( $this->never() )
+			->method( 'execute' );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost/query',
+				''
+			),
+			$httpRequest
+		);
+
+		$this->assertFalse( $instance->ping( GenericRepositoryConnector::ENDP_UPDATE ) );
+	}
+
+	public function testPingDataEndpointEmptyReturnsFalse() {
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->any() )
+			->method( 'setOption' )
+			->willReturn( true );
+
+		$httpRequest->expects( $this->never() )
+			->method( 'execute' );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost/query',
+				'',
+				''
+			),
+			$httpRequest
+		);
+
+		$this->assertFalse( $instance->ping( GenericRepositoryConnector::ENDP_DATA ) );
+	}
+
+	public function testPingDataEndpointDelegatesToDoHttpPost() {
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->any() )
+			->method( 'setOption' )
+			->willReturn( true );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( '' );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastErrorCode' )
+			->willReturn( 0 );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost/query',
+				'',
+				'http://localhost/data'
+			),
+			$httpRequest
+		);
+
+		$this->assertTrue( $instance->ping( GenericRepositoryConnector::ENDP_DATA ) );
+	}
+
+	public function testDoQuerySuccessSetsCorrectOptionsAndParsesResponse() {
+		$rawResultProvider = new FakeRawResultProvider();
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( $rawResultProvider->getEmptySparqlResultXml() );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastErrorCode' )
+			->willReturn( 0 );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost:9999/query'
+			),
+			$httpRequest
+		);
+
+		$sparql = 'SELECT ?s WHERE { ?s ?p ?o }';
+		$result = $instance->doQuery( $sparql );
+
+		$this->assertInstanceOf( RepositoryResult::class, $result );
+		$this->assertSame( 'http://localhost:9999/query', $capturedOptions[CURLOPT_URL] );
+		$this->assertTrue( $capturedOptions[CURLOPT_POST] );
+		$this->assertSame(
+			[
+				'Accept: application/sparql-results+xml,application/xml;q=0.8',
+				'Content-Type: application/x-www-form-urlencoded;charset=UTF-8'
+			],
+			$capturedOptions[CURLOPT_HTTPHEADER]
+		);
+
+		$expectedPostFields = 'query=' . urlencode( $sparql ) .
+			'&default-graph-uri=' . urlencode( 'http://foo/myDefaultGraph' );
+		$this->assertSame( $expectedPostFields, $capturedOptions[CURLOPT_POSTFIELDS] );
+	}
+
+	public function testDoQuerySuccessWithoutDefaultGraph() {
+		$rawResultProvider = new FakeRawResultProvider();
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( $rawResultProvider->getEmptySparqlResultXml() );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastErrorCode' )
+			->willReturn( 0 );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient( '', 'http://localhost:9999/query' ),
+			$httpRequest
+		);
+
+		$sparql = 'ASK { ?s ?p ?o }';
+		$instance->doQuery( $sparql );
+
+		$this->assertSame( 'query=' . urlencode( $sparql ), $capturedOptions[CURLOPT_POSTFIELDS] );
+	}
+
+	public function testDoQueryErrorReturnsUnreachableResult() {
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->any() )
+			->method( 'setOption' )
+			->willReturn( true );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( '' );
+
+		$httpRequest->method( 'getLastErrorCode' )
+			->willReturn( CURLE_COULDNT_CONNECT );
+
+		$httpRequest->method( 'getLastError' )
+			->willReturn( 'Connection refused' );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient( '', 'http://localhost:9999/query' ),
+			$httpRequest
+		);
+
+		$result = $instance->doQuery( 'SELECT ?s WHERE { ?s ?p ?o }' );
+
+		$this->assertInstanceOf( RepositoryResult::class, $result );
+		$this->assertSame( RepositoryResult::ERROR_UNREACHABLE, $result->getErrorCode() );
+	}
+
+	public function testDoUpdateSuccessSetsCorrectOptions() {
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( '' );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastErrorCode' )
+			->willReturn( 0 );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost/query',
+				'http://localhost/update'
+			),
+			$httpRequest
+		);
+
+		$sparql = 'DELETE { ?s ?p ?o } WHERE { ?s ?p ?o }';
+		$this->assertTrue( $instance->doUpdate( $sparql ) );
+
+		$this->assertSame( 'http://localhost/update', $capturedOptions[CURLOPT_URL] );
+		$this->assertTrue( $capturedOptions[CURLOPT_POST] );
+		$this->assertSame( 'update=' . urlencode( $sparql ), $capturedOptions[CURLOPT_POSTFIELDS] );
+		$this->assertSame(
+			[ 'Content-Type: application/x-www-form-urlencoded;charset=UTF-8' ],
+			$capturedOptions[CURLOPT_HTTPHEADER]
+		);
+	}
+
+	public function testDoUpdateErrorReturnsFalse() {
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->any() )
+			->method( 'setOption' )
+			->willReturn( true );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( '' );
+
+		$httpRequest->method( 'getLastErrorCode' )
+			->willReturn( CURLE_COULDNT_CONNECT );
+
+		$httpRequest->method( 'getLastError' )
+			->willReturn( 'Connection refused' );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient( '', 'http://localhost/query', 'http://localhost/update' ),
+			$httpRequest
+		);
+
+		$this->assertFalse( $instance->doUpdate( 'INSERT DATA { <s> <p> <o> }' ) );
+	}
+
+	public function testDoHttpPostSuccessSetsCorrectOptions() {
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( '' );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'getLastErrorCode' )
+			->willReturn( 0 );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost/query',
+				'http://localhost/update',
+				'http://localhost/data'
+			),
+			$httpRequest
+		);
+
+		$payload = '<http://example.org/s> <http://example.org/p> "object" .';
+		$this->assertTrue( $instance->doHttpPost( $payload ) );
+
+		$expectedUrl = 'http://localhost/data?graph=' . urlencode( 'http://foo/myDefaultGraph' );
+		$this->assertSame( $expectedUrl, $capturedOptions[CURLOPT_URL] );
+		$this->assertTrue( $capturedOptions[CURLOPT_POST] );
+		$this->assertSame( [ 'Content-Type: application/x-turtle' ], $capturedOptions[CURLOPT_HTTPHEADER] );
+		$this->assertIsResource( $capturedOptions[CURLOPT_INFILE] );
+		$this->assertSame( strlen( $payload ), $capturedOptions[CURLOPT_INFILESIZE] );
+	}
+
+	public function testDoHttpPostWithoutDefaultGraphUsesDefaultParam() {
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->method( 'getLastErrorCode' )->willReturn( 0 );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient( '', 'http://localhost/query', '', 'http://localhost/data' ),
+			$httpRequest
+		);
+
+		$instance->doHttpPost( 'some turtle data' );
+
+		$this->assertSame( 'http://localhost/data?default', $capturedOptions[CURLOPT_URL] );
+	}
+
+	public function testDoHttpPostErrorReturnsFalse() {
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->any() )
+			->method( 'setOption' )
+			->willReturn( true );
+
+		$httpRequest->expects( $this->once() )
+			->method( 'execute' )
+			->willReturn( '' );
+
+		$httpRequest->method( 'getLastErrorCode' )
+			->willReturn( CURLE_COULDNT_CONNECT );
+
+		$httpRequest->method( 'getLastError' )
+			->willReturn( 'Connection refused' );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient( '', 'http://localhost/query', '', 'http://localhost/data' ),
+			$httpRequest
+		);
+
+		$this->assertFalse( $instance->doHttpPost( 'data' ) );
+	}
+
+	public function testInsertDataRoutesToDoHttpPostWhenDataEndpointSet() {
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->method( 'getLastErrorCode' )->willReturn( 0 );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost/query',
+				'http://localhost/update',
+				'http://localhost/data'
+			),
+			$httpRequest
+		);
+
+		$this->assertTrue( $instance->insertData( 'property:Foo wiki:Bar;' ) );
+		$this->assertStringStartsWith( 'http://localhost/data', $capturedOptions[CURLOPT_URL] );
+	}
+
+	public function testInsertDataRoutesToDoUpdateWhenNoDataEndpoint() {
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->method( 'getLastErrorCode' )->willReturn( 0 );
+
+		$instance = new GenericRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/myDefaultGraph',
+				'http://localhost/query',
+				'http://localhost/update',
+				''
+			),
+			$httpRequest
+		);
+
+		$this->assertTrue( $instance->insertData( '<s> <p> <o> .' ) );
+		$this->assertSame( 'http://localhost/update', $capturedOptions[CURLOPT_URL] );
+		$this->assertStringContainsString( 'INSERT+DATA', $capturedOptions[CURLOPT_POSTFIELDS] );
 	}
 
 	public function endpointProvider() {

--- a/tests/phpunit/SPARQLStore/RepositoryConnectors/VirtuosoRepositoryConnectorTest.php
+++ b/tests/phpunit/SPARQLStore/RepositoryConnectors/VirtuosoRepositoryConnectorTest.php
@@ -2,6 +2,8 @@
 
 namespace SMW\Tests\SPARQLStore\RepositoryConnectors;
 
+use Onoi\HttpRequest\HttpRequest;
+use SMW\SPARQLStore\RepositoryClient;
 use SMW\SPARQLStore\RepositoryConnectors\VirtuosoRepositoryConnector;
 
 /**
@@ -9,9 +11,6 @@ use SMW\SPARQLStore\RepositoryConnectors\VirtuosoRepositoryConnector;
  * @group semantic-mediawiki
  *
  * @license GPL-2.0-or-later
- * @since 3.0
- *
- * @author mwjames
  */
 class VirtuosoRepositoryConnectorTest extends ElementaryRepositoryConnectorTest {
 
@@ -19,6 +18,65 @@ class VirtuosoRepositoryConnectorTest extends ElementaryRepositoryConnectorTest 
 		return [
 			VirtuosoRepositoryConnector::class
 		];
+	}
+
+	public function testDoUpdateUsesQueryParameter() {
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->method( 'getLastErrorCode' )->willReturn( 0 );
+
+		$instance = new VirtuosoRepositoryConnector(
+			new RepositoryClient( '', 'http://localhost/query', 'http://localhost/update' ),
+			$httpRequest
+		);
+
+		$instance->doUpdate( 'DELETE { ?s ?p ?o } WHERE { ?s ?p ?o }' );
+
+		// Virtuoso uses 'query=' not 'update='
+		$this->assertStringStartsWith( 'query=', $capturedOptions[CURLOPT_POSTFIELDS] );
+	}
+
+	public function testDeleteUsesFromSyntax() {
+		$capturedOptions = [];
+
+		$httpRequest = $this->getMockBuilder( HttpRequest::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$httpRequest->expects( $this->atLeastOnce() )
+			->method( 'setOption' )
+			->willReturnCallback( static function ( $option, $value ) use ( &$capturedOptions ) {
+				$capturedOptions[$option] = $value;
+				return true;
+			} );
+
+		$httpRequest->method( 'getLastErrorCode' )->willReturn( 0 );
+
+		$instance = new VirtuosoRepositoryConnector(
+			new RepositoryClient(
+				'http://foo/graph',
+				'http://localhost/query',
+				'http://localhost/update'
+			),
+			$httpRequest
+		);
+
+		$instance->delete( '?s ?p ?o', '?s ?p ?o' );
+
+		// Virtuoso uses DELETE FROM <graph> not WITH <graph> DELETE
+		$decoded = urldecode( $capturedOptions[CURLOPT_POSTFIELDS] );
+		$this->assertStringContainsString( 'DELETE FROM <http://foo/graph>', $decoded );
 	}
 
 }


### PR DESCRIPTION
## Summary

- Add unit tests verifying CURL options, URL construction, POST fields, headers, and error handling across the SPARQL store connectors and RemoteRequest
- This coverage enables safe refactoring of the HTTP layer to use MW core's `HttpRequestFactory` in a follow-up PR

### Tests added (29 new test methods across 6 files)

**GenericRepositoryConnector** (19 tests): constructor CURL options, `ping()` branches (query/update/data endpoints, HTTP 400/500 as alive), `doQuery()` options and parsing, `doUpdate()` options, `doHttpPost()` file streaming and URL construction, `insertData()` routing logic, error paths

**HttpResponseErrorMapper**: expanded data providers with CURL error code 52 and HTTP 503

**RemoteRequest** (4 tests): `fetch()` CURL options and POST params, `canConnect()` static caching, missing REQUEST_ID handling, fetch error handling

**Connector subclasses** (6 tests):
- Fuseki: `&output=xml` query parameter
- Virtuoso: `query=` (not `update=`) in doUpdate, `DELETE FROM` syntax
- Fourstore: `&restricted=1`, form-encoded doHttpPost, charset-less Content-Type

## Test plan

- [x] All 83 tests pass (168 assertions, 0 failures)
- [x] PHPCS clean (0 errors, 0 warnings)
- [x] CI passes