### PR TITLE
Move symfony/css-selector to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
 		"onoi/event-dispatcher": "~1.0",
 		"onoi/blob-store": "~1.2",
 		"onoi/callback-container": "~2.0",
-		"symfony/css-selector": "^5|^4|^3.3",
 		"seld/jsonlint": "^1.7",
 		"justinrainbow/json-schema": "~5.2",
 		"jeroen/file-fetcher": "^6|^5|^4.4",
@@ -64,7 +63,8 @@
 		"mediawiki/mediawiki-phan-config": "0.20.0",
 		"mediawiki/minus-x": "1.1.3",
 		"php-parallel-lint/php-console-highlighter": "1.0.0",
-		"php-parallel-lint/php-parallel-lint": "1.4.0"
+		"php-parallel-lint/php-parallel-lint": "1.4.0",
+		"symfony/css-selector": "^5"
 	},
 	"suggest": {
 		"mediawiki/semantic-result-formats": "Provides additional result formats for queries of structured data"


### PR DESCRIPTION
## Summary

- Move `symfony/css-selector` from `require` to `require-dev` — it is only used in test utilities (`HtmlValidator`) for CSS-to-XPath conversion in `parser-html` test assertions (2 test files)
- Tighten version constraint from `^5|^4|^3.3` to `^5` — older versions cannot be installed alongside MW 1.43+

## Test plan

- [x] No production code uses this library
- [x] Test utilities have a `canUse()` guard that skips gracefully if unavailable