### PR TITLE
Fix TypeError in Rebuilder when handling DB rows

### DIFF
--- a/src/SQLStore/Rebuilder/EntityValidator.php
+++ b/src/SQLStore/Rebuilder/EntityValidator.php
@@ -280,7 +280,7 @@ class EntityValidator {
 	 *
 	 * @return bool
 	 */
-	public function hasLatestRevID( Title $title, $row = false ): bool {
+	public function hasLatestRevID( Title $title, stdClass|false $row = false ): bool {
 		$latestRevID = $this->revisionGuard->getLatestRevID( $title );
 
 		if ( $row !== false ) {

--- a/src/SQLStore/Rebuilder/Rebuilder.php
+++ b/src/SQLStore/Rebuilder/Rebuilder.php
@@ -14,6 +14,7 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\SQLStore\SQLStore;
 use SMW\Utils\Lru;
+use stdClass;
 
 /**
  * @private
@@ -426,7 +427,7 @@ class Rebuilder {
 		$id = $nextPosition ?: -1;
 	}
 
-	private function hasSkippableRevision( $title, bool $row = false ): bool {
+	private function hasSkippableRevision( $title, stdClass|false $row = false ): bool {
 		if ( $this->getOption( 'force-update' ) ) {
 			return false;
 		}
@@ -438,7 +439,7 @@ class Rebuilder {
 		$this->dispatchedEntities[] = [ $key => $row->smw_title . '#' . $row->smw_namespace . '#' . $row->smw_subobject ];
 	}
 
-	private function addJob( $title, $row = false ): void {
+	private function addJob( $title, stdClass|false $row = false ): void {
 		$hash = $title->getDBKey() . '#' . $title->getNamespace();
 		$this->lru->set( $hash, true );
 


### PR DESCRIPTION
## Summary

Fixes #6651. `php maintenance/run.php SemanticMediaWiki:rebuildData` aborts with a `TypeError` as soon as it dispatches a non-skipped entity.

## Root cause

`Rebuilder::hasSkippableRevision()` was typed as `bool $row = false`, but the callers pass a `stdClass` DB row from `SQLStore::ID_TABLE`:

```
matchAsSubject() → checkRow(stdClass) → addJob(Title, stdClass)
                                     → hasSkippableRevision(Title, stdClass)  💥
```

The `bool` type was introduced by automated type inference in #6505 — it picked up `bool` from the `= false` default without checking what callers actually pass. The real contract for `$row` is `stdClass|false` — `false` is a legacy sentinel meaning \"no pre-fetched row\", otherwise it's a DB result object whose `smw_rev` is compared against the latest revision.

## Fix

Correct the type on three correlated signatures:
- `Rebuilder::hasSkippableRevision()`
- `Rebuilder::addJob()`
- `EntityValidator::hasLatestRevID()`

## Test plan

- [x] `composer analyze` clean on changed files
- [x] `tests/phpunit/Unit/SQLStore/Rebuilder/` — 10/10 pass
- [ ] Manual: run `rebuildData` on a wiki with existing pages and confirm no `TypeError`