### PR TITLE
Remove mediawiki/parser-hooks dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,6 @@
 		"php": ">=8.1",
 		"ext-mbstring": "*",
 		"composer/installers": "^2.2.0|^1.0.1",
-		"mediawiki/parser-hooks": "~1.4",
 		"param-processor/param-processor": "~1.2",
 		"serialization/serialization": "~3.2|~4.0",
 		"onoi/message-reporter": "~1.0",

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -7,9 +7,11 @@ use MediaWiki\Context\IContextSource;
 use MediaWiki\HookContainer\HookContainer;
 use MediaWiki\Linker\LinkTarget;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\PPFrame;
 use MediaWiki\User\User;
 use MediaWiki\User\UserIdentity;
-use ParserHooks\HookRegistrant;
+use ParamProcessor\Processor;
 use SMW\DataTypeRegistry;
 use SMW\MediaWiki\Content\SchemaContentHandler;
 use SMW\MediaWiki\Hooks\AdminLinks;
@@ -1162,17 +1164,55 @@ class Hooks {
 		$parserFunctionFactory = $applicationFactory->newParserFunctionFactory();
 		$parserFunctionFactory->registerFunctionHandlers( $parser );
 
-		$hookRegistrant = new HookRegistrant( $parser );
+		[ $name, $definition, $flag ] = $parserFunctionFactory->getInfoParserFunctionDefinition();
+		$parser->setFunctionHook( $name, $definition, $flag );
 
-		$infoFunctionDefinition = InfoParserFunction::getHookDefinition();
-		$infoFunctionHandler = new InfoParserFunction();
-		$hookRegistrant->registerFunctionHandler( $infoFunctionDefinition, $infoFunctionHandler );
-		$hookRegistrant->registerHookHandler( $infoFunctionDefinition, $infoFunctionHandler );
+		$parser->setHook( 'info', static function ( $input, array $attribs, Parser $parser, PPFrame $frame ) {
+			$defaultParams = InfoParserFunction::getDefaultParams();
+			$defaultParam = array_shift( $defaultParams );
 
-		$docsFunctionDefinition = DocumentationParserFunction::getHookDefinition();
-		$docsFunctionHandler = new DocumentationParserFunction();
-		$hookRegistrant->registerFunctionHandler( $docsFunctionDefinition, $docsFunctionHandler );
-		$hookRegistrant->registerHookHandler( $docsFunctionDefinition, $docsFunctionHandler );
+			if ( $defaultParam !== null && $input !== null ) {
+				$attribs[$defaultParam] = $input;
+			}
+
+			$processor = Processor::newDefault();
+			$processor->setParameters(
+				$attribs,
+				InfoParserFunction::getParamDefinitions()
+			);
+
+			$result = $processor->processParameters();
+
+			$handler = new InfoParserFunction();
+			$resultText = $handler->handle( $parser, $result );
+
+			return $parser->recursiveTagParse( $resultText, $frame );
+		} );
+
+		[ $name, $definition, $flag ] = $parserFunctionFactory->getDocumentationParserFunctionDefinition();
+		$parser->setFunctionHook( $name, $definition, $flag );
+
+		$parser->setHook( 'smwdoc', static function ( $input, array $attribs, Parser $parser, PPFrame $frame ) {
+			$defaultParams = DocumentationParserFunction::getDefaultParams();
+			$defaultParam = array_shift( $defaultParams );
+
+			if ( $defaultParam !== null && $input !== null ) {
+				$attribs[$defaultParam] = $input;
+			}
+
+			$processor = Processor::newDefault();
+			$processor->setParameters(
+				$attribs,
+				DocumentationParserFunction::getParamDefinitions()
+			);
+
+			$result = $processor->processParameters();
+
+			$handler = new DocumentationParserFunction();
+			$resultText = $handler->handle( $parser, $result );
+
+			return $parser->recursiveTagParse( $resultText, $frame );
+		} );
 
 		/**
 		 * Support for <section> ... </section>

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -4,11 +4,15 @@ namespace SMW;
 
 // Fatal error: Cannot use SMW\ParserFunctions\SubobjectParserFunction as SubobjectParserFunction because the name is already in use
 use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\PPFrame;
+use ParamProcessor\Processor;
 use SMW\Parser\RecursiveTextProcessor;
 use SMW\ParserFunctions\AskParserFunction;
 use SMW\ParserFunctions\ConceptParserFunction;
 use SMW\ParserFunctions\DeclareParserFunction;
+use SMW\ParserFunctions\DocumentationParserFunction;
 use SMW\ParserFunctions\ExpensiveFuncExecutionWatcher;
+use SMW\ParserFunctions\InfoParserFunction;
 use SMW\ParserFunctions\RecurringEventsParserFunction as RecurringEventsParserFunc;
 use SMW\ParserFunctions\SetParserFunction;
 use SMW\ParserFunctions\ShowParserFunction;
@@ -505,6 +509,62 @@ class ParserFunctionFactory {
 		};
 
 		return [ 'declare', $declareParserFunctionDefinition, Parser::SFH_OBJECT_ARGS ];
+	}
+
+	/**
+	 * @since 5.1
+	 *
+	 * @return array
+	 */
+	public function getDocumentationParserFunctionDefinition() {
+		$smwdocDefinition = static function ( Parser $parser, PPFrame $frame, array $args ) {
+			$expandedArgs = [];
+			foreach ( $args as $arg ) {
+				$expandedArgs[] = $frame->expand( $arg );
+			}
+
+			$processor = Processor::newDefault();
+			$processor->setFunctionParams(
+				$expandedArgs,
+				DocumentationParserFunction::getParamDefinitions(),
+				DocumentationParserFunction::getDefaultParams()
+			);
+
+			$result = $processor->processParameters();
+
+			$handler = new DocumentationParserFunction();
+			return [ $handler->handle( $parser, $result ) ];
+		};
+
+		return [ 'smwdoc', $smwdocDefinition, Parser::SFH_OBJECT_ARGS ];
+	}
+
+	/**
+	 * @since 5.1
+	 *
+	 * @return array
+	 */
+	public function getInfoParserFunctionDefinition() {
+		$infoDefinition = static function ( Parser $parser, PPFrame $frame, array $args ) {
+			$expandedArgs = [];
+			foreach ( $args as $arg ) {
+				$expandedArgs[] = $frame->expand( $arg );
+			}
+
+			$processor = Processor::newDefault();
+			$processor->setFunctionParams(
+				$expandedArgs,
+				InfoParserFunction::getParamDefinitions(),
+				InfoParserFunction::getDefaultParams()
+			);
+
+			$result = $processor->processParameters();
+
+			$handler = new InfoParserFunction();
+			return [ $handler->handle( $parser, $result ) ];
+		};
+
+		return [ 'info', $infoDefinition, Parser::SFH_OBJECT_ARGS ];
 	}
 
 }

