### PR TITLE
Fix ElementaryRepositoryConnectorTest test

### DIFF
--- a/tests/phpunit/Unit/SPARQLStore/RepositoryConnectors/ElementaryRepositoryConnectorTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/RepositoryConnectors/ElementaryRepositoryConnectorTest.php
@@ -7,6 +7,7 @@ use MWHttpRequest;
 use PHPUnit\Framework\TestCase;
 use SMW\SPARQLStore\QueryEngine\RepositoryResult;
 use SMW\SPARQLStore\RepositoryClient;
+use SMW\SPARQLStore\RepositoryConnectors\GenericRepositoryConnector;
 use SMW\Tests\Utils\Fixtures\Results\FakeRawResultProvider;
 use StatusValue;
 
@@ -21,7 +22,9 @@ use StatusValue;
 class ElementaryRepositoryConnectorTest extends TestCase {
 
 	public function getRepositoryConnectors() {
-		return [];
+		return [
+			GenericRepositoryConnector::class
+		];
 	}
 
 	protected function createMockHttpRequestFactory( MWHttpRequest $mockRequest ): HttpRequestFactory {


### PR DESCRIPTION
I removed the deprecated class that was used in this [0]. But never replaced it.

[0] https://github.com/SemanticMediaWiki/SemanticMediaWiki/commit/9dd59b687921cbf5d28249ccb8c7233445b5bcd1#diff-76303286c04b2d241a0d0b91b3c4b9bbd031be29133446c00266f4fffe5ed564