### PR TITLE
Drop buildResult return type

### DIFF
--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -320,13 +320,16 @@ abstract class ResultPrinter implements IResultPrinter {
 	/**
 	 * Build and return the HTML result.
 	 *
+	 * FIXME: The Datatable format in SRF can return array.
+	 * We can not use ?string as return type until that is patched.
+	 *
 	 * @since 1.8
 	 *
 	 * @param QueryResult $results
 	 *
 	 * @return string
 	 */
-	protected function buildResult( QueryResult $results ): ?string {
+	protected function buildResult( QueryResult $results ) {
 		$this->isHTML = false;
 		$this->hasTemplates = false;
 


### PR DESCRIPTION
Datatable in SemanticResultFormats can return array. We can only type this when SRF is patched.

SRF: https://github.com/SemanticMediaWiki/SemanticResultFormats/blob/7517c40d0cccbe8b5c7aa788e6a83d66f6965edf/formats/datatables/DataTables.php#L421

Tagging @thomas-topway-it since they are the author of the Datatable format