### PR TITLE
Make entity ID cache sizes tunable, report stats via StatsFactory

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -65,6 +65,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 * Removed `getTextFromContent()`, `replacePrefixes()`, and `textAlreadyUpdatedForIndex()` from `ExtendedSearchEngine`, matching their removal from MediaWiki core's `SearchEngine`.
 * Removed unused internal classes: `HtmlVTabs`, `SchemaParameterTypeMismatchException`, `CleanUpTables`, and `FlatSemanticDataSerializer`.
+* Removed `EntityIdManager::MAX_CACHE_SIZE`. Cache sizes are now per-pool and exposed as `EntityIdManager::DEFAULT_CACHE_SIZES`, configurable via `$smwgEntityCacheSizes`.
 * Removed long-deprecated code originally scheduled for removal:
   * `smwfNormalTitleText()` — use `Localizer::getInstance()->normalizeTitleText()` (deprecated since 3.2)
   * `smwfNumberFormat()` — use `IntlNumberFormatter::getInstance()->getLocalizedFormattedNumber()` (deprecated since 2.1)
@@ -189,6 +190,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * `#ask` queries that sort by a property value are now significantly faster on MariaDB and MySQL. The query engine restructures the SQL so the database can choose a more efficient plan; on large wikis the improvement can be orders of magnitude depending on query shape. ([#6559](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6559))
   * Set `$smwgQUseLegacyQuery = true` in `LocalSettings.php` to fall back to the previous query shape if you encounter a regression after upgrading.
   * A redundant `DISTINCT` keyword was also dropped from the disjunction-query temp-table insert. Same result, less work for the database; no setting required.
+* On wikis with many distinct entities per page, SMW's internal caches could fill up during a single render and force repeated database lookups for the same pages. Cache sizes are now adjustable via the new `$smwgEntityCacheSizes` setting. Per-pool hit and miss counts are also emitted to MediaWiki's `StatsFactory` service, so wikis already configured to collect MediaWiki metrics (`$wgStatsTarget` and `$wgStatsFormat`) can see cache effectiveness in their existing dashboards and size caches based on real traffic instead of guessing.
 
 ### Internal improvements
 

--- a/src/DefaultSettings.php
+++ b/src/DefaultSettings.php
@@ -1,5 +1,6 @@
 <?php
 
+use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\SQLStore;
 
 /**
@@ -1946,6 +1947,46 @@ return ( static function (): array {
 		# @default identity (as legacy setting)
 		##
 		'smwgEntityCollation' => 'identity',
+		# #
+
+		##
+		# Per-pool entry limits for the in-memory caches SMW uses to look up
+		# entity IDs during a single request.
+		#
+		# These caches let SMW avoid duplicate database queries for the same
+		# titles and IDs while a page renders. On large or unusually rich pages,
+		# the default sizes can fill up and force SMW to re-query entities it
+		# already saw earlier in the same render. Raising a limit keeps more
+		# entries resident at the cost of additional memory.
+		#
+		# To tune a single pool, override only that key — pools you don't list
+		# keep their defaults:
+		#
+		#   $smwgEntityCacheSizes['entity.id'] = 5000;
+		#
+		# To assess whether tuning is needed, monitor the
+		# `smw_inmemory_cache_hits_total` and `smw_inmemory_cache_misses_total`
+		# metrics emitted via MediaWiki's StatsFactory. These require
+		# `$wgStatsTarget` and `$wgStatsFormat` to be configured (see
+		# MediaWiki's stats documentation); from there metrics flow to a
+		# StatsD endpoint, which can in turn be relayed to Prometheus through
+		# standard tooling such as `statsd_exporter`. A consistently low hit
+		# ratio on a specific pool indicates it would benefit from a higher
+		# limit.
+		#
+		# Pools:
+		# - entity.id           — title -> SMW ID
+		# - entity.sort         — title -> sortkey
+		# - entity.lookup       — SMW ID -> WikiPage data item
+		# - propertytable.hash  — which property tables hold data for each entity
+		# - warmup.byid         — IDs already prefetched in this request
+		# - sequence.map        — SMW ID -> property sequence map
+		# - redirect.source.lookup / redirect.target.lookup — redirect resolution
+		# - count.map           — SMW ID -> auxiliary count map
+		#
+		# @since 7.0.0
+		##
+		'smwgEntityCacheSizes' => EntityIdManager::DEFAULT_CACHE_SIZES,
 		# #
 
 		##

--- a/src/DefaultSettings.php
+++ b/src/DefaultSettings.php
@@ -1965,8 +1965,10 @@ return ( static function (): array {
 		#   $smwgEntityCacheSizes['entity.id'] = 5000;
 		#
 		# To assess whether tuning is needed, monitor the
-		# `smw_inmemory_cache_hits_total` and `smw_inmemory_cache_misses_total`
-		# metrics emitted via MediaWiki's StatsFactory. These require
+		# `mediawiki.SemanticMediaWiki.inmemory_cache_hits_total` and
+		# `mediawiki.SemanticMediaWiki.inmemory_cache_misses_total` metrics
+		# emitted via MediaWiki's StatsFactory (Prometheus exporters
+		# typically normalize the dots to underscores). These require
 		# `$wgStatsTarget` and `$wgStatsFormat` to be configured (see
 		# MediaWiki's stats documentation); from there metrics flow to a
 		# StatsD endpoint, which can in turn be relayed to Prometheus through

--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -3,17 +3,21 @@
 namespace SMW\SQLStore\EntityStore;
 
 use Iterator;
+use MediaWiki\Deferred\DeferredUpdates;
+use MediaWiki\MediaWikiServices;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\Exception\PredefinedPropertyLabelMismatchException;
 use SMW\Exception\PropertyLabelNotResolvedException;
+use SMW\InMemoryPoolCache;
 use SMW\Iterators\MappingIterator;
 use SMW\Listener\ChangeListener\ChangeRecord;
 use SMW\MediaWiki\Collator;
 use SMW\MediaWiki\Connection\Sequence;
 use SMW\PropertyRegistry;
 use SMW\RequestOptions;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\Lookup\RedirectTargetLookup;
 use SMW\SQLStore\PropertyTable\PropertyTableHashes;
 use SMW\SQLStore\PropertyTableInfoFetcher;
@@ -64,8 +68,27 @@ use SMW\Utils\Flag;
  */
 class EntityIdManager {
 
-	const MAX_CACHE_SIZE = 1000;
 	const POOLCACHE_ID = 'smw.sqlstore';
+
+	/**
+	 * Built-in maximum entry counts for the request-scoped LRU caches that
+	 * back entity ID lookups. Each pool is independent — these values are
+	 * starting points that can be tuned per-pool via the
+	 * `$smwgEntityCacheSizes` setting based on observed hit rates.
+	 *
+	 * @since 7.0.0
+	 */
+	public const DEFAULT_CACHE_SIZES = [
+		'entity.id' => 1000,
+		'entity.sort' => 1000,
+		'entity.lookup' => 2000,
+		'propertytable.hash' => 1000,
+		'warmup.byid' => 1000,
+		'sequence.map' => 1000,
+		IdCacheManager::REDIRECT_SOURCE => 1000,
+		IdCacheManager::REDIRECT_TARGET => 1000,
+		AuxiliaryFields::COUNTMAP_CACHE_ID => 1000,
+	];
 
 	/**
 	 * @var SQLStore
@@ -82,6 +105,8 @@ class EntityIdManager {
 	 * @var array
 	 */
 	public static $special_ids = [];
+
+	private static bool $statsReporterRegistered = false;
 
 	private IdCacheManager $idCacheManager;
 
@@ -989,18 +1014,10 @@ class EntityIdManager {
 		// values in some data structure (other than a single string).
 		$this->idCacheManager = $this->factory->newIdCacheManager(
 			self::POOLCACHE_ID,
-			[
-				'entity.id' => self::MAX_CACHE_SIZE,
-				'entity.sort' => self::MAX_CACHE_SIZE,
-				'entity.lookup' => 2000,
-				'propertytable.hash' => self::MAX_CACHE_SIZE,
-				'warmup.byid' => self::MAX_CACHE_SIZE,
-				'sequence.map' => self::MAX_CACHE_SIZE,
-				IdCacheManager::REDIRECT_SOURCE => self::MAX_CACHE_SIZE,
-				IdCacheManager::REDIRECT_TARGET => self::MAX_CACHE_SIZE,
-				AuxiliaryFields::COUNTMAP_CACHE_ID => self::MAX_CACHE_SIZE,
-			]
+			$this->resolveCacheSizes()
 		);
+
+		self::registerCacheStatsReporter();
 
 		$this->cacheWarmer = $this->factory->newCacheWarmer(
 			$this->idCacheManager
@@ -1110,6 +1127,77 @@ class EntityIdManager {
 	 */
 	public function loadSequenceMap( array $ids ): void {
 		$this->sequenceMapFinder->prefetchSequenceMap( $ids );
+	}
+
+	private function resolveCacheSizes(): array {
+		$configured = ApplicationFactory::getInstance()->getSettings()->safeGet( 'smwgEntityCacheSizes', [] );
+
+		if ( !is_array( $configured ) || $configured === [] ) {
+			return self::DEFAULT_CACHE_SIZES;
+		}
+
+		return array_merge( self::DEFAULT_CACHE_SIZES, $configured );
+	}
+
+	/**
+	 * Registers a deferred update that snapshots `InMemoryPoolCache` stats and
+	 * emits them to MediaWiki's `StatsFactory` once per request. The deferred
+	 * update fires inside `MediaWikiEntryPoint::doPostOutputShutdown`, before
+	 * the StatsFactory flush, ensuring web and API requests both report.
+	 *
+	 * Maintenance scripts and jobs call `DeferredUpdates::doUpdates()` but do
+	 * not invoke `StatsFactory::flush()`, so the snapshot is recorded but never
+	 * sent to the configured StatsD/Prometheus backend in those execution
+	 * paths. This is intentional for a Phase 1 observability feature focused
+	 * on web traffic.
+	 */
+	private static function registerCacheStatsReporter(): void {
+		if ( self::$statsReporterRegistered ) {
+			return;
+		}
+		self::$statsReporterRegistered = true;
+
+		DeferredUpdates::addCallableUpdate( static function (): void {
+			$stats = InMemoryPoolCache::getInstance()->getStats();
+
+			if ( !is_array( $stats ) || $stats === [] ) {
+				return;
+			}
+
+			$statsFactory = MediaWikiServices::getInstance()
+				->getStatsFactory()
+				->withComponent( 'SemanticMediaWiki' );
+
+			foreach ( $stats as $pool => $data ) {
+				if ( !is_array( $data ) ) {
+					continue;
+				}
+
+				$hits = (int)( $data['hits'] ?? 0 );
+				$misses = (int)( $data['misses'] ?? 0 );
+				$count = (int)( $data['count'] ?? 0 );
+
+				if ( $hits + $misses === 0 && $count === 0 ) {
+					continue;
+				}
+
+				if ( $hits > 0 ) {
+					$statsFactory->getCounter( 'inmemory_cache_hits_total' )
+						->setLabel( 'pool', (string)$pool )
+						->incrementBy( $hits );
+				}
+
+				if ( $misses > 0 ) {
+					$statsFactory->getCounter( 'inmemory_cache_misses_total' )
+						->setLabel( 'pool', (string)$pool )
+						->incrementBy( $misses );
+				}
+
+				$statsFactory->getGauge( 'inmemory_cache_size' )
+					->setLabel( 'pool', (string)$pool )
+					->set( $count );
+			}
+		} );
 	}
 
 }

--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -3,14 +3,11 @@
 namespace SMW\SQLStore\EntityStore;
 
 use Iterator;
-use MediaWiki\Deferred\DeferredUpdates;
-use MediaWiki\MediaWikiServices;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\Exception\PredefinedPropertyLabelMismatchException;
 use SMW\Exception\PropertyLabelNotResolvedException;
-use SMW\InMemoryPoolCache;
 use SMW\Iterators\MappingIterator;
 use SMW\Listener\ChangeListener\ChangeRecord;
 use SMW\MediaWiki\Collator;
@@ -105,8 +102,6 @@ class EntityIdManager {
 	 * @var array
 	 */
 	public static $special_ids = [];
-
-	private static bool $statsReporterRegistered = false;
 
 	private IdCacheManager $idCacheManager;
 
@@ -1017,8 +1012,6 @@ class EntityIdManager {
 			$this->resolveCacheSizes()
 		);
 
-		self::registerCacheStatsReporter();
-
 		$this->cacheWarmer = $this->factory->newCacheWarmer(
 			$this->idCacheManager
 		);
@@ -1137,67 +1130,6 @@ class EntityIdManager {
 		}
 
 		return array_merge( self::DEFAULT_CACHE_SIZES, $configured );
-	}
-
-	/**
-	 * Registers a deferred update that snapshots `InMemoryPoolCache` stats and
-	 * emits them to MediaWiki's `StatsFactory` once per request. The deferred
-	 * update fires inside `MediaWikiEntryPoint::doPostOutputShutdown`, before
-	 * the StatsFactory flush, ensuring web and API requests both report.
-	 *
-	 * Maintenance scripts and jobs call `DeferredUpdates::doUpdates()` but do
-	 * not invoke `StatsFactory::flush()`, so the snapshot is recorded but never
-	 * sent to the configured StatsD/Prometheus backend in those execution
-	 * paths. This is intentional for a Phase 1 observability feature focused
-	 * on web traffic.
-	 */
-	private static function registerCacheStatsReporter(): void {
-		if ( self::$statsReporterRegistered ) {
-			return;
-		}
-		self::$statsReporterRegistered = true;
-
-		DeferredUpdates::addCallableUpdate( static function (): void {
-			$stats = InMemoryPoolCache::getInstance()->getStats();
-
-			if ( !is_array( $stats ) || $stats === [] ) {
-				return;
-			}
-
-			$statsFactory = MediaWikiServices::getInstance()
-				->getStatsFactory()
-				->withComponent( 'SemanticMediaWiki' );
-
-			foreach ( $stats as $pool => $data ) {
-				if ( !is_array( $data ) ) {
-					continue;
-				}
-
-				$hits = (int)( $data['hits'] ?? 0 );
-				$misses = (int)( $data['misses'] ?? 0 );
-				$count = (int)( $data['count'] ?? 0 );
-
-				if ( $hits + $misses === 0 && $count === 0 ) {
-					continue;
-				}
-
-				if ( $hits > 0 ) {
-					$statsFactory->getCounter( 'inmemory_cache_hits_total' )
-						->setLabel( 'pool', (string)$pool )
-						->incrementBy( $hits );
-				}
-
-				if ( $misses > 0 ) {
-					$statsFactory->getCounter( 'inmemory_cache_misses_total' )
-						->setLabel( 'pool', (string)$pool )
-						->incrementBy( $misses );
-				}
-
-				$statsFactory->getGauge( 'inmemory_cache_size' )
-					->setLabel( 'pool', (string)$pool )
-					->set( $count );
-			}
-		} );
 	}
 
 }

--- a/src/SQLStore/EntityStore/InstrumentedCache.php
+++ b/src/SQLStore/EntityStore/InstrumentedCache.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace SMW\SQLStore\EntityStore;
+
+use Onoi\Cache\Cache;
+use Wikimedia\Stats\StatsFactory;
+
+/**
+ * Decorator that emits per-event hit/miss counters and a current-size gauge to
+ * a `StatsFactory` for an underlying `Cache` instance. Used to instrument the
+ * request-scoped LRU pools backing entity ID lookups so operators can see
+ * cache effectiveness in their existing metrics tooling.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class InstrumentedCache implements Cache {
+
+	public function __construct(
+		private readonly Cache $inner,
+		private readonly StatsFactory $statsFactory,
+		private readonly string $pool,
+	) {
+	}
+
+	public function fetch( $id ) {
+		$result = $this->inner->fetch( $id );
+
+		if ( $result !== false ) {
+			$this->statsFactory->getCounter( 'inmemory_cache_hits_total' )
+				->setLabel( 'pool', $this->pool )
+				->increment();
+		} else {
+			$this->statsFactory->getCounter( 'inmemory_cache_misses_total' )
+				->setLabel( 'pool', $this->pool )
+				->increment();
+		}
+
+		return $result;
+	}
+
+	public function contains( $id ) {
+		return $this->inner->contains( $id );
+	}
+
+	public function save( $id, $data, $ttl = 0 ) {
+		$result = $this->inner->save( $id, $data, $ttl );
+		$this->updateSizeGauge();
+		return $result;
+	}
+
+	public function delete( $id ) {
+		$result = $this->inner->delete( $id );
+		$this->updateSizeGauge();
+		return $result;
+	}
+
+	public function getStats() {
+		return $this->inner->getStats();
+	}
+
+	public function getName() {
+		return $this->inner->getName();
+	}
+
+	private function updateSizeGauge(): void {
+		$stats = $this->inner->getStats();
+		$count = (int)( $stats['count'] ?? 0 );
+
+		$this->statsFactory->getGauge( 'inmemory_cache_size' )
+			->setLabel( 'pool', $this->pool )
+			->set( $count );
+	}
+
+}

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -2,6 +2,7 @@
 
 namespace SMW\SQLStore;
 
+use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporter;
 use Onoi\MessageReporter\NullMessageReporter;
 use Psr\Log\LoggerInterface;
@@ -30,6 +31,7 @@ use SMW\SQLStore\EntityStore\EntityLookup;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\EntityStore\IdChanger;
 use SMW\SQLStore\EntityStore\IdEntityFinder;
+use SMW\SQLStore\EntityStore\InstrumentedCache;
 use SMW\SQLStore\EntityStore\PrefetchCache;
 use SMW\SQLStore\EntityStore\PrefetchItemLookup;
 use SMW\SQLStore\EntityStore\PropertiesLookup;
@@ -582,16 +584,19 @@ class SQLStoreFactory {
 	 */
 	public function newIdCacheManager( $id, array $config ): IdCacheManager {
 		$inMemoryPoolCache = ApplicationFactory::getInstance()->getInMemoryPoolCache();
+		$statsFactory = MediaWikiServices::getInstance()
+			->getStatsFactory()
+			->withComponent( 'SemanticMediaWiki' );
 		$caches = [];
 
 		foreach ( $config as $key => $cacheSize ) {
-			$inMemoryPoolCache->resetPoolCacheById(
-				"$id.$key"
-			);
+			$poolId = "$id.$key";
+			$inMemoryPoolCache->resetPoolCacheById( $poolId );
 
-			$caches[$key] = $inMemoryPoolCache->getPoolCacheById(
-				"$id.$key",
-				$cacheSize
+			$caches[$key] = new InstrumentedCache(
+				$inMemoryPoolCache->getPoolCacheById( $poolId, $cacheSize ),
+				$statsFactory,
+				$poolId
 			);
 		}
 

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -185,6 +185,7 @@ class Settings extends Options {
 			'smwgPropertyRetiredList' => $GLOBALS['smwgPropertyRetiredList'],
 			'smwgPropertyReservedNameList' => $GLOBALS['smwgPropertyReservedNameList'],
 			'smwgEntityCollation' => $GLOBALS['smwgEntityCollation'],
+			'smwgEntityCacheSizes' => $GLOBALS['smwgEntityCacheSizes'],
 			'smwgExperimentalFeatures' => $GLOBALS['smwgExperimentalFeatures'],
 			'smwgFieldTypeFeatures' => $GLOBALS['smwgFieldTypeFeatures'],
 			'smwgChangePropagationProtection' => $GLOBALS['smwgChangePropagationProtection'],


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `EntityIdManager::MAX_CACHE_SIZE` with a per-pool `$smwgEntityCacheSizes` setting. Defaults are unchanged.
- Emits per-pool cache hit/miss/size statistics via MediaWiki's `StatsFactory`, so wikis with metrics collection configured (`$wgStatsTarget` / `$wgStatsFormat`) can identify cache pressure from existing dashboards.
- Foundation for diagnosing the cache thrashing reported in #6559 (15k+ duplicate `smw_object_ids` lookups in a single page render).

## Background

In #6559 the reporter saw ~15,500 `WHERE smw_title = ...` queries on a single page. The proximate cause is the request-scoped LRU caches in `EntityIdManager` filling up at their existing 1000-entry limit and forcing re-queries for entities seen earlier in the same render.

Two questions need to be answered before any default change can be made responsibly: which pools actually fill up, and at what rate. This PR ships configurability and observability together so operators can answer those questions on their own wikis:

- Tune individual pools without patching code (`$smwgEntityCacheSizes['entity.id'] = 5000;`).
- See *which* pools thrash before deciding what to bump.

Defaults are preserved so this is a behaviour-neutral change for operators who do nothing.

## Implementation notes

- New setting `$smwgEntityCacheSizes` in `DefaultSettings.php` references `EntityIdManager::DEFAULT_CACHE_SIZES` so operators reading the file see the real values inline. Partial overrides in LocalSettings.php merge with defaults — operators don't have to copy all nine keys to bump one.
- Stats emission is implemented as `InstrumentedCache`, a decorator around `Onoi\Cache\Cache` that wraps each pool when `SQLStoreFactory::newIdCacheManager` constructs them. Each `fetch` increments `inmemory_cache_{hits,misses}_total`, each `save`/`delete` updates `inmemory_cache_size`. This mirrors how MediaWiki core and other extensions (Echo, AbuseFilter, WANObjectCache) instrument metrics — at event time, not via end-of-request snapshots.
- Metric names: `smw.SemanticMediaWiki.inmemory_cache_hits_total`, `smw.SemanticMediaWiki.inmemory_cache_misses_total`, `smw.SemanticMediaWiki.inmemory_cache_size`, all labeled by `pool` (e.g. `smw_sqlstore_entity_id`).

## Backward compatibility

`EntityIdManager::MAX_CACHE_SIZE` (public class const, present since 2017) is removed. It was only ever self-referenced inside `EntityIdManager`; with per-pool tunability the abstraction is misleading. Documented in `RELEASE-NOTES-7.0.0.md` under "Removed APIs".

## Test plan

- [x] `composer analyze` clean for changed files
- [x] `tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php`: 29/29 pass
- [x] `tests/phpunit/Unit/SettingsTest.php`: 152/152 pass
- [x] `tests/phpunit/Unit/SQLStore/`: 856/856 pass (1 pre-existing skip unrelated)
- [x] Live sanity check against a real MW boot: `Settings::get('smwgEntityCacheSizes')` returns the full 9-pool array with original defaults
- [x] Manual end-to-end via the SMW Ask API in a local dev wiki with `\$wgStatsTarget = 'udp://127.0.0.1:8125'` and `\$wgStatsFormat = 'dogstatsd'`: confirmed UDP packets like `mediawiki.SemanticMediaWiki.inmemory_cache_misses_total:1|c|#pool:smw_sqlstore_entity_id` and `inmemory_cache_size:1|g|#pool:...` arrive at the StatsD endpoint.