### PR TITLE
Use MediaWikiTeardownPHPUnitExtension in phpunit.xml.dist

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -60,4 +60,8 @@
     <var name="benchmarkPageCopyCount" value="1000"/>
     <var name="benchmarkPageEditRepetitionCount" value="50"/>
   </php>
+  <extensions>
+    <extension class="MediaWikiLoggerPHPUnitExtension" />
+    <extension class="MediaWikiTeardownPHPUnitExtension" />
+  </extensions>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -76,7 +76,6 @@
     <var name="benchmarkPageEditRepetitionCount" value="50"/>
   </php>
   <extensions>
-    <extension class="MediaWikiLoggerPHPUnitExtension" />
     <extension class="MediaWikiTeardownPHPUnitExtension" />
   </extensions>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" stopOnError="false" stopOnFailure="false" stopOnIncomplete="false" stopOnSkipped="false" beStrictAboutTestsThatDoNotTestAnything="true" printerClass="SMW\Tests\PHPUnitResultPrinter" printerFile="tests/phpunit/PHPUnitResultPrinter.php" stderr="true" verbose="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          backupGlobals="false"
+          backupStaticAttributes="false"
+          colors="true" convertErrorsToExceptions="true"
+          convertNoticesToExceptions="true"
+          convertWarningsToExceptions="true"
+          stopOnError="false"
+          stopOnFailure="false"
+          stopOnIncomplete="false"
+          stopOnSkipped="false"
+          beStrictAboutTestsThatDoNotTestAnything="true"
+          printerClass="SMW\Tests\PHPUnitResultPrinter"
+          printerFile="tests/phpunit/PHPUnitResultPrinter.php"
+          stderr="true" verbose="true"
+          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage includeUncoveredFiles="true">
     <include>
       <directory suffix=".php">src</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -12,7 +12,8 @@
           beStrictAboutTestsThatDoNotTestAnything="true"
           printerClass="SMW\Tests\PHPUnitResultPrinter"
           printerFile="tests/phpunit/PHPUnitResultPrinter.php"
-          stderr="true" verbose="true"
+          stderr="true"
+          verbose="true"
           xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
   <coverage includeUncoveredFiles="true">
     <include>


### PR DESCRIPTION

We don't use MediaWiki core phpunit.xml file and thus need to specify MediaWikiTeardownPHPUnitExtension ourselves.

MediaWiki CI for gerrit.wikimedia.org repoed extensions use the MW core phpunit.xml file.

It's possible this may fix our issue with db lockouts but not guaranteed and only a guess (MediaWikiTeardownPHPUnitExtension)