### PR TITLE
Fix code coverage for Unit tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,12 +77,8 @@ jobs:
         run: make ci
         if: matrix.coverage == false
 
-      - name: Run unit tests with coverage
-        run: make ci-coverage COMPOSER_PARAMS="-- --testsuite=semantic-mediawiki-unit"
-        if: matrix.coverage == true
-
       - name: Run tests with coverage
-        run: make ci-coverage COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
+        run: make ci-coverage COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-unit,semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
         if: matrix.coverage == true
 
       - name: Upload code coverage


### PR DESCRIPTION
We ran code coverage for the Unit tests before everything else. This led to it being overwritten.