### PR TITLE
Revert #6455: release connections in tearDown made lock timeouts worse

### DIFF
--- a/tests/phpunit/SMWIntegrationTestCase.php
+++ b/tests/phpunit/SMWIntegrationTestCase.php
@@ -67,6 +67,11 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		// (or the unit suite) are destroyed before we set up fresh ones.
 		$this->resetSMWServices();
 
+		// Release cached connections on the fresh ServicesFactory so the
+		// Store picks up the test DB connection (with unittest_ prefix)
+		// instead of stale boot connections.
+		ServicesFactory::getInstance()->getConnectionManager()->releaseConnections();
+
 		$this->clearGlobalCaches();
 
 		// Prepare test environment for SMW-specific requirements
@@ -137,14 +142,6 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		MediaWikiServices::getInstance()
 			->getDBLoadBalancerFactory()
 			->commitPrimaryChanges( __METHOD__ );
-
-		// Release all SMW connection references so that when MW's
-		// restoreMwServices() destroys the test LBFactory, no stale
-		// Database objects survive. A stale reference can silently
-		// reconnect (via replaceLostConnection) and create an untracked
-		// MySQL connection whose implicit transaction blocks TRUNCATE
-		// in mediaWikiTearDownAfterClass().
-		ServicesFactory::getInstance()->getConnectionManager()->releaseConnections();
 
 		parent::tearDown();
 	}


### PR DESCRIPTION
Reverts #6455.

Lock timeouts in CI became more frequent after #6455, not less. Moving `releaseConnections()` back to `setUp()` where it was before.

See #6387 for details.