### PR TITLE
Enable "MediaWiki.Commenting.PropertyDocumentation.MissingVarType"

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -32,7 +32,6 @@
 		<exclude name="MediaWiki.Usage.ForbiddenFunctions.exec" />
 		<exclude name="MediaWiki.Usage.SuperGlobalsUsage.SuperGlobals" />
 		<exclude name="Generic.PHP.NoSilencedErrors.Discouraged" />
-		<exclude name="MediaWiki.Commenting.PropertyDocumentation.MissingVarType" />
 		<exclude name="Generic.NamingConventions.UpperCaseConstantName.ClassConstantNotUpperCase" />
 		<exclude name="MediaWiki.Commenting.FunctionComment.MissingReturnType" />
 		<exclude name="MediaWiki.Usage.ExtendClassUsage.FunctionConfigUsage" />


### PR DESCRIPTION
It passes.