### PR TITLE
Fix upgrade impossible when smw_hash table exceeds 200k rows

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -229,6 +229,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed null argument error in entity lookup task handler ([#6228](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6228))
 * Improved wording of the post-edit reload notice ([#6301](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6301))
 * Fixed maintenance log entries showing "performed unknown action" instead of a proper message, and improved log comment formatting from raw JSON to human-readable text ([#6146](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6146), [#6554](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6554))
+* Fixed `update.php` failing with "Data too long for column 'smw_hash'" on wikis with more than 200,000 entities. The pre-upgrade hex-to-binary conversion now always runs as a single server-side `UPDATE`, regardless of row count. Setting `$smwgIgnoreUpgradeKeyCheck = true` now also lets maintenance scripts run when the schema is in an intermediate state, providing a documented escape hatch for stalled upgrades. ([#6715](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6715))
 
 ### Enhancements
 
@@ -250,7 +251,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 ## Upgrading
 
-**Run `update.php` after upgrading.** This release changes the `smw_hash` column type from `VARBINARY(40)` to `BINARY(20)`. The update script converts existing hash values automatically. For wikis with more than 200,000 entities, run `populateHashField.php --force-update` before `update.php`.
+**Run `update.php` after upgrading.** This release changes the `smw_hash` column type from `VARBINARY(40)` to `BINARY(20)`. The update script converts existing hash values automatically via a single server-side `UPDATE` before the column-type change. On wikis with millions of entities, expect this UPDATE to hold a write lock on `smw_object_ids` for the duration of the conversion — plan a maintenance window if needed.
 
 **If you use fulltext search** (`smwgEnabledFulltextSearch`): run `rebuildFulltextSearchTable.php` after upgrading to rebuild the index with the new ICU-based transliteration.
 

--- a/src/DefaultSettings.php
+++ b/src/DefaultSettings.php
@@ -130,6 +130,16 @@ return ( static function (): array {
 		# #
 
 		###
+		# Bypass schema validation gates that would otherwise block extension and
+		# maintenance-script execution when the schema is in an intermediate
+		# state. When set to `true`:
+		#
+		# - The early `SetupCheck` invoked from `Setup::init` is skipped, so the
+		#   extension loads even if the upgrade key does not match the schema.
+		# - `MaintenanceCheck` no longer aborts maintenance scripts with the
+		#   "setup wasn't finalized" message, allowing recovery scripts such as
+		#   `populateHashField.php` to run when an upgrade is stalled.
+		#
 		# @since 4.1.3
 		##
 		'smwgIgnoreUpgradeKeyCheck' => false,

--- a/src/Maintenance/MaintenanceCheck.php
+++ b/src/Maintenance/MaintenanceCheck.php
@@ -37,7 +37,13 @@ class MaintenanceCheck {
 			$this->message .= "\n" . $cliMsgFormatter->wordwrap( $text ) . "\n";
 		}
 
-		if ( !Setup::isValid( true ) ) {
+		// `smwgIgnoreUpgradeKeyCheck` is the documented escape hatch for
+		// running maintenance scripts when the schema is in an intermediate
+		// state — notably when an upgrade was blocked by data that requires
+		// a maintenance script (e.g. `populateHashField.php`) to fix first.
+		// Read directly from `$GLOBALS` because this runs before `Setup::init`
+		// has populated the Settings registry.
+		if ( !( $GLOBALS['smwgIgnoreUpgradeKeyCheck'] ?? false ) && !$this->isSchemaValid() ) {
 			$text = [
 				"It seems that the setup of Semantic MediaWiki wasn't finalized or a",
 				"new upgrade key is required.\n\n",
@@ -51,6 +57,14 @@ class MaintenanceCheck {
 		}
 
 		return $this->message === '';
+	}
+
+	/**
+	 * Indirection to allow tests to assert behavior independent of
+	 * `SetupFile::isGoodSchema`'s test-environment short-circuit.
+	 */
+	protected function isSchemaValid(): bool {
+		return Setup::isValid( true );
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/Examiner/HashField.php
+++ b/src/SQLStore/TableBuilder/Examiner/HashField.php
@@ -6,6 +6,7 @@ use Onoi\MessageReporter\MessageReporterAwareTrait;
 use SMW\Maintenance\populateHashField;
 use SMW\SQLStore\SQLStore;
 use SMW\Utils\CliMsgFormatter;
+use Wikimedia\Rdbms\DBError;
 
 /**
  * @license GPL-2.0-or-later
@@ -49,6 +50,11 @@ class HashField {
 	 * The LENGTH check distinguishes hex (40) from already-converted
 	 * binary (20) and empty values.
 	 *
+	 * Always runs to completion regardless of row count: this is a
+	 * single server-side UPDATE on MySQL/Postgres, and skipping it would
+	 * leave 40-byte hex values that the subsequent ALTER TABLE cannot
+	 * narrow to BINARY(20) without truncation.
+	 *
 	 * @since 7.0
 	 */
 	public function migrateHexHashes(): void {
@@ -66,17 +72,6 @@ class HashField {
 			return;
 		}
 
-		if ( $count > self::threshold() ) {
-			$this->messageReporter->reportMessage(
-				$cliMsgFormatter->twoCols(
-					"... hex hashes to convert ...",
-					"(rows) $count — run populateHashField.php --force-update",
-					3
-				)
-			);
-			return;
-		}
-
 		$this->messageReporter->reportMessage(
 			$cliMsgFormatter->twoCols( "... converting hex hashes to binary ...", "(rows) $count", 3 )
 		);
@@ -84,20 +79,49 @@ class HashField {
 		$table = $connection->tableName( SQLStore::ID_TABLE );
 		$type = $connection->getType();
 
-		if ( $type === 'postgres' ) {
-			$connection->query(
-				"UPDATE $table SET smw_hash = decode(smw_hash, 'hex') WHERE LENGTH(smw_hash) = 40",
-				__METHOD__
-			);
-		} elseif ( $type === 'sqlite' ) {
-			// unhex() requires SQLite 3.38+; fall back to PHP-side conversion
-			$this->migrateHexHashesViaPHP( $connection );
-		} else {
-			$connection->query(
-				"UPDATE $table SET smw_hash = UNHEX(smw_hash) WHERE LENGTH(smw_hash) = 40",
-				__METHOD__
-			);
+		try {
+			if ( $type === 'postgres' ) {
+				$connection->query(
+					"UPDATE $table SET smw_hash = decode(smw_hash, 'hex') WHERE LENGTH(smw_hash) = 40",
+					__METHOD__
+				);
+			} elseif ( $type === 'sqlite' ) {
+				// unhex() requires SQLite 3.38+; fall back to PHP-side conversion
+				$this->migrateHexHashesViaPHP( $connection );
+			} else {
+				$connection->query(
+					"UPDATE $table SET smw_hash = UNHEX(smw_hash) WHERE LENGTH(smw_hash) = 40",
+					__METHOD__
+				);
+			}
+		} catch ( DBError $e ) {
+			$this->reportMigrationFailure( $cliMsgFormatter );
+			throw $e;
 		}
+	}
+
+	/**
+	 * Surface a recovery hint before the raw `DBError` propagates and aborts
+	 * `update.php`. The conversion is wrapped in a single transactional UPDATE
+	 * (or, on SQLite, a sequence of per-row UPDATEs each in its own implicit
+	 * transaction), so partial state cannot persist across a failure — the
+	 * operator just needs to resolve the underlying issue and re-run.
+	 */
+	private function reportMigrationFailure( CliMsgFormatter $cliMsgFormatter ): void {
+		$text = [
+			$cliMsgFormatter->red(
+				"\n... hex-to-binary conversion failed; the schema change " .
+				"cannot proceed until this UPDATE succeeds."
+			),
+			"Common causes: lock contention on `smw_object_ids`, insufficient " .
+			"disk space, or a restrictive SQL mode. Resolve the underlying " .
+			"database error and re-run `update.php` — the conversion is atomic " .
+			"and safe to retry.",
+		];
+
+		$this->messageReporter->reportMessage(
+			"\n" . $cliMsgFormatter->wordwrap( $text ) . "\n"
+		);
 	}
 
 	/**

--- a/src/SQLStore/TableBuilder/Examiner/HashField.php
+++ b/src/SQLStore/TableBuilder/Examiner/HashField.php
@@ -102,10 +102,10 @@ class HashField {
 
 	/**
 	 * Surface a recovery hint before the raw `DBError` propagates and aborts
-	 * `update.php`. The conversion is wrapped in a single transactional UPDATE
-	 * (or, on SQLite, a sequence of per-row UPDATEs each in its own implicit
-	 * transaction), so partial state cannot persist across a failure — the
-	 * operator just needs to resolve the underlying issue and re-run.
+	 * `update.php`. The migration is safe to retry after a partial failure
+	 * because the `LENGTH(smw_hash) = 40` predicate skips already-converted
+	 * rows — the SQLite per-row fallback in particular is not transactional,
+	 * but the idempotent predicate makes that safe.
 	 */
 	private function reportMigrationFailure( CliMsgFormatter $cliMsgFormatter ): void {
 		$text = [
@@ -115,8 +115,8 @@ class HashField {
 			),
 			"Common causes: lock contention on `smw_object_ids`, insufficient " .
 			"disk space, or a restrictive SQL mode. Resolve the underlying " .
-			"database error and re-run `update.php` — the conversion is atomic " .
-			"and safe to retry.",
+			"database error and re-run `update.php` — already-converted rows " .
+			"are skipped, so the migration is safe to retry.",
 		];
 
 		$this->messageReporter->reportMessage(

--- a/tests/phpunit/Unit/Maintenance/MaintenanceCheckTest.php
+++ b/tests/phpunit/Unit/Maintenance/MaintenanceCheckTest.php
@@ -44,7 +44,8 @@ class MaintenanceCheckTest extends TestCase {
 	 * would pass even with the bypass missing.
 	 */
 	public function testCanExecute_HonorsIgnoreUpgradeKeyCheck() {
-		$previous = $GLOBALS['smwgIgnoreUpgradeKeyCheck'] ?? false;
+		$hadPrevious = array_key_exists( 'smwgIgnoreUpgradeKeyCheck', $GLOBALS );
+		$previous = $GLOBALS['smwgIgnoreUpgradeKeyCheck'] ?? null;
 		$GLOBALS['smwgIgnoreUpgradeKeyCheck'] = true;
 
 		try {
@@ -57,7 +58,11 @@ class MaintenanceCheckTest extends TestCase {
 			$this->assertTrue( $instance->canExecute() );
 			$this->assertSame( '', $instance->getMessage() );
 		} finally {
-			$GLOBALS['smwgIgnoreUpgradeKeyCheck'] = $previous;
+			if ( $hadPrevious ) {
+				$GLOBALS['smwgIgnoreUpgradeKeyCheck'] = $previous;
+			} else {
+				unset( $GLOBALS['smwgIgnoreUpgradeKeyCheck'] );
+			}
 		}
 	}
 
@@ -69,7 +74,8 @@ class MaintenanceCheckTest extends TestCase {
 	 * lets the previous case succeed.
 	 */
 	public function testCanExecute_BlocksWhenSchemaInvalidAndFlagUnset() {
-		$previous = $GLOBALS['smwgIgnoreUpgradeKeyCheck'] ?? false;
+		$hadPrevious = array_key_exists( 'smwgIgnoreUpgradeKeyCheck', $GLOBALS );
+		$previous = $GLOBALS['smwgIgnoreUpgradeKeyCheck'] ?? null;
 		$GLOBALS['smwgIgnoreUpgradeKeyCheck'] = false;
 
 		try {
@@ -85,7 +91,11 @@ class MaintenanceCheckTest extends TestCase {
 				$instance->getMessage()
 			);
 		} finally {
-			$GLOBALS['smwgIgnoreUpgradeKeyCheck'] = $previous;
+			if ( $hadPrevious ) {
+				$GLOBALS['smwgIgnoreUpgradeKeyCheck'] = $previous;
+			} else {
+				unset( $GLOBALS['smwgIgnoreUpgradeKeyCheck'] );
+			}
 		}
 	}
 

--- a/tests/phpunit/Unit/Maintenance/MaintenanceCheckTest.php
+++ b/tests/phpunit/Unit/Maintenance/MaintenanceCheckTest.php
@@ -32,6 +32,63 @@ class MaintenanceCheckTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Regression test for issue #6715: setting `$smwgIgnoreUpgradeKeyCheck`
+	 * must allow maintenance scripts to run even when the schema is in an
+	 * intermediate state — otherwise scripts like `populateHashField.php`
+	 * cannot be used to recover a stalled upgrade.
+	 *
+	 * Uses an anonymous subclass so the schema-validity check returns
+	 * `false` deterministically — `SetupFile::isGoodSchema` short-circuits
+	 * to `true` under `MW_PHPUNIT_TEST`, so without this override the test
+	 * would pass even with the bypass missing.
+	 */
+	public function testCanExecute_HonorsIgnoreUpgradeKeyCheck() {
+		$previous = $GLOBALS['smwgIgnoreUpgradeKeyCheck'] ?? false;
+		$GLOBALS['smwgIgnoreUpgradeKeyCheck'] = true;
+
+		try {
+			$instance = new class extends MaintenanceCheck {
+				protected function isSchemaValid(): bool {
+					return false;
+				}
+			};
+
+			$this->assertTrue( $instance->canExecute() );
+			$this->assertSame( '', $instance->getMessage() );
+		} finally {
+			$GLOBALS['smwgIgnoreUpgradeKeyCheck'] = $previous;
+		}
+	}
+
+	/**
+	 * Without the bypass flag and with an invalid schema,
+	 * `canExecute()` must refuse and emit the compatibility notice.
+	 * This is the inverse of `testCanExecute_HonorsIgnoreUpgradeKeyCheck`
+	 * and proves the bypass flag — not just the test override — is what
+	 * lets the previous case succeed.
+	 */
+	public function testCanExecute_BlocksWhenSchemaInvalidAndFlagUnset() {
+		$previous = $GLOBALS['smwgIgnoreUpgradeKeyCheck'] ?? false;
+		$GLOBALS['smwgIgnoreUpgradeKeyCheck'] = false;
+
+		try {
+			$instance = new class extends MaintenanceCheck {
+				protected function isSchemaValid(): bool {
+					return false;
+				}
+			};
+
+			$this->assertFalse( $instance->canExecute() );
+			$this->assertStringContainsString(
+				"setup of Semantic MediaWiki wasn't finalized",
+				$instance->getMessage()
+			);
+		} finally {
+			$GLOBALS['smwgIgnoreUpgradeKeyCheck'] = $previous;
+		}
+	}
+
 	public function testGetMessage() {
 		$instance = new MaintenanceCheck();
 

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
@@ -3,9 +3,12 @@
 namespace SMW\Tests\Unit\SQLStore\TableBuilder\Examiner;
 
 use PHPUnit\Framework\TestCase;
+use SMW\Maintenance\populateHashField;
+use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder\Examiner\HashField;
 use SMW\Tests\TestEnvironment;
+use Wikimedia\Rdbms\DBError;
 use Wikimedia\Rdbms\ResultWrapper;
 
 /**
@@ -28,7 +31,7 @@ class HashFieldTest extends TestCase {
 		parent::setUp();
 		$this->spyMessageReporter = TestEnvironment::getUtilityFactory()->newSpyMessageReporter();
 
-		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Connection\Database' )
+		$this->connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -42,7 +45,7 @@ class HashFieldTest extends TestCase {
 		$this->store->method( 'getConnection' )
 			->willReturn( $this->connection );
 
-		$this->populateHashField = $this->getMockBuilder( '\SMW\Maintenance\populateHashField' )
+		$this->populateHashField = $this->getMockBuilder( populateHashField::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -89,7 +92,7 @@ class HashFieldTest extends TestCase {
 		// hashes exist, the SQL conversion must still run — otherwise the
 		// subsequent ALTER TABLE BINARY(20) truncates the 40-byte values
 		// and the upgrade fails.
-		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Connection\Database' )
+		$this->connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -124,7 +127,7 @@ class HashFieldTest extends TestCase {
 	}
 
 	public function testMigrateHexHashes_EmitsRecoveryHintOnDBError() {
-		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Connection\Database' )
+		$this->connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -137,7 +140,7 @@ class HashFieldTest extends TestCase {
 		$this->connection->method( 'getType' )
 			->willReturn( 'mysql' );
 
-		$dbError = $this->getMockBuilder( '\Wikimedia\Rdbms\DBError' )
+		$dbError = $this->getMockBuilder( DBError::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -157,7 +160,7 @@ class HashFieldTest extends TestCase {
 		try {
 			$instance->migrateHexHashes();
 			$this->fail( 'Expected DBError to be re-thrown' );
-		} catch ( \Wikimedia\Rdbms\DBError $e ) {
+		} catch ( DBError $e ) {
 			// expected
 		}
 

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
@@ -22,16 +22,17 @@ class HashFieldTest extends TestCase {
 	private $spyMessageReporter;
 	private $store;
 	private $populateHashField;
+	private $connection;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->spyMessageReporter = TestEnvironment::getUtilityFactory()->newSpyMessageReporter();
 
-		$connection = $this->getMockBuilder( '\SMW\MediaWiki\Connection\Database' )
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Connection\Database' )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->method( 'selectField' )
+		$this->connection->method( 'selectField' )
 			->willReturn( 0 );
 
 		$this->store = $this->getMockBuilder( SQLStore::class )
@@ -39,7 +40,7 @@ class HashFieldTest extends TestCase {
 			->getMock();
 
 		$this->store->method( 'getConnection' )
-			->willReturn( $connection );
+			->willReturn( $this->connection );
 
 		$this->populateHashField = $this->getMockBuilder( '\SMW\Maintenance\populateHashField' )
 			->disableOriginalConstructor()
@@ -81,6 +82,97 @@ class HashFieldTest extends TestCase {
 			'Checking smw_hash field consistency',
 			$this->spyMessageReporter->getMessagesAsString()
 		);
+	}
+
+	public function testMigrateHexHashes_RunsWhenCountExceedsThreshold() {
+		// Regression test for issue #6715: when more than threshold hex
+		// hashes exist, the SQL conversion must still run — otherwise the
+		// subsequent ALTER TABLE BINARY(20) truncates the 40-byte values
+		// and the upgrade fails.
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Connection\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection->method( 'selectField' )
+			->willReturn( HashField::threshold() + 1 );
+
+		$this->connection->method( 'tableName' )
+			->willReturn( 'smw_object_ids' );
+
+		$this->connection->method( 'getType' )
+			->willReturn( 'mysql' );
+
+		$this->connection->expects( $this->once() )
+			->method( 'query' )
+			->with( $this->stringContains( 'UNHEX(smw_hash)' ) );
+
+		$this->store = $this->getMockBuilder( SQLStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->method( 'getConnection' )
+			->willReturn( $this->connection );
+
+		$instance = new HashField( $this->store );
+		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->migrateHexHashes();
+
+		$this->assertStringContainsString(
+			'converting hex hashes to binary',
+			$this->spyMessageReporter->getMessagesAsString()
+		);
+	}
+
+	public function testMigrateHexHashes_EmitsRecoveryHintOnDBError() {
+		$this->connection = $this->getMockBuilder( '\SMW\MediaWiki\Connection\Database' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection->method( 'selectField' )
+			->willReturn( 1 );
+
+		$this->connection->method( 'tableName' )
+			->willReturn( 'smw_object_ids' );
+
+		$this->connection->method( 'getType' )
+			->willReturn( 'mysql' );
+
+		$dbError = $this->getMockBuilder( '\Wikimedia\Rdbms\DBError' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection->method( 'query' )
+			->willThrowException( $dbError );
+
+		$this->store = $this->getMockBuilder( SQLStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->method( 'getConnection' )
+			->willReturn( $this->connection );
+
+		$instance = new HashField( $this->store );
+		$instance->setMessageReporter( $this->spyMessageReporter );
+
+		try {
+			$instance->migrateHexHashes();
+			$this->fail( 'Expected DBError to be re-thrown' );
+		} catch ( \Wikimedia\Rdbms\DBError $e ) {
+			// expected
+		}
+
+		$messages = $this->spyMessageReporter->getMessagesAsString();
+		$this->assertStringContainsString( 'hex-to-binary conversion failed', $messages );
+		$this->assertStringContainsString( 're-run `update.php`', $messages );
+	}
+
+	public function testMigrateHexHashes_NoOpWhenCountIsZero() {
+		$this->connection->expects( $this->never() )
+			->method( 'query' );
+
+		$instance = new HashField( $this->store );
+		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->migrateHexHashes();
 	}
 
 	public function testCheck_Incomplete() {


### PR DESCRIPTION
## Summary

Fixes [#6715](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6715) — `update.php` aborted with `Wikimedia\Rdbms\DBQueryError: Error 1406: Data too long for column 'smw_hash' at row 1` on wikis with more than 200,000 entities, and the documented workaround (`populateHashField.php --force-update` plus `\$smwgIgnoreUpgradeKeyCheck = true`) did not work.

Two interacting bugs:

- **`HashField::migrateHexHashes()` skipped when row count exceeded the threshold**, deferring to a maintenance script that wouldn't run. The threshold was wrongly inherited from the per-row PHP `check()` method — `migrateHexHashes()` is a single server-side `UPDATE ... UNHEX()` (or `decode()` on PostgreSQL) and scales fine regardless of row count.
- **`MaintenanceCheck::canExecute()` ignored `\$smwgIgnoreUpgradeKeyCheck`**, so the documented bypass flag did not help users recover. Setting the flag previously only suppressed the early `SetupCheck` in `Setup::init`.

## Changes

- `HashField::migrateHexHashes()` — removed the threshold-skip branch; the SQL UPDATE always runs. Wrapped in `try { ... } catch ( DBError )` that emits a recovery hint before re-throwing.
- `MaintenanceCheck::canExecute()` — bypass the schema-validity check when `\$smwgIgnoreUpgradeKeyCheck` is true. Extracted the `Setup::isValid()` call behind a protected `isSchemaValid()` method so the bypass behavior is testable (`SetupFile::isGoodSchema` short-circuits to true under `MW_PHPUNIT_TEST`).
- `DefaultSettings.php` — broadened the `\$smwgIgnoreUpgradeKeyCheck` docblock to document both the existing and new effects.
- Release notes — added bug-fix entry; removed the now-unnecessary "run `populateHashField.php` first" upgrade instruction; added a maintenance-window note for multi-million-row wikis.
- Regression tests:
  - `testMigrateHexHashes_RunsWhenCountExceedsThreshold` — pins the bug (asserts `query()` is invoked with `UNHEX(smw_hash)` at count > threshold).
  - `testMigrateHexHashes_NoOpWhenCountIsZero` — preserves existing short-circuit behavior.
  - `testMigrateHexHashes_EmitsRecoveryHintOnDBError` — verifies the new error-reporting path.
  - `testCanExecute_BlocksWhenSchemaInvalidAndFlagUnset` — verifies the bypass is what enables recovery (verified to fail without the fix via stash test).
  - `testCanExecute_HonorsIgnoreUpgradeKeyCheck` — verifies the positive path.

## Test plan

- [x] `composer phpunit -- --filter HashFieldTest tests/phpunit/Unit` — 5/5 pass
- [x] `composer phpunit -- --filter MaintenanceCheckTest tests/phpunit/Unit` — 5/5 pass
- [x] Broader sweep across `tests/phpunit/Unit/Maintenance` and `tests/phpunit/Unit/SQLStore/TableBuilder` — 86/86 pass
- [x] `vendor/bin/phpcs -sp` on changed files — clean
- [x] **End-to-end verification on the test DB (MariaDB 11.4)**: reverted `smw_hash` to `VARBINARY(40)`, inserted 5 rows with 40-byte hex hashes, ran `HashField::migrateHexHashes()` (converted all to 20-byte binary, content matches `hex2bin(\$input)` byte-for-byte), then ran `ALTER TABLE ... BINARY(20)` (the exact statement that failed in the bug report) — succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)