### PR TITLE
Simplify tearDown method in JSONScriptTestCaseRunner

### DIFF
--- a/tests/phpunit/JSONScriptTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptTestCaseRunner.php
@@ -78,11 +78,7 @@ abstract class JSONScriptTestCaseRunner extends SMWIntegrationTestCase {
 				$this->testEnvironment->flushPages( $this->itemsMarkedForDeletion );
 			}
 		} finally {
-			try {
-				$this->testEnvironment->tearDown();
-			} finally {
-				parent::tearDown();
-			}
+			parent::tearDown();
 		}
 	}
 


### PR DESCRIPTION
We already do this here https://github.com/SemanticMediaWiki/SemanticMediaWiki/blob/7a9a351a2dbf2121d94df3ee624e731f13261879/tests/phpunit/SMWIntegrationTestCase.php#L135