### PR TITLE
Fix "ProfileForm::addProfile(): Argument #1 ($type) must be of type string, null"

### DIFF
--- a/src/MediaWiki/Search/ProfileForm/ProfileForm.php
+++ b/src/MediaWiki/Search/ProfileForm/ProfileForm.php
@@ -53,7 +53,7 @@ class ProfileForm {
 	/**
 	 * @since 3.0
 	 */
-	public static function addProfile( string $type, array &$profiles, array $options ): void {
+	public static function addProfile( ?string $type, array &$profiles, array $options ): void {
 		if ( $type !== SMW_SPECIAL_SEARCHTYPE ) {
 			return;
 		}


### PR DESCRIPTION
It seems https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/master/src/MediaWiki/Hooks.php#L486 can return null because wgSearchType isn't set.

Fixes #6655