### PR TITLE
refactor: add void return types to methods with no return statements

### DIFF
--- a/src/Constraint/Constraint.php
+++ b/src/Constraint/Constraint.php
@@ -55,6 +55,6 @@ interface Constraint {
 	 * @param array $constraint
 	 * @param mixed $value
 	 */
-	public function checkConstraint( array $constraint, $value );
+	public function checkConstraint( array $constraint, $value ): void;
 
 }

--- a/src/Constraint/Constraints/MandatoryPropertiesConstraint.php
+++ b/src/Constraint/Constraints/MandatoryPropertiesConstraint.php
@@ -47,7 +47,7 @@ class MandatoryPropertiesConstraint implements Constraint {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function checkConstraint( array $constraint, $dataValue ) {
+	public function checkConstraint( array $constraint, $dataValue ): void {
 		$this->hasViolation = false;
 
 		if ( !$dataValue instanceof DataValue ) {
@@ -57,7 +57,8 @@ class MandatoryPropertiesConstraint implements Constraint {
 		$key = key( $constraint );
 
 		if ( $key === self::CONSTRAINT_KEY ) {
-			return $this->check( $constraint[$key], $dataValue );
+			$this->check( $constraint[$key], $dataValue );
+			return;
 		}
 	}
 

--- a/src/Constraint/Constraints/MustExistsConstraint.php
+++ b/src/Constraint/Constraints/MustExistsConstraint.php
@@ -46,7 +46,7 @@ class MustExistsConstraint implements Constraint {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function checkConstraint( array $constraint, $dataValue ) {
+	public function checkConstraint( array $constraint, $dataValue ): void {
 		$this->hasViolation = false;
 
 		if ( !$dataValue instanceof DataValue ) {
@@ -56,7 +56,8 @@ class MustExistsConstraint implements Constraint {
 		$key = key( $constraint );
 
 		if ( $key === self::CONSTRAINT_KEY ) {
-			return $this->check( $constraint[$key], $dataValue );
+			$this->check( $constraint[$key], $dataValue );
+			return;
 		}
 	}
 

--- a/src/Constraint/Constraints/NamespaceConstraint.php
+++ b/src/Constraint/Constraints/NamespaceConstraint.php
@@ -46,7 +46,7 @@ class NamespaceConstraint implements Constraint {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function checkConstraint( array $constraint, $dataValue ) {
+	public function checkConstraint( array $constraint, $dataValue ): void {
 		$this->hasViolation = false;
 
 		if ( !$dataValue instanceof DataValue ) {
@@ -56,7 +56,8 @@ class NamespaceConstraint implements Constraint {
 		$key = key( $constraint );
 
 		if ( $key === self::CONSTRAINT_KEY ) {
-			return $this->check( $constraint[$key], $dataValue );
+			$this->check( $constraint[$key], $dataValue );
+			return;
 		}
 	}
 

--- a/src/Constraint/Constraints/NullConstraint.php
+++ b/src/Constraint/Constraints/NullConstraint.php
@@ -35,7 +35,7 @@ class NullConstraint implements Constraint {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function checkConstraint( array $constraint, $value ) {
+	public function checkConstraint( array $constraint, $value ): void {
 	}
 
 }

--- a/src/Constraint/Constraints/SingleValueConstraint.php
+++ b/src/Constraint/Constraints/SingleValueConstraint.php
@@ -47,7 +47,7 @@ class SingleValueConstraint implements Constraint {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function checkConstraint( array $constraint, $dataValue ) {
+	public function checkConstraint( array $constraint, $dataValue ): void {
 		$this->hasViolation = false;
 
 		if ( !$dataValue instanceof DataValue ) {
@@ -57,7 +57,8 @@ class SingleValueConstraint implements Constraint {
 		$key = key( $constraint );
 
 		if ( $key === self::CONSTRAINT_KEY ) {
-			return $this->check( $constraint[$key], $dataValue );
+			$this->check( $constraint[$key], $dataValue );
+			return;
 		}
 	}
 

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -484,7 +484,7 @@ class DataTypeRegistry {
 	 * associations. This method is called before most methods of this
 	 * factory.
 	 */
-	protected function initDatatypes( array $typeList ) {
+	protected function initDatatypes( array $typeList ): void {
 		foreach ( $typeList as $id => $definition ) {
 
 			if ( isset( $definition[0] ) ) {

--- a/src/DataValues/AllowsListValue.php
+++ b/src/DataValues/AllowsListValue.php
@@ -39,7 +39,7 @@ class AllowsListValue extends StringValue {
 	 *
 	 * @param string $value
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		if ( $value === '' ) {
 			$this->addErrorMsg( 'smw_emptystring' );
 		}

--- a/src/DataValues/AllowsPatternValue.php
+++ b/src/DataValues/AllowsPatternValue.php
@@ -41,7 +41,7 @@ class AllowsPatternValue extends StringValue {
 	 *
 	 * @param string $value
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		if ( $value === '' ) {
 			$this->addErrorMsg( 'smw_emptystring' );
 		}

--- a/src/DataValues/BooleanValue.php
+++ b/src/DataValues/BooleanValue.php
@@ -43,7 +43,7 @@ class BooleanValue extends DataValue {
 	/**
 	 * @see DataValue::parseUserValue
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		$value = trim( $value );
 
 		if ( $this->m_caption === false ) {

--- a/src/DataValues/ConceptValue.php
+++ b/src/DataValues/ConceptValue.php
@@ -37,7 +37,7 @@ class ConceptValue extends DataValue {
 		return true;
 	}
 
-	protected function clear() {
+	protected function clear(): void {
 		$this->m_dataitem = new Concept( '', '', 0, -1, -1, $this->m_typeid );
 	}
 

--- a/src/DataValues/ConstraintSchemaValue.php
+++ b/src/DataValues/ConstraintSchemaValue.php
@@ -33,7 +33,7 @@ class ConstraintSchemaValue extends WikiPageValue {
 	 *
 	 * @param string $value
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		parent::parseUserValue( $value );
 
 		$dataItem = $this->getDataItem();

--- a/src/DataValues/DataValue.php
+++ b/src/DataValues/DataValue.php
@@ -922,7 +922,7 @@ abstract class DataValue {
 	 *
 	 * @param string $value
 	 */
-	abstract protected function parseUserValue( $value );
+	abstract protected function parseUserValue( $value ): void;
 
 	/**
 	 * Set the actual data contained in this object. The method returns
@@ -955,7 +955,7 @@ abstract class DataValue {
 	/**
 	 * @deprecated since 3.1, use DataValue::checkConstraints
 	 */
-	protected function checkAllowedValues() {
+	protected function checkAllowedValues(): void {
 		$this->checkConstraints();
 	}
 

--- a/src/DataValues/ErrorMsgTextValue.php
+++ b/src/DataValues/ErrorMsgTextValue.php
@@ -28,7 +28,7 @@ class ErrorMsgTextValue extends DataValue {
 	 *
 	 * @param string $value
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		if ( $value === '' ) {
 			$this->addErrorMsg( 'smw_emptystring' );
 		}

--- a/src/DataValues/ErrorValue.php
+++ b/src/DataValues/ErrorValue.php
@@ -27,7 +27,7 @@ class ErrorValue extends DataValue {
 		}
 	}
 
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		if ( $this->m_caption === false ) {
 			$this->m_caption = $value;
 		}

--- a/src/DataValues/ExternalFormatterUriValue.php
+++ b/src/DataValues/ExternalFormatterUriValue.php
@@ -29,7 +29,7 @@ class ExternalFormatterUriValue extends URIValue {
 	 *
 	 * @param string $value
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		if ( $value === '' ) {
 			$this->addErrorMsg( 'smw_emptystring' );
 			return;

--- a/src/DataValues/ExternalIdentifierValue.php
+++ b/src/DataValues/ExternalIdentifierValue.php
@@ -38,7 +38,7 @@ class ExternalIdentifierValue extends StringValue {
 	 *
 	 * @param string $value
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		parent::parseUserValue( $value );
 	}
 

--- a/src/DataValues/ImportValue.php
+++ b/src/DataValues/ImportValue.php
@@ -80,7 +80,7 @@ class ImportValue extends DataValue {
 	 *
 	 * @param string $value
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		$this->qname = $value;
 
 		$importValueParser = $this->dataValueServiceFactory->getValueParser(

--- a/src/DataValues/KeywordValue.php
+++ b/src/DataValues/KeywordValue.php
@@ -40,7 +40,7 @@ class KeywordValue extends StringValue {
 	 *
 	 * @param string $value
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		// For the normal blob field setup multi-byte requires more space and
 		// since we use the o_hash field to store the normalized content and
 		// as match field, ensure to have enough space to actually store

--- a/src/DataValues/LanguageCodeValue.php
+++ b/src/DataValues/LanguageCodeValue.php
@@ -45,7 +45,7 @@ class LanguageCodeValue extends StringValue {
 	 *
 	 * @param string $userValue
 	 */
-	protected function parseUserValue( $userValue ) {
+	protected function parseUserValue( $userValue ): void {
 		$languageCode = Localizer::asBCP47FormattedLanguageCode( $userValue );
 
 		if ( $languageCode === '' ) {

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -102,7 +102,7 @@ class MonolingualTextValue extends AbstractMultiValue {
 	 *
 	 * @param string $userValue
 	 */
-	protected function parseUserValue( $userValue ) {
+	protected function parseUserValue( $userValue ): void {
 		[ $text, $languageCode ] = $this->getValuesFromString( $userValue );
 
 		$languageCodeValue = $this->newLanguageCodeValue( $languageCode );

--- a/src/DataValues/NumberValue.php
+++ b/src/DataValues/NumberValue.php
@@ -171,7 +171,7 @@ class NumberValue extends DataValue {
 	/**
 	 * @see DataValue::parseUserValue
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		// Set caption
 		if ( $this->m_caption === false ) {
 			$this->m_caption = $value;
@@ -469,7 +469,7 @@ class NumberValue extends DataValue {
 	 *
 	 * Overwritten by subclasses that support units.
 	 */
-	protected function makeConversionValues() {
+	protected function makeConversionValues(): void {
 		$this->m_unitvalues = [ '' => $this->m_dataitem->getNumber() ];
 	}
 
@@ -482,7 +482,7 @@ class NumberValue extends DataValue {
 	 *
 	 * Overwritten by subclasses that support units.
 	 */
-	protected function makeUserValue() {
+	protected function makeUserValue(): void {
 		$this->m_caption = '';
 
 		$number = $this->m_dataitem->getNumber();

--- a/src/DataValues/PropertyChainValue.php
+++ b/src/DataValues/PropertyChainValue.php
@@ -163,7 +163,7 @@ class PropertyChainValue extends StringValue {
 	 *
 	 * @param string $value
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		if ( $value === '' ) {
 			$this->addErrorMsg( 'smw_emptystring' );
 		}

--- a/src/DataValues/PropertyListValue.php
+++ b/src/DataValues/PropertyListValue.php
@@ -25,7 +25,7 @@ class PropertyListValue extends DataValue {
 	 */
 	protected $m_diProperties;
 
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		$this->m_diProperties = [];
 		$stringValue = '';
 		$localizer = Localizer::getInstance();

--- a/src/DataValues/PropertyValue.php
+++ b/src/DataValues/PropertyValue.php
@@ -118,7 +118,7 @@ class PropertyValue extends DataValue {
 	 * Clone it to make sure that data can be modified independently from the
 	 * original object's content.
 	 */
-	public function __clone() {
+	public function __clone(): void {
 		if ( $this->m_wikipage !== null ) {
 			$this->m_wikipage = clone $this->m_wikipage;
 		}
@@ -143,7 +143,7 @@ class PropertyValue extends DataValue {
 	 *
 	 * @todo Accept/enforce property namespace.
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		$this->m_wikipage = null;
 
 		$propertyValueParser = $this->dataValueServiceFactory->getValueParser(
@@ -163,7 +163,8 @@ class PropertyValue extends DataValue {
 		[ $propertyName, $capitalizedName, $inverse ] = $propertyValueParser->parse( $value );
 
 		foreach ( $propertyValueParser->getErrors() as $error ) {
-			return $this->addErrorMsg( $error, Message::PARSE );
+			$this->addErrorMsg( $error, Message::PARSE );
+			return;
 		}
 
 		try {

--- a/src/DataValues/QuantityValue.php
+++ b/src/DataValues/QuantityValue.php
@@ -57,7 +57,7 @@ class QuantityValue extends NumberValue {
 		}
 	}
 
-	protected function makeConversionValues() {
+	protected function makeConversionValues(): void {
 		if ( $this->m_unitvalues !== false ) {
 			return; // do this only once
 		}
@@ -87,7 +87,7 @@ class QuantityValue extends NumberValue {
 		}
 	}
 
-	protected function makeUserValue() {
+	protected function makeUserValue(): void {
 		 // The normalised string of a known unit to use for printouts
 		$printunit = false;
 		$unitfactor = 1;
@@ -162,7 +162,7 @@ class QuantityValue extends NumberValue {
 	/**
 	 * This method initializes $m_unitfactors, $m_unitids, and $m_mainunit.
 	 */
-	protected function initConversionData() {
+	protected function initConversionData(): void {
 		if ( $this->m_unitids !== false ) {
 			return;
 		}
@@ -182,7 +182,7 @@ class QuantityValue extends NumberValue {
 	/**
 	 * This method initializes $m_displayunits.
 	 */
-	protected function initDisplayData() {
+	protected function initDisplayData(): void {
 		if ( $this->m_displayunits !== false ) {
 			return; // do the below only once
 		}

--- a/src/DataValues/RecordValue.php
+++ b/src/DataValues/RecordValue.php
@@ -74,7 +74,7 @@ class RecordValue extends AbstractMultiValue {
 		return str_replace( "-3B", ";", $values );
 	}
 
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		if ( $value === '' ) {
 			$this->addErrorMsg( [ 'smw_novalues' ] );
 			return;

--- a/src/DataValues/ReferenceValue.php
+++ b/src/DataValues/ReferenceValue.php
@@ -182,7 +182,7 @@ class ReferenceValue extends AbstractMultiValue {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		if ( $value === '' ) {
 			$this->addErrorMsg( [ 'smw_novalues' ] );
 			return;

--- a/src/DataValues/StringValue.php
+++ b/src/DataValues/StringValue.php
@@ -134,7 +134,7 @@ class StringValue extends DataValue {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		if ( $value === '' ) {
 			$this->addErrorMsg( 'smw_emptystring' );
 		}

--- a/src/DataValues/TemperatureValue.php
+++ b/src/DataValues/TemperatureValue.php
@@ -46,7 +46,7 @@ class TemperatureValue extends NumberValue {
 	/**
 	 * NumberValue::makeConversionValues
 	 */
-	protected function makeConversionValues() {
+	protected function makeConversionValues(): void {
 		if ( $this->m_unitvalues !== false ) {
 			return; // do this only once
 		}
@@ -54,7 +54,7 @@ class TemperatureValue extends NumberValue {
 		$this->m_unitvalues = [];
 
 		if ( !$this->isValid() ) {
-			return $this->m_unitvalues;
+			return;
 		}
 
 		$displayUnit = $this->getPreferredDisplayUnit();
@@ -77,7 +77,7 @@ class TemperatureValue extends NumberValue {
 	/**
 	 * NumberValue::makeUserValue
 	 */
-	protected function makeUserValue() {
+	protected function makeUserValue(): void {
 		if ( ( $this->m_outformat ) && ( $this->m_outformat != '-' ) &&
 			 ( $this->m_outformat != '-n' ) && ( $this->m_outformat != '-u' ) ) { // first try given output unit
 			$printUnit = $this->normalizeUnit( $this->m_outformat );

--- a/src/DataValues/TimeValue.php
+++ b/src/DataValues/TimeValue.php
@@ -146,7 +146,7 @@ class TimeValue extends DataValue {
 	/**
 	 * @see DataValue::parseUserValue
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		$value = Localizer::convertDoubleWidth( $value );
 
 		$this->m_wikivalue = $value;

--- a/src/DataValues/TypesValue.php
+++ b/src/DataValues/TypesValue.php
@@ -181,7 +181,7 @@ class TypesValue extends DataValue {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		$value = (string)$value;
 
 		if ( $this->m_caption === false ) {

--- a/src/DataValues/URIValue.php
+++ b/src/DataValues/URIValue.php
@@ -67,7 +67,7 @@ class URIValue extends DataValue {
 		$this->schemeList = array_flip( $GLOBALS['smwgURITypeSchemeList'] );
 	}
 
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		$value = trim( $value );
 		$this->m_wikitext = $value;
 		if ( $this->m_caption === false ) {
@@ -141,7 +141,8 @@ class URIValue extends DataValue {
 
 				// #3540
 				if ( $hierpart !== '' && $hierpart[0] === '/' ) {
-					return $this->addErrorMsg( [ 'smw-datavalue-uri-invalid-authority-path-component', $value, $hierpart ] );
+					$this->addErrorMsg( [ 'smw-datavalue-uri-invalid-authority-path-component', $value, $hierpart ] );
+					return;
 				}
 
 				break;

--- a/src/DataValues/UniquenessConstraintValue.php
+++ b/src/DataValues/UniquenessConstraintValue.php
@@ -24,7 +24,7 @@ class UniquenessConstraintValue extends BooleanValue {
 	 *
 	 * @param string $userValue
 	 */
-	protected function parseUserValue( $userValue ) {
+	protected function parseUserValue( $userValue ): void {
 		if ( !$this->isEnabledFeature( SMW_DV_PVUC ) ) {
 			$this->addErrorMsg(
 				[

--- a/src/DataValues/ValueValidators/PropertySpecificationConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/PropertySpecificationConstraintValueValidator.php
@@ -48,15 +48,16 @@ class PropertySpecificationConstraintValueValidator implements ConstraintValueVa
 		}
 	}
 
-	private function doValidateCodifiedPreferredPropertyLabelConstraints( DataValue $dataValue ) {
+	private function doValidateCodifiedPreferredPropertyLabelConstraints( DataValue $dataValue ): void {
 		// Annotated but not enabled
 		if ( !$dataValue->isEnabledFeature( SMW_DV_PPLB ) ) {
-			return $dataValue->addErrorMsg(
+			$dataValue->addErrorMsg(
 				[
 					'smw-datavalue-feature-not-supported',
 					'SMW_DV_PPLB'
 				]
 			);
+			return;
 		}
 
 		$value = $dataValue->toArray();

--- a/src/DataValues/WikiPageValue.php
+++ b/src/DataValues/WikiPageValue.php
@@ -127,7 +127,7 @@ class WikiPageValue extends DataValue {
 		}
 	}
 
-	protected function parseUserValue( $value ) {
+	protected function parseUserValue( $value ): void {
 		$localizer = Localizer::getInstance();
 		$titleFactory = MediaWikiServices::getInstance()->getTitleFactory();
 
@@ -163,17 +163,17 @@ class WikiPageValue extends DataValue {
 			// instead of the transformed DBKey which would be `Ab c*`
 			if ( $title !== null && $title->getNamespace() === NS_MAIN && $this->getOption( 'isCapitalLinks' ) === false ) {
 				$this->m_dataitem = new WikiPage( $value, NS_MAIN );
-				return $this->m_dataitem;
+				return;
 			// If we know that it is a wikipage in a query context and the wiki
 			// requires `isCapitalLinks` then use the standard transformation so
 			// they appear as standard links even though the user input was `abc`.
 			// T:P0902 (`[[Help:]]`)
 			} elseif ( $title !== null ) {
 				$this->m_dataitem = WikiPage::newFromTitle( $title );
-				return $this->m_dataitem;
+				return;
 			} elseif ( !$localizer->getNsIndex( substr( $value, 0, -1 ) ) ) {
 				$this->m_dataitem = new WikiPage( $value, NS_MAIN );
-				return $this->m_dataitem;
+				return;
 			}
 		}
 

--- a/src/Elastic/Admin/ElasticClientTaskHandler.php
+++ b/src/Elastic/Admin/ElasticClientTaskHandler.php
@@ -112,12 +112,13 @@ class ElasticClientTaskHandler extends TaskHandler implements ActionableTask {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function handleRequest( WebRequest $webRequest ) {
+	public function handleRequest( WebRequest $webRequest ): void {
 		$connection = $this->getStore()->getConnection( 'elastic' );
 		$action = $webRequest->getText( 'action' );
 
 		if ( !$connection->ping() ) {
-			return $this->outputNoNodesAvailable( $connection );
+			$this->outputNoNodesAvailable( $connection );
+			return;
 		} elseif ( $action === $this->getTask() ) {
 			$this->outputHead();
 		} else {
@@ -128,7 +129,8 @@ class ElasticClientTaskHandler extends TaskHandler implements ActionableTask {
 						$this->getStore()
 					);
 
-					return $taskHandler->handleRequest( $webRequest );
+					$taskHandler->handleRequest( $webRequest );
+					return;
 				}
 			}
 		}

--- a/src/Elastic/Connection/DummyClient.php
+++ b/src/Elastic/Connection/DummyClient.php
@@ -193,19 +193,19 @@ class DummyClient extends Client {
 	/**
 	 * @see Client::update
 	 */
-	public function update( array $params ) {
+	public function update( array $params ): void {
 	}
 
 	/**
 	 * @see Client::index
 	 */
-	public function index( array $params ) {
+	public function index( array $params ): void {
 	}
 
 	/**
 	 * @see Client::bulk
 	 */
-	public function bulk( array $params ) {
+	public function bulk( array $params ): void {
 	}
 
 	/**

--- a/src/Elastic/Indexer/Indexer.php
+++ b/src/Elastic/Indexer/Indexer.php
@@ -204,11 +204,12 @@ class Indexer {
 	 * @param WikiPage $dataItem
 	 * @param array $data
 	 */
-	public function create( WikiPage $dataItem, array $data = [] ) {
+	public function create( WikiPage $dataItem, array $data = [] ): void {
 		$title = $dataItem->getTitle();
 
 		if ( !$this->canReplicate() ) {
-			return IndexerRecoveryJob::pushFromParams( $title, [ 'create' => $dataItem->getHash() ] );
+			IndexerRecoveryJob::pushFromParams( $title, [ 'create' => $dataItem->getHash() ] );
+			return;
 		}
 
 		if ( $dataItem->getId() == 0 ) {
@@ -283,13 +284,14 @@ class Indexer {
 	 * @param Document $document
 	 * @param string $type
 	 */
-	public function indexDocument( Document $document, $type = self::REQUIRE_SAFE_REPLICATION ) {
+	public function indexDocument( Document $document, $type = self::REQUIRE_SAFE_REPLICATION ): void {
 		Timer::start( __METHOD__ );
 
 		$subject = $document->getSubject();
 
 		if ( $type === self::REQUIRE_SAFE_REPLICATION && !$this->canReplicate() ) {
-			return IndexerRecoveryJob::pushFromDocument( $document );
+			IndexerRecoveryJob::pushFromDocument( $document );
+			return;
 		}
 
 		$params = [

--- a/src/Elastic/QueryEngine/TermsLookup/TermsLookup.php
+++ b/src/Elastic/QueryEngine/TermsLookup/TermsLookup.php
@@ -41,7 +41,7 @@ class TermsLookup implements ITermsLookup {
 	/**
 	 * @since 3.0
 	 */
-	public function clear() {
+	public function clear(): void {
 	}
 
 	/**

--- a/src/Export/ExportController.php
+++ b/src/Export/ExportController.php
@@ -362,7 +362,7 @@ class ExportController {
 	 * Send to the output what has been serialized so far. The flush might
 	 * be deferred until later unless $force is true.
 	 */
-	protected function flush( $force = false ) {
+	protected function flush( $force = false ): void {
 		if ( !$force && ( $this->delay_flush > 0 ) ) {
 			$this->delay_flush -= 1;
 		} elseif ( $this->outputfile !== null ) {
@@ -492,7 +492,7 @@ class ExportController {
 	/**
 	 * @since 2.0 made protected; use printAllToFile or printAllToOutput
 	 */
-	protected function printAll( $ns_restriction, $delay, $delayeach ) {
+	protected function printAll( $ns_restriction, $delay, $delayeach ): void {
 		$mwServices = MediaWikiServices::getInstance();
 		$titleFactory = $mwServices->getTitleFactory();
 		$linkCache = $mwServices->getLinkCache();

--- a/src/Exporter/ResourceBuilders/PropertyValueResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/PropertyValueResourceBuilder.php
@@ -76,11 +76,11 @@ class PropertyValueResourceBuilder implements ResourceBuilder {
 		);
 	}
 
-	protected function addResourceHelperValue( ExpData $expData, Property $property, DataItem $dataItem ) {
-		return $this->addAuxiliaryResourceValue( $expData, $property, $dataItem );
+	protected function addResourceHelperValue( ExpData $expData, Property $property, DataItem $dataItem ): void {
+		$this->addAuxiliaryResourceValue( $expData, $property, $dataItem );
 	}
 
-	protected function addAuxiliaryResourceValue( ExpData $expData, Property $property, DataItem $dataItem ) {
+	protected function addAuxiliaryResourceValue( ExpData $expData, Property $property, DataItem $dataItem ): void {
 		$auxiliaryExpElement = $this->exporter->newAuxiliaryExpElement(
 			$dataItem
 		);

--- a/src/Exporter/Serializer/RDFXMLSerializer.php
+++ b/src/Exporter/Serializer/RDFXMLSerializer.php
@@ -52,7 +52,7 @@ class RDFXMLSerializer extends Serializer {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function serializeHeader() {
+	protected function serializeHeader(): void {
 		$exporter = Exporter::getInstance();
 
 		$this->namespaces_are_global = true;
@@ -99,7 +99,7 @@ class RDFXMLSerializer extends Serializer {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function serializeFooter() {
+	protected function serializeFooter(): void {
 		$this->post_ns_buffer .= "\t<!-- Created by Semantic MediaWiki, https://www.semantic-mediawiki.org/ -->\n";
 		$this->post_ns_buffer .= '</rdf:RDF>';
 	}
@@ -142,7 +142,7 @@ class RDFXMLSerializer extends Serializer {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function serializeNamespace( $shortname, $uri ) {
+	protected function serializeNamespace( $shortname, $uri ): void {
 		if ( $this->namespaces_are_global ) {
 			$this->global_namespaces[$shortname] = true;
 			$this->pre_ns_buffer .= "\n\t";
@@ -234,7 +234,7 @@ class RDFXMLSerializer extends Serializer {
 	 * @param $expLiteral ExpLiteral the data value to use
 	 * @param $indent string specifying a prefix for indentation (usually a sequence of tabs)
 	 */
-	protected function serializeExpLiteral( ExpNsResource $expResourceProperty, ExpLiteral $expLiteral, string $indent ) {
+	protected function serializeExpLiteral( ExpNsResource $expResourceProperty, ExpLiteral $expLiteral, string $indent ): void {
 		$this->post_ns_buffer .= $indent . '<' . $expResourceProperty->getQName();
 
 		// https://www.w3.org/TR/rdf-syntax-grammar/#section-Syntax-languages
@@ -262,7 +262,7 @@ class RDFXMLSerializer extends Serializer {
 	 * @param $indent string specifying a prefix for indentation (usually a sequence of tabs)
 	 * @param $isClassTypeProp boolean whether the resource must be declared as a class
 	 */
-	protected function serializeExpResource( ExpNsResource $expResourceProperty, ExpResource $expResource, string $indent, $isClassTypeProp ) {
+	protected function serializeExpResource( ExpNsResource $expResourceProperty, ExpResource $expResource, string $indent, $isClassTypeProp ): void {
 		$this->post_ns_buffer .= $indent . '<' . $expResourceProperty->getQName();
 
 		if ( !$expResource->isBlankNode() ) {
@@ -294,7 +294,7 @@ class RDFXMLSerializer extends Serializer {
 	 * @bug The $isClassTypeProp parameter is not properly taken into account.
 	 * @bug Individual resources are not serialised properly.
 	 */
-	protected function serializeExpCollection( ExpNsResource $expResourceProperty, array $collection, string $indent, $isClassTypeProp ) {
+	protected function serializeExpCollection( ExpNsResource $expResourceProperty, array $collection, string $indent, $isClassTypeProp ): void {
 		$this->post_ns_buffer .= $indent . '<' . $expResourceProperty->getQName() . " rdf:parseType=\"Collection\">\n";
 
 		foreach ( $collection as $expElement ) {

--- a/src/Exporter/Serializer/Serializer.php
+++ b/src/Exporter/Serializer/Serializer.php
@@ -134,12 +134,12 @@ abstract class Serializer {
 	 * include standard syntax to start output but also declare some common
 	 * namespaces globally.
 	 */
-	abstract protected function serializeHeader();
+	abstract protected function serializeHeader(): void;
 
 	/**
 	 * Serialise the footer (i.e. write it to the internal buffer).
 	 */
-	abstract protected function serializeFooter();
+	abstract protected function serializeFooter(): void;
 
 	/**
 	 * Serialize any declarations that have been found to be missing while
@@ -216,7 +216,7 @@ abstract class Serializer {
 	/**
 	 * Include collected namespace information into the serialization.
 	 */
-	protected function serializeNamespaces() {
+	protected function serializeNamespaces(): void {
 		foreach ( $this->extra_namespaces as $nsshort => $nsuri ) {
 			$this->serializeNamespace( $nsshort, $nsuri );
 		}
@@ -233,14 +233,14 @@ abstract class Serializer {
 	 * @param $shortname string abbreviation/prefix to declare
 	 * @param $uri string URI prefix that the namespace encodes
 	 */
-	abstract protected function serializeNamespace( $shortname, $uri );
+	abstract protected function serializeNamespace( $shortname, $uri ): void;
 
 	/**
 	 * Require an additional namespace to be declared in the serialization.
 	 * The function checks whether the required namespace is available globally
 	 * and add it to the list of required namespaces otherwise.
 	 */
-	protected function requireNamespace( $nsshort, $nsuri ) {
+	protected function requireNamespace( $nsshort, $nsuri ): void {
 		if ( !array_key_exists( $nsshort, $this->global_namespaces ) ) {
 			$this->extra_namespaces[$nsshort] = $nsuri;
 		}
@@ -250,7 +250,7 @@ abstract class Serializer {
 	 * State that a certain declaration is needed. The method checks if the
 	 * declaration is already available, and records a todo otherwise.
 	 */
-	protected function requireDeclaration( ExpResource $resource, $decltype ) {
+	protected function requireDeclaration( ExpResource $resource, $decltype ): void {
 		// Do not declare predefined OWL language constructs:
 		if ( $resource instanceof ExpNsResource ) {
 			$nsId = $resource->getNamespaceId();
@@ -283,7 +283,7 @@ abstract class Serializer {
 	 *
 	 * @param ExpData $expData
 	 */
-	protected function recordDeclarationTypes( ExpData $expData ) {
+	protected function recordDeclarationTypes( ExpData $expData ): void {
 		foreach ( $expData->getSpecialValues( 'rdf', 'type' ) as $typeresource ) {
 
 			if ( $typeresource instanceof ExpNsResource ) {
@@ -315,7 +315,7 @@ abstract class Serializer {
 	 * @param ExpResource $element specifying the element to update
 	 * @param $typeflag integer specifying the type (e.g. SMW_SERIALIZER_DECL_CLASS)
 	 */
-	protected function declarationDone( ExpResource $element, int $typeflag ) {
+	protected function declarationDone( ExpResource $element, int $typeflag ): void {
 		$name = $element->getUri();
 		$curdone = array_key_exists( $name, $this->decl_done ) ? $this->decl_done[$name] : 0;
 		$this->decl_done[$name] = $curdone | $typeflag;

--- a/src/Exporter/Serializer/TurtleSerializer.php
+++ b/src/Exporter/Serializer/TurtleSerializer.php
@@ -81,7 +81,7 @@ class TurtleSerializer extends Serializer {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function serializeHeader() {
+	protected function serializeHeader(): void {
 		$exporter = Exporter::getInstance();
 
 		if ( $this->sparqlmode ) {
@@ -133,7 +133,7 @@ class TurtleSerializer extends Serializer {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function serializeFooter() {
+	protected function serializeFooter(): void {
 		if ( !$this->sparqlmode ) {
 			$this->post_ns_buffer .= "\n# Created by Semantic MediaWiki, https://www.semantic-mediawiki.org/\n";
 		}
@@ -162,7 +162,7 @@ class TurtleSerializer extends Serializer {
 	/**
 	 * {@inheritDoc}
 	 */
-	protected function serializeNamespace( $shortname, $uri ) {
+	protected function serializeNamespace( $shortname, $uri ): void {
 		$this->global_namespaces[$shortname] = true;
 		if ( $this->sparqlmode ) {
 			$this->sparql_namespaces[$shortname] = $uri;
@@ -178,7 +178,7 @@ class TurtleSerializer extends Serializer {
 	 * @param $data ExpData containing the data to be serialised.
 	 * @param $indent string specifying a prefix for indentation (usually a sequence of tabs)
 	 */
-	protected function serializeNestedExpData( ExpData $data, string $indent ) {
+	protected function serializeNestedExpData( ExpData $data, string $indent ): void {
 		if ( count( $data->getProperties() ) == 0 ) {
 			return; // nothing to export
 		}
@@ -277,11 +277,11 @@ class TurtleSerializer extends Serializer {
 		$this->post_ns_buffer .= ( $bnode ? " ]" : " ." ) . ( $indent === '' ? "\n\n" : '' );
 	}
 
-	protected function serializeExpLiteral( ExpLiteral $element ) {
+	protected function serializeExpLiteral( ExpLiteral $element ): void {
 		$this->post_ns_buffer .= self::getTurtleNameForExpElement( $element );
 	}
 
-	protected function serializeExpResource( ExpResource $element ) {
+	protected function serializeExpResource( ExpResource $element ): void {
 		if ( $element instanceof ExpNsResource ) {
 			$this->requireNamespace( $element->getNamespaceID(), $element->getNamespace() );
 		}

--- a/src/Importer/ContentModeller.php
+++ b/src/Importer/ContentModeller.php
@@ -79,21 +79,24 @@ class ContentModeller {
 		return $importContents;
 	}
 
-	private function setContents( ImportContents $importContents, string $fileDir, $contents ) {
+	private function setContents( ImportContents $importContents, string $fileDir, $contents ): void {
 		if ( !is_array( $contents ) || !isset( $contents['importFrom'] ) ) {
-			return $importContents->setContents( $contents );
+			$importContents->setContents( $contents );
+			return;
 		}
 
 		$file = $this->normalizeFile( $fileDir, $contents['importFrom'] );
 
 		if ( !is_readable( $file ) ) {
-			return $importContents->addError( "File: " . $file . " wasn't accessible" );
+			$importContents->addError( "File: " . $file . " wasn't accessible" );
+			return;
 		}
 
 		$extension = pathinfo( $file, PATHINFO_EXTENSION );
 
 		if ( isset( $contents['type'] ) && $contents['type'] === 'xml' && $extension !== 'xml' ) {
-			return $importContents->addError( "XML: " . $file . " is not recognized as xml file extension" );
+			$importContents->addError( "XML: " . $file . " is not recognized as xml file extension" );
+			return;
 		}
 
 		if ( $extension === 'xml' ) {

--- a/src/Indicator/EntityExaminerIndicators/ConstraintErrorEntityExaminerDeferrableIndicatorProvider.php
+++ b/src/Indicator/EntityExaminerIndicators/ConstraintErrorEntityExaminerDeferrableIndicatorProvider.php
@@ -35,9 +35,10 @@ class ConstraintErrorEntityExaminerDeferrableIndicatorProvider extends Constrain
 	/**
 	 * @see ConstraintErrorEntityExaminerIndicatorProvider::checkConstraintErrors
 	 */
-	protected function checkConstraintErrors( $subject, $options ) {
+	protected function checkConstraintErrors( $subject, $options ): void {
 		if ( $this->isDeferredMode ) {
-			return $this->runCheck( $subject, $options );
+			$this->runCheck( $subject, $options );
+			return;
 		}
 
 		$this->indicators = [ 'id' => $this->getName() ];

--- a/src/Indicator/EntityExaminerIndicators/ConstraintErrorEntityExaminerIndicatorProvider.php
+++ b/src/Indicator/EntityExaminerIndicators/ConstraintErrorEntityExaminerIndicatorProvider.php
@@ -128,7 +128,7 @@ class ConstraintErrorEntityExaminerIndicatorProvider implements TypableSeverityI
 		return '#mw-indicator-mw-helplink {display:none;}';
 	}
 
-	protected function checkConstraintErrors( $subject, array $options ) {
+	protected function checkConstraintErrors( $subject, array $options ): void {
 		$this->runCheck( $subject, $options );
 	}
 

--- a/src/Iterators/ResultIterator.php
+++ b/src/Iterators/ResultIterator.php
@@ -135,7 +135,7 @@ class ResultIterator implements Iterator, Countable, SeekableIterator {
 		return $this->current !== false && $this->position < $this->count();
 	}
 
-	protected function setCurrent( $row ) {
+	protected function setCurrent( $row ): void {
 		if ( $row === false || $row === null ) {
 			$this->current = false;
 		} else {

--- a/src/Listener/ChangeListener/CallableChangeListenerTrait.php
+++ b/src/Listener/ChangeListener/CallableChangeListenerTrait.php
@@ -71,7 +71,7 @@ trait CallableChangeListenerTrait {
 		$this->triggerByKey( $key, $changeRecord );
 	}
 
-	protected function triggerByKey( string $key, ChangeRecord $changeRecord ) {
+	protected function triggerByKey( string $key, ChangeRecord $changeRecord ): void {
 		foreach ( $this->changeListeners[$key] as $changeListener ) {
 
 			if ( !is_callable( $changeListener ) ) {

--- a/src/Listener/ChangeListener/ChangeListeners/PropertyChangeListener.php
+++ b/src/Listener/ChangeListener/ChangeListeners/PropertyChangeListener.php
@@ -135,7 +135,7 @@ class PropertyChangeListener implements ChangeListener {
 	/**
 	 * @see CallableChangeListenerTrait::triggerByKey
 	 */
-	protected function triggerByKey( string $key, ChangeRecord $changeRecord ) {
+	protected function triggerByKey( string $key, ChangeRecord $changeRecord ): void {
 		$property = new Property( $key );
 
 		foreach ( $this->changeListeners[$key] as $changeListener ) {

--- a/src/Maintenance/PropertyStatisticsRebuilder.php
+++ b/src/Maintenance/PropertyStatisticsRebuilder.php
@@ -201,7 +201,7 @@ class PropertyStatisticsRebuilder {
 		return [ $usageCount, $nullCount ];
 	}
 
-	protected function reportMessage( $message ) {
+	protected function reportMessage( $message ): void {
 		$this->messageReporter->reportMessage( $message );
 	}
 

--- a/src/MediaWiki/Api/BrowseBySubject.php
+++ b/src/MediaWiki/Api/BrowseBySubject.php
@@ -120,7 +120,7 @@ class BrowseBySubject extends ApiBase {
 		return $serialized;
 	}
 
-	protected function addIndexTags( array|string &$serialized ) {
+	protected function addIndexTags( array|string &$serialized ): void {
 		if ( isset( $serialized['data'] ) && is_array( $serialized['data'] ) ) {
 
 			$this->getResult()->setIndexedTagName( $serialized['data'], 'property' );

--- a/src/MediaWiki/Api/Query.php
+++ b/src/MediaWiki/Api/Query.php
@@ -67,7 +67,7 @@ abstract class Query extends ApiBase {
 	 *
 	 * @param QueryResult $queryResult
 	 */
-	protected function addQueryResult( QueryResult $queryResult, $outputFormat = 'json' ) {
+	protected function addQueryResult( QueryResult $queryResult, $outputFormat = 'json' ): void {
 		$result = $this->getResult();
 
 		$resultFormatter = new ApiQueryResultFormatter( $queryResult );

--- a/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
+++ b/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
@@ -46,7 +46,7 @@ class LoadBalancerConnectionProvider implements IConnectionProvider {
 	 *
 	 * @param boolean $asConnectionRef
 	 */
-	public function asConnectionRef( $asConnectionRef ) {
+	public function asConnectionRef( $asConnectionRef ): void {
 	}
 
 	/**

--- a/src/MediaWiki/Content/SchemaContentHandler.php
+++ b/src/MediaWiki/Content/SchemaContentHandler.php
@@ -183,7 +183,7 @@ class SchemaContentHandler extends JsonContentHandler {
 		Content $content,
 		ContentParseParams $cpoParams,
 		ParserOutput &$output
-	) {
+	): void {
 		$title = Title::castFromPageReference( $cpoParams->getPage() );
 
 		if ( !$cpoParams->getGenerateHtml() || !$content->isValid() ) {

--- a/src/MediaWiki/Deferred/CallableUpdate.php
+++ b/src/MediaWiki/Deferred/CallableUpdate.php
@@ -274,7 +274,7 @@ class CallableUpdate implements DeferrableUpdate {
 		$this->doUpdate();
 	}
 
-	protected function registerUpdate( $update ) {
+	protected function registerUpdate( $update ): void {
 		$this->logger->info(
 			[ 'DeferrableUpdate', 'Added: {ctx}' ],
 			[ 'method' => __METHOD__, 'role' => 'developer', 'ctx' => $this->loggableContext() ]
@@ -297,7 +297,7 @@ class CallableUpdate implements DeferrableUpdate {
 		return [ 'origin' => $this->origin, 'fingerprint' => $this->fingerprint, 'stage' => $this->stage ];
 	}
 
-	protected function emptyCallback() {
+	protected function emptyCallback(): void {
 		$this->logger->info(
 			[ 'DeferrableUpdate', 'Empty callback!' ],
 			[ 'role' => 'developer', 'method' => __METHOD__ ]

--- a/src/MediaWiki/Deferred/TransactionalCallableUpdate.php
+++ b/src/MediaWiki/Deferred/TransactionalCallableUpdate.php
@@ -175,17 +175,18 @@ class TransactionalCallableUpdate extends CallableUpdate {
 		}
 	}
 
-	protected function registerUpdate( $update ) {
+	protected function registerUpdate( $update ): void {
 		if ( $this->onTransactionIdle ) {
 			$this->logger->info(
 				[ 'DeferrableUpdate', 'Transactional', 'Added: {origin} (onTransactionIdle)' ],
 				[ 'method' => __METHOD__, 'role' => 'developer', 'origin' => $this->getOrigin() ]
 			);
 
-			return $this->connection->onTransactionCommitOrIdle( function () use( $update ): void {
+			$this->connection->onTransactionCommitOrIdle( function () use( $update ): void {
 				$update->onTransactionIdle = false;
 				parent::registerUpdate( $update );
 			} );
+			return;
 		}
 
 		parent::registerUpdate( $update );
@@ -231,7 +232,7 @@ class TransactionalCallableUpdate extends CallableUpdate {
 		}
 	}
 
-	protected function emptyCancelCallback() {
+	protected function emptyCancelCallback(): void {
 		$this->logger->info(
 			[ 'DeferrableUpdate', 'cancelOnRollback' ],
 			[ 'role' => 'developer', 'method' => __METHOD__ ]

--- a/src/MediaWiki/Jobs/NullJob.php
+++ b/src/MediaWiki/Jobs/NullJob.php
@@ -36,7 +36,7 @@ class NullJob extends Job {
 	 *
 	 * @since  2.5
 	 */
-	public function insert() {
+	public function insert(): void {
 	}
 
 }

--- a/src/MediaWiki/Jobs/RefreshJob.php
+++ b/src/MediaWiki/Jobs/RefreshJob.php
@@ -110,7 +110,7 @@ class RefreshJob extends Job {
 		return true;
 	}
 
-	protected function createNextJob( array $parameters ) {
+	protected function createNextJob( array $parameters ): void {
 		$job = new self(
 			$this->getTitle(),
 			$parameters

--- a/src/MediaWiki/Page/Page.php
+++ b/src/MediaWiki/Page/Page.php
@@ -159,7 +159,7 @@ abstract class Page extends Article {
 	/**
 	 * Main method for adding all additional HTML to the output stream.
 	 */
-	protected function showList() {
+	protected function showList(): void {
 		$outputPage = $this->getContext()->getOutput();
 		$request = $this->getContext()->getRequest();
 
@@ -179,7 +179,7 @@ abstract class Page extends Article {
 	 *
 	 * @return true
 	 */
-	protected function initParameters() {
+	protected function initParameters(): void {
 		$this->limit = 20;
 	}
 

--- a/src/MediaWiki/Page/PropertyPage.php
+++ b/src/MediaWiki/Page/PropertyPage.php
@@ -63,7 +63,7 @@ class PropertyPage extends Page {
 	/**
 	 * @see Page::initParameters()
 	 */
-	protected function initParameters() {
+	protected function initParameters(): void {
 		// We use a smaller limit here; property pages might become large
 		$this->limit = $this->getOption( 'pagingLimit' );
 		$this->property = Property::newFromUserLabel( $this->getTitle()->getText() );

--- a/src/MediaWiki/Specials/Admin/ActionableTask.php
+++ b/src/MediaWiki/Specials/Admin/ActionableTask.php
@@ -33,6 +33,6 @@ interface ActionableTask {
 	 *
 	 * @param WebRequest $webRequest
 	 */
-	public function handleRequest( WebRequest $webRequest );
+	public function handleRequest( WebRequest $webRequest ): void;
 
 }

--- a/src/MediaWiki/Specials/Admin/AlertsTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/AlertsTaskHandler.php
@@ -114,7 +114,7 @@ class AlertsTaskHandler extends TaskHandler {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function handleRequest( WebRequest $webRequest ) {
+	public function handleRequest( WebRequest $webRequest ): void {
 	}
 
 }

--- a/src/MediaWiki/Specials/Admin/Maintenance/DataRefreshJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/DataRefreshJobTaskHandler.php
@@ -109,9 +109,9 @@ class DataRefreshJobTaskHandler extends TaskHandler implements ActionableTask {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function handleRequest( WebRequest $webRequest ) {
+	public function handleRequest( WebRequest $webRequest ): void {
 		if ( !$this->hasFeature( SMW_ADM_REFRESH ) ) {
-			return '';
+			return;
 		}
 
 		$sure = $webRequest->getText( 'rfsure' );

--- a/src/MediaWiki/Specials/Admin/Maintenance/DisposeJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/DisposeJobTaskHandler.php
@@ -141,9 +141,10 @@ class DisposeJobTaskHandler extends TaskHandler implements ActionableTask {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function handleRequest( WebRequest $webRequest ) {
+	public function handleRequest( WebRequest $webRequest ): void {
 		if ( !$this->hasFeature( SMW_ADM_DISPOSAL ) || $this->hasPendingJob() || $this->isApiTask() ) {
-			return $this->outputFormatter->redirectToRootPage( '', [ 'tab' => 'maintenance' ] );
+			$this->outputFormatter->redirectToRootPage( '', [ 'tab' => 'maintenance' ] );
+			return;
 		}
 
 		$job = ApplicationFactory::getInstance()->newJobFactory()->newByType(

--- a/src/MediaWiki/Specials/Admin/Maintenance/FulltextSearchTableRebuildJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/FulltextSearchTableRebuildJobTaskHandler.php
@@ -126,9 +126,10 @@ class FulltextSearchTableRebuildJobTaskHandler extends TaskHandler implements Ac
 	 *
 	 * {@inheritDoc}
 	 */
-	public function handleRequest( WebRequest $webRequest ) {
+	public function handleRequest( WebRequest $webRequest ): void {
 		if ( !$this->hasFeature( SMW_ADM_FULLT ) || $this->hasPendingJob() || $this->isApiTask() ) {
-			return $this->outputFormatter->redirectToRootPage( '', [ 'tab' => 'maintenance' ] );
+			$this->outputFormatter->redirectToRootPage( '', [ 'tab' => 'maintenance' ] );
+			return;
 		}
 
 		$job = ApplicationFactory::getInstance()->newJobFactory()->newByType(

--- a/src/MediaWiki/Specials/Admin/Maintenance/PropertyStatsRebuildJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/PropertyStatsRebuildJobTaskHandler.php
@@ -129,9 +129,10 @@ class PropertyStatsRebuildJobTaskHandler extends TaskHandler implements Actionab
 	 *
 	 * {@inheritDoc}
 	 */
-	public function handleRequest( WebRequest $webRequest ) {
+	public function handleRequest( WebRequest $webRequest ): void {
 		if ( !$this->hasFeature( SMW_ADM_PSTATS ) || $this->hasPendingJob() || $this->isApiTask() ) {
-			return $this->outputFormatter->redirectToRootPage( '', [ 'tab' => 'maintenance' ] );
+			$this->outputFormatter->redirectToRootPage( '', [ 'tab' => 'maintenance' ] );
+			return;
 		}
 
 		$job = ApplicationFactory::getInstance()->newJobFactory()->newByType(

--- a/src/MediaWiki/Specials/Admin/MaintenanceTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/MaintenanceTaskHandler.php
@@ -106,7 +106,7 @@ class MaintenanceTaskHandler extends TaskHandler implements ActionableTask {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function handleRequest( WebRequest $webRequest ) {
+	public function handleRequest( WebRequest $webRequest ): void {
 		$action = $webRequest->getText( 'action' );
 
 		foreach ( $this->taskHandlers as $taskHandler ) {
@@ -119,7 +119,8 @@ class MaintenanceTaskHandler extends TaskHandler implements ActionableTask {
 				$taskHandler->setStore( $this->getStore() );
 			}
 
-			return $taskHandler->handleRequest( $webRequest );
+			$taskHandler->handleRequest( $webRequest );
+			return;
 		}
 	}
 

--- a/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
@@ -103,7 +103,7 @@ class EntityLookupTaskHandler extends TaskHandler implements ActionableTask {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function handleRequest( WebRequest $webRequest ) {
+	public function handleRequest( WebRequest $webRequest ): void {
 		$this->outputFormatter->setPageTitle(
 			$this->msg( [ 'smw-admin-main-title', $this->msg( 'smw-admin-supplementary-idlookup-title' ) ] )
 		);
@@ -112,7 +112,8 @@ class EntityLookupTaskHandler extends TaskHandler implements ActionableTask {
 
 		// https://phabricator.wikimedia.org/T109652#1562641
 		if ( !$this->user->matchEditToken( $webRequest->getVal( 'wpEditToken' ) ) ) {
-			return $this->outputFormatter->addHtml( $this->msg( 'sessionfailure' ) );
+			$this->outputFormatter->addHtml( $this->msg( 'sessionfailure' ) );
+			return;
 		}
 
 		$id = $webRequest->getText( 'id' );

--- a/src/MediaWiki/Specials/Admin/Supplement/OperationalStatisticsListTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/OperationalStatisticsListTaskHandler.php
@@ -90,7 +90,7 @@ class OperationalStatisticsListTaskHandler extends TaskHandler implements Action
 	 *
 	 * {@inheritDoc}
 	 */
-	public function handleRequest( WebRequest $webRequest ) {
+	public function handleRequest( WebRequest $webRequest ): void {
 		$action = $webRequest->getText( 'action' );
 
 		if ( $action === 'stats' ) {
@@ -106,7 +106,8 @@ class OperationalStatisticsListTaskHandler extends TaskHandler implements Action
 					$taskHandler->setStore( $this->getStore() );
 				}
 
-				return $taskHandler->handleRequest( $webRequest );
+				$taskHandler->handleRequest( $webRequest );
+				return;
 			}
 		}
 

--- a/src/MediaWiki/Specials/Admin/SupplementTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/SupplementTaskHandler.php
@@ -79,7 +79,7 @@ class SupplementTaskHandler extends TaskHandler implements ActionableTask {
 	 *
 	 * {@inheritDoc}
 	 */
-	public function handleRequest( WebRequest $webRequest ) {
+	public function handleRequest( WebRequest $webRequest ): void {
 		$action = $webRequest->getText( 'action' );
 
 		foreach ( $this->taskHandlers as $taskHandler ) {
@@ -92,7 +92,8 @@ class SupplementTaskHandler extends TaskHandler implements ActionableTask {
 				$taskHandler->setStore( $this->getStore() );
 			}
 
-			return $taskHandler->handleRequest( $webRequest );
+			$taskHandler->handleRequest( $webRequest );
+			return;
 		}
 	}
 

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -245,7 +245,7 @@ class SpecialAsk extends SpecialPage {
 	/**
 	 * @param string $p
 	 */
-	protected function extractQueryParameters( $p ) {
+	protected function extractQueryParameters( $p ): void {
 		$request = $this->getRequest();
 		$this->isEditMode = false;
 
@@ -269,7 +269,7 @@ class SpecialAsk extends SpecialPage {
 		}
 	}
 
-	protected function makeHTMLResult() {
+	protected function makeHTMLResult(): void {
 		$result = '';
 		$res = null;
 		$settings = ApplicationFactory::getInstance()->getSettings();
@@ -309,7 +309,8 @@ class SpecialAsk extends SpecialPage {
 				// Generate raw content when being requested from a remote special_page
 				echo $printer->getResult( $res, $this->params, SMW_OUTPUT_FILE ) . RemoteRequest::REQUEST_ID;
 			} else {
-				return $printer->outputAsFile( $res, $this->params );
+				$printer->outputAsFile( $res, $this->params );
+				return;
 			}
 		}
 

--- a/src/MediaWiki/Specials/SpecialOWLExport.php
+++ b/src/MediaWiki/Specials/SpecialOWLExport.php
@@ -84,7 +84,7 @@ class SpecialOWLExport extends SpecialPage {
 	 *
 	 * @return void
 	 */
-	protected function showForm() {
+	protected function showForm(): void {
 		global $smwgAllowRecursiveExport, $smwgExportBacklinks, $smwgExportAll;
 
 		$out = $this->getOutput();
@@ -119,7 +119,7 @@ class SpecialOWLExport extends SpecialPage {
 	 *
 	 * @return void
 	 */
-	protected function startRDFExport() {
+	protected function startRDFExport(): void {
 		$out = $this->getOutput();
 		$request = $this->getRequest();
 
@@ -159,7 +159,7 @@ class SpecialOWLExport extends SpecialPage {
 	 *
 	 * @return void
 	 */
-	protected function exportPages( array $pages ) {
+	protected function exportPages( array $pages ): void {
 		global $smwgExportBacklinks, $smwgAllowRecursiveExport;
 
 		$request = $this->getRequest();

--- a/src/Parser/InTextAnnotationParser.php
+++ b/src/Parser/InTextAnnotationParser.php
@@ -253,7 +253,7 @@ class InTextAnnotationParser {
 		$this->redirectTargetFinder->setRedirectTarget( $redirectTarget );
 	}
 
-	protected function addRedirectTargetAnnotationFromText( $text ) {
+	protected function addRedirectTargetAnnotationFromText( $text ): void {
 		if ( !$this->isEnabledNamespace ) {
 			return;
 		}

--- a/src/Property/Annotators/AttachmentLinkPropertyAnnotator.php
+++ b/src/Property/Annotators/AttachmentLinkPropertyAnnotator.php
@@ -33,7 +33,7 @@ class AttachmentLinkPropertyAnnotator extends PropertyAnnotatorDecorator {
 		$this->predefinedPropertyList = array_flip( $predefinedPropertyList );
 	}
 
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		if ( !is_array( $this->attachments ) || !isset( $this->predefinedPropertyList['_ATTCH_LINK'] ) ) {
 			return;
 		}

--- a/src/Property/Annotators/CategoryPropertyAnnotator.php
+++ b/src/Property/Annotators/CategoryPropertyAnnotator.php
@@ -87,7 +87,7 @@ class CategoryPropertyAnnotator extends PropertyAnnotatorDecorator {
 	/**
 	 * @see PropertyAnnotatorDecorator::addPropertyValues
 	 */
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		$subject = $this->getSemanticData()->getSubject();
 		$namespace = $subject->getNamespace();
 		$property = null;
@@ -123,7 +123,7 @@ class CategoryPropertyAnnotator extends PropertyAnnotatorDecorator {
 		$annotationProcessor->release();
 	}
 
-	private function modifySemanticData( SemanticData $semanticData, AnnotationProcessor $annotationProcessor, $subject, Property $property, $catname ) {
+	private function modifySemanticData( SemanticData $semanticData, AnnotationProcessor $annotationProcessor, $subject, Property $property, $catname ): void {
 		$cat = new WikiPage( $catname, NS_CATEGORY );
 
 		if ( ( $cat = $this->getRedirectTarget( $cat ) ) && $cat->getNamespace() === NS_CATEGORY ) {
@@ -145,7 +145,8 @@ class CategoryPropertyAnnotator extends PropertyAnnotatorDecorator {
 				$cat
 			);
 
-			return $semanticData->addDataValue( $dataValue );
+			$semanticData->addDataValue( $dataValue );
+			return;
 		}
 
 		$container = $this->processingErrorMsgHandler->newErrorContainerFromMsg(

--- a/src/Property/Annotators/DisplayTitlePropertyAnnotator.php
+++ b/src/Property/Annotators/DisplayTitlePropertyAnnotator.php
@@ -36,7 +36,7 @@ class DisplayTitlePropertyAnnotator extends PropertyAnnotatorDecorator {
 		$this->canCreateAnnotation = (bool)$canCreateAnnotation;
 	}
 
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		if ( !$this->canCreateAnnotation || !$this->displayTitle || $this->displayTitle === '' ) {
 			return;
 		}

--- a/src/Property/Annotators/EditProtectedPropertyAnnotator.php
+++ b/src/Property/Annotators/EditProtectedPropertyAnnotator.php
@@ -82,9 +82,9 @@ class EditProtectedPropertyAnnotator extends PropertyAnnotatorDecorator {
 	/**
 	 * @see PropertyAnnotatorDecorator::addPropertyValues
 	 */
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		if ( $this->editProtectionRight === false ) {
-			return false;
+			return;
 		}
 
 		$property = $this->dataItemFactory->newDIProperty( '_EDIP' );

--- a/src/Property/Annotators/MandatoryTypePropertyAnnotator.php
+++ b/src/Property/Annotators/MandatoryTypePropertyAnnotator.php
@@ -37,7 +37,7 @@ class MandatoryTypePropertyAnnotator extends PropertyAnnotatorDecorator {
 		$this->subpropertyParentTypeInheritance = (bool)$subpropertyParentTypeInheritance;
 	}
 
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		$subject = $this->getSemanticData()->getSubject();
 
 		if ( $subject->getNamespace() !== SMW_NS_PROPERTY ) {

--- a/src/Property/Annotators/PredefinedPropertyAnnotator.php
+++ b/src/Property/Annotators/PredefinedPropertyAnnotator.php
@@ -41,7 +41,7 @@ class PredefinedPropertyAnnotator extends PropertyAnnotatorDecorator {
 		$this->predefinedPropertyList = $predefinedPropertyList;
 	}
 
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		$cachedProperties = [];
 
 		foreach ( $this->predefinedPropertyList as $propertyId ) {

--- a/src/Property/Annotators/PropertyAnnotatorDecorator.php
+++ b/src/Property/Annotators/PropertyAnnotatorDecorator.php
@@ -60,6 +60,6 @@ abstract class PropertyAnnotatorDecorator implements Annotator {
 	/**
 	 * @since 1.9
 	 */
-	abstract protected function addPropertyValues();
+	abstract protected function addPropertyValues(): void;
 
 }

--- a/src/Property/Annotators/RedirectPropertyAnnotator.php
+++ b/src/Property/Annotators/RedirectPropertyAnnotator.php
@@ -30,7 +30,7 @@ class RedirectPropertyAnnotator extends PropertyAnnotatorDecorator {
 	/**
 	 * @see PropertyAnnotatorDecorator::addPropertyValues
 	 */
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		if ( !$this->redirectTargetFinder->hasRedirectTarget() ) {
 			return;
 		}

--- a/src/Property/Annotators/SchemaPropertyAnnotator.php
+++ b/src/Property/Annotators/SchemaPropertyAnnotator.php
@@ -24,7 +24,7 @@ class SchemaPropertyAnnotator extends PropertyAnnotatorDecorator {
 		parent::__construct( $propertyAnnotator );
 	}
 
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		if ( $this->schema === null ) {
 			return;
 		}

--- a/src/Property/Annotators/SortKeyPropertyAnnotator.php
+++ b/src/Property/Annotators/SortKeyPropertyAnnotator.php
@@ -23,7 +23,7 @@ class SortKeyPropertyAnnotator extends PropertyAnnotatorDecorator {
 		parent::__construct( $propertyAnnotator );
 	}
 
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		$sortkey = $this->defaultSort ? $this->defaultSort : $this->getSemanticData()->getSubject()->getSortKey();
 
 		$property = $this->dataItemFactory->newDIProperty(

--- a/src/Property/Annotators/TranslationPropertyAnnotator.php
+++ b/src/Property/Annotators/TranslationPropertyAnnotator.php
@@ -35,7 +35,7 @@ class TranslationPropertyAnnotator extends PropertyAnnotatorDecorator {
 		$this->predefinedPropertyList = array_flip( $predefinedPropertyList );
 	}
 
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		// Expected identifiers, @see https://gerrit.wikimedia.org/r/387548
 		if ( !is_array( $this->translation ) || !isset( $this->predefinedPropertyList['_TRANS'] ) ) {
 			return;

--- a/src/Property/DeclarationExaminer/ChangePropagationExaminer.php
+++ b/src/Property/DeclarationExaminer/ChangePropagationExaminer.php
@@ -63,7 +63,7 @@ class ChangePropagationExaminer extends DeclarationExaminer {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function validate( Property $property ) {
+	protected function validate( Property $property ): void {
 		$subject = $property->getCanonicalDiWikiPage();
 		$semanticData = $this->store->getSemanticData( $subject );
 

--- a/src/Property/DeclarationExaminer/CommonExaminer.php
+++ b/src/Property/DeclarationExaminer/CommonExaminer.php
@@ -68,7 +68,7 @@ class CommonExaminer extends DeclarationExaminer {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function validate( Property $property ) {
+	protected function validate( Property $property ): void {
 		$dataValue = DataValueFactory::getInstance()->newDataValueByItem(
 			$property
 		);

--- a/src/Property/DeclarationExaminer/DeclarationExaminer.php
+++ b/src/Property/DeclarationExaminer/DeclarationExaminer.php
@@ -79,6 +79,6 @@ abstract class DeclarationExaminer implements IDeclarationExaminer {
 	/**
 	 * @since 3.1
 	 */
-	abstract protected function validate( Property $property );
+	abstract protected function validate( Property $property ): void;
 
 }

--- a/src/Property/DeclarationExaminer/PredefinedPropertyExaminer.php
+++ b/src/Property/DeclarationExaminer/PredefinedPropertyExaminer.php
@@ -33,7 +33,7 @@ class PredefinedPropertyExaminer extends DeclarationExaminer {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function validate( Property $property ) {
+	protected function validate( Property $property ): void {
 		if ( $property->isUserDefined() ) {
 			return;
 		}

--- a/src/Property/DeclarationExaminer/ProtectionExaminer.php
+++ b/src/Property/DeclarationExaminer/ProtectionExaminer.php
@@ -30,7 +30,7 @@ class ProtectionExaminer extends DeclarationExaminer {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function validate( Property $property ) {
+	protected function validate( Property $property ): void {
 		if ( $this->declarationExaminer->isLocked() ) {
 			return;
 		}

--- a/src/Property/DeclarationExaminer/UserdefinedPropertyExaminer.php
+++ b/src/Property/DeclarationExaminer/UserdefinedPropertyExaminer.php
@@ -35,7 +35,7 @@ class UserdefinedPropertyExaminer extends DeclarationExaminer {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function validate( Property $property ) {
+	protected function validate( Property $property ): void {
 		if ( !$property->isUserDefined() ) {
 			return;
 		}

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -476,7 +476,7 @@ class PropertyRegistry {
 	 * cannot be entered by or displayed to users, whatever their "show" value
 	 * below.
 	 */
-	protected function initProperties( array $propertyList ) {
+	protected function initProperties( array $propertyList ): void {
 		$this->propertyList = $propertyList;
 
 		foreach ( $this->datatypeLabels as $id => $label ) {

--- a/src/Query/DescriptionBuilders/DescriptionBuilder.php
+++ b/src/Query/DescriptionBuilders/DescriptionBuilder.php
@@ -111,7 +111,7 @@ abstract class DescriptionBuilder {
 	 * @param string|null &$value
 	 * @param string|int &$comparator
 	 */
-	protected function prepareValue( ?Property $property, &$value, &$comparator ) {
+	protected function prepareValue( ?Property $property, &$value, &$comparator ): void {
 		$comparator = QueryComparator::getInstance()->extractComparatorFromString( $value );
 
 		// [[in:lorem ipsum]] / [[Has text::in:lorem ipsum]] to be turned into a

--- a/src/Query/ProfileAnnotators/DescriptionProfileAnnotator.php
+++ b/src/Query/ProfileAnnotators/DescriptionProfileAnnotator.php
@@ -29,7 +29,7 @@ class DescriptionProfileAnnotator extends ProfileAnnotatorDecorator {
 	/**
 	 * ProfileAnnotatorDecorator::addPropertyValues
 	 */
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		$this->addQueryString( $this->description->getQueryString() );
 		$this->addQuerySize( $this->description->getSize() );
 		$this->addQueryDepth( $this->description->getDepth() );

--- a/src/Query/ProfileAnnotators/DurationProfileAnnotator.php
+++ b/src/Query/ProfileAnnotators/DurationProfileAnnotator.php
@@ -27,7 +27,7 @@ class DurationProfileAnnotator extends ProfileAnnotatorDecorator {
 	/**
 	 * ProfileAnnotatorDecorator::addPropertyValues
 	 */
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		if ( $this->duration > 0 ) {
 			$this->addGreaterThanZeroQueryDuration( $this->duration );
 		}

--- a/src/Query/ProfileAnnotators/FormatProfileAnnotator.php
+++ b/src/Query/ProfileAnnotators/FormatProfileAnnotator.php
@@ -27,7 +27,7 @@ class FormatProfileAnnotator extends ProfileAnnotatorDecorator {
 	/**
 	 * ProfileAnnotatorDecorator::addPropertyValues
 	 */
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		$this->addQueryFormat( $this->format );
 	}
 

--- a/src/Query/ProfileAnnotators/NullProfileAnnotator.php
+++ b/src/Query/ProfileAnnotators/NullProfileAnnotator.php
@@ -67,7 +67,7 @@ class NullProfileAnnotator implements ProfileAnnotator {
 	 *
 	 * @since 1.9
 	 */
-	public function addAnnotation() {
+	public function addAnnotation(): void {
 	}
 
 }

--- a/src/Query/ProfileAnnotators/ParametersProfileAnnotator.php
+++ b/src/Query/ProfileAnnotators/ParametersProfileAnnotator.php
@@ -28,7 +28,7 @@ class ParametersProfileAnnotator extends ProfileAnnotatorDecorator {
 	/**
 	 * ProfileAnnotatorDecorator::addPropertyValues
 	 */
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		[ $sort, $order ] = $this->doSerializeSortKeys( $this->query );
 
 		$options = [

--- a/src/Query/ProfileAnnotators/ProfileAnnotatorDecorator.php
+++ b/src/Query/ProfileAnnotators/ProfileAnnotatorDecorator.php
@@ -88,6 +88,6 @@ abstract class ProfileAnnotatorDecorator implements ProfileAnnotator {
 	/**
 	 * @since 1.9
 	 */
-	abstract protected function addPropertyValues();
+	abstract protected function addPropertyValues(): void;
 
 }

--- a/src/Query/ProfileAnnotators/SchemaLinkProfileAnnotator.php
+++ b/src/Query/ProfileAnnotators/SchemaLinkProfileAnnotator.php
@@ -28,7 +28,7 @@ class SchemaLinkProfileAnnotator extends ProfileAnnotatorDecorator {
 	/**
 	 * ProfileAnnotatorDecorator::addPropertyValues
 	 */
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		if ( $this->schemaLink === '' ) {
 			return;
 		}

--- a/src/Query/ProfileAnnotators/SourceProfileAnnotator.php
+++ b/src/Query/ProfileAnnotators/SourceProfileAnnotator.php
@@ -27,7 +27,7 @@ class SourceProfileAnnotator extends ProfileAnnotatorDecorator {
 	/**
 	 * ProfileAnnotatorDecorator::addPropertyValues
 	 */
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		if ( $this->querySource !== '' ) {
 			$this->addQuerySource( $this->querySource );
 		}

--- a/src/Query/ProfileAnnotators/StatusCodeProfileAnnotator.php
+++ b/src/Query/ProfileAnnotators/StatusCodeProfileAnnotator.php
@@ -27,7 +27,7 @@ class StatusCodeProfileAnnotator extends ProfileAnnotatorDecorator {
 	/**
 	 * ProfileAnnotatorDecorator::addPropertyValues
 	 */
-	protected function addPropertyValues() {
+	protected function addPropertyValues(): void {
 		if ( $this->statusCodes !== [] ) {
 			foreach ( $this->statusCodes as $statusCode ) {
 				$this->addStatusCodeAnnotation( $statusCode );

--- a/src/Query/ResultPrinters/AggregatablePrinter.php
+++ b/src/Query/ResultPrinters/AggregatablePrinter.php
@@ -88,7 +88,7 @@ abstract class AggregatablePrinter extends ResultPrinter {
 	 *
 	 * @since 1.7
 	 */
-	protected function addResources() {
+	protected function addResources(): void {
 	}
 
 	/**
@@ -117,7 +117,7 @@ abstract class AggregatablePrinter extends ResultPrinter {
 	 *
 	 * @param array &$data
 	 */
-	protected function applyDistributionParams( array &$data ) {
+	protected function applyDistributionParams( array &$data ): void {
 		if ( $this->params['distributionsort'] == 'asc' ) {
 			asort( $data, SORT_NUMERIC );
 		} elseif ( $this->params['distributionsort'] == 'desc' ) {
@@ -258,7 +258,7 @@ abstract class AggregatablePrinter extends ResultPrinter {
 	 * @param array &$values
 	 * @param string $name
 	 */
-	protected function addNumbersForDataItem( DataItem $dataItem, array &$values, $name ) {
+	protected function addNumbersForDataItem( DataItem $dataItem, array &$values, $name ): void {
 		switch ( $dataItem->getDIType() ) {
 			case DataItem::TYPE_NUMBER:
 				// Collect and aggregate values for the same array key

--- a/src/Query/ResultPrinters/CategoryResultPrinter.php
+++ b/src/Query/ResultPrinters/CategoryResultPrinter.php
@@ -120,7 +120,7 @@ class CategoryResultPrinter extends ResultPrinter {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function handleParameters( array $params, $outputmode ) {
+	protected function handleParameters( array $params, $outputmode ): void {
 		parent::handleParameters( $params, $outputmode );
 
 		$this->userParam = isset( $params['userparam'] ) ? trim( $params['userparam'] ) : '';
@@ -132,7 +132,7 @@ class CategoryResultPrinter extends ResultPrinter {
 	/**
 	 * @since 3.0
 	 */
-	protected function initServices() {
+	protected function initServices(): void {
 		$mwCollaboratorFactory = ApplicationFactory::getInstance()->newMwCollaboratorFactory();
 
 		$this->htmlColumns = new HtmlColumns();

--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -443,7 +443,7 @@ abstract class ResultPrinter implements IResultPrinter {
 	 * @param array $params
 	 * @param $outputMode
 	 */
-	protected function handleParameters( array $params, $outputMode ) {
+	protected function handleParameters( array $params, $outputMode ): void {
 		// No-op
 	}
 
@@ -452,7 +452,7 @@ abstract class ResultPrinter implements IResultPrinter {
 	 *
 	 * @since 1.8
 	 */
-	protected function postProcessParameters() {
+	protected function postProcessParameters(): void {
 		$params = $this->params;
 
 		$this->mIntro = isset( $params['intro'] ) ? str_replace( '_', ' ', $params['intro'] ) : '';
@@ -660,7 +660,7 @@ abstract class ResultPrinter implements IResultPrinter {
 	 *
 	 * @param string $errorMessage
 	 */
-	protected function addError( $errorMessage ) {
+	protected function addError( $errorMessage ): void {
 		$this->mErrors[] = $errorMessage;
 	}
 

--- a/src/Query/ResultPrinters/TableResultPrinter.php
+++ b/src/Query/ResultPrinters/TableResultPrinter.php
@@ -244,7 +244,7 @@ class TableResultPrinter extends ResultPrinter {
 	 *
 	 * @return string
 	 */
-	protected function getCellForPropVals( ResultArray $resultArray, $outputMode, string $columnClass ) {
+	protected function getCellForPropVals( ResultArray $resultArray, $outputMode, string $columnClass ): void {
 		/** @var DataValue[] $dataValues */
 		$dataValues = [];
 

--- a/src/SPARQLStore/QueryEngine/ConditionBuilder.php
+++ b/src/SPARQLStore/QueryEngine/ConditionBuilder.php
@@ -455,7 +455,7 @@ class ConditionBuilder {
 	 *
 	 * @param Condition &$condition condition to modify
 	 */
-	protected function addMissingOrderByConditions( Condition &$condition ) {
+	protected function addMissingOrderByConditions( Condition &$condition ): void {
 		foreach ( $this->sortKeys as $propertyKey => $order ) {
 
 			if ( !is_string( $propertyKey ) ) {

--- a/src/SPARQLStore/SPARQLStore.php
+++ b/src/SPARQLStore/SPARQLStore.php
@@ -240,7 +240,7 @@ class SPARQLStore extends Store {
 	 * @see Store::doDataUpdate()
 	 * @since 1.6
 	 */
-	protected function doDataUpdate( SemanticData $semanticData ) {
+	protected function doDataUpdate( SemanticData $semanticData ): void {
 		$this->baseStore->doDataUpdate( $semanticData );
 		$this->doSparqlDataUpdate( $semanticData );
 	}

--- a/src/SQLStore/EntityStore/StubSemanticData.php
+++ b/src/SQLStore/EntityStore/StubSemanticData.php
@@ -87,7 +87,7 @@ class StubSemanticData extends SemanticData {
 	/**
 	 * @since 2.3
 	 */
-	public function __wakeup() {
+	public function __wakeup(): void {
 		$this->store = StoreFactory::getStore( SQLStore::class );
 	}
 
@@ -324,7 +324,7 @@ class StubSemanticData extends SemanticData {
 	 *
 	 * @since 1.8
 	 */
-	protected function unstubProperties() {
+	protected function unstubProperties(): void {
 		foreach ( $this->mStubPropVals as $pkey => $values ) { // unstub property values only, the value lists are still kept as stubs
 			try {
 				$this->unstubProperty( $pkey );
@@ -350,7 +350,7 @@ class StubSemanticData extends SemanticData {
 	 * @throws DataItemException if property key is not valid
 	 * 	and $diProperty is null
 	 */
-	protected function unstubProperty( $propertyKey, $diProperty = null ) {
+	protected function unstubProperty( $propertyKey, $diProperty = null ): void {
 		if ( !array_key_exists( $propertyKey, $this->mProperties ) ) {
 			if ( $diProperty === null ) {
 				$diProperty = new Property( $propertyKey, false );

--- a/src/SQLStore/PropertyTableDefinitionBuilder.php
+++ b/src/SQLStore/PropertyTableDefinitionBuilder.php
@@ -158,7 +158,7 @@ class PropertyTableDefinitionBuilder {
 	 * @param $tableName
 	 * @param $fixedProperty
 	 */
-	protected function addPropertyTable( $diType, $tableName, $fixedProperty = false, string $tableType = '' ) {
+	protected function addPropertyTable( $diType, $tableName, $fixedProperty = false, string $tableType = '' ): void {
 		$this->propertyTables[$tableName] = $this->newTableDefinition( $diType, $tableName, $fixedProperty );
 		$this->propertyTables[$tableName]->setTableType( $tableType );
 	}

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
@@ -131,9 +131,10 @@ class SearchTableUpdater {
 	 * @param int $pid
 	 * @param string $text
 	 */
-	public function update( $sid, $pid, $text ) {
+	public function update( $sid, $pid, $text ): void {
 		if ( trim( $text ) === '' || ( $indexableText = $this->textSanitizer->sanitize( $text ) ) === '' ) {
-			return $this->delete( $sid, $pid );
+			$this->delete( $sid, $pid );
+			return;
 		}
 
 		$this->connection->update(

--- a/src/SQLStore/TableBuilder/MySQLTableBuilder.php
+++ b/src/SQLStore/TableBuilder/MySQLTableBuilder.php
@@ -66,7 +66,7 @@ class MySQLTableBuilder extends TableBuilder {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doCreateTable( $tableName, array $attributes ) {
+	protected function doCreateTable( $tableName, array $attributes ): void {
 		$tableName = $this->connection->tableName( $tableName );
 		$sql = '';
 
@@ -116,7 +116,7 @@ class MySQLTableBuilder extends TableBuilder {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doUpdateTable( $tableName, array $attributes ) {
+	protected function doUpdateTable( $tableName, array $attributes ): void {
 		$tableName = $this->connection->tableName( $tableName );
 		$currentFields = $this->getCurrentFields( $tableName );
 
@@ -262,7 +262,7 @@ class MySQLTableBuilder extends TableBuilder {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doCreateIndices( $tableName, array $indexOptions ) {
+	protected function doCreateIndices( $tableName, array $indexOptions ): void {
 		$indices = $indexOptions['indices'];
 
 		// First remove possible obsolete indices
@@ -394,7 +394,7 @@ class MySQLTableBuilder extends TableBuilder {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doDropTable( $tableName ) {
+	protected function doDropTable( $tableName ): void {
 		$this->connection->query( 'DROP TABLE ' . $this->connection->tableName( $tableName ), __METHOD__, ISQLPlatform::QUERY_CHANGE_SCHEMA );
 	}
 
@@ -403,7 +403,7 @@ class MySQLTableBuilder extends TableBuilder {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doOptimize( $tableName ) {
+	protected function doOptimize( $tableName ): void {
 		$cliMsgFormatter = new CliMsgFormatter();
 
 		$this->reportMessage(

--- a/src/SQLStore/TableBuilder/PostgresTableBuilder.php
+++ b/src/SQLStore/TableBuilder/PostgresTableBuilder.php
@@ -69,7 +69,7 @@ class PostgresTableBuilder extends TableBuilder {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doCreateTable( $tableName, array $attributes ) {
+	protected function doCreateTable( $tableName, array $attributes ): void {
 		$tableName = $this->connection->tableName( $tableName );
 
 		$fieldSql = [];
@@ -91,7 +91,7 @@ class PostgresTableBuilder extends TableBuilder {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doUpdateTable( $tableName, array $attributes ) {
+	protected function doUpdateTable( $tableName, array $attributes ): void {
 		$tableName = $this->connection->tableName( $tableName );
 		$currentFields = $this->getCurrentFields( $tableName );
 
@@ -293,7 +293,7 @@ EOT;
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doCreateIndices( $tableName, array $indexOptions ) {
+	protected function doCreateIndices( $tableName, array $indexOptions ): void {
 		$indices = $indexOptions['indices'];
 		$ix = [];
 
@@ -416,7 +416,7 @@ EOT;
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doDropTable( $tableName ) {
+	protected function doDropTable( $tableName ): void {
 		// Function: SMW\SQLStore\TableBuilder\PostgresTableBuilder::doDropTable
 		// Error: 2BP01 ERROR:  cannot drop table smw_object_ids because other objects depend on it
 		// DETAIL:  default for table sunittest_smw_object_ids column smw_id depends on sequence smw_object_ids_smw_id_seq
@@ -429,7 +429,7 @@ EOT;
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doOptimize( $tableName ) {
+	protected function doOptimize( $tableName ): void {
 		$cliMsgFormatter = new CliMsgFormatter();
 
 		$this->reportMessage(

--- a/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
+++ b/src/SQLStore/TableBuilder/SQLiteTableBuilder.php
@@ -72,7 +72,7 @@ class SQLiteTableBuilder extends TableBuilder {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doCreateTable( $tableName, array $attributes ) {
+	protected function doCreateTable( $tableName, array $attributes ): void {
 		$mode = '';
 		$option = '';
 
@@ -119,7 +119,7 @@ class SQLiteTableBuilder extends TableBuilder {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doUpdateTable( $tableName, array $attributes ) {
+	protected function doUpdateTable( $tableName, array $attributes ): void {
 		$tableName = $this->connection->tableName( $tableName );
 		$currentFields = $this->getCurrentFields( $tableName );
 
@@ -259,7 +259,7 @@ class SQLiteTableBuilder extends TableBuilder {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doCreateIndices( $tableName, array $indexOptions ) {
+	protected function doCreateIndices( $tableName, array $indexOptions ): void {
 		$indices = $indexOptions['indices'];
 		$ix = [];
 
@@ -358,7 +358,7 @@ class SQLiteTableBuilder extends TableBuilder {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doDropTable( $tableName ) {
+	protected function doDropTable( $tableName ): void {
 		$this->connection->query( 'DROP TABLE ' . $this->connection->tableName( $tableName ), __METHOD__, ISQLPlatform::QUERY_CHANGE_SCHEMA );
 	}
 
@@ -367,7 +367,7 @@ class SQLiteTableBuilder extends TableBuilder {
 	 *
 	 * {@inheritDoc}
 	 */
-	protected function doOptimize( $tableName ) {
+	protected function doOptimize( $tableName ): void {
 		$this->reportMessage( "Checking table $tableName ...\n" );
 
 		// https://sqlite.org/lang_analyze.html

--- a/src/SQLStore/TableBuilder/TableBuilder.php
+++ b/src/SQLStore/TableBuilder/TableBuilder.php
@@ -128,7 +128,7 @@ abstract class TableBuilder implements TableBuilderInterface, MessageReporterAwa
 	 *
 	 * {@inheritDoc}
 	 */
-	public function create( Table $table ) {
+	public function create( Table $table ): void {
 		$attributes = $table->getAttributes();
 		$tableName = $table->getName();
 
@@ -145,7 +145,8 @@ abstract class TableBuilder implements TableBuilderInterface, MessageReporterAwa
 		$this->reportMessage( "   ... done.\n" );
 
 		if ( !isset( $attributes['indices'] ) ) {
-			return $this->reportMessage( "No index structures for table $tableName ...\n" );
+			$this->reportMessage( "No index structures for table $tableName ...\n" );
+			return;
 		}
 
 		$this->reportMessage( "Checking index structures for table $tableName ...\n" );
@@ -222,29 +223,29 @@ abstract class TableBuilder implements TableBuilderInterface, MessageReporterAwa
 	 * @param string $tableName
 	 * @param array $tableOptions
 	 */
-	abstract protected function doCreateTable( $tableName, array $tableOptions );
+	abstract protected function doCreateTable( $tableName, array $tableOptions ): void;
 
 	/**
 	 * @param string $tableName
 	 * @param array $tableOptions
 	 */
-	abstract protected function doUpdateTable( $tableName, array $tableOptions );
+	abstract protected function doUpdateTable( $tableName, array $tableOptions ): void;
 
 	/**
 	 * @param string $tableName
 	 * @param array $indexOptions
 	 */
-	abstract protected function doCreateIndices( $tableName, array $indexOptions );
+	abstract protected function doCreateIndices( $tableName, array $indexOptions ): void;
 
 	/**
 	 * @param string $tableName
 	 */
-	abstract protected function doDropTable( $tableName );
+	abstract protected function doDropTable( $tableName ): void;
 
 	/**
 	 * @param string $tableName
 	 */
-	abstract protected function doOptimize( $tableName );
+	abstract protected function doOptimize( $tableName ): void;
 
 	// #1978
 	// http://php.net/manual/en/function.array-search.php

--- a/tests/phpunit/Unit/Constraint/ConstraintCheckRunnerTest.php
+++ b/tests/phpunit/Unit/Constraint/ConstraintCheckRunnerTest.php
@@ -47,8 +47,7 @@ class ConstraintCheckRunnerTest extends TestCase {
 			->method( 'checkConstraint' )
 			->with(
 				[ 'foo_bar' => [] ],
-				'__value__' )
-			->willReturn( false );
+				'__value__' );
 
 		$constraint->expects( $this->atLeastOnce() )
 			->method( 'hasViolation' )

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/TaskHandlerRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/TaskHandlerRegistryTest.php
@@ -157,8 +157,7 @@ class TaskHandlerRegistryTest extends TestCase {
 				return '';
 			}
 
-			public function handleRequest( WebRequest $webRequest ) {
-				return '';
+			public function handleRequest( WebRequest $webRequest ): void {
 			}
 		};
 	}


### PR DESCRIPTION
## Summary

Adds `: void` return types to ~160 methods across `src/` that have no return statements or only bare `return;`. This is the first batch of a push toward 100% return type coverage.

Includes parent abstract/interface declarations and all their implementations to maintain inheritance compatibility. Also fixes `return expr;` patterns in void methods where the return value was never used by callers.

### Type coverage (native types only, via `tomasvotruba/type-coverage`)

| Category | Before | After | Delta |
|----------|--------|-------|-------|
| Return types | 4576/6830 (67.0%) | 4747/6830 (69.5%) | +171 (+2.5%) |
| Param types | 4543/8636 (52.6%) | 4543/8636 (52.6%) | — |
| Property types | 947/1613 (58.7%) | 947/1613 (58.7%) | — |

### What changed

- Methods with no `return` statements → `: void`
- Methods with only bare `return;` → `: void`
- Abstract/interface declarations updated to match (e.g. `DataValue::parseUserValue()`, `Constraint::checkConstraint()`, `ActionableTask::handleRequest()`, `Serializer` methods, `TableBuilder` methods)
- `return voidExpr();` patterns split into `voidExpr(); return;` (the return values were never used by callers)
- Two test mocks updated to match new void signatures

## Test plan

- [x] `parallel-lint` passes
- [x] PHPCS clean (no errors or warnings)
- [x] Unit tests pass (0 new failures, 27 skipped + 1 risky = pre-existing baseline)
- [x] CI green on all builds