### PR TITLE
Fix and improve maintenance log entries

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -176,6 +176,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed float-to-int precision loss in maintenance script progress output ([#6229](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6229))
 * Fixed null argument error in entity lookup task handler ([#6228](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6228))
 * Improved wording of the post-edit reload notice ([#6301](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6301))
+* Fixed maintenance log entries showing "performed unknown action" instead of a proper message, and improved log comment formatting from raw JSON to human-readable text ([#6146](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6146), [#6554](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6554))
 
 ### Internal improvements
 

--- a/extension.json
+++ b/extension.json
@@ -136,6 +136,9 @@
 	"FilterLogTypes": {
 		"smw": true
 	},
+	"LogActionsHandlers": {
+		"smw/maintenance": "LogFormatter"
+	},
 	"ContentHandlers": {
 		"smw/schema": "SMW\\MediaWiki\\Content\\SchemaContentHandler"
 	},

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -696,7 +696,7 @@
 	"log-show-hide-smw": "$1 Semantic MediaWiki log",
 	"logeventslist-smw-log": "Semantic MediaWiki log",
 	"log-description-smw": "Activities for [https://www.semantic-mediawiki.org/wiki/Help:Logging enabled event types] that have been reported by Semantic MediaWiki and its components.",
-	"logentry-smw-maintenance": "Maintenance related events emitted by Semantic MediaWiki",
+	"logentry-smw-maintenance": "$1 {{GENDER:$2|performed}} maintenance",
 	"smw-datavalue-import-unknown-namespace": "The import namespace \"$1\" is unknown. Please ensure that OWL import details are available via [[MediaWiki:Smw import $1]]",
 	"smw-datavalue-import-missing-namespace-uri": "Unable to find a \"$1\" namespace URI in the [[MediaWiki:Smw import $1|$1 import]].",
 	"smw-datavalue-import-missing-type": "No type definition was found for \"$1\" in the [[MediaWiki:Smw import $2|$2 import]].",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -694,7 +694,7 @@
 	"log-show-hide-smw": "This is the name for an entry added by Semantic MediaWiki to special page \"[[Special:Log]]\".\nParameters:\n* $1 - one of {{msg-mw|Show}} or {{msg-mw|Hide}}\n{{Related|Log-show-hide}}",
 	"logeventslist-smw-log": "Semantic MediaWiki log option label on [[Special:Log]]",
 	"log-description-smw": "A description for Semantic MediaWiki entries displayed in [[Special:Log]].",
-	"logentry-smw-maintenance": "This is the message for an entry added by Semantic MediaWiki to special page \"[[Special:Log]]\".",
+	"logentry-smw-maintenance": "{{Logentry}}\nThis is the message for a maintenance entry added by Semantic MediaWiki to special page \"[[Special:Log]]\".",
 	"smw-datavalue-import-unknown-namespace": "This is an error message.\n\nParameter:\n* $1 holds the name of the namespace.",
 	"smw-datavalue-import-missing-namespace-uri": "This is an error message.\n\nParameter:\n* $1 holds the name of the namespace.",
 	"smw-datavalue-import-missing-type": "This is an error message show to the user during [https://semantic-mediawiki.org/wiki/Help:Import_vocabulary the import of an vocabulary]\n\nParameters:\n* $1 - name of the property to be imported\n* $2 - number of vocabulary to be imported",

--- a/src/Maintenance/MaintenanceLogger.php
+++ b/src/Maintenance/MaintenanceLogger.php
@@ -56,7 +56,42 @@ class MaintenanceLogger {
 			}
 		}
 
-		$this->log( json_encode( $message ), $target );
+		$this->log( self::formatMessage( $message ), $target );
+	}
+
+	private static function formatMessage( array $message ): string {
+		$parts = [];
+
+		foreach ( $message as $key => $value ) {
+			if ( is_array( $value ) ) {
+				if ( $value === [] ) {
+					continue;
+				}
+				$value = json_encode( $value );
+			} elseif ( $key === 'Memory used' ) {
+				$value = self::formatBytes( (int)$value );
+			}
+
+			$parts[] = "$key: $value";
+		}
+
+		return implode( ', ', $parts );
+	}
+
+	private static function formatBytes( int $bytes ): string {
+		if ( $bytes >= 1073741824 ) {
+			return round( $bytes / 1073741824, 2 ) . ' GB';
+		}
+
+		if ( $bytes >= 1048576 ) {
+			return round( $bytes / 1048576, 2 ) . ' MB';
+		}
+
+		if ( $bytes >= 1024 ) {
+			return round( $bytes / 1024, 2 ) . ' KB';
+		}
+
+		return $bytes . ' bytes';
 	}
 
 	/**


### PR DESCRIPTION
<img width="920" height="32" alt="image" src="https://github.com/user-attachments/assets/e89bcfd6-35e6-4ede-bba1-d01b68ef516a" />

## Summary

Fixes #6146 — maintenance log entries displayed as `performed unknown action "smw/maintenance"` instead of a proper message.

**Root cause:** No `LogActionsHandlers` entry in `extension.json` for `smw/maintenance`, so MediaWiki didn't know which `LogFormatter` to use.

**Changes:**
- Register `LogActionsHandlers` mapping `smw/maintenance` → `LogFormatter` in `extension.json`
- Update `logentry-smw-maintenance` to use the standard `LogFormatter` message format with `$1` (performer) and `{{GENDER}}` support for translators
- Format maintenance log comments as human-readable text instead of raw JSON, with memory values converted to human-readable units (KB/MB/GB)

**Before:**
> DisposeOutdatedEntitiesLogger performed unknown action "smw/maintenance" on DisposeOutdatedEntitiesLogger ({"Memory used":3780696,"Time used":"0.04 sec"})

**After:**
> DisposeOutdatedEntitiesLogger (talk | contribs) performed maintenance (Memory used: 3.61 MB, Time used: 0.04 sec)

## Test plan
- [x] Run a maintenance script with `--with-maintenance-log` (e.g. `disposeOutdatedEntities`)
- [x] Check `Special:Log/smw` — entries should show "performed maintenance" with human-readable stats
- [x] Run `composer analyze` — no new warnings
- [x] Run `ManualEntryLoggerTest` and `MaintenanceLoggerTest` — all pass