### PR TITLE
Fix "Deprecated: Function xml_set_object() is deprecated since 8.4"

### DIFF
--- a/src/SPARQLStore/QueryEngine/XmlResponseParser.php
+++ b/src/SPARQLStore/QueryEngine/XmlResponseParser.php
@@ -74,7 +74,6 @@ class XmlResponseParser implements HttpResponseParser {
 		xml_parser_set_option( $this->parser, XML_OPTION_SKIP_WHITE, 0 );
 		xml_parser_set_option( $this->parser, XML_OPTION_TARGET_ENCODING, 'UTF-8' );
 		xml_parser_set_option( $this->parser, XML_OPTION_CASE_FOLDING, 0 );
-		xml_set_object( $this->parser, $this );
 		xml_set_element_handler( $this->parser, $this->handleOpenElement( ... ), $this->handleCloseElement( ... ) );
 		xml_set_character_data_handler( $this->parser, $this->handleCharacterData( ... ) );
 		xml_set_default_handler( $this->parser, $this->handleDefault( ... ) );


### PR DESCRIPTION
It's a noop since php 8.0 and we require php 8.1+. So we can safely drop this.