### PR TITLE
tests: Add missing `@group Database` to BenchmarkJsonScriptRunnerTest

### DIFF
--- a/tests/phpunit/Benchmark/BenchmarkJsonScriptRunnerTest.php
+++ b/tests/phpunit/Benchmark/BenchmarkJsonScriptRunnerTest.php
@@ -8,6 +8,7 @@ use SMW\Tests\Utils\JSONScript\JsonTestCaseFileHandler;
 
 /**
  * @group semantic-mediawiki-benchmark
+ * @group Database
  * @group medium
  *
  * @license GPL-2.0-or-later


### PR DESCRIPTION
## Summary

Add missing `@group Database` annotation to `BenchmarkJsonScriptRunnerTest`.

## Problem

MediaWiki's `MediaWikiIntegrationTestCase::needsDB()` checks for `@group Database` on the **concrete test class** docblock using `static::class`, not parent classes. `BenchmarkJsonScriptRunnerTest` inherits from `JSONScriptTestCaseRunner` which has the annotation, but the reflection-based check doesn't see it.

All 3 benchmark tests fail with:
```
LogicException: This test does not need DB but tried to access it anyway
```

## Fix

One-line addition of `@group Database` to the class docblock.

## Test plan

- [ ] `composer benchmark` runs without `LogicException`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)