### PR TITLE
Fix JsonContentsFileReaderTest::testWriteToFile test

### DIFF
--- a/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
+++ b/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
@@ -118,7 +118,7 @@ class JsonContentsFileReaderTest extends TestCase {
 		$didWrite = false;
 
 		var_dump( $instance->readByLanguageCode( 'en', true ) );
-		var_dump ( $GLOBALS['smwgExtraneousLanguageFileDir'] );
+		var_dump( $GLOBALS['smwgExtraneousLanguageFileDir'] );
 
 		foreach ( explode( ',', $list ) as $lang ) {
 			$contents = $instance->readByLanguageCode( $lang, true );

--- a/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
+++ b/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
@@ -115,6 +115,8 @@ class JsonContentsFileReaderTest extends TestCase {
 		$instance = new JsonContentsFileReader();
 		$list = 'ar,arz,ca,de,es,fi,fr,he,hu,id,it,nb,nl,pl,pt,ru,sk,zh-cn,zh-tw';
 
+		$didWrite = false;
+
 		foreach ( explode( ',', $list ) as $lang ) {
 			$contents = $instance->readByLanguageCode( $lang, true );
 
@@ -125,7 +127,14 @@ class JsonContentsFileReaderTest extends TestCase {
 			$contents[$topic] = $contents[$topic] + $extension;
 
 			$instance->writeByLanguageCode( $lang, $contents );
+
+			$didWrite = true;
 		}
+
+		$this->assertTrue(
+			$didWrite,
+			'Expected at least one language file to be written'
+		);
 	}
 
 	/**

--- a/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
+++ b/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
@@ -118,6 +118,7 @@ class JsonContentsFileReaderTest extends TestCase {
 		$didWrite = false;
 
 		var_dump( $instance->readByLanguageCode( 'en', true ) );
+		var_dump ( $GLOBALS['smwgExtraneousLanguageFileDir'] );
 
 		foreach ( explode( ',', $list ) as $lang ) {
 			$contents = $instance->readByLanguageCode( $lang, true );

--- a/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
+++ b/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
@@ -122,6 +122,10 @@ class JsonContentsFileReaderTest extends TestCase {
 		foreach ( explode( ',', $list ) as $lang ) {
 			$contents = $instance->readByLanguageCode( $lang, true );
 
+			var_dump( $lang );
+			var_dump( $contents );
+			var_dump( $contents[$topic] );
+
 			if ( $contents === '' || !isset( $contents[$topic] ) ) {
 				continue;
 			}

--- a/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
+++ b/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
@@ -115,24 +115,25 @@ class JsonContentsFileReaderTest extends TestCase {
 		$instance = new JsonContentsFileReader();
 		$list = 'ar,arz,ca,de,es,fi,fr,he,hu,id,it,nb,nl,pl,pt,ru,sk,zh-cn,zh-tw';
 
-		$didWrite = true;
+		$didWrite = false;
 
 		foreach ( explode( ',', $list ) as $lang ) {
 			$contents = $instance->readByLanguageCode( $lang, true );
 
 			if ( $contents === '' ) {
-				$didWrite = false;
 				continue;
 			}
 
 			$contents[$topic] = ( $contents[$topic] ?? [] ) + $extension;
 
 			$instance->writeByLanguageCode( $lang, $contents );
+
+			$didWrite = true;
 		}
 
 		$this->assertTrue(
 			$didWrite,
-			'Expected all language files specified to be written to'
+			'Expected at least one language file to be written'
 		);
 	}
 

--- a/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
+++ b/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
@@ -166,9 +166,11 @@ class JsonContentsFileReaderTest extends TestCase {
 
 	public function dataExtensionProvider() {
 		$provider[] = [
-			'dataTypeLabels',
+			'datatype',
 			[
-				"_ref_rec" => "Reference"
+				'labels' => [
+					"_ref_rec" => "Reference"
+				]
 			]
 		];
 

--- a/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
+++ b/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
@@ -117,6 +117,8 @@ class JsonContentsFileReaderTest extends TestCase {
 
 		$didWrite = false;
 
+		var_dump( $instance->readByLanguageCode( 'en', true ) );
+
 		foreach ( explode( ',', $list ) as $lang ) {
 			$contents = $instance->readByLanguageCode( $lang, true );
 

--- a/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
+++ b/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
@@ -117,21 +117,14 @@ class JsonContentsFileReaderTest extends TestCase {
 
 		$didWrite = false;
 
-		var_dump( $instance->readByLanguageCode( 'en', true ) );
-		var_dump( $GLOBALS['smwgExtraneousLanguageFileDir'] );
-
 		foreach ( explode( ',', $list ) as $lang ) {
 			$contents = $instance->readByLanguageCode( $lang, true );
 
-			var_dump( $lang );
-			var_dump( $contents );
-			var_dump( $contents[$topic] );
-
-			if ( $contents === '' || !isset( $contents[$topic] ) ) {
+			if ( $contents === '' ) {
 				continue;
 			}
 
-			$contents[$topic] = $contents[$topic] + $extension;
+			$contents[$topic] = ( $contents[$topic] ?? [] ) + $extension;
 
 			$instance->writeByLanguageCode( $lang, $contents );
 
@@ -166,11 +159,9 @@ class JsonContentsFileReaderTest extends TestCase {
 
 	public function dataExtensionProvider() {
 		$provider[] = [
-			'datatype',
+			'dataTypeLabels',
 			[
-				'labels' => [
-					"_ref_rec" => "Reference"
-				]
+				"_ref_rec" => "Reference"
 			]
 		];
 

--- a/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
+++ b/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
@@ -115,25 +115,24 @@ class JsonContentsFileReaderTest extends TestCase {
 		$instance = new JsonContentsFileReader();
 		$list = 'ar,arz,ca,de,es,fi,fr,he,hu,id,it,nb,nl,pl,pt,ru,sk,zh-cn,zh-tw';
 
-		$didWrite = false;
+		$didWrite = true;
 
 		foreach ( explode( ',', $list ) as $lang ) {
 			$contents = $instance->readByLanguageCode( $lang, true );
 
 			if ( $contents === '' ) {
+				$didWrite = false;
 				continue;
 			}
 
 			$contents[$topic] = ( $contents[$topic] ?? [] ) + $extension;
 
 			$instance->writeByLanguageCode( $lang, $contents );
-
-			$didWrite = true;
 		}
 
 		$this->assertTrue(
 			$didWrite,
-			'Expected at least one language file to be written'
+			'Expected all language files specified to be written to'
 		);
 	}
 


### PR DESCRIPTION
```
1) SMW\Tests\Unit\Localizer\LocalLanguage\JsonContentsFileReaderTest::testWriteToFile with data set #0 ('dataTypeLabels', array('Reference'))
This test did not perform any assertions
/var/www/html/extensions/SemanticMediaWiki/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php:114
```