### PR TITLE
Drop redundant SELECT DISTINCT in disjunction temp-table inserts

### DIFF
--- a/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
+++ b/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
@@ -233,7 +233,7 @@ class QuerySegmentListProcessor {
 			if ( $subQuery->joinTable !== '' ) {
 				$sql = 'INSERT ' . 'IGNORE ' . 'INTO ' .
 					   $this->connection->tableName( $query->alias ) .
-					   " SELECT DISTINCT $subQuery->joinfield FROM " . $this->connection->tableName( $subQuery->joinTable ) .
+					   " SELECT $subQuery->joinfield FROM " . $this->connection->tableName( $subQuery->joinTable ) .
 					   " AS $subQuery->alias $subQuery->from" . ( $subQuery->where ? " WHERE $subQuery->where" : '' );
 			} elseif ( $subQuery->joinfield !== '' ) {
 				// NOTE: this works only for single "unconditional" values without further

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/QuerySegmentListProcessorTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/QuerySegmentListProcessorTest.php
@@ -4,7 +4,9 @@ namespace SMW\Tests\Unit\SQLStore\QueryEngine;
 
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
+use SMW\Query\Query;
 use SMW\SQLStore\QueryEngine\HierarchyTempTableBuilder;
+use SMW\SQLStore\QueryEngine\QuerySegment;
 use SMW\SQLStore\QueryEngine\QuerySegmentListProcessor;
 use SMW\SQLStore\TableBuilder\TemporaryTableBuilder;
 
@@ -59,6 +61,60 @@ class QuerySegmentListProcessorTest extends TestCase {
 
 		$this->expectException( 'RuntimeException' );
 		$instance->process( 42 );
+	}
+
+	public function testProcessDisjunctionDoesNotEmitSelectDistinct() {
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->method( 'tableName' )
+			->willReturnArgument( 0 );
+
+		$temporaryTableBuilder = $this->getMockBuilder( TemporaryTableBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$hierarchyTempTableBuilder = $this->getMockBuilder( HierarchyTempTableBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		QuerySegment::$qnum = 0;
+
+		$subQuery = new QuerySegment();
+		$subQuery->type = QuerySegment::Q_TABLE;
+		$subQuery->joinTable = 'smw_object_ids';
+		$subQuery->joinfield = "{$subQuery->alias}.smw_id";
+
+		$disjunction = new QuerySegment();
+		$disjunction->type = QuerySegment::Q_DISJUNCTION;
+		$disjunction->components = [ $subQuery->queryNumber => "{$disjunction->alias}.id" ];
+
+		$querySegmentList = [
+			$disjunction->queryNumber => $disjunction,
+			$subQuery->queryNumber => $subQuery,
+		];
+
+		$instance = new QuerySegmentListProcessor(
+			$connection,
+			$temporaryTableBuilder,
+			$hierarchyTempTableBuilder
+		);
+
+		$instance->setQueryMode( Query::MODE_NONE );
+		$instance->setQuerySegmentList( $querySegmentList );
+		$instance->process( $disjunction->queryNumber );
+
+		$executedQueries = $instance->getExecutedQueries();
+		$allSQL = '';
+
+		foreach ( $executedQueries as $queries ) {
+			$allSQL .= implode( "\n", $queries ) . "\n";
+		}
+
+		$this->assertNotEmpty( $allSQL, 'Expected at least one disjunction SQL statement to be recorded' );
+		$this->assertStringContainsString( 'INSERT IGNORE INTO', $allSQL );
+		$this->assertStringNotContainsString( 'SELECT DISTINCT', $allSQL );
 	}
 
 }


### PR DESCRIPTION
## Summary

`QuerySegmentListProcessor::disjunction` emits `INSERT IGNORE INTO <temp> SELECT ... FROM ...` to populate a temp table during disjunction processing. The temp table's primary key already deduplicates rows on insert, so the `DISTINCT` keyword on the source side adds a sort/unique step that is pure overhead.

This drops the keyword and adds a unit-test assertion that the executed-queries log no longer contains `SELECT DISTINCT`. The new test guards the regression via positive assertions (`INSERT IGNORE INTO` is present) so the negative assertion (`SELECT DISTINCT` is absent) cannot vacuously pass.

Refs #6559.

## Test plan

- [x] `composer phpunit -- --filter QuerySegmentListProcessorTest` — 3/3 green (the existing 2 plus the new assertion)
- [x] `composer analyze` clean for the changed files
- [x] CI green