### PR TITLE
Drop redundant wikimedia/cdb dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,6 @@
 		"seld/jsonlint": "^1.7",
 		"justinrainbow/json-schema": "~5.2",
 		"jeroen/file-fetcher": "^6|^5|^4.4",
-		"wikimedia/cdb": "^3|^2|^1",
 		"wikimedia/textcat": "^2|^1.1"
 	},
 	"require-dev": {


### PR DESCRIPTION
## Summary

- Remove `wikimedia/cdb` from `composer.json` — MW core already hard-requires it (`3.0.0`), making SMW's `^3|^2|^1` declaration redundant

No code changes — SMW continues to use the library for reading CDB stopword files in fulltext search (`TextSanitizer`).

## Test plan

- [x] No code changes, only `composer.json`
- [x] Library remains available via MW core's dependency