### PR TITLE
Move includes/formatters to src/Formatters

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -60,7 +60,8 @@
 		"SMWWikiPageValue": "src/DataValues/WikiPageValue.php",
 		"SMWExpData": "src/Export/ExpData.php",
 		"SMWExportController": "src/Export/ExportController.php",
-		"SMWExporter": "src/Export/Exporter.php"
+		"SMWExporter": "src/Export/Exporter.php",
+		"SMW\\MessageFormatter": "src/Formatters/MessageFormatter.php"
 	},
 	"callback": "SemanticMediaWiki::initExtension",
 	"ExtensionFunctions": [

--- a/src/Formatters/MessageFormatter.php
+++ b/src/Formatters/MessageFormatter.php
@@ -1,29 +1,25 @@
 <?php
 
-namespace SMW;
+namespace SMW\Formatters;
 
 use MediaWiki\Html\Html;
 use MediaWiki\Language\Language;
 use MediaWiki\Message\Message;
+use SMW\Highlighter;
+use SMW\ProcessingErrorMsgHandler;
 
 /**
- * Class implementing message output formatting
+ * Class implementing message output formatting.
  *
- *
- * @license GPL-2.0-or-later
- * @since   1.9
- *
- * @author mwjames
- */
-
-/**
- * This class is implementing message output formatting to avoid having
- * classes to invoke a language object that is not a direct dependency (which
- * means that context relevant information is mostly missing from the invoking
- * class) therefore it is more appropriate to collect Message objects from the
- * source and initiate an output formatting only when necessary and requested.
+ * This class handles message output formatting to avoid requiring calling
+ * classes to directly depend on a language object (which would otherwise lack
+ * necessary context). Instead, it collects Message objects from the source and
+ * performs formatting only when explicitly needed.
  *
  * @ingroup Formatter
+ * @since 1.9
+ * @license GPL-2.0-or-later
+ * @author mwjames
  */
 class MessageFormatter {
 
@@ -287,3 +283,8 @@ class MessageFormatter {
 		return $this->exists() ? $this->getString( false ) : '';
 	}
 }
+
+/**
+ * @deprecated since 7.0.0
+ */
+class_alias( MessageFormatter::class, 'SMW\MessageFormatter' );

--- a/tests/phpunit/Formatters/MessageFormatterTest.php
+++ b/tests/phpunit/Formatters/MessageFormatterTest.php
@@ -1,10 +1,11 @@
 <?php
 
-namespace SMW\Tests;
+namespace SMW\Tests\Formatters;
 
 use MediaWiki\Message\Message;
 use ReflectionClass;
-use SMW\MessageFormatter;
+use SMW\Formatters\MessageFormatter;
+use SMW\Tests\SemanticMediaWikiTestCase;
 
 /**
  * Tests for the MessageFormatter class
@@ -18,7 +19,7 @@ use SMW\MessageFormatter;
  */
 
 /**
- * @covers \SMW\MessageFormatter
+ * @covers \SMW\Formatters\MessageFormatter
  *
  *
  * @group SMW
@@ -97,7 +98,7 @@ class MessageFormatterTest extends SemanticMediaWikiTestCase {
 		$this->assertCount( 3, $messages );
 
 		foreach ( $messages as $msg ) {
-			$this->assertInstanceOf( '\Message', $msg );
+			$this->assertInstanceOf( Message::class, $msg );
 
 			foreach ( $msg->getParams() as $result ) {
 				$this->assertEquals( $param, $result );


### PR DESCRIPTION
Also correctly namespace the files including class name.

The old classname is still available but deprecated.