### PR TITLE
CharArmor: Fix phan errors

### DIFF
--- a/src/Utils/CharArmor.php
+++ b/src/Utils/CharArmor.php
@@ -19,7 +19,7 @@ class CharArmor {
 	 *
 	 * @param string $text
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public static function removeControlChars( $text ): ?string {
 		return preg_replace( '/[^\PC\s]/u', '', $text );


### PR DESCRIPTION
> src/Utils/CharArmor.php:22 PhanTypeMismatchDeclaredReturnNullable Doc-block of removeControlChars has declared return type string which is not a permitted replacement of the nullable return type ?string declared in the signature ('?T' should be documented as 'T|null' or '?T')