### PR TITLE
Release SMW connections in tearDown to prevent lock timeout

### DIFF
--- a/tests/phpunit/SMWIntegrationTestCase.php
+++ b/tests/phpunit/SMWIntegrationTestCase.php
@@ -67,11 +67,6 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		// (or the unit suite) are destroyed before we set up fresh ones.
 		$this->resetSMWServices();
 
-		// Release cached connections on the fresh ServicesFactory so the
-		// Store picks up the test DB connection (with unittest_ prefix)
-		// instead of stale boot connections.
-		ServicesFactory::getInstance()->getConnectionManager()->releaseConnections();
-
 		$this->clearGlobalCaches();
 
 		// Prepare test environment for SMW-specific requirements
@@ -142,6 +137,14 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		MediaWikiServices::getInstance()
 			->getDBLoadBalancerFactory()
 			->commitPrimaryChanges( __METHOD__ );
+
+		// Release all SMW connection references so that when MW's
+		// restoreMwServices() destroys the test LBFactory, no stale
+		// Database objects survive. A stale reference can silently
+		// reconnect (via replaceLostConnection) and create an untracked
+		// MySQL connection whose implicit transaction blocks TRUNCATE
+		// in mediaWikiTearDownAfterClass().
+		ServicesFactory::getInstance()->getConnectionManager()->releaseConnections();
 
 		parent::tearDown();
 	}


### PR DESCRIPTION
Attempt to address #6387

## Summary

- Move `releaseConnections()` from `setUp()` to `tearDown()` (after `commitPrimaryChanges()`) to ensure SMW drops all DB connection references before MW's `restoreMwServices()` destroys the test LBFactory
- The `addDBDataOnce()` call (once per class) is retained for initial table setup with the correct `unittest_` prefix

## Problem

Integration tests sporadically fail with `Lock wait timeout exceeded` on `TRUNCATE TABLE` during `mediaWikiTearDownAfterClass()`. This happens because:

1. SMW's `ConnectionManager` holds static references to `LoadBalancerConnectionProvider` instances that cache resolved `IDatabase` connections
2. When MW's `restoreMwServices()` destroys the test service container, `LBFactory::destroy()` closes all connections tracked by the LoadBalancer
3. But if SMW still holds a reference to the resolved `IDatabase` object, any subsequent access triggers `replaceLostConnection()`, creating an **untracked** MySQL connection
4. This zombie connection's implicit transaction holds locks that block `TRUNCATE` from the restored (original) service container's connection

## Fix

Release all SMW connection references in `tearDown()` after committing pending writes. This ensures no stale `Database` objects survive the service container destruction.

The `releaseConnections()` call previously in `setUp()` is removed as redundant — the `tearDown()` call at the end of test N covers the `setUp()` call at the start of test N+1.

## Test plan

- [ ] CI passes without lock timeout errors on repeated runs
- [ ] Integration test suite completes successfully

Fixes #6387