--- a/src/ParserFunctions/DocumentationParserFunction.php
+++ b/src/ParserFunctions/DocumentationParserFunction.php
@@ -6,8 +6,6 @@ use MediaWiki\Parser\Parser;
 use ParamProcessor\ProcessedParam;
 use ParamProcessor\ProcessingError;
 use ParamProcessor\ProcessingResult;
-use ParserHooks\HookDefinition;
-use ParserHooks\HookHandler;
 use SMW\ParameterListDocBuilder;
 use SMWQueryProcessor as QueryProcessor;
 
@@ -20,7 +18,7 @@ use SMWQueryProcessor as QueryProcessor;
  * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class DocumentationParserFunction implements HookHandler {
+class DocumentationParserFunction {
 
 	/**
 	 * @var string
@@ -54,32 +52,29 @@ class DocumentationParserFunction implements HookHandler {
 		return $this->buildParameterListDocumentation( $parameters, $formatParameters );
 	}
 
-	/**
-	 * @return HookDefinition
-	 */
-	public static function getHookDefinition() {
-		return new HookDefinition(
-			'smwdoc',
+	public static function getParamDefinitions(): array {
+		return [
 			[
-				[
-					'name' => 'format',
-					'message' => 'smw-smwdoc-par-format',
-					'values' => array_keys( $GLOBALS['smwgResultFormats'] ),
-				],
-				[
-					'name' => 'language',
-					'message' => 'smw-smwdoc-par-language',
-					'default' => $GLOBALS['wgLanguageCode'],
-				],
-				[
-					'name' => 'parameters',
-					'message' => 'smw-smwdoc-par-parameters',
-					'values' => [ 'all', 'specific', 'base' ],
-					'default' => 'specific',
-				],
+				'name' => 'format',
+				'message' => 'smw-smwdoc-par-format',
+				'values' => array_keys( $GLOBALS['smwgResultFormats'] ),
 			],
-			[ 'format', 'language', 'parameters' ]
-		);
+			[
+				'name' => 'language',
+				'message' => 'smw-smwdoc-par-language',
+				'default' => $GLOBALS['wgLanguageCode'],
+			],
+			[
+				'name' => 'parameters',
+				'message' => 'smw-smwdoc-par-parameters',
+				'values' => [ 'all', 'specific', 'base' ],
+				'default' => 'specific',
+			],
+		];
+	}
+
+	public static function getDefaultParams(): array {
+		return [ 'format', 'language', 'parameters' ];
 	}
 
 	/**

--- a/src/ParserFunctions/InfoParserFunction.php
+++ b/src/ParserFunctions/InfoParserFunction.php
@@ -5,8 +5,6 @@ namespace SMW\ParserFunctions;
 use MediaWiki\Parser\Parser;
 use ParamProcessor\ProcessingError;
 use ParamProcessor\ProcessingResult;
-use ParserHooks\HookDefinition;
-use ParserHooks\HookHandler;
 use SMW\Highlighter;
 use SMWOutputs;
 
@@ -18,7 +16,7 @@ use SMWOutputs;
  * @author Markus Krötzsch
  * @author Jeroen De Dauw
  */
-class InfoParserFunction implements HookHandler {
+class InfoParserFunction {
 
 	/**
 	 * @param Parser $parser
@@ -97,37 +95,34 @@ class InfoParserFunction implements HookHandler {
 		return 'A fatal error occurred in the #info parser function';
 	}
 
-	public static function getHookDefinition() {
-		return new HookDefinition(
-			'info',
+	public static function getParamDefinitions(): array {
+		return [
 			[
-				[
-					'name' => 'message',
-					'message' => 'smw-info-par-message',
-				],
-				[
-					'name' => 'icon',
-					'message' => 'smw-info-par-icon',
-					'default' => 'info',
-					'values' => [ 'info', 'warning', 'error', 'note' ],
-				],
-				[
-					'name' => 'max-width',
-					'default' => '',
-					'message' => 'smw-info-par-max-width',
-				],
-				[
-					'name' => 'theme',
-					'default' => '',
-					'values' => [ 'square-border', 'square-border-light' ],
-					'message' => 'smw-info-par-theme',
-				]
+				'name' => 'message',
+				'message' => 'smw-info-par-message',
 			],
 			[
-				'message',
-				'icon'
-			]
-		);
+				'name' => 'icon',
+				'message' => 'smw-info-par-icon',
+				'default' => 'info',
+				'values' => [ 'info', 'warning', 'error', 'note' ],
+			],
+			[
+				'name' => 'max-width',
+				'default' => '',
+				'message' => 'smw-info-par-max-width',
+			],
+			[
+				'name' => 'theme',
+				'default' => '',
+				'values' => [ 'square-border', 'square-border-light' ],
+				'message' => 'smw-info-par-theme',
+			],
+		];
+	}
+
+	public static function getDefaultParams(): array {
+		return [ 'message', 'icon' ];
 	}
 
 }


### PR DESCRIPTION
## Summary

Removes the abandoned `mediawiki/parser-hooks` ~1.4 dependency by migrating the last two parser functions that still used it (`#info` and `#smwdoc`) to direct `Parser::setFunctionHook()` / `Parser::setHook()` registration.

- **`InfoParserFunction`** and **`DocumentationParserFunction`**: removed `HookHandler` interface, replaced `getHookDefinition()` with `getParamDefinitions()` / `getDefaultParams()`
- **`ParserFunctionFactory`**: added `getInfoParserFunctionDefinition()` and `getDocumentationParserFunctionDefinition()`, following the same pattern as the other 7 parser functions
- **`Hooks.php`**: replaced `HookRegistrant` with direct `setFunctionHook` + `setHook` calls
- **`composer.json`**: removed `mediawiki/parser-hooks` requirement

`param-processor` is retained — it's used across the query engine and result printers.

Closes #6114

## Test plan

- [x] `composer analyze` passes (lint + PHPCS clean)
- [x] `InfoParserFunctionTest`, `DocumentationParserFunctionTest`, `ParserFunctionFactoryTest` all pass
- [x] Browser: `{{#info:...}}`, `{{#info:...|icon=warning}}`, `<info>...</info>` render correctly
- [x] Browser: `{{#smwdoc:table}}`, `<smwdoc>table</smwdoc>` render parameter tables
- [x] No console errors