### PR TITLE
Setup: Move log type registration to extension.json

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -94,6 +94,12 @@
 		"SemanticMediaWikiAlias": "i18n/extra/SemanticMediaWiki.alias.php",
 		"SemanticMediaWikiMagic": "i18n/extra/SemanticMediaWiki.magic.php"
 	},
+	"LogTypes": [
+		"smw"
+	],
+	"FilterLogTypes": {
+		"smw": true
+	},
 	"ContentHandlers": {
 		"smw/schema": "SMW\\MediaWiki\\Content\\SchemaContentHandler"
 	},

--- a/src/Setup.php
+++ b/src/Setup.php
@@ -207,9 +207,6 @@ final class Setup {
 			define( 'SMW_PHPUNIT_DIR', __DIR__ . '/../tests/phpunit' );
 		}
 
-		$vars['wgLogTypes'][] = 'smw';
-		$vars['wgFilterLogTypes']['smw'] = true;
-
 		$vars['smwgMasterStore'] = null;
 		$vars['smwgIQRunningNumber'] = 0;
 


### PR DESCRIPTION
## Summary

- Moves the `smw` log type and filter registration from PHP (`Setup::addDefaultConfigurations`) to declarative `LogTypes` and `FilterLogTypes` keys in extension.json
- Part of an incremental effort to move registrations from Setup.php to extension.json where MediaWiki supports declarative equivalents

## Test plan

- [x] Verify `Special:Log/smw` loads correctly and shows "Semantic MediaWiki log" in the dropdown
- [x] Run CI