### PR TITLE
Fix strpos() null deprecation in DebugFormatter

### DIFF
--- a/src/Query/DebugFormatter.php
+++ b/src/Query/DebugFormatter.php
@@ -143,7 +143,7 @@ class DebugFormatter {
 				$possible_keys = $row->possible_keys;
 				$ref = $row->ref;
 
-				if ( strpos( $possible_keys, ',' ) !== false ) {
+				if ( strpos( $possible_keys ?? '', ',' ) !== false ) {
 					$possible_keys = implode( ', ', explode( ',', $possible_keys ) );
 				}
 


### PR DESCRIPTION
## Summary
- MySQL `EXPLAIN`'s `possible_keys` column can be `NULL` when no index could be used. Passing `NULL` to `strpos()` triggers a PHP 8.1+ deprecation warning in CI:
  > `Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in src/Query/DebugFormatter.php on line 146`
- Apply the same `?? ''` pattern already used two lines below for `$ref`.

## Test plan
- [x] `vendor/bin/phpcs` clean on the changed file
- [x] `DebugFormatterTest` passes (9/9)
- [x] Full `semantic-mediawiki-unit` suite passes (6814 tests, 0 failures)