### PR TITLE
Fix MW notices inside db-primary-keys.php

### DIFF
--- a/data/config/db-primary-keys.php
+++ b/data/config/db-primary-keys.php
@@ -141,7 +141,7 @@ $GLOBALS[ 'wgHooks' ][ 'SMW::SQLStore::Installer::BeforeCreateTablesComplete' ][
 		$messageReporter->reportMessage(
 			$cliMsgFormatter->oneCol( "... done.", 3 )
 		);
-};
+	};
 
 return [
 


### PR DESCRIPTION
When using the db-primary-keys.php config. there a multiple deprecation warnings i've tried to fix them here.
```
PHP Deprecated:  Premature access to service container [Called from require_once in /Users/ravy1/Projects/Devimg/workspace/composer-ext/SMW/data/config/db-primary-keys.php at line 95] in /var/platform/mediawiki/1.43/core/20260323081830/includes/debug/MWDebug.php on line 385
Deprecated: Premature access to service container [Called from require_once in /Users/ravy1/Projects/Devimg/workspace/composer-ext/SMW/data/config/db-primary-keys.php at line 95] in /var/platform/mediawiki/1.43/core/20260323081830/includes/debug/MWDebug.php on line 385
PHP Deprecated:  Premature access to service 'HookContainer' [Called from MediaWiki\MediaWikiServices::getInstance in /var/platform/mediawiki/1.43/core/20260323081830/includes/MediaWikiServices.php at line 345] in /var/platform/mediawiki/1.43/core/20260323081830/includes/debug/MWDebug.php on line 385
Deprecated: Premature access to service 'HookContainer' [Called from MediaWiki\MediaWikiServices::getInstance in /var/platform/mediawiki/1.43/core/20260323081830/includes/MediaWikiServices.php at line 345] in /var/platform/mediawiki/1.43/core/20260323081830/includes/debug/MWDebug.php on line 385
PHP Deprecated:  Premature access to service 'BootstrapConfig' [Called from Wikimedia\Services\ServiceContainer::{closure} in /var/platform/mediawiki/1.43/core/20260323081830/includes/ServiceWiring.php at line 929] in /var/platform/mediawiki/1.43/core/20260323081830/includes/debug/MWDebug.php on line 385
Deprecated: Premature access to service 'BootstrapConfig' [Called from Wikimedia\Services\ServiceContainer::{closure} in /var/platform/mediawiki/1.43/core/20260323081830/includes/ServiceWiring.php at line 929] in /var/platform/mediawiki/1.43/core/20260323081830/includes/debug/MWDebug.php on line 385
PHP Deprecated:  Premature access to service 'ObjectFactory' [Called from Wikimedia\Services\ServiceContainer::{closure} in /var/platform/mediawiki/1.43/core/20260323081830/includes/ServiceWiring.php at line 945] in /var/platform/mediawiki/1.43/core/20260323081830/includes/debug/MWDebug.php on line 385
Deprecated: Premature access to service 'ObjectFactory' [Called from Wikimedia\Services\ServiceContainer::{closure} in /var/platform/mediawiki/1.43/core/20260323081830/includes/ServiceWiring.php at line 945] in /var/platform/mediawiki/1.43/core/20260323081830/includes/debug/MWDebug.php on line 385
```