### PR TITLE
Drop redundant (o_id) index from smw_di_wikipage

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -189,6 +189,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * `#ask` queries that sort by a property value are now significantly faster on MariaDB and MySQL. The query engine restructures the SQL so the database can choose a more efficient plan; on large wikis the improvement can be orders of magnitude depending on query shape. ([#6559](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6559))
   * Set `$smwgQUseLegacyQuery = true` in `LocalSettings.php` to fall back to the previous query shape if you encounter a regression after upgrading.
   * A redundant `DISTINCT` keyword was also dropped from the disjunction-query temp-table insert. Same result, less work for the database; no setting required.
+* Page saves are a little faster and the database uses less memory on large wikis. A redundant index on `smw_di_wikipage` and related fixed-property tables has been removed. ([#6559](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6559))
 
 ### Internal improvements
 

--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -189,7 +189,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * `#ask` queries that sort by a property value are now significantly faster on MariaDB and MySQL. The query engine restructures the SQL so the database can choose a more efficient plan; on large wikis the improvement can be orders of magnitude depending on query shape. ([#6559](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6559))
   * Set `$smwgQUseLegacyQuery = true` in `LocalSettings.php` to fall back to the previous query shape if you encounter a regression after upgrading.
   * A redundant `DISTINCT` keyword was also dropped from the disjunction-query temp-table insert. Same result, less work for the database; no setting required.
-* Page saves are a little faster and the database uses less memory on large wikis. A redundant index on `smw_di_wikipage` and related fixed-property tables has been removed. ([#6559](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6559))
+* Page saves are a little faster, and the database has more memory available for caching on large wikis. A redundant index has been removed from `smw_di_wikipage` and the `smw_fpt_*` fixed-property tables that store wikipage values. On very large wikis, the index drop runs as part of `update.php` and may take some time. ([#6559](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6559))
 
 ### Internal improvements
 

--- a/src/SQLStore/EntityStore/DataItemHandlers/DIWikiPageHandler.php
+++ b/src/SQLStore/EntityStore/DataItemHandlers/DIWikiPageHandler.php
@@ -55,7 +55,7 @@ class DIWikiPageHandler extends DataItemHandler {
 		return [
 			// Standalone (o_id) intentionally omitted — it is a leftmost prefix
 			// of (o_id, s_id) and (o_id, p_id) below, so the composites cover
-			// every query a standalone (o_id) index could serve. See #6559.
+			// any query a standalone (o_id) index could serve. See #6559.
 
 			// SMWSQLStore3Readers::getPropertySubjects
 			'p_id,s_id',

--- a/src/SQLStore/EntityStore/DataItemHandlers/DIWikiPageHandler.php
+++ b/src/SQLStore/EntityStore/DataItemHandlers/DIWikiPageHandler.php
@@ -53,7 +53,9 @@ class DIWikiPageHandler extends DataItemHandler {
 	 */
 	public function getTableIndexes(): array {
 		return [
-			'o_id',
+			// Standalone (o_id) intentionally omitted — it is a leftmost prefix
+			// of (o_id, s_id) and (o_id, p_id) below, so the composites cover
+			// every query a standalone (o_id) index could serve. See #6559.
 
 			// SMWSQLStore3Readers::getPropertySubjects
 			'p_id,s_id',


### PR DESCRIPTION
## Summary

- Removes the standalone `(o_id)` entry from `DIWikiPageHandler::getTableIndexes()`. It was a leftmost prefix of `(o_id, s_id)` and `(o_id, p_id)`, so the composites cover any query the standalone could serve while it imposed B-tree maintenance cost on every INSERT/UPDATE/DELETE to `smw_di_wikipage` and to every `smw_fpt_*` fixed-property table backed by the wikipage handler.
- Audited the other DataItem handlers (`DIBlobHandler`, `DIBooleanHandler`, `DIConceptHandler`, `DIGeoCoordinateHandler`, `DINumberHandler`, `DITimeHandler`, `DIUriHandler`); `DIWikiPageHandler` was the only one with prefix-redundancy.
- Existing wikis pick up the change automatically on `update.php` via the existing `TableBuilder` schema-reconciliation path. **On very large wikis, the resulting `ALTER TABLE ... DROP INDEX` may take some time.** No data migration, no application-side flag.

Refs #6559 (the broader index-reshuffle proposed in that thread is intentionally out of scope here — it depends on `EXPLAIN` evidence from real-world wikis and interacts with the existing `getIndexHint` workaround in `DIWikiPageHandler.php`).

## Test plan

- [x] `composer test -- --filter "DIWikiPageHandlerTest|TableSchemaManagerTest"` — 17 tests, 33 assertions, OK
- [x] `composer analyze` — no new errors or warnings on the modified files
- [x] CI green
- [ ] Smoke-test on a dev wiki: after `update.php`, the standalone `o_id` index is gone from `smw_di_wikipage` and from each `smw_fpt_*` table whose value type is wikipage; the five composite indexes remain intact