### PR TITLE
Speedup CI slightly by simplifying

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,18 +32,6 @@ jobs:
             database_image: "mariadb:11.2"
             coverage: false
             experimental: false
-          - mediawiki_version: '1.43'
-            php_version: 8.3
-            database_type: mysql
-            database_image: "mariadb:11.2"
-            coverage: false
-            experimental: false
-          - mediawiki_version: '1.44'
-            php_version: 8.3
-            database_type: mysql
-            database_image: "mariadb:11.2"
-            coverage: false
-            experimental: false
           - mediawiki_version: '1.44'
             php_version: 8.3
             database_type: mysql


### PR DESCRIPTION
We don't need to run MW 1.43 jobs on php 8.2 and 8.3 We run 8.3 on MW 1.44 which is enough.