### PR TITLE
Fix undefined enableSemantics function

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,6 +69,11 @@
 	"suggest": {
 		"mediawiki/semantic-result-formats": "Provides additional result formats for queries of structured data"
 	},
+	"autoload": {
+		"files": [
+			"src/enableSemantics.php"
+		]
+	},
 	"extra": {
 		"branch-alias": {
 			"dev-master": "7.x-dev"

--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -201,14 +201,3 @@ function smwfGetLinker() {
 
 	return $linker;
 }
-
-/**
- * @deprecated since 7.0.0. Use wfLoadExtension( 'SemanticMediaWiki' ) instead.
- *
- * @param mixed $namespace
- * @param bool $complete
- */
-// phpcs:ignore MediaWiki.NamingConventions.PrefixedGlobalFunctions.allowedPrefix
-function enableSemantics( $namespace = null, $complete = false ): void {
-	wfDeprecated( __FUNCTION__, '7.0.0' );
-}

--- a/src/enableSemantics.php
+++ b/src/enableSemantics.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * Deprecated entry point for enabling Semantic MediaWiki.
+ *
+ * This file is loaded via Composer autoload so that the function is available
+ * during LocalSettings.php execution, before the extension callback runs.
+ *
+ * @deprecated since 7.0.0. Use wfLoadExtension( 'SemanticMediaWiki' ) instead.
+ *
+ * @param mixed $namespace
+ * @param bool $complete
+ */
+// phpcs:ignore MediaWiki.NamingConventions.PrefixedGlobalFunctions.allowedPrefix
+function enableSemantics( $namespace = null, $complete = false ): void {
+	if ( function_exists( 'wfDeprecated' ) ) {
+		wfDeprecated( __FUNCTION__, '7.0.0' );
+	}
+}


### PR DESCRIPTION
Fix https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6372#issuecomment-4103037470

The autoloader refactor also made the original enableSemantics function unreachable in localSettings.php. Let's move it to a dedicated php file for autoloading.

Verified locally.