### PR TITLE
Remove smwfNumberFormat(), deprecated since 2.1

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -31,6 +31,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
   ```
 
 * Replaced the vendored `Onoi\Tesa` text sanitizer library with PHP `intl` built-ins for fulltext search text processing. Users with `smwgEnabledFulltextSearch` enabled must run `rebuildFulltextSearchTable.php` after upgrading. Transliteration now uses ICU instead of a static mapping table, which produces minor differences for some characters (e.g., German ü→u instead of ü→ue). This does not affect search match quality.
+* Removed `smwfNumberFormat()`, deprecated since 2.1. Use `IntlNumberFormatter::getInstance()->getLocalizedFormattedNumber()` instead.
 * Removed unused internal classes: `HtmlVTabs`, `SchemaParameterTypeMismatchException`, `CleanUpTables`, and `FlatSemanticDataSerializer`.
 * Moved permission rights and group assignments to declarative `AvailableRights` and `GroupPermissions` keys in `extension.json`. The `SMW::GroupPermissions::BeforeInitializationComplete` hook has been removed. Extensions that modified SMW permissions via this hook should use MediaWiki's standard `$wgGroupPermissions` override in `LocalSettings.php` instead.
 * Removed the `$smwgSparqlRepositoryConnectorForcedHttpVersion` setting. HTTP version negotiation is now handled by MediaWiki's HTTP layer. The `mediawiki/http-request` (`Onoi\HttpRequest`) dependency has been dropped — SPARQL store connectors and `RemoteRequest` now use MediaWiki core's `HttpRequestFactory`.

--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -3,7 +3,6 @@
 use MediaWiki\Linker\Linker;
 use MediaWiki\Parser\Sanitizer;
 use MediaWiki\WikiMap\WikiMap;
-use SMW\DataValues\Number\IntlNumberFormatter;
 use SMW\Formatters\Highlighter;
 use SMW\Localizer\Localizer;
 use SMW\Localizer\LocalLanguage\LocalLanguage;
@@ -77,13 +76,6 @@ function smwfXMLContentEncode( ?string $text ): string {
  */
 function smwfHTMLtoUTF8( ?string $text ): string {
 	return Sanitizer::decodeCharReferences( $text ?? '' );
-}
-
-/**
- * @deprecated since 2.1, use NumberFormatter instead
- */
-function smwfNumberFormat( $value, $decplaces = 3 ) {
-	return IntlNumberFormatter::getInstance()->getLocalizedFormattedNumber( $value, $decplaces );
 }
 
 /**


### PR DESCRIPTION
## Summary

- Remove `smwfNumberFormat()` from `GlobalFunctions.php` — deprecated since 2.1 with no remaining callers
- Remove now-unused `IntlNumberFormatter` import
- Add removal note to 7.0.0 release notes; callers should use `IntlNumberFormatter::getInstance()->getLocalizedFormattedNumber()` instead

## Test plan

- [x] `composer analyze` passes
- [x] `composer test` passes