### PR TITLE
Migrate SQLStore/Lookup callsites to MW Rdbms QueryBuilder

### DIFF
--- a/src/MediaWiki/Connection/LegacyOptionsApplier.php
+++ b/src/MediaWiki/Connection/LegacyOptionsApplier.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SMW\MediaWiki\Connection;
+
+use Wikimedia\Rdbms\SelectQueryBuilder;
+
+/**
+ * Translates a legacy SQL-options array (as produced by
+ * `Store::getSQLOptions()` and similar callers) into the equivalent
+ * `SelectQueryBuilder` method calls.
+ *
+ * This is a transitional helper used by callsites being migrated from the
+ * legacy `IDatabase::select( ..., $options )` API onto the Rdbms
+ * `SelectQueryBuilder` fluent API. Once every callsite has been migrated to
+ * pass typed parameters directly, this class can be removed alongside its
+ * sibling `OptionsBuilder`.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class LegacyOptionsApplier {
+
+	/**
+	 * Recognised keys (matching MediaWiki's legacy `select()` options array):
+	 * - `LIMIT`        (int)            → `->limit()`
+	 * - `OFFSET`       (int)            → `->offset()`
+	 * - `ORDER BY`     (string|array)   → `->orderBy()`
+	 * - `GROUP BY`     (string|array)   → `->groupBy()`
+	 * - `HAVING`       (string|array)   → `->having()`
+	 * - `DISTINCT`     (truthy or numeric-keyed `'DISTINCT'`) → `->distinct()`
+	 *
+	 * Numeric-keyed entries (e.g. `[ 'DISTINCT' ]`) are recognised in addition
+	 * to string-keyed ones, matching the MW Rdbms convention.
+	 *
+	 * Unknown keys are ignored — callsites are expected to apply any
+	 * non-portable option directly via a builder method.
+	 *
+	 * @since 7.0.0
+	 */
+	public static function applyTo( SelectQueryBuilder $queryBuilder, array $options ): void {
+		if ( isset( $options['LIMIT'] ) ) {
+			$queryBuilder->limit( (int)$options['LIMIT'] );
+		}
+
+		if ( isset( $options['OFFSET'] ) ) {
+			$queryBuilder->offset( (int)$options['OFFSET'] );
+		}
+
+		if ( isset( $options['ORDER BY'] ) ) {
+			$queryBuilder->orderBy( $options['ORDER BY'] );
+		}
+
+		if ( isset( $options['GROUP BY'] ) ) {
+			$queryBuilder->groupBy( $options['GROUP BY'] );
+		}
+
+		if ( isset( $options['HAVING'] ) ) {
+			$queryBuilder->having( $options['HAVING'] );
+		}
+
+		if ( !empty( $options['DISTINCT'] ) || in_array( 'DISTINCT', $options, true ) ) {
+			$queryBuilder->distinct();
+		}
+	}
+}

--- a/src/SQLStore/EntityStore/AuxiliaryFields.php
+++ b/src/SQLStore/EntityStore/AuxiliaryFields.php
@@ -94,44 +94,33 @@ class AuxiliaryFields {
 			$countmap = null;
 		}
 
-		$this->connection->upsert(
-			SQLStore::ID_AUXILIARY_TABLE,
-			[
+		$this->connection->newInsertQueryBuilder()
+			->insertInto( SQLStore::ID_AUXILIARY_TABLE )
+			->row( [
 				'smw_id' => $sid,
 				'smw_seqmap' => $seqmap,
 				'smw_countmap' => $countmap
-			],
-			'smw_id',
-			[
+			] )
+			->onDuplicateKeyUpdate()
+			->uniqueIndexFields( [ 'smw_id' ] )
+			->set( [
 				'smw_seqmap' => $seqmap,
 				'smw_countmap' => $countmap
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$cache->save( $sid, $countmap );
 	}
 
 	private function fetchCountMap( array $hashes ) {
-		return $this->connection->select(
-			[
-				't' => SQLStore::ID_TABLE,
-				'p' => SQLStore::ID_AUXILIARY_TABLE
-			],
-			[
-				't.smw_id',
-				't.smw_hash',
-				'p.smw_countmap',
-			],
-			[
-				't.smw_hash' => $hashes
-			],
-			__METHOD__,
-			[],
-			[
-				'p' => [ 'INNER JOIN', [ 'p.smw_id=t.smw_id' ] ],
-			]
-		);
+		return $this->connection->newSelectQueryBuilder()
+			->select( [ 't.smw_id', 't.smw_hash', 'p.smw_countmap' ] )
+			->from( SQLStore::ID_TABLE, 't' )
+			->join( SQLStore::ID_AUXILIARY_TABLE, 'p', 'p.smw_id=t.smw_id' )
+			->where( [ 't.smw_hash' => $hashes ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 	}
 
 }

--- a/src/SQLStore/EntityStore/CacheWarmer.php
+++ b/src/SQLStore/EntityStore/CacheWarmer.php
@@ -138,9 +138,8 @@ class CacheWarmer {
 
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$rows = $connection->select(
-			SQLStore::ID_TABLE,
-			[
+		$rows = $connection->newSelectQueryBuilder()
+			->select( [
 				'smw_id',
 				'smw_title',
 				'smw_namespace',
@@ -148,12 +147,11 @@ class CacheWarmer {
 				'smw_subobject',
 				'smw_sortkey',
 				'smw_sort'
-			],
-			[
-				'smw_hash' => $hashList
-			],
-			__METHOD__
-		);
+			] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_hash' => $hashList ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 		foreach ( $rows as $row ) {
 			$sortkey = $row->smw_sort === null ? '' : $row->smw_sortkey;
 
@@ -191,9 +189,8 @@ class CacheWarmer {
 			return;
 		}
 
-		$rows = $connection->select(
-			SQLStore::ID_TABLE,
-			[
+		$rows = $connection->newSelectQueryBuilder()
+			->select( [
 				'smw_id',
 				'smw_title',
 				'smw_namespace',
@@ -201,12 +198,11 @@ class CacheWarmer {
 				'smw_subobject',
 				'smw_sortkey',
 				'smw_sort'
-			],
-			[
-				'smw_id' => $idList
-			],
-			__METHOD__
-		);
+			] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $idList ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		foreach ( $rows as $row ) {
 			$sortkey = $row->smw_sort === null ? '' : $row->smw_sortkey;

--- a/src/SQLStore/EntityStore/DuplicateFinder.php
+++ b/src/SQLStore/EntityStore/DuplicateFinder.php
@@ -11,6 +11,7 @@ use SMW\SQLStore\PropertyTableInfoFetcher;
 use SMW\SQLStore\RedirectStore;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @license GPL-2.0-or-later
@@ -44,36 +45,31 @@ class DuplicateFinder {
 		}
 
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
 
-		$query->type( 'SELECT' );
-		$query->options( [ 'LIMIT' => 2 ] );
-
-		$query->table( SQLStore::ID_TABLE );
-
-		// Only find entities
-		$query->fields( [ 'smw_id', 'smw_sortkey' ] );
+		$qb = $connection->newSelectQueryBuilder()
+			->from( SQLStore::ID_TABLE )
+			->select( [ 'smw_id', 'smw_sortkey' ] )
+			->limit( 2 );
 
 		if ( $type === DataItem::TYPE_WIKIPAGE ) {
-			$query->condition( $query->eq( 'smw_title', $dataItem->getDBKey() ) );
-			$query->condition( $query->eq( 'smw_namespace', $dataItem->getNamespace() ) );
-			$query->condition( $query->eq( 'smw_subobject', $dataItem->getSubobjectName() ) );
+			$qb->where( [
+				'smw_title' => $dataItem->getDBKey(),
+				'smw_namespace' => $dataItem->getNamespace(),
+				'smw_subobject' => $dataItem->getSubobjectName(),
+			] );
 		} else {
-			$query->condition( $query->eq( 'smw_sortkey', $dataItem->getCanonicalLabel() ) );
-			$query->condition( $query->eq( 'smw_namespace', SMW_NS_PROPERTY ) );
-			$query->condition( $query->eq( 'smw_subobject', '' ) );
+			$qb->where( [
+				'smw_sortkey' => $dataItem->getCanonicalLabel(),
+				'smw_namespace' => SMW_NS_PROPERTY,
+				'smw_subobject' => '',
+			] );
 		}
 
-		$query->condition( $query->neq( 'smw_iw', SMW_SQL3_SMWIW_OUTDATED ) );
-		$query->condition( $query->neq( 'smw_iw', SMW_SQL3_SMWDELETEIW ) );
-		$query->condition( $query->neq( 'smw_iw', SMW_SQL3_SMWREDIIW ) );
+		foreach ( [ SMW_SQL3_SMWIW_OUTDATED, SMW_SQL3_SMWDELETEIW, SMW_SQL3_SMWREDIIW ] as $iw ) {
+			$qb->andWhere( $connection->expr( 'smw_iw', '!=', $iw ) );
+		}
 
-		$res = $connection->readQuery(
-			$query,
-			__METHOD__
-		);
-
-		return $res->numRows() > 1;
+		return $qb->caller( __METHOD__ )->fetchResultSet()->numRows() > 1;
 	}
 
 	/**
@@ -85,26 +81,25 @@ class DuplicateFinder {
 	 */
 	public function findDuplicates( $table = null ): Iterator|array {
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
-
-		$query->type( 'SELECT' );
 
 		if ( $table === null ) {
 			$table = SQLStore::ID_TABLE;
 		}
 
+		$qb = $connection->newSelectQueryBuilder()->from( $table );
+
 		if ( $table === SQLStore::ID_TABLE ) {
-			$this->id_table( $table, $query );
+			$this->id_table( $table, $qb );
 		} elseif ( $table === PropertyTableInfoFetcher::findTableIdForDataItemTypeId( DataItem::TYPE_WIKIPAGE ) ) {
-			$this->common_table( $table, $query );
+			$this->common_table( $table, $qb );
 		} elseif ( $table === RedirectStore::TABLE_NAME ) {
-			$this->common_table( $table, $query );
+			$this->common_table( $table, $qb );
 		}
 
-		$rows = $query->execute( __METHOD__ );
+		$rows = $qb->caller( __METHOD__ )->fetchResultSet();
 		$fname = __METHOD__;
 
-		if ( $rows === false ) {
+		if ( $rows->numRows() === 0 ) {
 			return [];
 		}
 
@@ -113,12 +108,12 @@ class DuplicateFinder {
 			$map = [ 'count' => $row->count ] + $map;
 
 			if ( $table === PropertyTableInfoFetcher::findTableIdForDataItemTypeId( DataItem::TYPE_WIKIPAGE ) ) {
-				$row = $connection->selectRow(
-					SQLStore::ID_TABLE,
-					[ 'smw_id', 'smw_title', 'smw_namespace', 'smw_iw', 'smw_subobject' ],
-					[ 'smw_id' => $row->s_id ],
-					$fname
-				);
+				$row = $connection->newSelectQueryBuilder()
+					->select( [ 'smw_id', 'smw_title', 'smw_namespace', 'smw_iw', 'smw_subobject' ] )
+					->from( SQLStore::ID_TABLE )
+					->where( [ 'smw_id' => $row->s_id ] )
+					->caller( $fname )
+					->fetchRow();
 
 				$map += [
 					'entity' => [
@@ -134,43 +129,29 @@ class DuplicateFinder {
 			return $map;
 		};
 
-		$mappingIterator = $this->iteratorFactory->newMappingIterator(
+		return $this->iteratorFactory->newMappingIterator(
 			$this->iteratorFactory->newResultIterator( $rows ),
 			$callback
 		);
-
-		return $mappingIterator;
 	}
 
-	private function id_table( string $table, $query ): void {
+	private function id_table( string $table, SelectQueryBuilder $qb ): void {
 		$fields = self::fields( $table );
+		$connection = $this->store->getConnection( 'mw.db' );
 
-		$query->table( $table );
-		$query->fields( array_merge( [ 'COUNT(*) as count' ], $fields ) );
-
-		$query->condition( $query->neq( 'smw_iw', SMW_SQL3_SMWIW_OUTDATED ) );
-		$query->condition( $query->neq( 'smw_iw', SMW_SQL3_SMWDELETEIW ) );
-
-		$query->options(
-			[
-				'GROUP BY' => implode( ',', $fields ),
-				'HAVING' => 'count(*) > 1'
-			]
-		);
+		$qb->select( array_merge( [ 'count' => 'COUNT(*)' ], $fields ) )
+			->andWhere( $connection->expr( 'smw_iw', '!=', SMW_SQL3_SMWIW_OUTDATED ) )
+			->andWhere( $connection->expr( 'smw_iw', '!=', SMW_SQL3_SMWDELETEIW ) )
+			->groupBy( $fields )
+			->having( 'count(*) > 1' );
 	}
 
-	private function common_table( string $table, $query ): void {
+	private function common_table( string $table, SelectQueryBuilder $qb ): void {
 		$fields = self::fields( $table );
 
-		$query->table( $table );
-		$query->fields( array_merge( [ 'COUNT(*) as count' ], $fields ) );
-
-		$query->options(
-			[
-				'GROUP BY' => implode( ',', $fields ),
-				'HAVING' => 'count(*) > 1'
-			]
-		);
+		$qb->select( array_merge( [ 'count' => 'COUNT(*)' ], $fields ) )
+			->groupBy( $fields )
+			->having( 'count(*) > 1' );
 	}
 
 	private static function fields( string $tableName ) {

--- a/src/SQLStore/EntityStore/EntityIdFinder.php
+++ b/src/SQLStore/EntityStore/EntityIdFinder.php
@@ -56,19 +56,17 @@ class EntityIdFinder {
 
 		$id = 0;
 
-		$row = $this->connection->selectRow(
-			SQLStore::ID_TABLE,
-			[
-				'smw_id'
-			],
-			[
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_id' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				'smw_title' => $dataItem->getDBKey(),
 				'smw_namespace' => $dataItem->getNamespace(),
 				'smw_iw' => $dataItem->getInterWiki(),
 				'smw_subobject' => $dataItem->getSubobjectName()
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row !== false ) {
 			$id = (int)$row->smw_id;
@@ -118,14 +116,12 @@ class EntityIdFinder {
 			$fields = [ 'smw_sortkey', 'smw_sort', 'smw_hash' ];
 		}
 
-		$row = $this->connection->selectRow(
-			SQLStore::ID_TABLE,
-			$fields,
-			[
-				'smw_id' => $id
-			],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( $fields )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row !== false ) {
 			// Make sure that smw_sort is being re-computed in case it is null
@@ -194,17 +190,17 @@ class EntityIdFinder {
 			$subobjectName = mb_substr( $subobjectName, 0, 255 );
 		}
 
-		$row = $this->connection->selectRow(
-			SQLStore::ID_TABLE,
-			$fields,
-			[
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( $fields )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				'smw_title' => $title,
 				'smw_namespace' => $namespace,
 				'smw_iw' => $iw,
 				'smw_subobject' => $subobjectName
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row !== false ) {
 			$id = $row->smw_id;
@@ -261,14 +257,12 @@ class EntityIdFinder {
 			unset( $conditions['smw_iw'] );
 		}
 
-		$rows = $this->connection->select(
-			SQLStore::ID_TABLE,
-			[
-				'smw_id'
-			],
-			$conditions,
-			__METHOD__
-		);
+		$rows = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_id' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( $conditions )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		foreach ( $rows as $row ) {
 			$matches[] = (int)$row->smw_id;

--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -621,9 +621,9 @@ class EntityIdManager {
 			// #2089 (MySQL 5.7 complained with "Data too long for column")
 			$sortkey = mb_substr( $sortkey, 0, 254 );
 
-			$db->insert(
-				SQLStore::ID_TABLE,
-				[
+			$db->newInsertQueryBuilder()
+				->insertInto( SQLStore::ID_TABLE )
+				->row( [
 					'smw_id' => $sequenceValue,
 					'smw_title' => $title,
 					'smw_namespace' => $namespace,
@@ -632,10 +632,10 @@ class EntityIdManager {
 					'smw_sortkey' => $sortkey,
 					'smw_sort' => $collator->getSortKey( $sortkey ),
 					'smw_hash' => $this->computeSha1( [ $title, (int)$namespace, $iw, $subobjectName ] ),
-					'smw_touched' => $db->timestamp()
-				],
-				__METHOD__
-			);
+					'smw_touched' => $db->timestamp(),
+				] )
+				->caller( __METHOD__ )
+				->execute();
 
 			$id = $db->insertId();
 
@@ -733,27 +733,27 @@ class EntityIdManager {
 
 		if ( $title instanceof WikiPage ) {
 			$cond = [
-				"smw_hash" => $title->getSha1()
+				'smw_hash' => $title->getSha1(),
 			];
 		} elseif ( is_int( $title ) ) {
 			$cond = [
-				"smw_id" => $title
+				'smw_id' => $title,
 			];
 		} else {
 			$cond = [
-				"smw_title =" . $connection->addQuotes( $title ),
-				"smw_namespace =" . $connection->addQuotes( $namespace ),
-				"smw_iw =" . $connection->addQuotes( $iw ),
-				"smw_subobject =''"
+				'smw_title' => $title,
+				'smw_namespace' => $namespace,
+				'smw_iw' => $iw,
+				'smw_subobject' => '',
 			];
 		}
 
-		$row = $connection->selectRow(
-			SQLStore::ID_TABLE,
-			'smw_rev',
-			$cond,
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( 'smw_rev' )
+			->from( SQLStore::ID_TABLE )
+			->where( $cond )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return $row === false ? 0 : (int)$row->smw_rev;
 	}

--- a/src/SQLStore/EntityStore/IdChanger.php
+++ b/src/SQLStore/EntityStore/IdChanger.php
@@ -47,14 +47,12 @@ class IdChanger {
 	public function move( $curid, $targetid = 0 ) {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$row = $connection->selectRow(
-			SQLStore::ID_TABLE,
-			'*',
-			[
-				'smw_id' => $curid
-			],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( '*' )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $curid ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		// No id at current position, ignore
 		if ( $row === false ) {
@@ -74,9 +72,9 @@ class IdChanger {
 			$row->smw_subobject
 		];
 
-		$connection->insert(
-			SQLStore::ID_TABLE,
-			[
+		$connection->newInsertQueryBuilder()
+			->insertInto( SQLStore::ID_TABLE )
+			->row( [
 				'smw_id' => $id,
 				'smw_title' => $row->smw_title,
 				'smw_namespace' => $row->smw_namespace,
@@ -85,27 +83,23 @@ class IdChanger {
 				'smw_sortkey' => $row->smw_sortkey,
 				'smw_sort' => $row->smw_sort,
 				'smw_hash' => IdCacheManager::computeSha1( $hash )
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$targetid = $targetid == 0 ? $connection->insertId() : $targetid;
 
-		$connection->delete(
-			SQLStore::ID_AUXILIARY_TABLE,
-			[
-				'smw_id' => $curid
-			],
-			__METHOD__
-		);
+		$connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::ID_AUXILIARY_TABLE )
+			->where( [ 'smw_id' => $curid ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$connection->delete(
-			SQLStore::ID_TABLE,
-			[
-				'smw_id' => $curid
-			],
-			__METHOD__
-		);
+		$connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $curid ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$row->smw_id = $targetid;
 
@@ -158,40 +152,40 @@ class IdChanger {
 
 			if ( $s_data && $proptable->usesIdSubject() ) {
 
-				$row = $connection->selectRow(
-					$proptable->getName(),
-					[ 's_id' ],
-					[ 's_id' => $old_id ],
-					__METHOD__
-				);
+				$row = $connection->newSelectQueryBuilder()
+					->select( [ 's_id' ] )
+					->from( $proptable->getName() )
+					->where( [ 's_id' => $old_id ] )
+					->caller( __METHOD__ )
+					->fetchRow();
 
 				if ( $row === false ) {
 					continue;
 				}
 
-				$connection->update(
-					$proptable->getName(),
-					[ 's_id' => $new_id ],
-					[ 's_id' => $old_id ],
-					__METHOD__
-				);
+				$connection->newUpdateQueryBuilder()
+					->update( $proptable->getName() )
+					->set( [ 's_id' => $new_id ] )
+					->where( [ 's_id' => $old_id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 
 			if ( $po_data ) {
 				if ( ( ( $old_ns == -1 ) || ( $old_ns == SMW_NS_PROPERTY ) ) && ( !$proptable->isFixedPropertyTable() ) ) {
 					if ( ( $new_ns == -1 ) || ( $new_ns == SMW_NS_PROPERTY ) ) {
-						$connection->update(
-							$proptable->getName(),
-							[ 'p_id' => $new_id ],
-							[ 'p_id' => $old_id ],
-							__METHOD__
-						);
+						$connection->newUpdateQueryBuilder()
+							->update( $proptable->getName() )
+							->set( [ 'p_id' => $new_id ] )
+							->where( [ 'p_id' => $old_id ] )
+							->caller( __METHOD__ )
+							->execute();
 					} else {
-						$connection->delete(
-							$proptable->getName(),
-							[ 'p_id' => $old_id ],
-							__METHOD__
-						);
+						$connection->newDeleteQueryBuilder()
+							->deleteFrom( $proptable->getName() )
+							->where( [ 'p_id' => $old_id ] )
+							->caller( __METHOD__ )
+							->execute();
 					}
 				}
 
@@ -201,23 +195,23 @@ class IdChanger {
 						continue;
 					}
 
-					$row = $connection->selectRow(
-						$proptable->getName(),
-						[ $fieldName ],
-						[ $fieldName => $old_id ],
-						__METHOD__
-					);
+					$row = $connection->newSelectQueryBuilder()
+						->select( [ $fieldName ] )
+						->from( $proptable->getName() )
+						->where( [ $fieldName => $old_id ] )
+						->caller( __METHOD__ )
+						->fetchRow();
 
 					if ( $row === false ) {
 						continue;
 					}
 
-					$connection->update(
-						$proptable->getName(),
-						[ $fieldName => $new_id ],
-						[ $fieldName => $old_id ],
-						__METHOD__
-					);
+					$connection->newUpdateQueryBuilder()
+						->update( $proptable->getName() )
+						->set( [ $fieldName => $new_id ] )
+						->where( [ $fieldName => $old_id ] )
+						->caller( __METHOD__ )
+						->execute();
 				}
 			}
 		}
@@ -230,41 +224,41 @@ class IdChanger {
 
 		if ( $s_data && ( ( $old_ns == -1 ) || ( $old_ns == SMW_NS_CONCEPT ) ) ) {
 			if ( ( $new_ns == -1 ) || ( $new_ns == SMW_NS_CONCEPT ) ) {
-				$connection->update(
-					SQLStore::CONCEPT_TABLE,
-					[ 's_id' => $new_id ],
-					[ 's_id' => $old_id ],
-					__METHOD__
-				);
+				$connection->newUpdateQueryBuilder()
+					->update( SQLStore::CONCEPT_TABLE )
+					->set( [ 's_id' => $new_id ] )
+					->where( [ 's_id' => $old_id ] )
+					->caller( __METHOD__ )
+					->execute();
 
-				$connection->update(
-					SQLStore::CONCEPT_CACHE_TABLE,
-					[ 's_id' => $new_id ],
-					[ 's_id' => $old_id ],
-					__METHOD__
-				);
+				$connection->newUpdateQueryBuilder()
+					->update( SQLStore::CONCEPT_CACHE_TABLE )
+					->set( [ 's_id' => $new_id ] )
+					->where( [ 's_id' => $old_id ] )
+					->caller( __METHOD__ )
+					->execute();
 			} else {
-				$connection->delete(
-					SQLStore::CONCEPT_TABLE,
-					[ 's_id' => $old_id ],
-					__METHOD__
-				);
+				$connection->newDeleteQueryBuilder()
+					->deleteFrom( SQLStore::CONCEPT_TABLE )
+					->where( [ 's_id' => $old_id ] )
+					->caller( __METHOD__ )
+					->execute();
 
-				$connection->delete(
-					SQLStore::CONCEPT_CACHE_TABLE,
-					[ 's_id' => $old_id ],
-					__METHOD__
-				);
+				$connection->newDeleteQueryBuilder()
+					->deleteFrom( SQLStore::CONCEPT_CACHE_TABLE )
+					->where( [ 's_id' => $old_id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 		}
 
 		if ( $po_data ) {
-			$connection->update(
-				SQLStore::CONCEPT_CACHE_TABLE,
-				[ 'o_id' => $new_id ],
-				[ 'o_id' => $old_id ],
-				__METHOD__
-			);
+			$connection->newUpdateQueryBuilder()
+				->update( SQLStore::CONCEPT_CACHE_TABLE )
+				->set( [ 'o_id' => $new_id ] )
+				->where( [ 'o_id' => $old_id ] )
+				->caller( __METHOD__ )
+				->execute();
 		}
 	}
 

--- a/src/SQLStore/EntityStore/IdEntityFinder.php
+++ b/src/SQLStore/EntityStore/IdEntityFinder.php
@@ -156,11 +156,17 @@ class IdEntityFinder {
 			'smw_hash'
 		];
 
+		$queryBuilder = $connection->newSelectQueryBuilder()
+			->select( $fields )
+			->from( SQLStore::ID_TABLE )
+			->where( $conditions )
+			->caller( __METHOD__ );
+
 		if ( $selectRow ) {
-			return $connection->selectRow( SQLStore::ID_TABLE, $fields, $conditions, __METHOD__ );
+			return $queryBuilder->fetchRow();
 		}
 
-		return $connection->select( SQLStore::ID_TABLE, $fields, $conditions, __METHOD__ );
+		return $queryBuilder->fetchResultSet();
 	}
 
 }

--- a/src/SQLStore/EntityStore/PropertiesLookup.php
+++ b/src/SQLStore/EntityStore/PropertiesLookup.php
@@ -3,9 +3,11 @@
 namespace SMW\SQLStore\EntityStore;
 
 use SMW\DataItems\WikiPage;
+use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\RequestOptions;
 use SMW\SQLStore\PropertyTableDefinition as TableDefinition;
 use SMW\SQLStore\SQLStore;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @license GPL-2.0-or-later
@@ -47,57 +49,56 @@ class PropertiesLookup {
 	 */
 	public function fetchFromTable( WikiPage $subject, TableDefinition $propertyTable, ?RequestOptions $requestOptions = null ) {
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
 
-		$query->type( 'SELECT' );
-		$query->table( $propertyTable->getName() );
+		$qb = $connection->newSelectQueryBuilder()
+			->from( $propertyTable->getName() );
 
 		if ( $propertyTable->usesIdSubject() ) {
-			$query->condition( $query->eq( 's_id', $subject->getId() ) );
+			$qb->where( [ 's_id' => $subject->getId() ] );
 		} elseif ( $subject->getInterwiki() === '' ) {
-			$query->condition( $query->eq( 's_title', $subject->getDBkey() ) );
-			$query->condition( $query->eq( 's_namespace', $subject->getNamespace() ) );
+			$qb->where( [
+				's_title' => $subject->getDBkey(),
+				's_namespace' => $subject->getNamespace(),
+			] );
 		} else {
 			// subjects with non-empty interwiki cannot have properties
 			return [];
 		}
 
 		if ( $propertyTable->isFixedPropertyTable() ) {
-			return $this->fetchFromFixedTable( $query, $propertyTable->getFixedProperty() );
+			return $this->fetchFromFixedTable( $qb, $propertyTable->getFixedProperty() );
 		}
 
-		$query->join(
-			'INNER JOIN',
-			[ SQLStore::ID_TABLE => "ON smw_id=p_id" ]
-		);
-
-		$query->fields( [ 'smw_title', 'smw_sortkey' ] );
+		$qb->join( SQLStore::ID_TABLE, null, 'smw_id=p_id' )
+			->select( [ 'smw_title', 'smw_sortkey' ] );
 
 		// (select sortkey since it might be used in ordering (needed by Postgres))
-		$query->condition( $this->store->getSQLConditions(
+		$sqlConds = $this->store->getSQLConditions(
 			$requestOptions,
 			'smw_sortkey',
 			'smw_sortkey'
-		) );
-
-		$opt = $this->store->getSQLOptions(
-			$requestOptions,
-			'smw_sortkey'
 		);
 
-		$query->options( $opt + [ 'DISTINCT' => true ] );
+		if ( $sqlConds !== '' ) {
+			$qb->andWhere( $sqlConds );
+		}
 
-		return $query->execute( __METHOD__ );
+		$qb->distinct();
+
+		LegacyOptionsApplier::applyTo(
+			$qb,
+			$this->store->getSQLOptions( $requestOptions, 'smw_sortkey' )
+		);
+
+		return $qb->caller( __METHOD__ )->fetchResultSet();
 	}
 
-	private function fetchFromFixedTable( $query, $title ): array {
+	private function fetchFromFixedTable( SelectQueryBuilder $qb, string $title ): array {
 		// just check if subject occurs in table
-		$query->options(
-			[ 'LIMIT' => 1 ]
-		);
-
-		$query->field( '*' );
-		$res = $query->execute( __METHOD__ );
+		$res = $qb->select( '*' )
+			->limit( 1 )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		if ( $res->numRows() > 0 ) {
 			return [ $title ];

--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -7,6 +7,7 @@ use SMW\DataItems\Container;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Property;
 use SMW\IteratorFactory;
+use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\Options;
 use SMW\RequestOptions;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -14,6 +15,7 @@ use SMW\SQLStore\EntityStore\Exception\DataItemHandlerException;
 use SMW\SQLStore\PropertyTableDefinition as TableDefinition;
 use SMW\SQLStore\SQLStore;
 use stdClass;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @license GPL-2.0-or-later
@@ -157,8 +159,6 @@ class PropertySubjectsLookup {
 		);
 
 		$sortField = $dataItemHandler->getSortField();
-		$query = $connection->newQuery();
-		$query->type( 'SELECT' );
 
 		if ( $requestOptions === null ) {
 			$requestOptions = new RequestOptions();
@@ -178,74 +178,67 @@ class PropertySubjectsLookup {
 		// and causes an unacceptable query time therefore force an index for
 		// those tables where the behaviour has been observed.
 		$index = $this->getIndexHint( $dataItemHandler, $pid, $dataItem );
-		$result = [];
+
+		$qb = $connection->newSelectQueryBuilder();
 
 		if ( $proptable->usesIdSubject() ) {
 			$group = true;
 
-			$query->table( SQLStore::ID_TABLE );
-
-			$query->join(
-				'INNER JOIN',
-				[ $proptable->getName() => "t1 $index ON t1.s_id=smw_id" ]
-			);
-
-			$query->fields(
-				[
+			$qb->from( SQLStore::ID_TABLE )
+				->join( $proptable->getName(), 't1', 't1.s_id=smw_id' )
+				->select( [
 					'smw_id',
 					'smw_title',
 					'smw_namespace',
 					'smw_iw',
 					'smw_subobject',
 					'smw_sortkey',
-					'smw_sort'
-				]
-			);
+					'smw_sort',
+				] );
 
-		} else { // no join needed, title+namespace as given in proptable
-			$query->table( $proptable->getName(), "t1" );
-
-			$query->fields(
-				[
+			// Preserve the FORCE INDEX(...) hint by translating to useIndex( [ 't1' => $name ] ).
+			// This emits USE INDEX on MySQL (vs the original FORCE INDEX). Both restrict the
+			// optimizer to the named index; on Postgres/SQLite both are no-ops. The semantic
+			// difference is documented in the PR description.
+			if ( $index !== '' && preg_match( '/^FORCE INDEX\(([^)]+)\)$/', $index, $m ) ) {
+				$qb->useIndex( [ 't1' => $m[1] ] );
+			}
+		} else {
+			// no join needed, title+namespace as given in proptable
+			$qb->from( $proptable->getName(), 't1' )
+				->select( [
 					's_title AS smw_title',
 					's_namespace AS smw_namespace',
-					'\'\' AS smw_iw',
-					'\'\' AS smw_subobject',
+					"'' AS smw_iw",
+					"'' AS smw_subobject",
 					's_title AS smw_sortkey',
-					's_title AS smw_sort'
-				]
-			);
+					's_title AS smw_sort',
+				] );
 
 			$requestOptions->setOption( 'ORDER BY', false );
 		}
 
 		if ( !$proptable->isFixedPropertyTable() ) {
-			$query->condition( $query->eq( "t1.p_id", $pid ) );
+			$qb->where( [ 't1.p_id' => $pid ] );
 		}
 
 		// Specified by the prefetch
 		if ( is_array( $dataItem ) ) {
-
-			$fieldname = 's_id';
-
-			if ( $proptable->getDiType() === DataItem::TYPE_WIKIPAGE ) {
-				$fieldname = 'o_id';
-			}
-
-			$query->condition( $query->in( "t1.$fieldname", $dataItem ) );
-			$query->field( "t1.$fieldname AS id" );
+			$fieldname = ( $proptable->getDiType() === DataItem::TYPE_WIKIPAGE ) ? 'o_id' : 's_id';
+			$qb->andWhere( [ "t1.$fieldname" => $dataItem ] )
+				->select( [ 'id' => "t1.$fieldname" ] );
 		} else {
-			$this->getWhereConds( $query, $dataItem );
+			$this->getWhereConds( $qb, $dataItem );
 		}
 
 		if ( $requestOptions !== null ) {
 			foreach ( $requestOptions->getExtraConditions() as $extraCondition ) {
 				if ( isset( $extraCondition['o_id'] ) ) {
-					$query->condition( $query->eq( 't1.o_id', $extraCondition['o_id'] ) );
+					$qb->andWhere( [ 't1.o_id' => $extraCondition['o_id'] ] );
 				}
 
 				if ( is_callable( $extraCondition ) ) {
-					$extraCondition( $query );
+					$extraCondition( $qb );
 				}
 			}
 
@@ -254,8 +247,8 @@ class PropertySubjectsLookup {
 		}
 
 		if ( $proptable->usesIdSubject() ) {
-			foreach ( [ SMW_SQL3_SMWIW_OUTDATED, SMW_SQL3_SMWDELETEIW, SMW_SQL3_SMWREDIIW ] as $v ) {
-				$query->condition( $query->neq( "smw_iw", $v ) );
+			foreach ( [ SMW_SQL3_SMWIW_OUTDATED, SMW_SQL3_SMWDELETEIW, SMW_SQL3_SMWREDIIW ] as $iw ) {
+				$qb->andWhere( $connection->expr( 'smw_iw', '!=', $iw ) );
 			}
 		}
 
@@ -290,30 +283,35 @@ class PropertySubjectsLookup {
 			false
 		);
 
-		$query->condition( $cond );
+		if ( $cond !== '' ) {
+			$qb->andWhere( $cond );
+		}
 
 		$opts = $this->store->getSQLOptions(
 			$requestOptions,
 			$sortField
 		);
 
-		$query->options( $opts );
+		// Preserve Postgres-specific `DISTINCT ON (...)` (a string DISTINCT value),
+		// which the legacy options array supports but `->distinct()` does not.
+		if ( isset( $opts['DISTINCT'] ) && is_string( $opts['DISTINCT'] ) ) {
+			$qb->option( 'DISTINCT', $opts['DISTINCT'] );
+			unset( $opts['DISTINCT'] );
+		}
 
 		if ( $requestOptions->exclude_limit ) {
-			$query->option( 'LIMIT', null );
-			$query->option( 'OFFSET', null );
+			unset( $opts['LIMIT'], $opts['OFFSET'] );
 		}
+
+		LegacyOptionsApplier::applyTo( $qb, $opts );
 
 		$caller = $this->caller;
 
 		if ( strval( $requestOptions->getCaller() ) !== '' ) {
-			$caller .= " (for " . $requestOptions->getCaller() . ")";
+			$caller .= ' (for ' . $requestOptions->getCaller() . ')';
 		}
 
-		$res = $connection->readQuery(
-			$query,
-			$caller
-		);
+		$res = $qb->caller( $caller )->fetchResultSet();
 
 		$this->dataItemHandler = $this->store->getDataItemHandlerForDIType(
 			DataItem::TYPE_WIKIPAGE
@@ -360,21 +358,21 @@ class PropertySubjectsLookup {
 		return $this->dataItemHandler->dataItemFromDBKeys( [ 'Blankpage/' . $title, NS_SPECIAL, '', '', '' ] );
 	}
 
-	private function getWhereConds( $query, DataItem|array|null $dataItem ): void {
-		$conds = '';
-
+	private function getWhereConds( SelectQueryBuilder $qb, ?DataItem $dataItem ): void {
 		if ( $dataItem instanceof Container ) {
 			throw new RuntimeException( '\SMW\DataItems\Container support is missing!' );
 		}
 
-		if ( $dataItem !== null ) {
-			$dataItemHandler = $this->store->getDataItemHandlerForDIType(
-				$dataItem->getDIType()
-			);
+		if ( $dataItem === null ) {
+			return;
+		}
 
-			foreach ( $dataItemHandler->getWhereConds( $dataItem ) as $fieldname => $value ) {
-				$query->condition( $query->eq( "t1.$fieldname", $value ) );
-			}
+		$dataItemHandler = $this->store->getDataItemHandlerForDIType(
+			$dataItem->getDIType()
+		);
+
+		foreach ( $dataItemHandler->getWhereConds( $dataItem ) as $fieldname => $value ) {
+			$qb->andWhere( [ "t1.$fieldname" => $value ] );
 		}
 	}
 
@@ -418,12 +416,12 @@ class PropertySubjectsLookup {
 		//
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$row = $connection->selectRow(
-			SQLStore::PROPERTY_STATISTICS_TABLE,
-			[ 'usage_count' ],
-			[ 'p_id' => $pid ],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'usage_count' ] )
+			->from( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->where( [ 'p_id' => $pid ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		// 5000? It just showed to be a sweet spot while doing some
 		// exploratory queries

--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -9,11 +9,13 @@ use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\DataModel\SequenceMap;
+use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\RequestOptions;
 use SMW\SQLStore\Lookup\RedirectTargetLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder\FieldType;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @license GPL-2.0-or-later
@@ -315,7 +317,6 @@ class SemanticDataLookup {
 			return [];
 		}
 
-		$result = [];
 		$connection = $this->store->getConnection( 'mw.db' );
 		$this->caller = __METHOD__;
 
@@ -334,26 +335,24 @@ class SemanticDataLookup {
 		// INNER JOIN `smw_object_ids` AS p ON p_id=p.smw_id
 		// WHERE s_id='80' AND p.smw_iw!=':smw' AND p.smw_iw!=':smw-delete'
 
-		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
-
-		$query->type( 'select' );
-		$query->table( $propTable->getName() );
+		$qb = $connection->newSelectQueryBuilder()->from( $propTable->getName() );
 
 		// Restrict to property
 		if ( !$isSubject && !$propTable->isFixedPropertyTable() ) {
-			$query->condition( $query->eq( 'p_id', $id ) );
+			$qb->where( [ 'p_id' => $id ] );
 		}
 
 		// Restrict subject, select property
 		if ( $isSubject && $propTable->usesIdSubject() ) {
-			$query->condition( $query->eq( 's_id', $id ) );
+			$qb->where( [ 's_id' => $id ] );
 		} elseif ( $isSubject ) {
-			$query->condition( $query->eq( 's_title', $dataItem->getDBkey() ) );
-			$query->condition( $query->eq( 's_namespace', $dataItem->getNamespace() ) );
+			$qb->where( [
+				's_title' => $dataItem->getDBkey(),
+				's_namespace' => $dataItem->getNamespace(),
+			] );
 		}
 
-		return $this->fetchFromTable( $query, $propTable, $isSubject, $requestOptions );
+		return $this->fetchFromTable( $qb, $propTable, $isSubject, $requestOptions );
 	}
 
 	/**
@@ -365,56 +364,52 @@ class SemanticDataLookup {
 		}
 
 		$isSubject = true;
-		$result = [];
 
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
-
-		$query->type( 'select' );
-		$query->table( $propTable->getName() );
+		$qb = $connection->newSelectQueryBuilder()->from( $propTable->getName() );
 
 		// Restrict property only
 		if ( !$propTable->isFixedPropertyTable() ) {
-			$query->condition( $query->eq( 'p_id', $pid ) );
+			$qb->where( [ 'p_id' => $pid ] );
 		}
+
+		$seedFields = [];
 
 		// Restrict subject, select property
 		if ( $propTable->usesIdSubject() ) {
-			$query->condition( $query->in( 's_id', $list ) );
-			$query->field( 's_id' );
+			$qb->where( [ 's_id' => $list ] );
+			$seedFields[] = 's_id';
 		} else {
 			throw new RuntimeException( "Need a table that has an ID subject column (ID: " . $pid . ')!' );
 		}
 
-		return $this->fetchFromTable( $query, $propTable, $isSubject, $requestOptions );
+		return $this->fetchFromTable( $qb, $propTable, $isSubject, $requestOptions, '', $seedFields );
 	}
 
 	/**
 	 * @return mixed[]
 	 */
-	private function fetchFromTable( $query, PropertyTableDefinition $propTable, bool $isSubject, ?RequestOptions $requestOptions, $field = '' ): array {
+	private function fetchFromTable( SelectQueryBuilder $qb, PropertyTableDefinition $propTable, bool $isSubject, ?RequestOptions $requestOptions, $field = '', array $selectFields = [] ): array {
 		$result = [];
 		$connection = $this->store->getConnection( 'mw.db' );
 
 		// Select property name
 		// In case of a fixed property, no select needed
 		if ( $isSubject && !$propTable->isFixedPropertyTable() ) {
-			$query->join(
-				'INNER JOIN',
-				[ SQLStore::ID_TABLE => 'p ON p_id=p.smw_id' ]
-			);
+			$qb->join( SQLStore::ID_TABLE, 'p', 'p_id=p.smw_id' );
 
-			$query->field( 'p.smw_title', 'prop' );
+			// Equivalent of `$query->field( 'p.smw_title', 'prop' )`.
+			$selectFields['prop'] = 'p.smw_title';
 
 			// Avoid displaying any property that has been marked deleted or outdated
-			$query->condition( $query->neq( "p.smw_iw", SMW_SQL3_SMWIW_OUTDATED ) );
-			$query->condition( $query->neq( "p.smw_iw", SMW_SQL3_SMWDELETEIW ) );
+			$qb->andWhere( $connection->expr( 'p.smw_iw', '!=', SMW_SQL3_SMWIW_OUTDATED ) )
+				->andWhere( $connection->expr( 'p.smw_iw', '!=', SMW_SQL3_SMWDELETEIW ) );
 		}
 
 		if ( $requestOptions !== null ) {
 			foreach ( $requestOptions->getExtraConditions() as $extraCondition ) {
 				if ( isset( $extraCondition['p_id'] ) ) {
-					$query->condition( $query->eq( 'p_id', $extraCondition['p_id'] ) );
+					$qb->andWhere( [ 'p_id' => $extraCondition['p_id'] ] );
 				}
 			}
 		} else {
@@ -436,7 +431,8 @@ class SemanticDataLookup {
 		$map = [];
 
 		$this->addFields(
-			$query,
+			$qb,
+			$selectFields,
 			$map,
 			$fields,
 			$valueField,
@@ -504,35 +500,41 @@ class SemanticDataLookup {
 				false
 			);
 
-			$query->condition( $conds );
+			if ( $conds !== '' ) {
+				$qb->andWhere( $conds );
+			}
 		} else {
 			$valueField = '';
 		}
 
 		if ( $field !== '' ) {
-			$query->field( $field );
+			$selectFields[] = $field;
 		}
 
-		$query->options(
-			$this->store->getSQLOptions( $requestOptions, $valueField )
-		);
+		$opts = $this->store->getSQLOptions( $requestOptions, $valueField );
 
-		if (
-			$requestOptions->getOption( RequestOptions::CONDITION_CONSTRAINT_RESULT, false ) ||
-			$requestOptions->getOption( RequestOptions::CONDITION_CONSTRAINT, false ) ) {
-			$sort = 'ASC';
-
-			if ( $requestOptions->sort ) {
-				$sort = $requestOptions->ascending ? 'ASC' : 'DESC';
-				$query->option( 'ORDER BY', $map[$sortField] . " $sort" );
-			}
+		// Preserve Postgres-specific `DISTINCT ON (...)` (a string DISTINCT value),
+		// which the legacy options array supports but `->distinct()` does not.
+		if ( isset( $opts['DISTINCT'] ) && is_string( $opts['DISTINCT'] ) ) {
+			$qb->option( 'DISTINCT', $opts['DISTINCT'] );
+			unset( $opts['DISTINCT'] );
 		}
 
 		// `exclude_limit` indicates an unrestricted query due to use of `WHERE IN`
 		// that is required by the prefetch mode
 		if ( $requestOptions->exclude_limit ) {
-			$query->option( 'LIMIT', null );
-			$query->option( 'OFFSET', null );
+			unset( $opts['LIMIT'], $opts['OFFSET'] );
+		}
+
+		LegacyOptionsApplier::applyTo( $qb, $opts );
+
+		if (
+			$requestOptions->getOption( RequestOptions::CONDITION_CONSTRAINT_RESULT, false ) ||
+			$requestOptions->getOption( RequestOptions::CONDITION_CONSTRAINT, false ) ) {
+			if ( $requestOptions->sort ) {
+				$sort = $requestOptions->ascending ? 'ASC' : 'DESC';
+				$qb->orderBy( $map[$sortField] . " $sort" );
+			}
 		}
 
 		$caller = $this->caller;
@@ -541,10 +543,9 @@ class SemanticDataLookup {
 			$caller .= " (for " . $requestOptions->getCaller() . ")";
 		}
 
-		$res = $connection->readQuery(
-			$query,
-			$caller
-		);
+		$qb->select( $selectFields );
+
+		$res = $qb->caller( $caller )->fetchResultSet();
 
 		$warmupCache = [];
 
@@ -610,31 +611,28 @@ class SemanticDataLookup {
 		return $result;
 	}
 
-	private function addFields( &$query, array &$map, $fields, $valueField, $labelField, int &$valueCount, string &$fieldname ): void {
+	private function addFields( SelectQueryBuilder $qb, array &$selectFields, array &$map, $fields, $valueField, $labelField, int &$valueCount, string &$fieldname ): void {
 		// Select dataItem column(s)
 		foreach ( $fields as $fieldname => $fieldType ) {
 
 			// Get data from ID table
 			if ( $fieldType === FieldType::FIELD_ID ) {
-				$query->join(
-					'INNER JOIN',
-					[ SQLStore::ID_TABLE => "o$valueCount ON $fieldname=o$valueCount.smw_id" ]
-				);
+				$qb->join( SQLStore::ID_TABLE, "o$valueCount", "$fieldname=o$valueCount.smw_id" );
 
-				$query->field( "$fieldname AS id$valueCount" );
-				$query->field( "o$valueCount.smw_title AS v$valueCount" );
-				$query->field( "o$valueCount.smw_namespace AS v" . ( $valueCount + 1 ) );
-				$query->field( "o$valueCount.smw_iw AS v" . ( $valueCount + 2 ) );
-				$query->field( "o$valueCount.smw_sortkey AS v" . ( $valueCount + 3 ) );
+				$selectFields[ "id$valueCount" ] = $fieldname;
+				$selectFields[ "v$valueCount" ] = "o$valueCount.smw_title";
+				$selectFields[ 'v' . ( $valueCount + 1 ) ] = "o$valueCount.smw_namespace";
+				$selectFields[ 'v' . ( $valueCount + 2 ) ] = "o$valueCount.smw_iw";
+				$selectFields[ 'v' . ( $valueCount + 3 ) ] = "o$valueCount.smw_sortkey";
 				$map[$fieldname] = "v" . ( $valueCount + 3 );
 
 				// In case of switching the position of v3/v4 (subobject, sortkey/sort)
 				// see below the position reassignment of sort
 				// Row position is important when building an instance using
 				// `DIWikiPageHandler::newDiWikiPage`
-				$query->field( "o$valueCount.smw_subobject AS v" . ( $valueCount + 4 ) );
+				$selectFields[ 'v' . ( $valueCount + 4 ) ] = "o$valueCount.smw_subobject";
 
-				$query->field( "o$valueCount.smw_sort AS v" . ( $valueCount + 5 ) );
+				$selectFields[ 'v' . ( $valueCount + 5 ) ] = "o$valueCount.smw_sort";
 				$map[$fieldname] = "v" . ( $valueCount + 5 );
 
 				if ( $valueField == $fieldname ) {
@@ -647,7 +645,7 @@ class SemanticDataLookup {
 				$valueCount += 5;
 			} else {
 				$map[$fieldname] = "v$valueCount";
-				$query->field( $fieldname, "v$valueCount" );
+				$selectFields[ "v$valueCount" ] = $fieldname;
 			}
 
 			$valueCount += 1;
@@ -656,9 +654,12 @@ class SemanticDataLookup {
 		// Postgres
 		// Function: SMWSQLStore3Readers::fetchSemanticData
 		// Error: 42P10 ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list
-		if ( !$query->hasField( $valueField ) ) {
+		// Replicates the legacy `Query::hasField()` check by testing whether the
+		// field already appears either as a select expression (value) or as an
+		// alias (key) in the in-progress select list.
+		if ( !in_array( $valueField, $selectFields, true ) && !array_key_exists( $valueField, $selectFields ) ) {
 			$map[$valueField] = "v" . ( $valueCount + 1 );
-			$query->field( $valueField, "v" . ( $valueCount + 1 ) );
+			$selectFields[ 'v' . ( $valueCount + 1 ) ] = $valueField;
 		}
 	}
 
@@ -747,27 +748,17 @@ class SemanticDataLookup {
 
 	private function fetchPropertiesFromTable( $id, PropertyTableDefinition $propTable ) {
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
 
-		$query->type( 'select' );
-		$query->table( $propTable->getName() );
-
-		$query->condition( $query->eq( 's_id', $id ) );
-
-		$query->join(
-			'INNER JOIN',
-			[ SQLStore::ID_TABLE => 'p ON p_id=p.smw_id' ]
-		);
-
-		$query->field( 'p_id' );
-
-		// Avoid displaying any property that have been marked deleted or outdated
-		$query->condition( $query->neq( "p.smw_iw", SMW_SQL3_SMWIW_OUTDATED ) );
-		$query->condition( $query->neq( "p.smw_iw", SMW_SQL3_SMWDELETEIW ) );
-
-		$query->option( 'DISTINCT', true );
-
-		return $query->execute( __METHOD__ );
+		return $connection->newSelectQueryBuilder()
+			->from( $propTable->getName() )
+			->join( SQLStore::ID_TABLE, 'p', 'p_id=p.smw_id' )
+			->select( 'p_id' )
+			->where( [ 's_id' => $id ] )
+			->andWhere( $connection->expr( 'p.smw_iw', '!=', SMW_SQL3_SMWIW_OUTDATED ) )
+			->andWhere( $connection->expr( 'p.smw_iw', '!=', SMW_SQL3_SMWDELETEIW ) )
+			->distinct()
+			->caller( __METHOD__ )
+			->fetchResultSet();
 	}
 
 	private function reportDuplicate( array $params ): void {

--- a/src/SQLStore/EntityStore/SequenceMapFinder.php
+++ b/src/SQLStore/EntityStore/SequenceMapFinder.php
@@ -49,18 +49,19 @@ class SequenceMapFinder {
 			$map = null;
 		}
 
-		$this->connection->upsert(
-			SQLStore::ID_AUXILIARY_TABLE,
-			[
+		$this->connection->newInsertQueryBuilder()
+			->insertInto( SQLStore::ID_AUXILIARY_TABLE )
+			->row( [
 				'smw_id' => $sid,
 				'smw_seqmap' => $map
-			],
-			'smw_id',
-			[
+			] )
+			->onDuplicateKeyUpdate()
+			->uniqueIndexFields( [ 'smw_id' ] )
+			->set( [
 				'smw_seqmap' => $map
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 	/**
@@ -79,16 +80,12 @@ class SequenceMapFinder {
 			return $map;
 		}
 
-		$row = $this->connection->selectRow(
-			SQLStore::ID_AUXILIARY_TABLE,
-			[
-				'smw_seqmap'
-			],
-			[
-				'smw_id' => $sid
-			],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_seqmap' ] )
+			->from( SQLStore::ID_AUXILIARY_TABLE )
+			->where( [ 'smw_id' => $sid ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row !== false ) {
 			$omap = $row->smw_seqmap;
@@ -124,17 +121,12 @@ class SequenceMapFinder {
 
 		$cache = $this->idCacheManager->get( 'sequence.map' );
 
-		$rows = $this->connection->select(
-			SQLStore::ID_AUXILIARY_TABLE,
-			[
-				'smw_id',
-				'smw_seqmap'
-			],
-			[
-				'smw_id' => $ids
-			],
-			__METHOD__
-		);
+		$rows = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_id', 'smw_seqmap' ] )
+			->from( SQLStore::ID_AUXILIARY_TABLE )
+			->where( [ 'smw_id' => $ids ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		$inverted_ids = array_flip( $ids );
 

--- a/src/SQLStore/EntityStore/SubobjectListFinder.php
+++ b/src/SQLStore/EntityStore/SubobjectListFinder.php
@@ -108,26 +108,26 @@ class SubobjectListFinder {
 		}
 
 		$conditions = [
-			'smw_title=' . $connection->addQuotes( $key ),
-			'smw_namespace=' . $connection->addQuotes( $subject->getNamespace() ),
-			'smw_iw=' . $connection->addQuotes( $subject->getInterwiki() ),
-			'smw_subobject!=' . $connection->addQuotes( '' )
+			'smw_title' => $key,
+			'smw_namespace' => $subject->getNamespace(),
+			'smw_iw' => $subject->getInterwiki(),
+			$connection->expr( 'smw_subobject', '!=', '' ),
 		];
 
 		foreach ( $this->skipConditions as $skipOn ) {
-			$conditions[] = 'smw_subobject!=' . $connection->addQuotes( $skipOn );
+			$conditions[] = $connection->expr( 'smw_subobject', '!=', $skipOn );
 		}
 
-		$res = $connection->select(
-			SQLStore::ID_TABLE,
-			[
+		$res = $connection->newSelectQueryBuilder()
+			->select( [
 				'smw_id',
 				'smw_subobject',
 				'smw_sortkey'
-			],
-			implode( ' AND ', $conditions ),
-			__METHOD__
-		);
+			] )
+			->from( SQLStore::ID_TABLE )
+			->where( $conditions )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		return $this->iteratorFactory->newResultIterator( $res );
 	}

--- a/src/SQLStore/EntityStore/TraversalPropertyLookup.php
+++ b/src/SQLStore/EntityStore/TraversalPropertyLookup.php
@@ -5,6 +5,7 @@ namespace SMW\SQLStore\EntityStore;
 use RuntimeException;
 use SMW\DataItems\DataItem;
 use SMW\DIContainer;
+use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\MediaWiki\Connection\OptionsBuilder;
 use SMW\RequestOptions;
 use SMW\SQLStore\PropertyTableDefinition as PropertyTableDef;
@@ -55,28 +56,26 @@ class TraversalPropertyLookup {
 			$conditions = '';
 
 			// No sorting
-			$options = $this->store->getSQLOptions( $subOptions, '' );
+			$subQueryOptions = $this->store->getSQLOptions( $subOptions, '' );
 
 			// Avoid any limit or offset for the sub-query in order to find all
 			// incoming properties
-			unset( $options['LIMIT'] );
-			unset( $options['OFFSET'] );
+			unset( $subQueryOptions['LIMIT'] );
+			unset( $subQueryOptions['OFFSET'] );
 
 			// Ensure to group same IDs to reduce the amount of data transferred
 			// from the inner join
-			$options['GROUP BY'] = 'p_id';
+			$subQueryOptions['GROUP BY'] = 'p_id';
 
-			$opt = OptionsBuilder::toString( $options );
+			$opt = OptionsBuilder::toString( $subQueryOptions );
 
 			$cond = ( $cond !== '' ? ' WHERE ' : '' ) . $cond;
 
 			// Use a subquery to match all possible IDs, no ORDER BY or DISTINCT to avoid
 			// a filesort
-			$from = [
-				SQLStore::ID_TABLE,
-				't1' => new Subquery( 'SELECT p_id FROM ' . $connection->tableName( $propertyTableDef->getName() ) . " $cond $opt" ),
-			];
-			$join = [ 't1' => [ 'INNER JOIN', 't1.p_id=smw_id' ] ];
+			$subquery = new Subquery(
+				'SELECT p_id FROM ' . $connection->tableName( $propertyTableDef->getName() ) . " $cond $opt"
+			);
 
 			$conditions .= ( $conditions ? ' AND ' : ' ' ) .
 				" smw_iw!=" . $connection->addQuotes( SMW_SQL3_SMWIW_OUTDATED ) .
@@ -84,28 +83,35 @@ class TraversalPropertyLookup {
 
 			$conditions .= $this->store->getSQLConditions( $subOptions, 'smw_sortkey', 'smw_sortkey', $conditions !== '' );
 
-			$options = $this->store->getSQLOptions( $subOptions, '' ) + [ 'DISTINCT' ];
+			$outerOptions = $this->store->getSQLOptions( $subOptions, '' ) + [ 'DISTINCT' ];
 
-			$result = $connection->select(
-				$from,
-				[ 'smw_title', 'smw_sortkey', 'smw_iw' ],
-				$conditions,
-				__METHOD__,
-				$options,
-				$join
-			);
+			$qb = $connection->newSelectQueryBuilder()
+				->rawTables( [ SQLStore::ID_TABLE, 't1' => $subquery ] )
+				->joinConds( [ 't1' => [ 'INNER JOIN', 't1.p_id=smw_id' ] ] )
+				->select( [ 'smw_title', 'smw_sortkey', 'smw_iw' ] );
+
+			if ( trim( $conditions ) !== '' ) {
+				$qb->andWhere( $conditions );
+			}
+
+			LegacyOptionsApplier::applyTo( $qb, $outerOptions );
+
+			$result = $qb->caller( __METHOD__ )->fetchResultSet();
 
 		} else {
 			$where = $this->getWhereConds( $dataItem );
 			$fields = $propertyTableDef->usesIdSubject() ? 's_id' : '*';
 
-			$result = $connection->select(
-				[ 't1' => $propertyTableDef->getName() ],
-				$fields,
-				$where,
-				__METHOD__,
-				[ 'LIMIT' => 1 ]
-			);
+			$qb = $connection->newSelectQueryBuilder()
+				->from( $propertyTableDef->getName(), 't1' )
+				->select( $fields )
+				->limit( 1 );
+
+			if ( $where !== '' ) {
+				$qb->where( $where );
+			}
+
+			$result = $qb->caller( __METHOD__ )->fetchResultSet();
 
 			if ( $result->numRows() > 0 ) {
 				$res = new stdClass;

--- a/src/SQLStore/Lookup/ByGroupPropertyValuesLookup.php
+++ b/src/SQLStore/Lookup/ByGroupPropertyValuesLookup.php
@@ -183,49 +183,34 @@ class ByGroupPropertyValuesLookup {
 		}
 
 		if ( $isIdField ) {
-			$res = $connection->select(
-				[
-					'o' => SQLStore::ID_TABLE,
-					'p' => $propTable->getName(),
-					'i' => SQLStore::ID_TABLE
-				],
-				$fields,
-				[
+			$res = $connection->newSelectQueryBuilder()
+				->select( $fields )
+				->from( SQLStore::ID_TABLE, 'o' )
+				->join( $propTable->getName(), 'p', [ 'p.s_id=o.smw_id' ] )
+				->join( SQLStore::ID_TABLE, 'i', [ 'p.o_id=i.smw_id' ] )
+				->where( [
 					'o.smw_hash' => $subjects,
 					'o.smw_iw!=' . $connection->addQuotes( SMW_SQL3_SMWIW_OUTDATED ),
 					'o.smw_iw!=' . $connection->addQuotes( SMW_SQL3_SMWDELETEIW ),
-				] + ( $pid !== '' ? [ 'p.p_id' => $pid ] : [] ),
-				__METHOD__,
-				[
-					'GROUP BY' => $groupBy,
-					'ORDER BY' => $orderBy
-				],
-				[
-					'p' => [ 'INNER JOIN', [ 'p.s_id=o.smw_id' ] ],
-					'i' => [ 'INNER JOIN', [ 'p.o_id=i.smw_id' ] ],
-				]
-			);
+				] + ( $pid !== '' ? [ 'p.p_id' => $pid ] : [] ) )
+				->groupBy( $groupBy )
+				->orderBy( $orderBy )
+				->caller( __METHOD__ )
+				->fetchResultSet();
 		} else {
-			$res = $connection->select(
-				[
-					'o' => SQLStore::ID_TABLE,
-					'p' => $propTable->getName()
-				],
-				$fields,
-				[
+			$res = $connection->newSelectQueryBuilder()
+				->select( $fields )
+				->from( SQLStore::ID_TABLE, 'o' )
+				->join( $propTable->getName(), 'p', [ 'p.s_id=o.smw_id' ] )
+				->where( [
 					'o.smw_hash' => $subjects,
 					'o.smw_iw!=' . $connection->addQuotes( SMW_SQL3_SMWIW_OUTDATED ),
 					'o.smw_iw!=' . $connection->addQuotes( SMW_SQL3_SMWDELETEIW ),
-				] + ( $pid !== '' ? [ 'p.p_id' => $pid ] : [] ),
-				__METHOD__,
-				[
-					'GROUP BY' => $groupBy,
-					'ORDER BY' => $orderBy
-				],
-				[
-					'p' => [ 'INNER JOIN', [ 'p.s_id=o.smw_id' ] ],
-				]
-			);
+				] + ( $pid !== '' ? [ 'p.p_id' => $pid ] : [] ) )
+				->groupBy( $groupBy )
+				->orderBy( $orderBy )
+				->caller( __METHOD__ )
+				->fetchResultSet();
 		}
 
 		return $res;

--- a/src/SQLStore/Lookup/ChangePropagationEntityLookup.php
+++ b/src/SQLStore/Lookup/ChangePropagationEntityLookup.php
@@ -147,16 +147,16 @@ class ChangePropagationEntityLookup {
 		foreach ( $dataItemTables as $tableName ) {
 
 			// Select any references that are hidden or remained active
-			$rows = $connection->select(
-				$tableName,
-				[
+			$rows = $connection->newSelectQueryBuilder()
+				->select( [
 					's_id'
-				],
-				[
+				] )
+				->from( $tableName )
+				->where( [
 					'p_id' => $pid
-				],
-				__METHOD__
-			);
+				] )
+				->caller( __METHOD__ )
+				->fetchResultSet();
 
 			foreach ( $rows as $row ) {
 				$idList[] = $row->s_id;

--- a/src/SQLStore/Lookup/DisplayTitleLookup.php
+++ b/src/SQLStore/Lookup/DisplayTitleLookup.php
@@ -47,19 +47,19 @@ class DisplayTitleLookup {
 			// - $dataItems[] expects to be of the format [ sha1 => DataItem ]
 			// - Adding smw_title, smw_namespace to ensure a `Using index condition`
 			//   during the select
-			$rows = $connection->select(
-				SQLStore::ID_TABLE,
-				[
+			$rows = $connection->newSelectQueryBuilder()
+				->select( [
 					'smw_id',
 					'smw_title',
 					'smw_namespace',
 					'smw_hash'
-				],
-				[
+				] )
+				->from( SQLStore::ID_TABLE )
+				->where( [
 					'smw_hash' => array_keys( $chunk )
-				],
-				__METHOD__
-			);
+				] )
+				->caller( __METHOD__ )
+				->fetchResultSet();
 
 			foreach ( $rows as $row ) {
 				$hashes[$row->smw_hash] = $row->smw_id;
@@ -113,18 +113,18 @@ class DisplayTitleLookup {
 
 		$propTable = $propTables[$propTableId];
 
-		$rows = $connection->select(
-			$propTable->getName(),
-			[
+		$rows = $connection->newSelectQueryBuilder()
+			->select( [
 				's_id',
 				'o_hash',
 				'o_blob'
-			],
-			[
+			] )
+			->from( $propTable->getName() )
+			->where( [
 				's_id' => array_keys( $list )
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		return $rows;
 	}

--- a/src/SQLStore/Lookup/EntityUniquenessLookup.php
+++ b/src/SQLStore/Lookup/EntityUniquenessLookup.php
@@ -11,7 +11,7 @@ use SMW\Iterators\MappingIterator;
 use SMW\RequestOptions;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
-use Wikimedia\Rdbms\Platform\ISQLPlatform;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @license GPL-2.0-or-later
@@ -58,35 +58,36 @@ class EntityUniquenessLookup {
 		}
 
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
 
-		$query->index = 1;
-		$query->alias = 't';
-		$i = $query->index;
+		$alias = 't';
+		$index = 1;
 
-		$query->table( $propertyTable->getName(), "{$query->alias}{$i}" );
+		$qb = $connection->newSelectQueryBuilder()
+			->select( "{$alias}{$index}.s_id" )
+			->from( $propertyTable->getName(), "{$alias}{$index}" );
 
-		// Only find entities
-		$query->field( "{$query->alias}{$i}.s_id" );
+		$this->resolve_value_condition( $propertyTable, $property, $dataItem, $qb, $alias, $index );
 
-		$this->resolve_value_condition( $propertyTable, $property, $dataItem, $query );
-
+		// The extra-condition callback signature is part of the public API and
+		// expects an object exposing string-formatting helpers like neq/eq/in.
+		// We instantiate a Query purely as a formatter — it never gets executed.
 		foreach ( $requestOptions->getExtraConditions() as $extraCondition ) {
 			if ( is_callable( $extraCondition ) ) {
-				$query->condition( $extraCondition( $this->store, $query, "{$query->alias}{$i}" ) );
+				$formatter = $connection->newQuery();
+				$formatter->alias = $alias;
+				$formatter->index = $index;
+				$cond = $extraCondition( $this->store, $formatter, "{$alias}{$index}" );
+				if ( $cond !== '' ) {
+					$qb->andWhere( $cond );
+				}
 			} else {
 				throw new RuntimeException( "Expected a callable at this point!" );
 			}
 		}
 
-		$query->type( 'SELECT' );
-		$query->options( [ 'LIMIT' => $requestOptions->getLimit() ] );
+		$qb->limit( $requestOptions->getLimit() );
 
-		$res = $connection->query(
-			$query,
-			__METHOD__,
-			ISQLPlatform::QUERY_CHANGE_NONE
-		);
+		$res = $qb->caller( __METHOD__ )->fetchResultSet();
 
 		$result = $this->iteratorFactory->newMappingIterator(
 			$this->iteratorFactory->newResultIterator( $res ),
@@ -98,13 +99,20 @@ class EntityUniquenessLookup {
 		return $result;
 	}
 
-	private function resolve_value_condition( $propertyTable, $property, $dataItem, $query ): void {
+	private function resolve_value_condition(
+		$propertyTable,
+		$property,
+		$dataItem,
+		SelectQueryBuilder $qb,
+		string $alias,
+		int &$index
+	): void {
 		// Collect conditions to appear as
 		// `... (t1.p_id='121913' AND t1.o_sortkey='3520062') ...`
 		$conditions = [];
 
 		// Keep the index in case of a recursive iteration
-		$i = $query->index;
+		$i = $index;
 
 		if ( !$propertyTable->isFixedPropertyTable() ) {
 
@@ -112,7 +120,7 @@ class EntityUniquenessLookup {
 				$property
 			);
 
-			$conditions[] = $query->eq( "{$query->alias}{$i}.p_id", $pid );
+			$conditions["{$alias}{$i}.p_id"] = $pid;
 		}
 
 		$diHandler = $this->store->getDataItemHandlerForDIType(
@@ -121,7 +129,7 @@ class EntityUniquenessLookup {
 
 		if ( !$dataItem instanceof Container ) {
 			foreach ( $diHandler->getWhereConds( $dataItem ) as $fieldName => $value ) {
-				$conditions[] = $query->eq( "{$query->alias}{$i}.$fieldName", $value );
+				$conditions["{$alias}{$i}.$fieldName"] = $value;
 			}
 		} else {
 
@@ -142,18 +150,25 @@ class EntityUniquenessLookup {
 			 */
 
 			// Handle containers recursively
-			$this->resolve_container_conditions( $propertyTable, $dataItem, $query );
+			$this->resolve_container_conditions( $propertyTable, $dataItem, $qb, $alias, $index );
 		}
 
-		$query->condition( $query->asAnd( $conditions ) );
+		if ( $conditions !== [] ) {
+			$qb->andWhere( $conditions );
+		}
 	}
 
-	private function resolve_container_conditions( $propertyTable, Container $dataItem, $query ): void {
+	private function resolve_container_conditions(
+		$propertyTable,
+		Container $dataItem,
+		SelectQueryBuilder $qb,
+		string $alias,
+		int &$index
+	): void {
 		$proptables = $this->store->getPropertyTables();
 		$semanticData = $dataItem->getSemanticData();
 
-		$alias = $query->alias;
-		$i = $query->index;
+		$i = $index;
 
 		// ought to be a type 'p' object
 		$keys = array_keys( $propertyTable->getFields( $this->store ) );
@@ -171,32 +186,29 @@ class EntityUniquenessLookup {
 
 				if ( $subproptable->usesIdSubject() ) {
 					// simply add property table to check values
-					$query->join(
-						'INNER JOIN',
-						[
-							// e.g. `... INNER JOIN `smw_di_wikipage` AS t2 ON t2.s_id=t1.o_id ...`
-							$subproptable->getName() => "{$alias}{$i} ON {$alias}{$i}.s_id=$joinfield"
-						]
+					// e.g. `... INNER JOIN `smw_di_wikipage` AS t2 ON t2.s_id=t1.o_id ...`
+					$qb->join(
+						$subproptable->getName(),
+						"{$alias}{$i}",
+						"{$alias}{$i}.s_id=$joinfield"
 					);
 				} else {
 					// Rare case with a table that uses subject title+namespace
 					// in a container object (should never happen in SMW core!!)
-					$query->join(
-						'INNER JOIN',
-						[
-							SQLStore::ID_TABLE => "ids{$i} ON ids{$i}.smw_id=$joinfield"
-						]
+					$qb->join(
+						SQLStore::ID_TABLE,
+						"ids{$i}",
+						"ids{$i}.smw_id=$joinfield"
 					);
-					$query->join(
-						'INNER JOIN',
-						[
-							$subproptable->getName() => "{$alias}{$i} ON {$alias}{$i}.s_title=ids{$alias}{$i}.smw_title AND {$alias}{$i}.s_namespace=ids{$alias}{$i}.smw_namespace"
-						]
+					$qb->join(
+						$subproptable->getName(),
+						"{$alias}{$i}",
+						"{$alias}{$i}.s_title=ids{$alias}{$i}.smw_title AND {$alias}{$i}.s_namespace=ids{$alias}{$i}.smw_namespace"
 					);
 				}
 
-				$query->index = $i;
-				$this->resolve_value_condition( $subproptable, $property, $subvalue, $query );
+				$index = $i;
+				$this->resolve_value_condition( $subproptable, $property, $subvalue, $qb, $alias, $index );
 			}
 		}
 	}

--- a/src/SQLStore/Lookup/EntityUniquenessLookup.php
+++ b/src/SQLStore/Lookup/EntityUniquenessLookup.php
@@ -203,7 +203,7 @@ class EntityUniquenessLookup {
 					$qb->join(
 						$subproptable->getName(),
 						"{$alias}{$i}",
-						"{$alias}{$i}.s_title=ids{$alias}{$i}.smw_title AND {$alias}{$i}.s_namespace=ids{$alias}{$i}.smw_namespace"
+						"{$alias}{$i}.s_title=ids{$i}.smw_title AND {$alias}{$i}.s_namespace=ids{$i}.smw_namespace"
 					);
 				}
 

--- a/src/SQLStore/Lookup/ErrorLookup.php
+++ b/src/SQLStore/Lookup/ErrorLookup.php
@@ -109,7 +109,6 @@ class ErrorLookup {
 		);
 
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
 
 		$wpg_table = $this->store->findDiTypeTableId(
 			DataItem::TYPE_WIKIPAGE
@@ -119,16 +118,11 @@ class ErrorLookup {
 			new Property( '_SOBJ' )
 		);
 
-		$query->type( 'SELECT' );
-
-		$query->table( SQLStore::ID_TABLE, 't0' );
-		$query->condition( $query->neq( "t0.smw_iw", SMW_SQL3_SMWIW_OUTDATED ) );
-		$query->condition( $query->neq( "t0.smw_iw", SMW_SQL3_SMWDELETEIW ) );
-
-		$query->join(
-			'INNER JOIN',
-			[ $wpg_table => 't1 ON t0.smw_id=t1.s_id' ]
-		);
+		$qb = $connection->newSelectQueryBuilder()
+			->from( SQLStore::ID_TABLE, 't0' )
+			->where( $connection->expr( 't0.smw_iw', '!=', SMW_SQL3_SMWIW_OUTDATED ) )
+			->andWhere( $connection->expr( 't0.smw_iw', '!=', SMW_SQL3_SMWDELETEIW ) )
+			->join( $wpg_table, 't1', 't0.smw_id=t1.s_id' );
 
 		if ( $subject !== null ) {
 
@@ -137,18 +131,18 @@ class ErrorLookup {
 			);
 
 			if ( $checkConstraintErrors === SMW_CONSTRAINT_ERR_CHECK_ALL ) {
-				$query->join(
-					'LEFT JOIN',
-					[ $sobj_type_table => 's1 ON s1.o_id=t1.s_id' ]
-				);
+				$qb->leftJoin( $sobj_type_table, 's1', 's1.o_id=t1.s_id' );
 
-				$query->condition( '(' . $query->eq( "s1.s_id", $sid ) . ' OR ' . $query->eq( "t1.s_id", $sid ) . ')' );
+				$qb->andWhere(
+					'(s1.s_id=' . $connection->addQuotes( $sid ) .
+					' OR t1.s_id=' . $connection->addQuotes( $sid ) . ')'
+				);
 			} else {
-				$query->condition( $query->eq( "t1.s_id", $sid ) );
+				$qb->andWhere( [ 't1.s_id' => $sid ] );
 			}
 		}
 
-		$query->condition( $query->eq( "t1.p_id", $pid ) );
+		$qb->andWhere( [ 't1.p_id' => $pid ] );
 
 		$property = new Property( '_ERR_TYPE' );
 
@@ -160,15 +154,12 @@ class ErrorLookup {
 			$property
 		);
 
-		$query->join(
-			'INNER JOIN',
-			[ $err_type_table => 't2 ON t1.o_id=t2.s_id' ]
-		);
+		$qb->join( $err_type_table, 't2', 't1.o_id=t2.s_id' );
 
-		$query->condition( $query->eq( "t2.p_id", $pid ) );
+		$qb->andWhere( [ 't2.p_id' => $pid ] );
 
 		if ( $errorType !== null ) {
-			$query->condition( $query->eq( "t2.o_hash", $errorType ) );
+			$qb->andWhere( [ 't2.o_hash' => $errorType ] );
 		}
 
 		$property = new Property( '_ERRT' );
@@ -181,19 +172,14 @@ class ErrorLookup {
 			$property
 		);
 
-		$query->join(
-			'INNER JOIN',
-			[ $errt_table => 't3 ON t3.s_id=t2.s_id' ]
-		);
+		$qb->join( $errt_table, 't3', 't3.s_id=t2.s_id' );
 
-		$query->condition( $query->eq( "t3.p_id", $pid ) );
+		$qb->andWhere( [ 't3.p_id' => $pid ] );
 
-		$query->field( 't2.s_id', 's_id' );
-		$query->field( 't3.o_hash', 'o_hash' );
-		$query->field( 't3.o_blob', 'o_blob' );
+		$qb->select( [ 's_id' => 't2.s_id', 'o_hash' => 't3.o_hash', 'o_blob' => 't3.o_blob' ] );
 
 		if ( $requestOptions->getLimit() > 0 ) {
-			$query->option( 'LIMIT', $requestOptions->getLimit() );
+			$qb->limit( $requestOptions->getLimit() );
 		}
 
 		$caller = __METHOD__;
@@ -202,7 +188,7 @@ class ErrorLookup {
 			$caller .= " (for " . $requestOptions->getCaller() . ")";
 		}
 
-		return $query->execute( $caller );
+		return $qb->caller( $caller )->fetchResultSet();
 	}
 
 }

--- a/src/SQLStore/Lookup/MissingRedirectLookup.php
+++ b/src/SQLStore/Lookup/MissingRedirectLookup.php
@@ -62,32 +62,22 @@ class MissingRedirectLookup {
 	private function fetchFromTable( array $namespaces ) {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$options = [
-			'ORDER BY' => 'page_namespace,page_title'
-		];
-
-		if ( $this->nosort ) {
-			unset( $options['ORDER BY'] );
-		}
-
-		$rows = $connection->select(
-			[ 'page', RedirectStore::TABLE_NAME ],
-			[ 'page_id', 'page_title', 'page_namespace' ],
-			[
+		$queryBuilder = $connection->newSelectQueryBuilder()
+			->select( [ 'page_id', 'page_title', 'page_namespace' ] )
+			->from( 'page' )
+			->leftJoin( RedirectStore::TABLE_NAME, null, [ 's_title=page_title', 's_namespace=page_namespace' ] )
+			->where( [
 				'page_is_redirect' => 1,
 				'page_namespace' => $namespaces,
 				's_title IS NULL'
-			],
-			__METHOD__,
-			$options,
-			[
-				RedirectStore::TABLE_NAME => [
-					'LEFT JOIN', [ "s_title=page_title", "s_namespace=page_namespace" ]
-				]
-			]
-		);
+			] )
+			->caller( __METHOD__ );
 
-		return $rows;
+		if ( !$this->nosort ) {
+			$queryBuilder->orderBy( 'page_namespace,page_title' );
+		}
+
+		return $queryBuilder->fetchResultSet();
 	}
 
 }

--- a/src/SQLStore/Lookup/MonolingualTextLookup.php
+++ b/src/SQLStore/Lookup/MonolingualTextLookup.php
@@ -198,15 +198,10 @@ class MonolingualTextLookup {
 		 *
 		 */
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
-
-		$query->type( 'SELECT' );
 
 		$propTable = $this->getPropertyTable(
 			$property
 		);
-
-		$query->table( $propTable->getName(), 't0' );
 
 		/**
 		 * In case of a _ML... reference use the o_id (object) field
@@ -243,27 +238,23 @@ class MonolingualTextLookup {
 			);
 		}
 
-		$query->join(
-			'INNER JOIN',
-			[ SQLStore::ID_TABLE => 'o0 ON t0.o_id=o0.smw_id' ]
-		);
+		$qb = $connection->newSelectQueryBuilder()
+			->from( $propTable->getName(), 't0' )
+			->join( SQLStore::ID_TABLE, 'o0', 't0.o_id=o0.smw_id' );
 
 		// Is it a Monolingual representation?
 		if ( $subject->isSubEntityOf( SMW_SUBENTITY_MONOLINGUAL ) ) {
-			$query->condition( $query->eq( "o0.smw_hash", $subject->getSha1() ) );
+			$qb->where( [ 'o0.smw_hash' => $subject->getSha1() ] );
 		} else {
 			// We don't have a _ML entity reference hence we add a JOIN to find
 			// such entity
-			$query->condition( $query->eq( "o1.smw_hash", $subject->getSha1() ) );
+			$qb->where( [ 'o1.smw_hash' => $subject->getSha1() ] );
 
-			$query->join(
-				'INNER JOIN',
-				[ SQLStore::ID_TABLE => 'o1 ON t0.s_id=o1.smw_id' ]
-			);
+			$qb->join( SQLStore::ID_TABLE, 'o1', 't0.s_id=o1.smw_id' );
 		}
 
-		$query->condition( $query->neq( "o0.smw_iw", SMW_SQL3_SMWIW_OUTDATED ) );
-		$query->condition( $query->neq( "o0.smw_iw", SMW_SQL3_SMWDELETEIW ) );
+		$qb->andWhere( $connection->expr( 'o0.smw_iw', '!=', SMW_SQL3_SMWIW_OUTDATED ) );
+		$qb->andWhere( $connection->expr( 'o0.smw_iw', '!=', SMW_SQL3_SMWDELETEIW ) );
 
 		if ( !$propTable->isFixedPropertyTable() ) {
 
@@ -271,12 +262,9 @@ class MonolingualTextLookup {
 				$property
 			);
 
-			$query->condition( $query->eq( "t0.p_id", $pid ) );
+			$qb->andWhere( [ 't0.p_id' => $pid ] );
 
-			$query->join(
-				'INNER JOIN',
-				[ SQLStore::ID_TABLE => 't1 ON t0.p_id=t1.smw_id' ]
-			);
+			$qb->join( SQLStore::ID_TABLE, 't1', 't0.p_id=t1.smw_id' );
 		}
 
 		$text = new Property( '_TEXT' );
@@ -285,10 +273,7 @@ class MonolingualTextLookup {
 			$text
 		);
 
-		$query->join(
-			'INNER JOIN',
-			[ $text_table->getName() => 't2 ON t2.s_id=o0.smw_id' ]
-		);
+		$qb->join( $text_table->getName(), 't2', 't2.s_id=o0.smw_id' );
 
 		$lcode = new Property( '_LCODE' );
 
@@ -296,23 +281,22 @@ class MonolingualTextLookup {
 			$lcode
 		);
 
-		$query->join(
-			'INNER JOIN',
-			[ $lcode_table->getName() => 't3 ON t3.s_id=o0.smw_id' ]
-		);
+		$qb->join( $lcode_table->getName(), 't3', 't3.s_id=o0.smw_id' );
 
 		if ( $languageCode !== null ) {
-			$query->condition( $query->eq( "t3.o_hash", $languageCode ) );
+			$qb->andWhere( [ 't3.o_hash' => $languageCode ] );
 		}
 
-		$query->field( 't0.o_id', 'id' );
-		$query->field( 'o0.smw_title', 'v0' );
-		$query->field( 'o0.smw_namespace', 'v1' );
-		$query->field( 'o0.smw_iw', 'v2' );
-		$query->field( 'o0.smw_subobject', 'v3' );
-		$query->field( 't2.o_hash', 'text_short' );
-		$query->field( 't2.o_blob', 'text_long' );
-		$query->field( 't3.o_hash', 'lcode' );
+		$qb->select( [
+			'id' => 't0.o_id',
+			'v0' => 'o0.smw_title',
+			'v1' => 'o0.smw_namespace',
+			'v2' => 'o0.smw_iw',
+			'v3' => 'o0.smw_subobject',
+			'text_short' => 't2.o_hash',
+			'text_long' => 't2.o_blob',
+			'lcode' => 't3.o_hash',
+		] );
 
 		$caller = __METHOD__;
 
@@ -320,7 +304,7 @@ class MonolingualTextLookup {
 			$caller .= " (for " . $this->caller . ")";
 		}
 
-		return $query->execute( $caller );
+		return $qb->caller( $caller )->fetchResultSet();
 	}
 
 	/**

--- a/src/SQLStore/Lookup/PropertyLabelSimilarityLookup.php
+++ b/src/SQLStore/Lookup/PropertyLabelSimilarityLookup.php
@@ -258,19 +258,11 @@ class PropertyLabelSimilarityLookup {
 	private function getPropertyList( ?RequestOptions $requestOptions = null ): array {
 		$propertyList = [];
 
-		// the query needs to do the filtering of internal properties, else LIMIT is wrong
-		$options = [ 'ORDER BY' => 'smw_sort' ];
-
 		$conditions = [
 			'smw_namespace' => SMW_NS_PROPERTY,
 			'smw_iw' => '',
 			'smw_subobject' => ''
 		];
-
-		if ( $requestOptions !== null && $requestOptions->getLimit() > 0 ) {
-			$options['LIMIT'] = $requestOptions->getLimit();
-			$options['OFFSET'] = max( $requestOptions->getOffset(), 0 );
-		}
 
 		if ( $requestOptions !== null && $requestOptions->getStringConditions() ) {
 			$conditions[] = $this->store->getSQLConditions( $requestOptions, '', 'smw_sortkey', false );
@@ -278,13 +270,20 @@ class PropertyLabelSimilarityLookup {
 
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$res = $connection->select(
-			SQLStore::ID_TABLE,
-			[ 'smw_id', 'smw_title' ],
-			$conditions,
-			__METHOD__,
-			$options
-		);
+		// the query needs to do the filtering of internal properties, else LIMIT is wrong
+		$queryBuilder = $connection->newSelectQueryBuilder()
+			->select( [ 'smw_id', 'smw_title' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( $conditions )
+			->orderBy( 'smw_sort' )
+			->caller( __METHOD__ );
+
+		if ( $requestOptions !== null && $requestOptions->getLimit() > 0 ) {
+			$queryBuilder->limit( $requestOptions->getLimit() );
+			$queryBuilder->offset( max( $requestOptions->getOffset(), 0 ) );
+		}
+
+		$res = $queryBuilder->fetchResultSet();
 
 		foreach ( $res as $row ) {
 

--- a/src/SQLStore/Lookup/ProximityPropertyValueLookup.php
+++ b/src/SQLStore/Lookup/ProximityPropertyValueLookup.php
@@ -82,9 +82,7 @@ class ProximityPropertyValueLookup {
 				$qb->andWhere( "$field LIKE " . $connection->addQuotes( '%' . $search . '%' ) );
 			}
 		} else {
-			// Preserve original semantics: filter against the literal string
-			// 'NULL', not the SQL NULL value.
-			$qb->andWhere( "$field != " . $connection->addQuotes( 'NULL' ) );
+			$qb->andWhere( "$field IS NOT NULL" );
 		}
 
 		if ( $this->isFixedPropertyTable( $table ) === false ) {

--- a/src/SQLStore/Lookup/ProximityPropertyValueLookup.php
+++ b/src/SQLStore/Lookup/ProximityPropertyValueLookup.php
@@ -7,6 +7,7 @@ use SMW\DataItems\Property;
 use SMW\DataItems\Time;
 use SMW\DataTypeRegistry;
 use SMW\DataValueFactory;
+use SMW\MediaWiki\Connection\Database;
 use SMW\RequestOptions;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
@@ -58,8 +59,7 @@ class ProximityPropertyValueLookup {
 		$pid = $this->store->getObjectIds()->getSMWPropertyID( $property );
 
 		$connection = $this->store->getConnection( 'mw.db' );
-		$qb = $connection->newSelectQueryBuilder()
-			->from( $table );
+		$qb = $connection->newSelectQueryBuilder();
 
 		[ $field, $diType ] = $this->getField( $property );
 
@@ -72,7 +72,8 @@ class ProximityPropertyValueLookup {
 			return $this->fetchFromIDTable( $qb, $pid, $table, $limit, $offset, $search, $sort );
 		}
 
-		$qb->select( $field );
+		$qb->from( $table )
+			->select( $field );
 
 		if ( trim( $search ) !== '' ) {
 			if ( $diType === DataItem::TYPE_BLOB || $diType === DataItem::TYPE_URI ) {
@@ -166,7 +167,8 @@ class ProximityPropertyValueLookup {
 
 		} elseif ( $this->isFixedPropertyTable( $table ) === false ) {
 
-			$qb->andWhere( [ 'p_id' => $pid ] );
+			$qb->from( $table )
+				->andWhere( [ 'p_id' => $pid ] );
 
 			// To make the MySQL query planner happy to pick the right index!
 			$qb->select( 'p_id' );
@@ -182,7 +184,8 @@ class ProximityPropertyValueLookup {
 			 * WHERE ( smw_sortkey LIKE '%foo%' OR smw_sortkey LIKE '%Foo%' OR smw_sortkey LIKE '%FOO%' )
 			 * LIMIT 11
 			 */
-			$qb->join( SQLStore::ID_TABLE, null, 'smw_id=o_id' );
+			$qb->from( $table )
+				->join( SQLStore::ID_TABLE, null, 'smw_id=o_id' );
 		}
 
 		$res = $qb->caller( __METHOD__ )->fetchResultSet();
@@ -219,7 +222,7 @@ class ProximityPropertyValueLookup {
 		return [ $diHandler->getLabelField(), $diType ];
 	}
 
-	private function build_like( SelectQueryBuilder $qb, $connection, string $field, string $search ): void {
+	private function build_like( SelectQueryBuilder $qb, Database $connection, string $field, string $search ): void {
 		$conds = [
 			// @phan-suppress-next-line PhanUselessBinaryAddRight
 			'%' . $search . '%',

--- a/src/SQLStore/Lookup/ProximityPropertyValueLookup.php
+++ b/src/SQLStore/Lookup/ProximityPropertyValueLookup.php
@@ -7,11 +7,10 @@ use SMW\DataItems\Property;
 use SMW\DataItems\Time;
 use SMW\DataTypeRegistry;
 use SMW\DataValueFactory;
-use SMW\MediaWiki\Connection\Query;
 use SMW\RequestOptions;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
-use Wikimedia\Rdbms\Platform\ISQLPlatform;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @license GPL-2.0-or-later
@@ -50,7 +49,6 @@ class ProximityPropertyValueLookup {
 	 * @return array
 	 */
 	public function fetchFromTable( Property $property, string $search, RequestOptions $opts ): array {
-		$options = [];
 		$list = [];
 
 		$table = $this->store->findPropertyTableID(
@@ -58,13 +56,10 @@ class ProximityPropertyValueLookup {
 		);
 
 		$pid = $this->store->getObjectIds()->getSMWPropertyID( $property );
-		$continueOffset = 0;
 
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
-
-		$query->type( 'SELECT' );
-		$query->table( $table );
+		$qb = $connection->newSelectQueryBuilder()
+			->from( $table );
 
 		[ $field, $diType ] = $this->getField( $property );
 
@@ -73,47 +68,40 @@ class ProximityPropertyValueLookup {
 		$offset = $opts->getOffset();
 		$sort = $opts->sort;
 
-		$options = [
-			'LIMIT' => $limit,
-			'OFFSET' => $offset
-		];
-
 		if ( $diType === DataItem::TYPE_WIKIPAGE ) {
-			return $this->fetchFromIDTable( $query, $pid, $table, $options, $search, $sort );
+			return $this->fetchFromIDTable( $qb, $pid, $table, $limit, $offset, $search, $sort );
 		}
 
-		$query->field( $field );
+		$qb->select( $field );
 
 		if ( trim( $search ) !== '' ) {
 			if ( $diType === DataItem::TYPE_BLOB || $diType === DataItem::TYPE_URI ) {
-				$this->build_like( $query, $field, $search );
+				$this->build_like( $qb, $connection, $field, $search );
 			} else {
-				$query->condition( $query->like( $field, '%' . $search . '%' ) );
+				$qb->andWhere( "$field LIKE " . $connection->addQuotes( '%' . $search . '%' ) );
 			}
 		} else {
-			$query->condition( $query->neq( $field, 'NULL' ) );
+			// Preserve original semantics: filter against the literal string
+			// 'NULL', not the SQL NULL value.
+			$qb->andWhere( "$field != " . $connection->addQuotes( 'NULL' ) );
 		}
 
 		if ( $this->isFixedPropertyTable( $table ) === false ) {
-			$query->condition( $query->asAnd( $query->eq( 'p_id', $pid ) ) );
+			$qb->andWhere( [ 'p_id' => $pid ] );
 
 			// To make the MySQL query planner happy to pick the right index!
-			$query->field( 'p_id' );
+			$qb->select( 'p_id' );
 		}
 
 		if ( $sort ) {
-			$options['ORDER BY'] = "$field $sort";
+			$qb->orderBy( $field, $sort );
 		}
 
-		$options['DISTINCT'] = true;
+		$qb->distinct()
+			->limit( $limit )
+			->offset( $offset );
 
-		$query->options( $options );
-
-		$res = $connection->query(
-			$query,
-			__METHOD__,
-			ISQLPlatform::QUERY_CHANGE_NONE
-		);
+		$res = $qb->caller( __METHOD__ )->fetchResultSet();
 
 		foreach ( $res as $row ) {
 
@@ -133,32 +121,24 @@ class ProximityPropertyValueLookup {
 	}
 
 	/**
-	 * @param Query $query
-	 * @param int $pid
-	 * @param ?string $table
-	 * @param array $options
-	 * @param string $search
-	 * @param string $sort
-	 *
 	 * @return mixed[][]|string[]
 	 */
-	private function fetchFromIDTable( Query $query, int $pid, ?string $table, array $options, string $search, string|false $sort ): array {
+	private function fetchFromIDTable( SelectQueryBuilder $qb, int $pid, ?string $table, int $limit, int $offset, string $search, string|false $sort ): array {
 		$connection = $this->store->getConnection( 'mw.db' );
-		$continueOffset = 0;
 		$res = [];
 
 		if ( trim( $search ) !== '' ) {
-			$this->build_like( $query, 'smw_sortkey', $search );
+			$this->build_like( $qb, $connection, 'smw_sortkey', $search );
 		}
 
 		if ( is_string( $sort ) && $sort !== '' ) {
-			$options['ORDER BY'] = "smw_title $sort";
+			$qb->orderBy( 'smw_title', $sort );
 		}
 
-		$options['DISTINCT'] = true;
-
-		$query->options( $options );
-		$query->fields( [ 'smw_id', 'smw_title', 'smw_sortkey' ] );
+		$qb->distinct()
+			->limit( $limit )
+			->offset( $offset )
+			->select( [ 'smw_id', 'smw_title', 'smw_sortkey' ] );
 
 		// Benchmarks showed that different select schema yield better results
 		// for the following use cases
@@ -174,27 +154,24 @@ class ProximityPropertyValueLookup {
 			 * 	LIMIT 11
 			 */
 
-			$query->table( SQLStore::ID_TABLE );
+			$qb->from( SQLStore::ID_TABLE );
 
-			$query->join(
-				'INNER JOIN',
-				'( SELECT o_id FROM ' . $connection->tableName( $table ) .
-					' WHERE p_id=' . $connection->addQuotes( $pid ) .
-					' GROUP BY o_id )' .
-				' AS t1 ON t1.o_id=smw_id'
-			);
+			$sub = $qb->newSubquery()
+				->select( 'o_id' )
+				->from( $table )
+				->where( [ 'p_id' => $pid ] )
+				->groupBy( 'o_id' );
+
+			$qb->join( $sub, 't1', 't1.o_id=smw_id' );
 
 		} elseif ( $this->isFixedPropertyTable( $table ) === false ) {
 
-			$query->condition( $query->asAnd( $query->eq( 'p_id', $pid ) ) );
+			$qb->andWhere( [ 'p_id' => $pid ] );
 
 			// To make the MySQL query planner happy to pick the right index!
-			$query->field( 'p_id' );
+			$qb->select( 'p_id' );
 
-			$query->join(
-				'INNER JOIN',
-				[ SQLStore::ID_TABLE => 'ON (smw_id=o_id)' ]
-			);
+			$qb->join( SQLStore::ID_TABLE, null, 'smw_id=o_id' );
 
 		} else {
 
@@ -205,17 +182,10 @@ class ProximityPropertyValueLookup {
 			 * WHERE ( smw_sortkey LIKE '%foo%' OR smw_sortkey LIKE '%Foo%' OR smw_sortkey LIKE '%FOO%' )
 			 * LIMIT 11
 			 */
-			$query->join(
-				'INNER JOIN',
-				[ SQLStore::ID_TABLE => 'ON (smw_id=o_id)' ]
-			);
+			$qb->join( SQLStore::ID_TABLE, null, 'smw_id=o_id' );
 		}
 
-		$res = $connection->query(
-			$query,
-			__METHOD__,
-			ISQLPlatform::QUERY_CHANGE_NONE
-		);
+		$res = $qb->caller( __METHOD__ )->fetchResultSet();
 
 		$list = [];
 
@@ -249,7 +219,7 @@ class ProximityPropertyValueLookup {
 		return [ $diHandler->getLabelField(), $diType ];
 	}
 
-	private function build_like( $query, $field, string $search ): void {
+	private function build_like( SelectQueryBuilder $qb, $connection, string $field, string $search ): void {
 		$conds = [
 			// @phan-suppress-next-line PhanUselessBinaryAddRight
 			'%' . $search . '%',
@@ -257,11 +227,13 @@ class ProximityPropertyValueLookup {
 			'%' . strtoupper( $search ) . '%'
 		] + ( $search !== strtolower( $search ) ? [ '%' . strtolower( $search ) . '%' ] : [] );
 
-		$cond = [];
+		$ors = [];
 
 		foreach ( $conds as $c ) {
-			$query->condition( $query->asOr( $query->like( $field, $c ) ) );
+			$ors[] = "$field LIKE " . $connection->addQuotes( $c );
 		}
+
+		$qb->andWhere( '(' . implode( ' OR ', $ors ) . ')' );
 	}
 
 }

--- a/src/SQLStore/Lookup/RedirectTargetLookup.php
+++ b/src/SQLStore/Lookup/RedirectTargetLookup.php
@@ -54,18 +54,18 @@ class RedirectTargetLookup {
 
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$rows = $connection->select(
-			RedirectStore::TABLE_NAME,
-			[
+		$rows = $connection->newSelectQueryBuilder()
+			->select( [
 				'o_id',
 				's_title',
 				's_namespace',
-			],
-			[
+			] )
+			->from( RedirectStore::TABLE_NAME )
+			->where( [
 				'o_id' => $ids
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		foreach ( $rows as $row ) {
 

--- a/src/SQLStore/Lookup/TableStatisticsLookup.php
+++ b/src/SQLStore/Lookup/TableStatisticsLookup.php
@@ -171,72 +171,67 @@ class TableStatisticsLookup {
 	}
 
 	private function last_id( $connection ): int {
-		return (int)$connection->selectField(
-			SQLStore::ID_TABLE,
-			'MAX(smw_id)',
-			'',
-			__METHOD__
-		);
+		return (int)$connection->newSelectQueryBuilder()
+			->select( 'MAX(smw_id)' )
+			->from( SQLStore::ID_TABLE )
+			->caller( __METHOD__ )
+			->fetchField();
 	}
 
 	private function rows_total_count( $connection ): int {
-		return (int)$connection->selectField(
-			SQLStore::ID_TABLE,
-			'Count(*)',
-			'',
-			__METHOD__
-		);
+		return (int)$connection->newSelectQueryBuilder()
+			->select( 'Count(*)' )
+			->from( SQLStore::ID_TABLE )
+			->caller( __METHOD__ )
+			->fetchField();
 	}
 
 	private function rows_delete_count( $connection ): int {
-		return (int)$connection->selectField(
-			SQLStore::ID_TABLE,
-			'Count(*)',
-			[
+		return (int)$connection->newSelectQueryBuilder()
+			->select( 'Count(*)' )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				'smw_iw' => SMW_SQL3_SMWDELETEIW
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchField();
 	}
 
 	private function rows_redirect_count( $connection ): int {
-		return (int)$connection->selectField(
-			SQLStore::ID_TABLE,
-			'Count(*)',
-			[
+		return (int)$connection->newSelectQueryBuilder()
+			->select( 'Count(*)' )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				'smw_iw' => SMW_SQL3_SMWREDIIW
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchField();
 	}
 
 	private function rows_rev_count( $connection ): int {
-		return (int)$connection->selectField(
-			SQLStore::ID_TABLE,
-			'Count(*)',
-			[
+		return (int)$connection->newSelectQueryBuilder()
+			->select( 'Count(*)' )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				'smw_rev IS NOT NULL'
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchField();
 	}
 
 	/**
 	 * @return int[]
 	 */
 	private function rows_group_by_namespace( $connection ): array {
-		$res = $connection->select(
-			SQLStore::ID_TABLE,
-			[
+		$res = $connection->newSelectQueryBuilder()
+			->select( [
 				'smw_namespace',
 				'Count(*) as count'
-			],
-			[],
-			__METHOD__,
-			[
-				'GROUP BY' => 'smw_namespace'
-			]
-		);
+			] )
+			->from( SQLStore::ID_TABLE )
+			->groupBy( 'smw_namespace' )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		$rows_group_by_namespace = [];
 
@@ -248,113 +243,96 @@ class TableStatisticsLookup {
 	}
 
 	private function rows_query_links_total_count( $connection ): int {
-		return (int)$connection->selectField(
-			SQLStore::QUERY_LINKS_TABLE,
-			'Count(*)',
-			'',
-			__METHOD__
-		);
+		return (int)$connection->newSelectQueryBuilder()
+			->select( 'Count(*)' )
+			->from( SQLStore::QUERY_LINKS_TABLE )
+			->caller( __METHOD__ )
+			->fetchField();
 	}
 
 	private function unlinked_query_proptable_hash_count( $connection ): int {
-		return (int)$connection->selectField(
-			SQLStore::ID_TABLE,
-			'Count(*)',
-			[
+		return (int)$connection->newSelectQueryBuilder()
+			->select( 'Count(*)' )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				'smw_subobject LIKE ' . $connection->addQuotes( Query::ID_PREFIX . '%' ),
 				'smw_proptable_hash IS NULL'
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchField();
 	}
 
 	private function linked_query_proptable_hash_count( $connection ): int {
-		return (int)$connection->selectField(
-			SQLStore::ID_TABLE,
-			'Count(*)',
-			[
+		return (int)$connection->newSelectQueryBuilder()
+			->select( 'Count(*)' )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				'smw_subobject LIKE ' . $connection->addQuotes( Query::ID_PREFIX . '%' ),
 				'smw_proptable_hash IS NOT NULL'
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchField();
 	}
 
 	private function active_query_links_count( $connection ): int {
-		$row = $connection->selectRow(
-			[ SQLStore::QUERY_LINKS_TABLE, SQLStore::ID_TABLE ],
-			'COUNT(*) as count',
-			[
+		$row = $connection->newSelectQueryBuilder()
+			->select( 'COUNT(*) as count' )
+			->from( SQLStore::QUERY_LINKS_TABLE )
+			->join( SQLStore::ID_TABLE, null, 's_id=smw_id' )
+			->where( [
 				'smw_subobject LIKE ' . $connection->addQuotes( Query::ID_PREFIX . '%' ),
-			],
-			__METHOD__,
-			[],
-			[
-				SQLStore::QUERY_LINKS_TABLE => [
-					'INNER JOIN', "s_id=smw_id"
-				]
-			]
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return (int)$row->count;
 	}
 
 	private function invalid_query_links_count( $connection ): int {
-		$row = $connection->selectRow(
-			[ SQLStore::QUERY_LINKS_TABLE, SQLStore::ID_TABLE ],
-			'COUNT(*) as count',
-			[
+		$row = $connection->newSelectQueryBuilder()
+			->select( 'COUNT(*) as count' )
+			->from( SQLStore::QUERY_LINKS_TABLE )
+			->join( SQLStore::ID_TABLE, null, 's_id=smw_id' )
+			->where( [
 				"smw_subobject=''"
-			],
-			__METHOD__,
-			[],
-			[
-				SQLStore::QUERY_LINKS_TABLE => [
-					'INNER JOIN', "s_id=smw_id"
-				]
-			]
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return (int)$row->count;
 	}
 
 	private function unassigned_query_links_count( $connection ): int {
-		$row = $connection->selectRow(
-			[ SQLStore::QUERY_LINKS_TABLE, SQLStore::ID_TABLE ],
-			'COUNT(*) as count',
-			[
+		$row = $connection->newSelectQueryBuilder()
+			->select( 'COUNT(*) as count' )
+			->from( SQLStore::QUERY_LINKS_TABLE )
+			->leftJoin( SQLStore::ID_TABLE, null, 'smw_id=s_id' )
+			->where( [
 				"smw_id IS NULL"
-			],
-			__METHOD__,
-			[],
-			[
-				SQLStore::ID_TABLE => [
-					'LEFT JOIN', "smw_id=s_id"
-				]
-			]
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return (int)$row->count;
 	}
 
 	private function rows_blob_table_total_count( $connection, $blobTable ): int {
-		return (int)$connection->selectField(
-			$blobTable,
-			'Count(o_hash)',
-			[],
-			__METHOD__
-		);
+		return (int)$connection->newSelectQueryBuilder()
+			->select( 'Count(o_hash)' )
+			->from( $blobTable )
+			->caller( __METHOD__ )
+			->fetchField();
 	}
 
 	private function blob_field_null_row_count( $connection, $blobTable ): int {
-		return (int)$connection->selectField(
-			$blobTable,
-			'Count(o_hash)',
-			[
+		return (int)$connection->newSelectQueryBuilder()
+			->select( 'Count(o_hash)' )
+			->from( $blobTable )
+			->where( [
 				'o_blob' => null
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchField();
 	}
 
 	private function hash_field_count( $connection, $blobTable ): array {
@@ -372,25 +350,18 @@ class TableStatisticsLookup {
 		 *    SELECT COUNT(o_hash) AS count FROM `smw_di_blob` GROUP BY o_hash HAVING COUNT(*) > 1
 		 *  ) AS t1
 		 */
-		$sub_query = $connection->newQuery();
-		$sub_query->type( 'SELECT' );
-		$sub_query->table( $blobTable );
-		$sub_query->field( 'COUNT(o_hash)', 'count' );
-		$sub_query->options(
-			[
-				'GROUP BY' => 'o_hash',
-				'HAVING' => 'COUNT(*) > 1'
-			]
-		);
+		$outer = $connection->newSelectQueryBuilder();
+		$sub = $outer->newSubquery()
+			->select( [ 'count' => 'COUNT(o_hash)' ] )
+			->from( $blobTable )
+			->groupBy( 'o_hash' )
+			->having( 'COUNT(*) > 1' );
 
-		$query = $connection->newQuery();
-		$query->type( 'SELECT' );
-		$query->table( $sub_query->getSQL(), 't1' );
-		$query->field( 'COUNT(count) as count' );
-
-		foreach ( $query->execute( __METHOD__ ) as $row ) {
-			$hash_field_multi_occurrence_total_count = (int)$row->count;
-		}
+		$hash_field_multi_occurrence_total_count = (int)$outer
+			->select( [ 'count' => 'COUNT(count)' ] )
+			->from( $sub, 't1' )
+			->caller( __METHOD__ )
+			->fetchField();
 
 		/**
 		 * Count the rows of those that have been grouped with a single
@@ -401,25 +372,18 @@ class TableStatisticsLookup {
 		 *    SELECT COUNT(o_hash) AS count FROM `smw_di_blob` GROUP BY o_hash HAVING COUNT(*) = 1
 		 *  ) AS t1
 		 */
-		$sub_query = $connection->newQuery();
-		$sub_query->type( 'SELECT' );
-		$sub_query->table( $blobTable );
-		$sub_query->field( 'COUNT(o_hash)', 'count' );
-		$sub_query->options(
-			[
-				'GROUP BY' => 'o_hash',
-				'HAVING' => 'COUNT(*) = 1'
-			]
-		);
+		$outer = $connection->newSelectQueryBuilder();
+		$sub = $outer->newSubquery()
+			->select( [ 'count' => 'COUNT(o_hash)' ] )
+			->from( $blobTable )
+			->groupBy( 'o_hash' )
+			->having( 'COUNT(*) = 1' );
 
-		$query = $connection->newQuery();
-		$query->type( 'SELECT' );
-		$query->table( $sub_query->getSQL(), 't1' );
-		$query->field( 'COUNT(count) as count' );
-
-		foreach ( $query->execute( __METHOD__ ) as $row ) {
-			$hash_field_single_occurrence_total_count = (int)$row->count;
-		}
+		$hash_field_single_occurrence_total_count = (int)$outer
+			->select( [ 'count' => 'COUNT(count)' ] )
+			->from( $sub, 't1' )
+			->caller( __METHOD__ )
+			->fetchField();
 
 		return [
 			$hash_field_multi_occurrence_total_count,

--- a/src/SQLStore/Lookup/UndeclaredPropertyListLookup.php
+++ b/src/SQLStore/Lookup/UndeclaredPropertyListLookup.php
@@ -106,20 +106,28 @@ class UndeclaredPropertyListLookup implements ListLookup {
 			}
 		}
 
-		$res = $this->store->getConnection( 'mw.db' )->select(
-			[ $idTable, $propertyTable->getName() ],
-			[ 'smw_id', 'smw_title', 'COUNT(*) as count' ],
-			$conditions,
-			__METHOD__,
-			$options,
-			[
-				$idTable => [
-					'INNER JOIN', "$joinCond=smw_id"
-				]
-			]
-		);
+		$queryBuilder = $this->store->getConnection( 'mw.db' )->newSelectQueryBuilder()
+			->select( [ 'smw_id', 'smw_title', 'COUNT(*) as count' ] )
+			->from( $propertyTable->getName() )
+			->join( $idTable, null, "$joinCond=smw_id" )
+			->where( $conditions )
+			->groupBy( $options['GROUP BY'] )
+			->orderBy( $options['ORDER BY'] )
+			->caller( __METHOD__ );
 
-		return $res;
+		if ( isset( $options['LIMIT'] ) ) {
+			$queryBuilder->limit( $options['LIMIT'] );
+		}
+
+		if ( isset( $options['OFFSET'] ) ) {
+			$queryBuilder->offset( $options['OFFSET'] );
+		}
+
+		if ( !empty( $options['DISTINCT'] ) ) {
+			$queryBuilder->distinct();
+		}
+
+		return $queryBuilder->fetchResultSet();
 	}
 
 	/**

--- a/src/SQLStore/Lookup/UndeclaredPropertyListLookup.php
+++ b/src/SQLStore/Lookup/UndeclaredPropertyListLookup.php
@@ -9,6 +9,7 @@ use SMW\DataItems\Error;
 use SMW\DataItems\Property;
 use SMW\Exception\PropertyLabelNotResolvedException;
 use SMW\Lookup\ListLookup;
+use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\RequestOptions;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
@@ -111,21 +112,9 @@ class UndeclaredPropertyListLookup implements ListLookup {
 			->from( $propertyTable->getName() )
 			->join( $idTable, null, "$joinCond=smw_id" )
 			->where( $conditions )
-			->groupBy( $options['GROUP BY'] )
-			->orderBy( $options['ORDER BY'] )
 			->caller( __METHOD__ );
 
-		if ( isset( $options['LIMIT'] ) ) {
-			$queryBuilder->limit( $options['LIMIT'] );
-		}
-
-		if ( isset( $options['OFFSET'] ) ) {
-			$queryBuilder->offset( $options['OFFSET'] );
-		}
-
-		if ( !empty( $options['DISTINCT'] ) ) {
-			$queryBuilder->distinct();
-		}
+		LegacyOptionsApplier::applyTo( $queryBuilder, $options );
 
 		return $queryBuilder->fetchResultSet();
 	}

--- a/src/SQLStore/Lookup/UsageStatisticsListLookup.php
+++ b/src/SQLStore/Lookup/UsageStatisticsListLookup.php
@@ -315,15 +315,11 @@ class UsageStatisticsListLookup implements ListLookup {
 	}
 
 	private function count( string $type ): int {
-		$res = $this->store->getConnection()->newSelectQueryBuilder()
-			->select( 'COUNT(s_id) AS count' )
+		return (int)$this->store->getConnection()->newSelectQueryBuilder()
+			->select( 'COUNT(s_id)' )
 			->from( $this->findPropertyTableByType( $type )->getName() )
 			->caller( __METHOD__ )
-			->fetchResultSet();
-
-		$row = $res->fetchObject();
-
-		return isset( $row->count ) ? (int)$row->count : 0;
+			->fetchField();
 	}
 
 	private function findPropertyTableByType( string $type ) {

--- a/src/SQLStore/Lookup/UsageStatisticsListLookup.php
+++ b/src/SQLStore/Lookup/UsageStatisticsListLookup.php
@@ -154,16 +154,13 @@ class UsageStatisticsListLookup implements ListLookup {
 	public function getQueryFormatsCount(): array {
 		$count = [];
 
-		$res = $this->store->getConnection()->select(
-			$this->findPropertyTableByType( '_ASKFO' )->getName(),
-			'o_hash, COUNT(s_id) AS count',
-			[],
-			__METHOD__,
-			[
-				'ORDER BY' => 'count DESC',
-				'GROUP BY' => 'o_hash'
-			]
-		);
+		$res = $this->store->getConnection()->newSelectQueryBuilder()
+			->select( 'o_hash, COUNT(s_id) AS count' )
+			->from( $this->findPropertyTableByType( '_ASKFO' )->getName() )
+			->groupBy( 'o_hash' )
+			->orderBy( 'count DESC' )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		foreach ( $res as $row ) {
 			$count[$row->o_hash] = (int)$row->count;
@@ -178,8 +175,6 @@ class UsageStatisticsListLookup implements ListLookup {
 	 * @return int
 	 */
 	public function getPropertyPageCount() {
-		$options = [];
-
 		// Only match entities that have a NOT null smw_proptable_hash entry
 		// which indicates that it is not a object but a subject value (has
 		// annotations such as `has type` == page was created with ... etc.)
@@ -193,14 +188,13 @@ class UsageStatisticsListLookup implements ListLookup {
 		$db = $this->store->getConnection( 'mw.db' );
 
 		// Select object ID's against known property ID's that match the conditions
-		$res = $db->select(
-			[ SQLStore::ID_TABLE, SQLStore::PROPERTY_STATISTICS_TABLE ],
-			'smw_id',
-			$conditions,
-			__METHOD__,
-			$options,
-			[ SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=p_id' ] ] ]
-		);
+		$res = $db->newSelectQueryBuilder()
+			->select( 'smw_id' )
+			->from( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->join( SQLStore::ID_TABLE, null, [ 'smw_id=p_id' ] )
+			->where( $conditions )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		return $res->numRows();
 	}
@@ -219,12 +213,11 @@ class UsageStatisticsListLookup implements ListLookup {
 	public function getPropertyUsageCount(): int {
 		$count = 0;
 
-		$row = $this->store->getConnection()->selectRow(
-			[ SQLStore::PROPERTY_STATISTICS_TABLE ],
-			'SUM( usage_count ) AS count',
-			[],
-			__METHOD__
-		);
+		$row = $this->store->getConnection()->newSelectQueryBuilder()
+			->select( 'SUM( usage_count ) AS count' )
+			->from( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		$count = $row ? $row->count : $count;
 
@@ -245,12 +238,12 @@ class UsageStatisticsListLookup implements ListLookup {
 			'smw_subobject' => ''
 		];
 
-		$row = $this->store->getConnection()->selectRow(
-			SQLStore::ID_TABLE,
-			'Count( * ) AS count',
-			$conditions,
-			__METHOD__
-		);
+		$row = $this->store->getConnection()->newSelectQueryBuilder()
+			->select( 'Count( * ) AS count' )
+			->from( SQLStore::ID_TABLE )
+			->where( $conditions )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		$count = $row ? $row->count : $count;
 
@@ -265,12 +258,11 @@ class UsageStatisticsListLookup implements ListLookup {
 	public function getTotalEntitiesCount(): int {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$row = $connection->selectRow(
-			SQLStore::ID_TABLE,
-			'Count( * ) AS count',
-			[],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( 'Count( * ) AS count' )
+			->from( SQLStore::ID_TABLE )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return isset( $row->count ) ? (int)$row->count : 0;
 	}
@@ -281,8 +273,6 @@ class UsageStatisticsListLookup implements ListLookup {
 	 * @return int
 	 */
 	public function getUsedPropertiesCount() {
-		$options = [];
-
 		$conditions = [
 			'smw_namespace' => SMW_NS_PROPERTY,
 			'smw_iw' => '',
@@ -293,16 +283,13 @@ class UsageStatisticsListLookup implements ListLookup {
 		$db = $this->store->getConnection( 'mw.db' );
 
 		// Select object ID's against known property ID's that match the conditions
-		$res = $db->select(
-			[ SQLStore::ID_TABLE, SQLStore::PROPERTY_STATISTICS_TABLE ],
-			'smw_id',
-			$conditions,
-			__METHOD__,
-			$options,
-			[
-				SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=p_id' ] ]
-			]
-		);
+		$res = $db->newSelectQueryBuilder()
+			->select( 'smw_id' )
+			->from( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->join( SQLStore::ID_TABLE, null, [ 'smw_id=p_id' ] )
+			->where( $conditions )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		return $res->numRows();
 	}
@@ -315,12 +302,12 @@ class UsageStatisticsListLookup implements ListLookup {
 	public function getDeleteCount(): int {
 		$count = 0;
 
-		$row = $this->store->getConnection()->selectRow(
-			SQLStore::ID_TABLE,
-			'Count( * ) AS count',
-			[ 'smw_iw' => ':smw-delete' ],
-			__METHOD__
-		);
+		$row = $this->store->getConnection()->newSelectQueryBuilder()
+			->select( 'Count( * ) AS count' )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_iw' => ':smw-delete' ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		$count = $row ? $row->count : $count;
 
@@ -328,12 +315,11 @@ class UsageStatisticsListLookup implements ListLookup {
 	}
 
 	private function count( string $type ): int {
-		$res = $this->store->getConnection()->select(
-			$this->findPropertyTableByType( $type )->getName(),
-			'COUNT(s_id) AS count',
-			[],
-			__METHOD__
-		);
+		$res = $this->store->getConnection()->newSelectQueryBuilder()
+			->select( 'COUNT(s_id) AS count' )
+			->from( $this->findPropertyTableByType( $type )->getName() )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		$row = $res->fetchObject();
 

--- a/src/SQLStore/PropertyTable/PropertyTableHashes.php
+++ b/src/SQLStore/PropertyTable/PropertyTableHashes.php
@@ -45,14 +45,12 @@ class PropertyTableHashes {
 			throw new RuntimeException( "Expected a null or an array as value!" );
 		}
 
-		$this->connection->update(
-			SQLStore::ID_TABLE,
-			$update,
-			[
-				'smw_id' => $id
-			],
-			__METHOD__
-		);
+		$this->connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( $update )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
 /*
 		$smw_proptable = $hash === null ? null : serialize( $hash );
@@ -100,16 +98,12 @@ class PropertyTableHashes {
 			return $hash;
 		}
 
-		$row = $this->connection->selectRow(
-			SQLStore::ID_TABLE,
-			[
-				'smw_proptable_hash'
-			],
-			[
-				'smw_id' => $id
-			],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_proptable_hash' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row !== false ) {
 			$hash = $row->smw_proptable_hash;

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -7,6 +7,7 @@ use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\DataItems\WikiPage;
 use SMW\Iterators\ResultIterator;
 use SMW\MediaWiki\Connection\Database;
+use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\RequestOptions;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use stdClass;
@@ -131,19 +132,18 @@ class PropertyTableIdReferenceDisposer {
 		if ( $requestOptions !== null ) {
 			$options = [
 				'LIMIT'  => $requestOptions->getLimit(),
-				'OFFSET' => $requestOptions->getOffset()
+				'OFFSET' => $requestOptions->getOffset(),
 			];
 		}
 
-		$res = $this->connection->select(
-			SQLStore::ID_TABLE,
-			[ 'smw_id' ],
-			[ 'smw_iw' => SMW_SQL3_SMWDELETEIW ],
-			__METHOD__,
-			$options
-		);
+		$qb = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_id' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_iw' => SMW_SQL3_SMWDELETEIW ] );
 
-		return new ResultIterator( $res );
+		LegacyOptionsApplier::applyTo( $qb, $options );
+
+		return new ResultIterator( $qb->caller( __METHOD__ )->fetchResultSet() );
 	}
 
 	/**
@@ -159,21 +159,18 @@ class PropertyTableIdReferenceDisposer {
 		if ( $requestOptions !== null ) {
 			$options = [
 				'LIMIT'  => $requestOptions->getLimit(),
-				'OFFSET' => $requestOptions->getOffset()
+				'OFFSET' => $requestOptions->getOffset(),
 			];
 		}
 
-		$res = $this->connection->select(
-			SQLStore::ID_TABLE,
-			[ 'smw_id' ],
-			[
-				'smw_namespace NOT IN (' . $this->connection->makeList( array_keys( $this->namespacesWithSemanticLinks ) ) . ')'
-			],
-			__METHOD__,
-			$options
-		);
+		$qb = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_id' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( 'smw_namespace NOT IN (' . $this->connection->makeList( array_keys( $this->namespacesWithSemanticLinks ) ) . ')' );
 
-		return new ResultIterator( $res );
+		LegacyOptionsApplier::applyTo( $qb, $options );
+
+		return new ResultIterator( $qb->caller( __METHOD__ )->fetchResultSet() );
 	}
 
 	/**
@@ -229,30 +226,30 @@ class PropertyTableIdReferenceDisposer {
 
 		foreach ( $this->store->getPropertyTables() as $proptable ) {
 			if ( $proptable->usesIdSubject() ) {
-				$this->connection->delete(
-					$proptable->getName(),
-					[ 's_id' => $id ],
-					__METHOD__
-				);
+				$this->connection->newDeleteQueryBuilder()
+					->deleteFrom( $proptable->getName() )
+					->where( [ 's_id' => $id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 
 			if ( !$proptable->isFixedPropertyTable() ) {
-				$this->connection->delete(
-					$proptable->getName(),
-					[ 'p_id' => $id ],
-					__METHOD__
-				);
+				$this->connection->newDeleteQueryBuilder()
+					->deleteFrom( $proptable->getName() )
+					->where( [ 'p_id' => $id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 
 			$fields = $proptable->getFields( $this->store );
 
 			// Match tables (including ftp_redi) that contain an object reference
 			if ( isset( $fields['o_id'] ) ) {
-				$this->connection->delete(
-					$proptable->getName(),
-					[ 'o_id' => $id ],
-					__METHOD__
-				);
+				$this->connection->newDeleteQueryBuilder()
+					->deleteFrom( $proptable->getName() )
+					->where( [ 'o_id' => $id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 		}
 
@@ -270,36 +267,36 @@ class PropertyTableIdReferenceDisposer {
 	private function cleanUpSecondaryReferencesById( $id, bool $isRedirect ): void {
 		// When marked as redirect, don't remove the reference
 		if ( !$isRedirect || $this->redirectRemoval ) {
-			$this->connection->delete(
-				SQLStore::ID_TABLE,
-				[ 'smw_id' => $id ],
-				__METHOD__
-			);
+			$this->connection->newDeleteQueryBuilder()
+				->deleteFrom( SQLStore::ID_TABLE )
+				->where( [ 'smw_id' => $id ] )
+				->caller( __METHOD__ )
+				->execute();
 		}
 
-		$this->connection->delete(
-			SQLStore::ID_AUXILIARY_TABLE,
-			[ 'smw_id' => $id ],
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::ID_AUXILIARY_TABLE )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$this->connection->delete(
-			SQLStore::PROPERTY_STATISTICS_TABLE,
-			[ 'p_id' => $id ],
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->where( [ 'p_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$this->connection->delete(
-			SQLStore::QUERY_LINKS_TABLE,
-			[ 's_id' => $id ],
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 's_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$this->connection->delete(
-			SQLStore::QUERY_LINKS_TABLE,
-			[ 'o_id' => $id ],
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 'o_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$tableExists = false;
 
@@ -314,7 +311,11 @@ class PropertyTableIdReferenceDisposer {
 		}
 
 		if ( $tableExists ) {
-			$this->connection->delete( SQLStore::FT_SEARCH_TABLE, [ 's_id' => $id ], __METHOD__ );
+			$this->connection->newDeleteQueryBuilder()
+				->deleteFrom( SQLStore::FT_SEARCH_TABLE )
+				->where( [ 's_id' => $id ] )
+				->caller( __METHOD__ )
+				->execute();
 		}
 	}
 

--- a/src/SQLStore/PropertyTableIdReferenceFinder.php
+++ b/src/SQLStore/PropertyTableIdReferenceFinder.php
@@ -187,12 +187,12 @@ class PropertyTableIdReferenceFinder {
 		$row = false;
 
 		if ( $proptable->usesIdSubject() ) {
-			$row = $this->connection->selectRow(
-				$proptable->getName(),
-				[ 's_id' ],
-				[ 's_id' => $id ],
-				__METHOD__
-			);
+			$row = $this->connection->newSelectQueryBuilder()
+				->select( [ 's_id' ] )
+				->from( $proptable->getName() )
+				->where( [ 's_id' => $id ] )
+				->caller( __METHOD__ )
+				->fetchRow();
 		}
 
 		if ( $row !== false ) {
@@ -207,12 +207,12 @@ class PropertyTableIdReferenceFinder {
 			// This next time someone ... I'm going to Alaska
 			$field = preg_match( '/redi$/', $proptable->getName() ?? '' ) ? [ 's_title', 's_namespace' ] : [ 's_id' ];
 
-			$row = $this->connection->selectRow(
-				$proptable->getName(),
-				$field,
-				[ 'o_id' => $id ],
-				__METHOD__
-			);
+			$row = $this->connection->newSelectQueryBuilder()
+				->select( $field )
+				->from( $proptable->getName() )
+				->where( [ 'o_id' => $id ] )
+				->caller( __METHOD__ )
+				->fetchRow();
 
 			if ( $row !== false && strpos( $proptable->getName(), 'redi' ) ) {
 				$row->s_id = $this->store->getObjectIds()->findRedirect( $row->s_title, $row->s_namespace );
@@ -223,12 +223,12 @@ class PropertyTableIdReferenceFinder {
 		// table to a specific property with the p_id column being suppressed)
 		// then check for the p_id field
 		if ( $row === false && !$proptable->isFixedPropertyTable() ) {
-			$row = $this->connection->selectRow(
-				$proptable->getName(),
-				[ 's_id' ],
-				[ 'p_id' => $id ],
-				__METHOD__
-			);
+			$row = $this->connection->newSelectQueryBuilder()
+				->select( [ 's_id' ] )
+				->from( $proptable->getName() )
+				->where( [ 'p_id' => $id ] )
+				->caller( __METHOD__ )
+				->fetchRow();
 		}
 
 		return $row;
@@ -238,12 +238,12 @@ class PropertyTableIdReferenceFinder {
 		// If the query table contains a reference then we keep the object (could
 		// be a subject, property, or printrequest) where in case the query is
 		// removed the object will also loose its reference
-		$row = $this->connection->selectRow(
-			SQLStore::QUERY_LINKS_TABLE,
-			[ 's_id' ],
-			[ 'o_id' => $id ],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 's_id' ] )
+			->from( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 'o_id' => $id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return $row;
 	}

--- a/src/SQLStore/PropertyTableRowDiffer.php
+++ b/src/SQLStore/PropertyTableRowDiffer.php
@@ -193,14 +193,12 @@ class PropertyTableRowDiffer {
 
 				// #3849
 				// Check the table that wasn't part of the old and new hash
-				$row = $connection->selectRow(
-					$propertyTable->getName(),
-					's_id',
-					[
-						's_id' => $sid
-					],
-					__METHOD__
-				);
+				$row = $connection->newSelectQueryBuilder()
+					->select( 's_id' )
+					->from( $propertyTable->getName() )
+					->where( [ 's_id' => $sid ] )
+					->caller( __METHOD__ )
+					->fetchRow();
 
 				// Find and remove any remnants (ghosts) from possible failed
 				// updates that weren't rollback correctly
@@ -272,12 +270,12 @@ class PropertyTableRowDiffer {
 		$contents = [];
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$result = $connection->select(
-			$propertyTable->getName(),
-			'*',
-			[ 's_id' => $sid ],
-			__METHOD__
-		);
+		$result = $connection->newSelectQueryBuilder()
+			->select( '*' )
+			->from( $propertyTable->getName() )
+			->where( [ 's_id' => $sid ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		foreach ( $result as $row ) {
 			if ( is_object( $row ) ) {

--- a/src/SQLStore/PropertyTableRowMapper.php
+++ b/src/SQLStore/PropertyTableRowMapper.php
@@ -281,12 +281,12 @@ class PropertyTableRowMapper {
 		}
 
 		// Add existing cache status data to this row:
-		$row = $connection->selectRow(
-			'smw_fpt_conc',
-			[ 'cache_date', 'cache_count' ],
-			[ 's_id' => $sid ],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'cache_date', 'cache_count' ] )
+			->from( 'smw_fpt_conc' )
+			->where( [ 's_id' => $sid ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row === false ) {
 			$insertValues['cache_date'] = null;

--- a/src/SQLStore/PropertyTableUpdater.php
+++ b/src/SQLStore/PropertyTableUpdater.php
@@ -173,11 +173,11 @@ class PropertyTableUpdater {
 		$connection = $this->store->getConnection( 'mw.db' );
 		$tableName = $propertyTable->getName();
 
-		$connection->insert(
-			$tableName,
-			$rows,
-			__METHOD__ . "-$tableName"
-		);
+		$connection->newInsertQueryBuilder()
+			->insertInto( $tableName )
+			->rows( $rows )
+			->caller( __METHOD__ . "-$tableName" )
+			->execute();
 	}
 
 	private function delete( PropertyTableDefinition $propertyTable, array $rows ): void {
@@ -215,11 +215,11 @@ class PropertyTableUpdater {
 
 		$condition = "s_id=" . $connection->addQuotes( $sid ) . " AND ($condition)";
 
-		$connection->delete(
-			$tableName,
-			[ $condition ],
-			__METHOD__ . "-$tableName"
-		);
+		$connection->newDeleteQueryBuilder()
+			->deleteFrom( $tableName )
+			->where( $condition )
+			->caller( __METHOD__ . "-$tableName" )
+			->execute();
 	}
 
 	private function aggregate_ids( array &$ids, $propertyTable, $rows ): void {
@@ -261,16 +261,12 @@ class PropertyTableUpdater {
 		// onTransctionIdle( ... ) to avoid locking the rows for succeeding
 		// updates?
 
-		$connection->update(
-			SQLStore::ID_TABLE,
-			[
-				'smw_touched' => $touched
-			],
-			[
-				'smw_id' => $ids
-			],
-			__METHOD__
-		);
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( [ 'smw_touched' => $touched ] )
+			->where( [ 'smw_id' => $ids ] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 }

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -34,6 +34,8 @@ use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\SQLStoreFactory;
 use SMW\SQLStore\SQLStoreUpdater;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @group semantic-mediawiki
@@ -44,6 +46,9 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $mwHooksHandler;
@@ -118,6 +123,22 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends TestCase {
 			$connection->expects( $this->any() )
 				->method( 'selectRow' )
 				->willReturn( false );
+
+			$connection->expects( $this->any() )
+				->method( 'newSelectQueryBuilder' )
+				->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
+
+			$connection->expects( $this->any() )
+				->method( 'newInsertQueryBuilder' )
+				->willReturnCallback( fn () => $this->createMockInsertQueryBuilder() );
+
+			$connection->expects( $this->any() )
+				->method( 'newUpdateQueryBuilder' )
+				->willReturnCallback( fn () => $this->createMockUpdateQueryBuilder() );
+
+			$connection->expects( $this->any() )
+				->method( 'newDeleteQueryBuilder' )
+				->willReturnCallback( fn () => $this->createMockDeleteQueryBuilder() );
 		}
 
 		return $connection;

--- a/tests/phpunit/Unit/Elastic/ElasticStoreTest.php
+++ b/tests/phpunit/Unit/Elastic/ElasticStoreTest.php
@@ -19,6 +19,8 @@ use SMW\Options;
 use SMW\SetupFile;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -31,6 +33,9 @@ use stdClass;
  * @author mwjames
  */
 class ElasticStoreTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $elasticFactory;
@@ -309,9 +314,15 @@ class ElasticStoreTest extends TestCase {
 			->method( 'getType' )
 			->willReturn( 'mysql' );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
 		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
+
+		$insertBuilder = $this->createMockInsertQueryBuilder();
+		$connection->expects( $this->any() )
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/PValueLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/PValueLookupTest.php
@@ -9,9 +9,8 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\Lookup\ProximityPropertyValueLookup;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\MediaWiki\Api\Browse\PValueLookup
@@ -23,6 +22,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class PValueLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 
@@ -308,51 +309,6 @@ class PValueLookupTest extends TestCase {
 			}
 		}
 		return $flat;
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where chained methods return $this,
-	 * fetchResultSet() returns the given rows wrapped in FakeResultWrapper,
-	 * and andWhere() arguments are captured into $whereConditions for
-	 * inspection by tests.
-	 */
-	private function createMockSelectQueryBuilder(
-		array $rows = [],
-		array &$whereConditions = []
-	) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'select', 'fields', 'field', 'from', 'table',
-			'join', 'leftJoin', 'where', 'groupBy', 'having', 'orderBy',
-			'caller', 'distinct', 'limit', 'offset', 'options', 'option' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'andWhere' )
-			->willReturnCallback( static function ( $conds ) use ( $queryBuilder, &$whereConditions ) {
-				$whereConditions[] = $conds;
-				return $queryBuilder;
-			} );
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'newSubquery' )
-			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder(
-				$rows,
-				$whereConditions
-			) );
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchResultSet' )
-			->willReturn( new FakeResultWrapper( $rows ) );
-
-		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/PValueLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/PValueLookupTest.php
@@ -6,12 +6,12 @@ use PHPUnit\Framework\TestCase;
 use SMW\DataItems\Property;
 use SMW\MediaWiki\Api\Browse\PValueLookup;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\Lookup\ProximityPropertyValueLookup;
 use SMW\SQLStore\SQLStore;
 use stdClass;
 use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\MediaWiki\Api\Browse\PValueLookup
@@ -53,19 +53,20 @@ class PValueLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$query = new Query( $connection );
-
 		$connection->expects( $this->any() )
 			->method( 'addQuotes' )
 			->willReturnArgument( 0 );
 
-		$connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $query );
+		$whereConditions = [];
 
-		$connection->expects( $this->atLeastOnce() )
-			->method( 'query' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( function () use ( $row, &$whereConditions ) {
+				return $this->createMockSelectQueryBuilder(
+					[ $row ],
+					$whereConditions
+				);
+			} );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
@@ -118,9 +119,11 @@ class PValueLookupTest extends TestCase {
 			$res['query']
 		);
 
-		$this->assertStringContainsString(
-			'[{"OR":"smw_sortkey LIKE %Foo%"},{"OR":"smw_sortkey LIKE %Foo%"},{"OR":"smw_sortkey LIKE %FOO%"}]',
-			$query->__toString()
+		$flat = $this->flattenWhereConditions( $whereConditions );
+
+		$this->assertContains(
+			'(smw_sortkey LIKE %Foo% OR smw_sortkey LIKE %Foo% OR smw_sortkey LIKE %FOO%)',
+			$flat
 		);
 	}
 
@@ -129,21 +132,24 @@ class PValueLookupTest extends TestCase {
 		$row->smw_title = 'Test';
 		$row->smw_id = 42;
 
-		$query = $this->getMockBuilder( Query::class )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $query );
+			->method( 'addQuotes' )
+			->willReturnArgument( 0 );
 
-		$connection->expects( $this->atLeastOnce() )
-			->method( 'query' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$whereConditions = [];
+
+		$connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( function () use ( $row, &$whereConditions ) {
+				return $this->createMockSelectQueryBuilder(
+					[ $row ],
+					$whereConditions
+				);
+			} );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
@@ -203,19 +209,20 @@ class PValueLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$query = new Query( $connection );
-
 		$connection->expects( $this->any() )
 			->method( 'addQuotes' )
 			->willReturnArgument( 0 );
 
-		$connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $query );
+		$whereConditions = [];
 
-		$connection->expects( $this->atLeastOnce() )
-			->method( 'query' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( function () use ( $row, &$whereConditions ) {
+				return $this->createMockSelectQueryBuilder(
+					[ $row ],
+					$whereConditions
+				);
+			} );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
@@ -272,10 +279,80 @@ class PValueLookupTest extends TestCase {
 			$res['query']
 		);
 
-		$this->assertStringContainsString(
-			'[{"OR":"o_hash LIKE %Foo%"},{"OR":"o_hash LIKE %Foo%"},{"OR":"o_hash LIKE %FOO%"},{"AND":"p_id=42"}]',
-			$query->__toString()
+		$flat = $this->flattenWhereConditions( $whereConditions );
+
+		$this->assertContains(
+			'(o_hash LIKE %Foo% OR o_hash LIKE %Foo% OR o_hash LIKE %FOO%)',
+			$flat
 		);
+
+		$this->assertContains(
+			[ 'p_id' => 42 ],
+			$whereConditions
+		);
+	}
+
+	/**
+	 * Flatten a list of captured andWhere() arguments into a list of strings
+	 * for easy substring assertions.
+	 */
+	private function flattenWhereConditions( array $conditions ): array {
+		$flat = [];
+		foreach ( $conditions as $cond ) {
+			if ( is_string( $cond ) ) {
+				$flat[] = $cond;
+			} elseif ( is_array( $cond ) ) {
+				foreach ( $cond as $k => $v ) {
+					$flat[] = is_int( $k ) ? (string)$v : "$k=$v";
+				}
+			}
+		}
+		return $flat;
+	}
+
+	/**
+	 * Creates a mock SelectQueryBuilder where chained methods return $this,
+	 * fetchResultSet() returns the given rows wrapped in FakeResultWrapper,
+	 * and andWhere() arguments are captured into $whereConditions for
+	 * inspection by tests.
+	 */
+	private function createMockSelectQueryBuilder(
+		array $rows = [],
+		array &$whereConditions = []
+	) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'select', 'fields', 'field', 'from', 'table',
+			'join', 'leftJoin', 'where', 'groupBy', 'having', 'orderBy',
+			'caller', 'distinct', 'limit', 'offset', 'options', 'option' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'andWhere' )
+			->willReturnCallback( static function ( $conds ) use ( $queryBuilder, &$whereConditions ) {
+				$whereConditions[] = $conds;
+				return $queryBuilder;
+			} );
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'newSubquery' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder(
+				$rows,
+				$whereConditions
+			) );
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Connection/LegacyOptionsApplierTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/LegacyOptionsApplierTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SMW\Tests\Unit\MediaWiki\Connection;
+
+use PHPUnit\Framework\TestCase;
+use SMW\MediaWiki\Connection\LegacyOptionsApplier;
+use Wikimedia\Rdbms\SelectQueryBuilder;
+
+/**
+ * @covers \SMW\MediaWiki\Connection\LegacyOptionsApplier
+ *
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class LegacyOptionsApplierTest extends TestCase {
+
+	public function testEmptyOptionsAppliesNothing(): void {
+		$queryBuilder = $this->createMock( SelectQueryBuilder::class );
+
+		$queryBuilder->expects( $this->never() )->method( 'limit' );
+		$queryBuilder->expects( $this->never() )->method( 'offset' );
+		$queryBuilder->expects( $this->never() )->method( 'orderBy' );
+		$queryBuilder->expects( $this->never() )->method( 'groupBy' );
+		$queryBuilder->expects( $this->never() )->method( 'having' );
+		$queryBuilder->expects( $this->never() )->method( 'distinct' );
+
+		LegacyOptionsApplier::applyTo( $queryBuilder, [] );
+	}
+
+	public function testAppliesAllRecognisedOptions(): void {
+		$queryBuilder = $this->createMock( SelectQueryBuilder::class );
+
+		$queryBuilder->expects( $this->once() )->method( 'limit' )->with( 50 )->willReturnSelf();
+		$queryBuilder->expects( $this->once() )->method( 'offset' )->with( 10 )->willReturnSelf();
+		$queryBuilder->expects( $this->once() )->method( 'orderBy' )->with( 'smw_sort' )->willReturnSelf();
+		$queryBuilder->expects( $this->once() )->method( 'groupBy' )->with( 'smw_id' )->willReturnSelf();
+		$queryBuilder->expects( $this->once() )->method( 'having' )->with( 'COUNT(*) > 1' )->willReturnSelf();
+		$queryBuilder->expects( $this->once() )->method( 'distinct' )->willReturnSelf();
+
+		LegacyOptionsApplier::applyTo( $queryBuilder, [
+			'LIMIT' => 50,
+			'OFFSET' => 10,
+			'ORDER BY' => 'smw_sort',
+			'GROUP BY' => 'smw_id',
+			'HAVING' => 'COUNT(*) > 1',
+			'DISTINCT' => true,
+		] );
+	}
+
+	public function testRecognisesNumericKeyedDistinct(): void {
+		$queryBuilder = $this->createMock( SelectQueryBuilder::class );
+
+		$queryBuilder->expects( $this->once() )->method( 'distinct' )->willReturnSelf();
+
+		LegacyOptionsApplier::applyTo( $queryBuilder, [ 'DISTINCT' ] );
+	}
+
+	public function testIgnoresUnknownKeys(): void {
+		$queryBuilder = $this->createMock( SelectQueryBuilder::class );
+
+		$queryBuilder->expects( $this->never() )->method( 'limit' );
+
+		// No method is invoked: arbitrary keys do not match any branch.
+		LegacyOptionsApplier::applyTo( $queryBuilder, [
+			'STRAIGHT_JOIN' => true,
+			'FOR UPDATE' => true,
+		] );
+
+		// Explicit assertion so the test is not flagged risky in strict mode.
+		$this->addToAssertionCount( 1 );
+	}
+}

--- a/tests/phpunit/Unit/MediaWiki/Connection/MockSelectQueryBuilderTrait.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/MockSelectQueryBuilderTrait.php
@@ -37,7 +37,7 @@ trait MockSelectQueryBuilderTrait {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$chainMethods = [ 'fields', 'field', 'from', 'table', 'tables',
+		$chainMethods = [ 'fields', 'field', 'from', 'table', 'tables', 'rawTables',
 			'join', 'leftJoin', 'straightJoin', 'joinConds',
 			'groupBy', 'having', 'orderBy', 'caller', 'distinct',
 			'limit', 'offset', 'options', 'option', 'conds',

--- a/tests/phpunit/Unit/MediaWiki/Connection/MockSelectQueryBuilderTrait.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/MockSelectQueryBuilderTrait.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace SMW\Tests\Unit\MediaWiki\Connection;
+
+use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
+
+/**
+ * Test helper for mocking `SelectQueryBuilder` chains. Returns a builder mock
+ * where every chain method returns the builder itself, where()/andWhere()
+ * arguments are captured into a shared array, fetchResultSet() returns the
+ * given rows wrapped in FakeResultWrapper, fetchRow() returns the first row
+ * (or false if empty), and fetchField() returns the first row's first scalar
+ * value. newSubquery() returns a child mock sharing the same captured
+ * conditions array.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+trait MockSelectQueryBuilderTrait {
+
+	/**
+	 * @param array $rows Rows for the builder to return on fetch* calls.
+	 *   Each row is typically a stdClass or associative array.
+	 * @param array &$whereConditions Captures where()/andWhere() arguments
+	 *   for assertion. Subqueries share the same array.
+	 * @param array &$capturedSelects Captures select() arguments for
+	 *   assertion. When omitted, select() simply returns the builder.
+	 *   Subqueries share the same array.
+	 */
+	private function createMockSelectQueryBuilder(
+		array $rows = [],
+		array &$whereConditions = [],
+		array &$capturedSelects = []
+	): SelectQueryBuilder {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'fields', 'field', 'from', 'table', 'tables',
+			'join', 'leftJoin', 'straightJoin', 'joinConds',
+			'groupBy', 'having', 'orderBy', 'caller', 'distinct',
+			'limit', 'offset', 'options', 'option', 'conds',
+			'useIndex', 'ignoreIndex', 'recency', 'clearFields',
+			'lockInShareMode', 'forUpdate' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$captureWhere = static function ( $conds ) use ( $queryBuilder, &$whereConditions ) {
+			$whereConditions[] = $conds;
+			return $queryBuilder;
+		};
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'where' )
+			->willReturnCallback( $captureWhere );
+		$queryBuilder->expects( $this->any() )
+			->method( 'andWhere' )
+			->willReturnCallback( $captureWhere );
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'select' )
+			->willReturnCallback( static function ( $fields ) use ( $queryBuilder, &$capturedSelects ) {
+				$capturedSelects[] = $fields;
+				return $queryBuilder;
+			} );
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'newSubquery' )
+			->willReturnCallback(
+				fn () => $this->createMockSelectQueryBuilder( $rows, $whereConditions, $capturedSelects )
+			);
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		$firstRow = $rows[0] ?? false;
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchRow' )
+			->willReturn( $firstRow );
+
+		$firstField = false;
+		if ( is_object( $firstRow ) ) {
+			$vars = get_object_vars( $firstRow );
+			$firstField = $vars[array_key_first( $vars )] ?? false;
+		} elseif ( is_array( $firstRow ) ) {
+			$firstField = reset( $firstRow );
+		}
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchField' )
+			->willReturn( $firstField );
+
+		return $queryBuilder;
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Connection/MockWriteQueryBuilderTrait.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/MockWriteQueryBuilderTrait.php
@@ -1,0 +1,211 @@
+<?php
+
+namespace SMW\Tests\Unit\MediaWiki\Connection;
+
+use Wikimedia\Rdbms\DeleteQueryBuilder;
+use Wikimedia\Rdbms\InsertQueryBuilder;
+use Wikimedia\Rdbms\ReplaceQueryBuilder;
+use Wikimedia\Rdbms\UpdateQueryBuilder;
+
+/**
+ * Test helper for mocking the write-side QueryBuilder chains
+ * (`InsertQueryBuilder`, `UpdateQueryBuilder`, `DeleteQueryBuilder`,
+ * `ReplaceQueryBuilder`). Each helper returns a chainable mock that
+ * captures the most relevant arguments into shared arrays so individual
+ * tests can assert on the row data, set clause, where conditions etc.
+ *
+ * `execute()` is stubbed (does nothing). Tests still need to wire the
+ * mock into the `Database` mock via `expects()->method('new*QueryBuilder')
+ * ->willReturn( $mock )`.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+trait MockWriteQueryBuilderTrait {
+
+	/**
+	 * @param array &$tables Captures `insertInto()`/`insert()`/`table()`
+	 *   arguments in call order. Successive calls append.
+	 * @param array &$rows Captures `row()` and `rows()` arguments in call
+	 *   order. `row($a)` followed by `rows([$b, $c])` yields
+	 *   `[$a, [$b, $c]]`.
+	 * @param array &$sets Captures `set()`/`andSet()` arguments in call
+	 *   order. Successive calls append.
+	 * @param array &$uniqueIndexFields Captures `uniqueIndexFields()`
+	 *   arguments in call order. Successive calls append.
+	 */
+	private function createMockInsertQueryBuilder(
+		array &$tables = [],
+		array &$rows = [],
+		array &$sets = [],
+		array &$uniqueIndexFields = []
+	): InsertQueryBuilder {
+		$builder = $this->getMockBuilder( InsertQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$captureTable = static function ( $table ) use ( $builder, &$tables ) {
+			$tables[] = $table;
+			return $builder;
+		};
+		$builder->method( 'insertInto' )->willReturnCallback( $captureTable );
+		$builder->method( 'insert' )->willReturnCallback( $captureTable );
+		$builder->method( 'table' )->willReturnCallback( $captureTable );
+
+		$captureRow = static function ( $row ) use ( $builder, &$rows ) {
+			$rows[] = $row;
+			return $builder;
+		};
+		$builder->method( 'row' )->willReturnCallback( $captureRow );
+		$builder->method( 'rows' )->willReturnCallback( $captureRow );
+
+		$captureSet = static function ( $set ) use ( $builder, &$sets ) {
+			$sets[] = $set;
+			return $builder;
+		};
+		$builder->method( 'set' )->willReturnCallback( $captureSet );
+		$builder->method( 'andSet' )->willReturnCallback( $captureSet );
+
+		$captureUnique = static function ( $fields ) use ( $builder, &$uniqueIndexFields ) {
+			$uniqueIndexFields[] = $fields;
+			return $builder;
+		};
+		$builder->method( 'uniqueIndexFields' )->willReturnCallback( $captureUnique );
+
+		foreach ( [ 'onDuplicateKeyUpdate', 'ignore', 'caller', 'option', 'options' ] as $passthrough ) {
+			$builder->method( $passthrough )->willReturn( $builder );
+		}
+
+		$builder->method( 'execute' );
+
+		return $builder;
+	}
+
+	/**
+	 * @param array &$tables Captures `update()`/`table()` arguments in call
+	 *   order. Successive calls append.
+	 * @param array &$sets Captures `set()`/`andSet()` arguments in call
+	 *   order. Successive calls append.
+	 * @param array &$wheres Captures `where()`/`andWhere()`/`conds()`
+	 *   arguments in call order. Successive calls append.
+	 */
+	private function createMockUpdateQueryBuilder(
+		array &$tables = [],
+		array &$sets = [],
+		array &$wheres = []
+	): UpdateQueryBuilder {
+		$builder = $this->getMockBuilder( UpdateQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$captureTable = static function ( $table ) use ( $builder, &$tables ) {
+			$tables[] = $table;
+			return $builder;
+		};
+		$builder->method( 'update' )->willReturnCallback( $captureTable );
+		$builder->method( 'table' )->willReturnCallback( $captureTable );
+
+		$captureSet = static function ( $set ) use ( $builder, &$sets ) {
+			$sets[] = $set;
+			return $builder;
+		};
+		$builder->method( 'set' )->willReturnCallback( $captureSet );
+		$builder->method( 'andSet' )->willReturnCallback( $captureSet );
+
+		$captureWhere = static function ( $cond ) use ( $builder, &$wheres ) {
+			$wheres[] = $cond;
+			return $builder;
+		};
+		$builder->method( 'where' )->willReturnCallback( $captureWhere );
+		$builder->method( 'andWhere' )->willReturnCallback( $captureWhere );
+		$builder->method( 'conds' )->willReturnCallback( $captureWhere );
+
+		foreach ( [ 'ignore', 'caller', 'option', 'options' ] as $passthrough ) {
+			$builder->method( $passthrough )->willReturn( $builder );
+		}
+
+		$builder->method( 'execute' );
+
+		return $builder;
+	}
+
+	/**
+	 * @param array &$tables Captures `deleteFrom()`/`delete()`/`table()`
+	 *   arguments in call order. Successive calls append.
+	 * @param array &$wheres Captures `where()`/`andWhere()`/`conds()`
+	 *   arguments in call order. Successive calls append.
+	 */
+	private function createMockDeleteQueryBuilder(
+		array &$tables = [],
+		array &$wheres = []
+	): DeleteQueryBuilder {
+		$builder = $this->getMockBuilder( DeleteQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$captureTable = static function ( $table ) use ( $builder, &$tables ) {
+			$tables[] = $table;
+			return $builder;
+		};
+		$builder->method( 'deleteFrom' )->willReturnCallback( $captureTable );
+		$builder->method( 'delete' )->willReturnCallback( $captureTable );
+		$builder->method( 'table' )->willReturnCallback( $captureTable );
+
+		$captureWhere = static function ( $cond ) use ( $builder, &$wheres ) {
+			$wheres[] = $cond;
+			return $builder;
+		};
+		$builder->method( 'where' )->willReturnCallback( $captureWhere );
+		$builder->method( 'andWhere' )->willReturnCallback( $captureWhere );
+		$builder->method( 'conds' )->willReturnCallback( $captureWhere );
+
+		$builder->method( 'caller' )->willReturn( $builder );
+		$builder->method( 'execute' );
+
+		return $builder;
+	}
+
+	/**
+	 * @param array &$tables Captures `replaceInto()`/`table()` arguments in
+	 *   call order. Successive calls append.
+	 * @param array &$rows Captures `row()` and `rows()` arguments in call
+	 *   order. `row($a)` followed by `rows([$b, $c])` yields
+	 *   `[$a, [$b, $c]]`.
+	 * @param array &$uniqueIndexFields Captures `uniqueIndexFields()`
+	 *   arguments in call order. Successive calls append.
+	 */
+	private function createMockReplaceQueryBuilder(
+		array &$tables = [],
+		array &$rows = [],
+		array &$uniqueIndexFields = []
+	): ReplaceQueryBuilder {
+		$builder = $this->getMockBuilder( ReplaceQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$captureTable = static function ( $table ) use ( $builder, &$tables ) {
+			$tables[] = $table;
+			return $builder;
+		};
+		$builder->method( 'replaceInto' )->willReturnCallback( $captureTable );
+		$builder->method( 'table' )->willReturnCallback( $captureTable );
+
+		$captureRow = static function ( $row ) use ( $builder, &$rows ) {
+			$rows[] = $row;
+			return $builder;
+		};
+		$builder->method( 'row' )->willReturnCallback( $captureRow );
+		$builder->method( 'rows' )->willReturnCallback( $captureRow );
+
+		$captureUnique = static function ( $fields ) use ( $builder, &$uniqueIndexFields ) {
+			$uniqueIndexFields[] = $fields;
+			return $builder;
+		};
+		$builder->method( 'uniqueIndexFields' )->willReturnCallback( $captureUnique );
+
+		$builder->method( 'caller' )->willReturn( $builder );
+		$builder->method( 'execute' );
+
+		return $builder;
+	}
+}

--- a/tests/phpunit/Unit/MediaWiki/Connection/MockWriteQueryBuilderTraitTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/MockWriteQueryBuilderTraitTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace SMW\Tests\Unit\MediaWiki\Connection;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait
+ *
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class MockWriteQueryBuilderTraitTest extends TestCase {
+
+	use MockWriteQueryBuilderTrait;
+
+	public function testInsertCapturesTableRowsAndUniqueIndex(): void {
+		$tables = $rows = $sets = $uniqueIndexFields = [];
+
+		$builder = $this->createMockInsertQueryBuilder( $tables, $rows, $sets, $uniqueIndexFields );
+
+		$builder
+			->insertInto( 'smw_test' )
+			->row( [ 'a' => 1 ] )
+			->onDuplicateKeyUpdate()
+			->uniqueIndexFields( [ 'a' ] )
+			->set( [ 'a' => 2 ] )
+			->caller( __METHOD__ )
+			->execute();
+
+		$this->assertSame( [ 'smw_test' ], $tables );
+		$this->assertSame( [ [ 'a' => 1 ] ], $rows );
+		$this->assertSame( [ [ 'a' => 2 ] ], $sets );
+		$this->assertSame( [ [ 'a' ] ], $uniqueIndexFields );
+	}
+
+	public function testInsertAppendsAcrossMultipleCalls(): void {
+		$tables = $rows = $sets = $uniqueIndexFields = [];
+
+		$builder = $this->createMockInsertQueryBuilder( $tables, $rows, $sets, $uniqueIndexFields );
+
+		$builder
+			->insertInto( 'smw_test' )
+			->row( [ 'a' => 1 ] )
+			->row( [ 'a' => 2 ] )
+			->rows( [ [ 'a' => 3 ], [ 'a' => 4 ] ] )
+			->caller( __METHOD__ )
+			->execute();
+
+		$this->assertSame( [ 'smw_test' ], $tables );
+		$this->assertSame(
+			[ [ 'a' => 1 ], [ 'a' => 2 ], [ [ 'a' => 3 ], [ 'a' => 4 ] ] ],
+			$rows
+		);
+	}
+
+	public function testUpdateCapturesTableSetAndWhere(): void {
+		$tables = $sets = $wheres = [];
+
+		$builder = $this->createMockUpdateQueryBuilder( $tables, $sets, $wheres );
+
+		$builder
+			->update( 'smw_test' )
+			->set( [ 'a' => 2 ] )
+			->where( [ 'id' => 1 ] )
+			->caller( __METHOD__ )
+			->execute();
+
+		$this->assertSame( [ 'smw_test' ], $tables );
+		$this->assertSame( [ [ 'a' => 2 ] ], $sets );
+		$this->assertSame( [ [ 'id' => 1 ] ], $wheres );
+	}
+
+	public function testDeleteCapturesTableAndWhere(): void {
+		$tables = $wheres = [];
+
+		$builder = $this->createMockDeleteQueryBuilder( $tables, $wheres );
+
+		$builder
+			->deleteFrom( 'smw_test' )
+			->where( [ 'id' => 1 ] )
+			->caller( __METHOD__ )
+			->execute();
+
+		$this->assertSame( [ 'smw_test' ], $tables );
+		$this->assertSame( [ [ 'id' => 1 ] ], $wheres );
+	}
+
+	public function testReplaceCapturesTableRowsAndUniqueIndex(): void {
+		$tables = $rows = $uniqueIndexFields = [];
+
+		$builder = $this->createMockReplaceQueryBuilder( $tables, $rows, $uniqueIndexFields );
+
+		$builder
+			->replaceInto( 'smw_test' )
+			->uniqueIndexFields( [ 'id' ] )
+			->row( [ 'id' => 1 ] )
+			->caller( __METHOD__ )
+			->execute();
+
+		$this->assertSame( [ 'smw_test' ], $tables );
+		$this->assertSame( [ [ 'id' => 1 ] ], $rows );
+		$this->assertSame( [ [ 'id' ] ], $uniqueIndexFields );
+	}
+}

--- a/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
@@ -11,6 +11,7 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\MediaWiki\Jobs\EntityIdDisposerJob
@@ -22,6 +23,8 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class EntityIdDisposerJobTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $connection;
@@ -38,6 +41,10 @@ class EntityIdDisposerJobTest extends TestCase {
 		$this->connection->expects( $this->any() )
 			->method( 'select' )
 			->willReturn( [ 'Foo' ] );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->getMockForAbstractClass();
@@ -138,9 +145,10 @@ class EntityIdDisposerJobTest extends TestCase {
 			'smw_hash' => ''
 		];
 
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
 		$this->connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$subject = WikiPage::newFromText( __METHOD__ );
 

--- a/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
@@ -23,6 +23,8 @@ use SMW\SQLStore\RedirectStore;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\SQLStoreFactory;
 use SMW\SQLStore\TableFieldUpdater;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -35,6 +37,9 @@ use stdClass;
  * @author mwjames
  */
 class EntityIdManagerTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $store;
 	private $cache;
@@ -212,9 +217,10 @@ class EntityIdManagerTest extends TestCase {
 		$selectRow->smw_sortkey = 'Foo';
 		$selectRow->smw_hash = '___hash___';
 
-		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( $selectRow );
+		$qb = $this->createMockSelectQueryBuilder( [ $selectRow ] );
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -245,9 +251,10 @@ class EntityIdManagerTest extends TestCase {
 		$selectRow->smw_proptable_hash = serialize( 'Foo' );
 		$selectRow->smw_hash = '___hash___';
 
-		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( $selectRow );
+		$qb = $this->createMockSelectQueryBuilder( [ $selectRow ] );
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -289,9 +296,16 @@ class EntityIdManagerTest extends TestCase {
 		$selectRow->smw_proptable_hash = serialize( 'Foo' );
 		$selectRow->smw_hash = '___hash___';
 
+		$qb = $this->createMockSelectQueryBuilder( [ $selectRow ] );
 		$this->connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( $selectRow );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
+
+		$insertTables = $insertRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $insertTables, $insertRows );
+		$this->connection->expects( $this->once() )
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$this->connection->expects( $this->once() )
 			->method( 'insertId' )
@@ -325,6 +339,8 @@ class EntityIdManagerTest extends TestCase {
 		);
 
 		$this->assertEquals( 9999, $result );
+		$this->assertSame( [ SQLStore::ID_TABLE ], $insertTables );
+		$this->assertCount( 1, $insertRows );
 	}
 
 	public function testGetDataItemById() {
@@ -418,9 +434,10 @@ class EntityIdManagerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( $row );
+		$qb = $this->createMockSelectQueryBuilder( [ $row ] );
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -519,9 +536,11 @@ class EntityIdManagerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions );
+		$connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -539,6 +558,16 @@ class EntityIdManagerTest extends TestCase {
 		$this->assertEquals(
 			1001,
 			$instance->findAssociatedRev( 'Foo', NS_MAIN, '', '' )
+		);
+
+		$this->assertSame(
+			[ [
+				'smw_title' => 'Foo',
+				'smw_namespace' => NS_MAIN,
+				'smw_iw' => '',
+				'smw_subobject' => '',
+			] ],
+			$whereConditions
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/EntityStore/AuxiliaryFieldsTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/AuxiliaryFieldsTest.php
@@ -10,6 +10,8 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\AuxiliaryFields;
 use SMW\SQLStore\EntityStore\FieldList;
 use SMW\SQLStore\EntityStore\IdCacheManager;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use SMW\Utils\HmacSerializer;
 
 /**
@@ -22,6 +24,9 @@ use SMW\Utils\HmacSerializer;
  * @author mwjames
  */
 class AuxiliaryFieldsTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $connection;
 	private $idCacheManager;
@@ -60,13 +65,12 @@ class AuxiliaryFieldsTest extends TestCase {
 			'smw_countmap' => 0
 		];
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions );
+
 		$this->connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 't.smw_hash' => [ sha1( json_encode( [ 'Foo', 0, '', '' ] ), true ) ] ] )
-			->willReturn( [ (object)$row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new AuxiliaryFields(
 			$this->connection,
@@ -77,6 +81,11 @@ class AuxiliaryFieldsTest extends TestCase {
 			FieldList::class,
 			$instance->prefetchFieldList( $subjects )
 		);
+
+		$this->assertContains(
+			[ 't.smw_hash' => [ sha1( json_encode( [ 'Foo', 0, '', '' ] ), true ) ] ],
+			$whereConditions
+		);
 	}
 
 	public function testSetFieldMaps_Empty() {
@@ -85,14 +94,12 @@ class AuxiliaryFieldsTest extends TestCase {
 			->with( AuxiliaryFields::COUNTMAP_CACHE_ID )
 			->willReturn( $this->cache );
 
+		$tables = $rows = $sets = $uniqueIndexFields = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $tables, $rows, $sets, $uniqueIndexFields );
+
 		$this->connection->expects( $this->once() )
-			->method( 'upsert' )
-			->with(
-				$this->anything(),
-				$this->equalTo( [
-					'smw_id' => 42,
-					'smw_seqmap' => null,
-					'smw_countmap' => null ] ) );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$instance = new AuxiliaryFields(
 			$this->connection,
@@ -100,6 +107,17 @@ class AuxiliaryFieldsTest extends TestCase {
 		);
 
 		$instance->setFieldMaps( 42, [], [] );
+
+		$this->assertSame( [ 'smw_object_aux' ], $tables );
+		$this->assertSame(
+			[ [ 'smw_id' => 42, 'smw_seqmap' => null, 'smw_countmap' => null ] ],
+			$rows
+		);
+		$this->assertSame( [ [ 'smw_id' ] ], $uniqueIndexFields );
+		$this->assertSame(
+			[ [ 'smw_seqmap' => null, 'smw_countmap' => null ] ],
+			$sets
+		);
 	}
 
 	public function testSetFieldMaps() {
@@ -112,14 +130,12 @@ class AuxiliaryFieldsTest extends TestCase {
 			->method( 'escape_bytea' )
 			->willReturnArgument( 0 );
 
+		$tables = $rows = $sets = $uniqueIndexFields = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $tables, $rows, $sets, $uniqueIndexFields );
+
 		$this->connection->expects( $this->once() )
-			->method( 'upsert' )
-			->with(
-				$this->anything(),
-				$this->equalTo( [
-					'smw_id' => 42,
-					'smw_seqmap' => HmacSerializer::compress( [ 'seqmap' ] ),
-					'smw_countmap' => HmacSerializer::compress( [ 'countmap' ] ) ] ) );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$instance = new AuxiliaryFields(
 			$this->connection,
@@ -127,6 +143,24 @@ class AuxiliaryFieldsTest extends TestCase {
 		);
 
 		$instance->setFieldMaps( 42, [ 'seqmap' ], [ 'countmap' ] );
+
+		$this->assertSame( [ 'smw_object_aux' ], $tables );
+		$this->assertSame(
+			[ [
+				'smw_id' => 42,
+				'smw_seqmap' => HmacSerializer::compress( [ 'seqmap' ] ),
+				'smw_countmap' => HmacSerializer::compress( [ 'countmap' ] )
+			] ],
+			$rows
+		);
+		$this->assertSame( [ [ 'smw_id' ] ], $uniqueIndexFields );
+		$this->assertSame(
+			[ [
+				'smw_seqmap' => HmacSerializer::compress( [ 'seqmap' ] ),
+				'smw_countmap' => HmacSerializer::compress( [ 'countmap' ] )
+			] ],
+			$sets
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/CacheWarmerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/CacheWarmerTest.php
@@ -11,6 +11,7 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\CacheWarmer;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\CacheWarmer
@@ -22,6 +23,8 @@ use SMW\SQLStore\SQLStore;
  * @author mwjames
  */
 class CacheWarmerTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $idCacheManager;
 	private $store;
@@ -72,13 +75,12 @@ class CacheWarmerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions );
+
 		$connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 'smw_hash' => [ sha1( json_encode( [ 'Bar', 0, '', '' ] ), true ) ] ] )
-			->willReturn( [ (object)$row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -95,6 +97,11 @@ class CacheWarmerTest extends TestCase {
 
 		$instance->setThresholdLimit( 1 );
 		$instance->prepareCache( $list );
+
+		$this->assertContains(
+			[ 'smw_hash' => [ sha1( json_encode( [ 'Bar', 0, '', '' ] ), true ) ] ],
+			$whereConditions
+		);
 	}
 
 	public function testPrepareCache_DisplayTitleFinder() {
@@ -144,13 +151,12 @@ class CacheWarmerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions );
+
 		$connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 'smw_hash' => [ sha1( json_encode( [ 'Foo', 102, '', '' ] ), true ) ] ] )
-			->willReturn( [ (object)$row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -167,6 +173,11 @@ class CacheWarmerTest extends TestCase {
 
 		$instance->setThresholdLimit( 1 );
 		$instance->prepareCache( $list );
+
+		$this->assertContains(
+			[ 'smw_hash' => [ sha1( json_encode( [ 'Foo', 102, '', '' ] ), true ) ] ],
+			$whereConditions
+		);
 	}
 
 	public function testPrepareCache_UnknownPredefinedProperty() {

--- a/tests/phpunit/Unit/SQLStore/EntityStore/DuplicateFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/DuplicateFinderTest.php
@@ -7,13 +7,11 @@ use SMW\DataItems\WikiPage;
 use SMW\IteratorFactory;
 use SMW\Iterators\MappingIterator;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\SQLStore\EntityStore\DuplicateFinder;
 use SMW\SQLStore\RedirectStore;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\ResultWrapper;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\DuplicateFinder
@@ -25,6 +23,8 @@ use Wikimedia\Rdbms\ResultWrapper;
  * @author mwjames
  */
 class DuplicateFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $connection;
@@ -57,47 +57,32 @@ class DuplicateFinderTest extends TestCase {
 	}
 
 	public function testHasDuplicate() {
-		$connection = $this->getMockBuilder( Database::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnArgument( 0 );
-
-		$connection->expects( $this->any() )
-			->method( 'tableName' )
-			->willReturnArgument( 0 );
-
-		$query = new Query( $connection );
-
-		$resultWrapper = $this->getMockBuilder( ResultWrapper::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder(
+			[ (object)[ 'smw_id' => 1 ], (object)[ 'smw_id' => 2 ] ],
+			$whereConditions
+		);
 
 		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'newQuery' )
-			->willReturn( $query );
-
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'readQuery' )
-			->willReturn( $resultWrapper );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new DuplicateFinder(
 			$this->store,
 			$this->iteratorFactory
 		);
 
-		$instance->hasDuplicate( WikiPage::newFromText( 'Foo' ) );
+		$this->assertTrue(
+			$instance->hasDuplicate( WikiPage::newFromText( 'Foo' ) )
+		);
 
-		$this->assertJsonStringEqualsJsonString(
-			'{' .
-			'"tables": "smw_object_ids",' .
-			'"fields":["smw_id","smw_sortkey"],' .
-			'"conditions":[["smw_title=Foo"],["smw_namespace=0"],["smw_subobject="],["smw_iw!=:smw"],["smw_iw!=:smw-delete"],["smw_iw!=:smw-redi"]],' .
-			'"joins":[],' .
-			'"options":{"LIMIT":2},"alias":"","index":0,"autocommit":false}',
-			(string)$query
+		$this->assertContains(
+			[
+				'smw_title' => 'Foo',
+				'smw_namespace' => 0,
+				'smw_subobject' => '',
+			],
+			$whereConditions
 		);
 	}
 
@@ -117,15 +102,11 @@ class DuplicateFinderTest extends TestCase {
 			'smw_subobject' => ''
 		];
 
-		$query = new Query( $this->connection );
+		$qb = $this->createMockSelectQueryBuilder( [ $row ] );
 
-		$this->connection->expects( $this->once() )
-			->method( 'newQuery' )
-			->willReturn( $query );
-
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$this->connection->expects( $this->atLeastOnce() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new DuplicateFinder(
 			$this->store,
@@ -137,11 +118,6 @@ class DuplicateFinderTest extends TestCase {
 		$this->assertInstanceOf(
 			MappingIterator::class,
 			$res
-		);
-
-		$this->assertStringContainsString(
-			'HAVING":"count(*) > 1',
-			$query->__toString()
 		);
 
 		$this->assertEquals(
@@ -164,15 +140,11 @@ class DuplicateFinderTest extends TestCase {
 			'o_id' => 1001
 		];
 
-		$query = new Query( $this->connection );
+		$qb = $this->createMockSelectQueryBuilder( [ $row ] );
 
-		$this->connection->expects( $this->once() )
-			->method( 'newQuery' )
-			->willReturn( $query );
-
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$this->connection->expects( $this->atLeastOnce() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new DuplicateFinder(
 			$this->store,
@@ -186,11 +158,6 @@ class DuplicateFinderTest extends TestCase {
 		$this->assertInstanceOf(
 			MappingIterator::class,
 			$res
-		);
-
-		$this->assertStringContainsString(
-			'HAVING":"count(*) > 1',
-			$query->__toString()
 		);
 
 		$this->assertEquals(

--- a/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdFinderTest.php
@@ -10,6 +10,7 @@ use SMW\SQLStore\EntityStore\EntityIdFinder;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\PropertyTable\PropertyTableHashes;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\EntityIdFinder
@@ -21,6 +22,8 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class EntityIdFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $cache;
@@ -75,9 +78,11 @@ class EntityIdFinderTest extends TestCase {
 		$this->idCacheManager->expects( $this->once() )
 			->method( 'setCache' );
 
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new EntityIdFinder(
 			$this->connection,
@@ -106,9 +111,11 @@ class EntityIdFinderTest extends TestCase {
 		$this->idCacheManager->expects( $this->once() )
 			->method( 'setCache' );
 
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new EntityIdFinder(
 			$this->connection,
@@ -139,9 +146,11 @@ class EntityIdFinderTest extends TestCase {
 		$this->idCacheManager->expects( $this->once() )
 			->method( 'setCache' );
 
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new EntityIdFinder(
 			$this->connection,
@@ -167,9 +176,11 @@ class EntityIdFinderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$qb = $this->createMockSelectQueryBuilder( $rows );
+
 		$this->connection->expects( $this->once() )
-			->method( 'select' )
-			->willReturn( $rows );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new EntityIdFinder(
 			$this->connection,

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdChangerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdChangerTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Unit\SQLStore\EntityStore;
 
-use PHPUnit\Framework\MockObject\Builder\InvocationMocker;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\JobFactory;
@@ -12,6 +11,8 @@ use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder\FieldType;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\IdChanger
@@ -23,6 +24,9 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class IdChangerTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $store;
@@ -63,26 +67,26 @@ class IdChangerTest extends TestCase {
 	}
 
 	public function testMove_NoMatch() {
+		$selectWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [], $selectWheres );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				'*',
-				[ 'smw_id' => 42 ] )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new IdChanger(
 			$this->store
 		);
 
 		$instance->move( 42 );
+
+		$this->assertSame(
+			[ [ 'smw_id' => 42 ] ],
+			$selectWheres
+		);
 	}
 
 	public function testMove_ZeroTarget() {
-		if ( !method_exists( InvocationMocker::class, 'withConsecutive' ) ) {
-			$this->markTestSkipped( 'PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive requires PHPUnit 5.7+.' );
-		}
-
 		$row = [
 			'smw_id' => 42,
 			'smw_title' => 'Foo',
@@ -94,33 +98,39 @@ class IdChangerTest extends TestCase {
 			'smw_hash' => sha1( json_encode( [ 'Foo', 0, '', '' ] ), true )
 		];
 
-		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				'*',
-				[ 'smw_id' => 42 ] )
-			->willReturn( (object)$row );
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)$row ] );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$this->connection->expects( $this->once() )
 			->method( 'nextSequenceValue' )
 			->willReturn( 1 );
 
+		$insertTables = $insertRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $insertTables, $insertRows );
+
 		$this->connection->expects( $this->once() )
-			->method( 'insert' )
-			->with(
-				$this->anything(),
-				[ 'smw_id' => 1 ] + $row );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$this->connection->expects( $this->once() )
 			->method( 'insertId' )
 			->willReturn( 9999 );
 
+		$deleteTables = $deleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $deleteTables, $deleteWheres );
+
 		$this->connection->expects( $this->any() )
-			->method( 'delete' )
-			->withConsecutive(
-				[ $this->equalTo( 'smw_object_aux' ), $this->equalTo( [ 'smw_id' => 42 ] ) ],
-				[ $this->equalTo( 'smw_object_ids' ), $this->equalTo( [ 'smw_id' => 42 ] ) ] );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
@@ -141,13 +151,22 @@ class IdChangerTest extends TestCase {
 			(object)$expected,
 			$instance->move( 42, 0 )
 		);
+
+		$this->assertSame(
+			[ [ 'smw_id' => 1 ] + $row ],
+			$insertRows
+		);
+		$this->assertSame(
+			[ SQLStore::ID_AUXILIARY_TABLE, SQLStore::ID_TABLE ],
+			$deleteTables
+		);
+		$this->assertSame(
+			[ [ 'smw_id' => 42 ], [ 'smw_id' => 42 ] ],
+			$deleteWheres
+		);
 	}
 
 	public function testMove_Target() {
-		if ( !method_exists( InvocationMocker::class, 'withConsecutive' ) ) {
-			$this->markTestSkipped( 'PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive requires PHPUnit 5.7+.' );
-		}
-
 		$row = [
 			'smw_id' => 42,
 			'smw_title' => 'Foo',
@@ -159,25 +178,31 @@ class IdChangerTest extends TestCase {
 			'smw_hash' => sha1( json_encode( [ 'Foo', 0, '', '' ] ), true )
 		];
 
-		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				'*',
-				[ 'smw_id' => 42 ] )
-			->willReturn( (object)$row );
-
-		$this->connection->expects( $this->once() )
-			->method( 'insert' )
-			->with(
-				$this->anything(),
-				[ 'smw_id' => 1001 ] + $row );
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)$row ] );
 
 		$this->connection->expects( $this->any() )
-			->method( 'delete' )
-			->withConsecutive(
-				[ $this->equalTo( 'smw_object_aux' ), $this->equalTo( [ 'smw_id' => 42 ] ) ],
-				[ $this->equalTo( 'smw_object_ids' ), $this->equalTo( [ 'smw_id' => 42 ] ) ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$insertTables = $insertRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $insertTables, $insertRows );
+
+		$this->connection->expects( $this->once() )
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
+
+		$deleteTables = $deleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $deleteTables, $deleteWheres );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
@@ -198,6 +223,19 @@ class IdChangerTest extends TestCase {
 			(object)$expected,
 			$instance->move( 42, 1001 )
 		);
+
+		$this->assertSame(
+			[ [ 'smw_id' => 1001 ] + $row ],
+			$insertRows
+		);
+		$this->assertSame(
+			[ SQLStore::ID_AUXILIARY_TABLE, SQLStore::ID_TABLE ],
+			$deleteTables
+		);
+		$this->assertSame(
+			[ [ 'smw_id' => 42 ], [ 'smw_id' => 42 ] ],
+			$deleteWheres
+		);
 	}
 
 	public function testChange_IdSubject_Fields_NotFixedPropertyTable() {
@@ -206,6 +244,10 @@ class IdChangerTest extends TestCase {
 			->getMock();
 
 		$table->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'smw_foo' );
+
+		$table->expects( $this->any() )
 			->method( 'usesIdSubject' )
 			->willReturn( true );
 
@@ -221,26 +263,28 @@ class IdChangerTest extends TestCase {
 			->method( 'getPropertyTables' )
 			->willReturnOnConsecutiveCalls( [ $table ] );
 
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'selectRow' )
-			->willReturnCallback( static function ( $table, $vars, $conds ) {
-				if ( isset( $conds['s_id'] ) && $conds['s_id'] === 42 ) {
-					return true;
-				}
-				return false;
-			} );
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)[] ] );
 
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'update' )
-			->willReturnCallback( static function ( $table, $set, $conds ) {
-				// Accepts calls for s_id, p_id, _foo updates
-			} );
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$updateTables = $updateSets = $updateWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder( $updateTables, $updateSets, $updateWheres );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$instance = new IdChanger(
 			$this->store
 		);
 
 		$instance->change( 42, 1001 );
+
+		$this->assertContains( [ 's_id' => 1001 ], $updateSets );
+		$this->assertContains( [ 'p_id' => 1001 ], $updateSets );
+		$this->assertContains( [ '_foo' => 1001 ], $updateSets );
 	}
 
 	public function testChange_IdSubject_PropertyNS_Fields_NotFixedPropertyTable() {
@@ -249,6 +293,10 @@ class IdChangerTest extends TestCase {
 			->getMock();
 
 		$table->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'smw_foo' );
+
+		$table->expects( $this->any() )
 			->method( 'usesIdSubject' )
 			->willReturn( true );
 
@@ -264,38 +312,45 @@ class IdChangerTest extends TestCase {
 			->method( 'getPropertyTables' )
 			->willReturnOnConsecutiveCalls( [ $table ] );
 
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'selectRow' )
-			->willReturnCallback( static function ( $table, $vars, $conds ) {
-				if ( isset( $conds['s_id'] ) && $conds['s_id'] === 42 ) {
-					return true;
-				}
-				return false;
-			} );
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)[] ] );
 
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'update' )
-			->willReturnCallback( static function ( $table, $set, $conds ) {
-				// Accepts calls for s_id and _foo updates
-			} );
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
+
+		$deleteTables = $deleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $deleteTables, $deleteWheres );
 
 		$this->connection->expects( $this->once() )
-			->method( 'delete' )
-			->with(
-				$this->anything(),
-				[ 'p_id' => 42 ] );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$instance = new IdChanger(
 			$this->store
 		);
 
 		$instance->change( 42, 1001, SMW_NS_PROPERTY, NS_MAIN );
+
+		$this->assertSame(
+			[ [ 'p_id' => 42 ] ],
+			$deleteWheres
+		);
 	}
 
 	public function testChange_IdSubject_ConceptNS_Fields_NotFixedPropertyTable() {
 		$table = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$table->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'smw_foo' );
 
 		$table->expects( $this->any() )
 			->method( 'usesIdSubject' )
@@ -313,31 +368,40 @@ class IdChangerTest extends TestCase {
 			->method( 'getPropertyTables' )
 			->willReturnOnConsecutiveCalls( [ $table ] );
 
-		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 's_id' => 42 ] )
-			->willReturn( true );
+		$selectWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)[] ], $selectWheres );
 
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'update' )
-			->willReturnCallback( static function ( $table, $set, $conds ) {
-				// Accepts calls for s_id and o_id updates
-			} );
+		$this->connection->expects( $this->once() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
+
+		$deleteTables = $deleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $deleteTables, $deleteWheres );
 
 		$this->connection->expects( $this->exactly( 2 ) )
-			->method( 'delete' )
-			->with(
-				$this->anything(),
-				[ 's_id' => 42 ] );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$instance = new IdChanger(
 			$this->store
 		);
 
 		$instance->change( 42, 1001, SMW_NS_CONCEPT, NS_MAIN );
+
+		$this->assertSame(
+			[ [ 's_id' => 42 ] ],
+			$selectWheres
+		);
+		$this->assertSame(
+			[ [ 's_id' => 42 ], [ 's_id' => 42 ] ],
+			$deleteWheres
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdEntityFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdEntityFinderTest.php
@@ -11,6 +11,7 @@ use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\EntityStore\IdEntityFinder;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -23,6 +24,8 @@ use stdClass;
  * @author mwjames
  */
 class IdEntityFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $cache;
@@ -92,13 +95,12 @@ class IdEntityFinderTest extends TestCase {
 			->method( 'fetch' )
 			->willReturn( false );
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 'smw_id' => 42 ] )
-			->willReturn( $row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new IdEntityFinder(
 			$this->store,
@@ -110,6 +112,8 @@ class IdEntityFinderTest extends TestCase {
 			WikiPage::class,
 			$instance->getDataItemById( 42 )
 		);
+
+		$this->assertContains( [ 'smw_id' => 42 ], $whereConditions );
 	}
 
 	public function testGetDataItemForCachedId() {
@@ -118,7 +122,7 @@ class IdEntityFinderTest extends TestCase {
 			->willReturn( new WikiPage( 'Foo', NS_MAIN ) );
 
 		$this->connection->expects( $this->never() )
-			->method( 'selectRow' );
+			->method( 'newSelectQueryBuilder' );
 
 		$instance = new IdEntityFinder(
 			$this->store,
@@ -152,13 +156,12 @@ class IdEntityFinderTest extends TestCase {
 			->method( 'fetch' )
 			->willReturn( false );
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 'smw_id' => 42 ] )
-			->willReturn( $row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new IdEntityFinder(
 			$this->store,
@@ -170,6 +173,8 @@ class IdEntityFinderTest extends TestCase {
 			$dataItem,
 			$instance->getDataItemById( 42 )
 		);
+
+		$this->assertContains( [ 'smw_id' => 42 ], $whereConditions );
 	}
 
 	public function testNullForUnknownId() {
@@ -177,9 +182,11 @@ class IdEntityFinderTest extends TestCase {
 			->method( 'fetch' )
 			->willReturn( false );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new IdEntityFinder(
 			$this->store,
@@ -208,13 +215,12 @@ class IdEntityFinderTest extends TestCase {
 		$row->smw_sort = '...';
 		$row->smw_hash = 'x99w';
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
+
 		$this->connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 'smw_id' => [ 42 ] ] )
-			->willReturn( [ $row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new IdEntityFinder(
 			$this->store,
@@ -228,6 +234,8 @@ class IdEntityFinderTest extends TestCase {
 				$value
 			);
 		}
+
+		$this->assertContains( [ 'smw_id' => [ 42 ] ], $whereConditions );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PropertiesLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PropertiesLookupTest.php
@@ -5,11 +5,10 @@ namespace SMW\Tests\Unit\SQLStore\EntityStore;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\SQLStore\EntityStore\PropertiesLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\PropertiesLookup
@@ -21,6 +20,8 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  * @author mwjames
  */
 class PropertiesLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$store = $this->getMockBuilder( SQLStore::class )
@@ -37,33 +38,28 @@ class PropertiesLookupTest extends TestCase {
 		$dataItem = WikiPage::newFromText( __METHOD__ );
 		$dataItem->setId( 42 );
 
-		$resultWrapper = $this->getMockBuilder( FakeResultWrapper::class )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$propertyTableDef = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$propertyTableDef->expects( $this->atLeastOnce() )
+			->method( 'usesIdSubject' )
+			->willReturn( true );
+
+		$propertyTableDef->expects( $this->atLeastOnce() )
 			->method( 'isFixedPropertyTable' )
 			->willReturn( false );
 
-		$query = $this->getMockBuilder( Query::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$query->expects( $this->atLeastOnce() )
-			->method( 'execute' )
-			->willReturn( $resultWrapper );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [], $whereConditions );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'newQuery' )
-			->willReturn( $query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -87,13 +83,13 @@ class PropertiesLookupTest extends TestCase {
 		);
 
 		$instance->fetchFromTable( $dataItem, $propertyTableDef );
+
+		$this->assertContains( [ 's_id' => 42 ], $whereConditions );
 	}
 
 	public function testLookupForFixedPropertyTable() {
 		$dataItem = WikiPage::newFromText( __METHOD__ );
 		$dataItem->setId( 1001 );
-
-		$resultWrapper = new FakeResultWrapper( [] );
 
 		$propertyTableDef = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
@@ -103,21 +99,15 @@ class PropertiesLookupTest extends TestCase {
 			->method( 'isFixedPropertyTable' )
 			->willReturn( true );
 
-		$query = $this->getMockBuilder( Query::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$query->expects( $this->atLeastOnce() )
-			->method( 'execute' )
-			->willReturn( $resultWrapper );
+		$qb = $this->createMockSelectQueryBuilder( [] );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'newQuery' )
-			->willReturn( $query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PropertySubjectsLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PropertySubjectsLookupTest.php
@@ -5,12 +5,11 @@ namespace SMW\Tests\Unit\SQLStore\EntityStore;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\EntityStore\PropertySubjectsLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\PropertySubjectsLookup
@@ -22,6 +21,8 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  * @author mwjames
  */
 class PropertySubjectsLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$store = $this->getMockBuilder( SQLStore::class )
@@ -53,21 +54,15 @@ class PropertySubjectsLookupTest extends TestCase {
 			->method( 'isFixedPropertyTable' )
 			->willReturn( false );
 
-		$query = $this->getMockBuilder( Query::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$qb = $this->createMockSelectQueryBuilder( [] );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'newQuery' )
-			->willReturn( $query );
-
-		$connection->expects( $this->atLeastOnce() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [] ) );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -100,8 +95,6 @@ class PropertySubjectsLookupTest extends TestCase {
 	public function testLookupForFixedPropertyTable() {
 		$dataItem = WikiPage::newFromText( __METHOD__ );
 
-		$resultWrapper = new FakeResultWrapper( [] );
-
 		$dataItemHandler = $this->getMockBuilder( DataItemHandler::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
@@ -118,21 +111,15 @@ class PropertySubjectsLookupTest extends TestCase {
 			->method( 'isFixedPropertyTable' )
 			->willReturn( true );
 
-		$query = $this->getMockBuilder( Query::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$qb = $this->createMockSelectQueryBuilder( [] );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'newQuery' )
-			->willReturn( $query );
-
-		$connection->expects( $this->atLeastOnce() )
-			->method( 'readQuery' )
-			->willReturn( $resultWrapper );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/EntityStore/SemanticDataLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/SemanticDataLookupTest.php
@@ -9,7 +9,6 @@ use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\RequestOptions;
 use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\EntityStore\EntityIdManager;
@@ -17,8 +16,8 @@ use SMW\SQLStore\EntityStore\SemanticDataLookup;
 use SMW\SQLStore\EntityStore\StubSemanticData;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
-use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\SemanticDataLookup
@@ -31,10 +30,11 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  */
 class SemanticDataLookupTest extends TestCase {
 
+	use MockSelectQueryBuilderTrait;
+
 	private $store;
 	private $connection;
 	private $dataItemHandler;
-	private $query;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -59,8 +59,6 @@ class SemanticDataLookupTest extends TestCase {
 		$this->connection->expects( $this->any() )
 			->method( 'tableName' )
 			->willReturnArgument( 0 );
-
-		$this->query = new Query( $this->connection );
 
 		$connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()
@@ -210,13 +208,12 @@ class SemanticDataLookupTest extends TestCase {
 			->method( 'getDIType' )
 			->willReturn( 'Foo' );
 
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
 		$this->connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $this->query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new SemanticDataLookup(
 			$this->store
@@ -224,11 +221,13 @@ class SemanticDataLookupTest extends TestCase {
 
 		$subject = WikiPage::newFromText( __METHOD__ );
 
-		$semanticData = $instance->fetchSemanticDataFromTable(
+		$instance->fetchSemanticDataFromTable(
 			42,
 			$subject,
 			$propertyTable
 		);
+
+		$this->assertContainsEquals( [ 's_id' => 42 ], $whereConditions );
 	}
 
 	public function testSemanticDataFromTable_WithConstraint() {
@@ -269,18 +268,12 @@ class SemanticDataLookupTest extends TestCase {
 			->method( 'getDIType' )
 			->willReturn( 'Foo' );
 
-		$this->connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnCallback( static function ( $value ) { return "'$value'";
-			} );
-
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
 		$this->connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $this->query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$subject = WikiPage::newFromText( __METHOD__ );
 
@@ -300,13 +293,10 @@ class SemanticDataLookupTest extends TestCase {
 
 		$instance->fetchSemanticDataFromTable( 42, $subject, $propertyTable, $requestOptions );
 
-		$this->assertEquals(
-			"SELECT p.smw_title AS prop, fooField AS v0 FROM  " .
-			"INNER JOIN smw_object_ids AS p ON p_id=p.smw_id " .
-			"WHERE (s_id='42') AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete') AND (p_id='9999') " .
-			"LIMIT 4",
-			$this->query->build()
-		);
+		// `s_id` from the subject restriction and `p_id` from the extra-condition
+		// constraint must both be present in the captured where conditions.
+		$this->assertContainsEquals( [ 's_id' => 42 ], $whereConditions );
+		$this->assertContainsEquals( [ 'p_id' => 9999 ], $whereConditions );
 	}
 
 	public function testFetchSemanticDataFromTable_NoDataItem() {
@@ -330,18 +320,12 @@ class SemanticDataLookupTest extends TestCase {
 			->method( 'getDIType' )
 			->willReturn( 'Foo' );
 
-		$this->connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnCallback( static function ( $value ) { return "'$value'";
-			} );
-
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
 		$this->connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $this->query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new SemanticDataLookup(
 			$this->store
@@ -349,12 +333,7 @@ class SemanticDataLookupTest extends TestCase {
 
 		$instance->fetchSemanticDataFromTable( 42, null, $propertyTable );
 
-		$this->assertEquals(
-			"SELECT p.smw_title AS prop, fooField AS v0 FROM  " .
-			"INNER JOIN smw_object_ids AS p ON p_id=p.smw_id " .
-			"WHERE (s_id='42') AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete')",
-			$this->query->build()
-		);
+		$this->assertContainsEquals( [ 's_id' => 42 ], $whereConditions );
 	}
 
 	public function testFetchSemanticDataFromTable_NoIdSubject() {
@@ -382,18 +361,12 @@ class SemanticDataLookupTest extends TestCase {
 			->method( 'getName' )
 			->willReturn( 'bar_table' );
 
-		$this->connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnCallback( static function ( $value ) { return "'$value'";
-			} );
-
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
 		$this->connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $this->query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$dataItem = WikiPage::newFromText( 'no_id_subject' );
 
@@ -403,11 +376,13 @@ class SemanticDataLookupTest extends TestCase {
 
 		$instance->fetchSemanticDataFromTable( 42, $dataItem, $propertyTable );
 
-		$this->assertEquals(
-			"SELECT p.smw_title AS prop, fooField AS v0 FROM bar_table " .
-			"INNER JOIN smw_object_ids AS p ON p_id=p.smw_id " .
-			"WHERE (s_title='no_id_subject') AND (s_namespace='0') AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete')",
-			$this->query->build()
+		// Subject without idSubject column → restriction by title+namespace.
+		$this->assertContainsEquals(
+			[
+				's_title' => 'no_id_subject',
+				's_namespace' => 0,
+			],
+			$whereConditions
 		);
 	}
 
@@ -489,18 +464,12 @@ class SemanticDataLookupTest extends TestCase {
 			->method( 'getName' )
 			->willReturn( 'bar_table' );
 
-		$this->connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnCallback( static function ( $value ) { return "'$value'";
-			} );
-
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
 		$this->connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $this->query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$dataItem = new Blob( __METHOD__ );
 
@@ -511,12 +480,12 @@ class SemanticDataLookupTest extends TestCase {
 			$this->store
 		);
 
+		// Non-WikiPage `Blob` data item → property branch (isSubject=false), which
+		// applies DISTINCT and a `p_id` restriction. `distinct()` on the trait mock
+		// is a `willReturnSelf()` no-op; assert the restriction made it through.
 		$instance->fetchSemanticDataFromTable( 42, $dataItem, $propertyTable, $requestOptions );
 
-		$this->assertEquals(
-			"SELECT DISTINCT fooField AS v0 FROM bar_table WHERE (p_id='42') LIMIT 4",
-			$this->query->build()
-		);
+		$this->assertContainsEquals( [ 'p_id' => 42 ], $whereConditions );
 	}
 
 	public function testGetSemanticData_OnLimit() {
@@ -527,9 +496,6 @@ class SemanticDataLookupTest extends TestCase {
 		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
 			->willReturn( $idTable );
-
-		$query_1 = new Query( $this->connection );
-		$query_2 = new Query( $this->connection );
 
 		$row = new stdClass;
 		$row->p_id = 9000;
@@ -560,18 +526,13 @@ class SemanticDataLookupTest extends TestCase {
 			->method( 'getName' )
 			->willReturn( 'bar_table' );
 
-		$this->connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnCallback( static function ( $value ) { return "'$value'";
-			} );
+		$whereConditions = [];
+		$qb1 = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
+		$qb2 = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
 		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'readQuery' )
-			->willReturnOnConsecutiveCalls( new FakeResultWrapper( [ $row ] ), new FakeResultWrapper( [ $row ] ) );
-
-		$this->connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturnOnConsecutiveCalls( $query_1, $query_2 );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnOnConsecutiveCalls( $qb1, $qb2 );
 
 		$dataItem = WikiPage::newFromText( 'Bar' );
 
@@ -584,17 +545,11 @@ class SemanticDataLookupTest extends TestCase {
 
 		$instance->getSemanticData( 42, $dataItem, $propertyTable, $requestOptions );
 
-		$this->assertEquals(
-			"SELECT DISTINCT p_id FROM bar_table INNER JOIN smw_object_ids " .
-			"AS p ON p_id=p.smw_id WHERE (s_id='42') AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete')",
-			$query_1->build()
-		);
-
-		$this->assertEquals(
-			"SELECT p.smw_title AS prop, fooField AS v0 FROM bar_table INNER JOIN smw_object_ids " .
-			"AS p ON p_id=p.smw_id WHERE (s_id='42') AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete') AND (p_id='9000') LIMIT 4",
-			$query_2->build()
-		);
+		// First query: `fetchPropertiesFromTable` restricts on `s_id`.
+		// Second query: `fetchSemanticDataFromTable` re-applies `s_id` and adds the
+		// extra-condition `p_id` discovered from the first query's row.
+		$this->assertContainsEquals( [ 's_id' => 42 ], $whereConditions );
+		$this->assertContainsEquals( [ 'p_id' => 9000 ], $whereConditions );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/SequenceMapFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/SequenceMapFinderTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\EntityStore\SequenceMapFinder;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use SMW\Utils\HmacSerializer;
 
 /**
@@ -19,6 +21,9 @@ use SMW\Utils\HmacSerializer;
  * @author mwjames
  */
 class SequenceMapFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $cache;
 	private $idCacheManager;
@@ -50,18 +55,16 @@ class SequenceMapFinderTest extends TestCase {
 	}
 
 	public function testSetMap() {
-		$row = [
-			'smw_id' => 42,
-			'smw_seqmap' => null
-		];
+		$this->connection->expects( $this->any() )
+			->method( 'escape_bytea' )
+			->willReturn( '' );
+
+		$tables = $rows = $sets = $uniqueIndexFields = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $tables, $rows, $sets, $uniqueIndexFields );
 
 		$this->connection->expects( $this->once() )
-			->method( 'upsert' )
-			->with(
-				$this->anything(),
-				$row,
-				'smw_id',
-				[ 'smw_seqmap' => null ] );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$instance = new SequenceMapFinder(
 			$this->connection,
@@ -69,6 +72,17 @@ class SequenceMapFinderTest extends TestCase {
 		);
 
 		$instance->setMap( 42, [ 'Foo' ] );
+
+		$this->assertSame( [ 'smw_object_aux' ], $tables );
+		$this->assertSame(
+			[ [ 'smw_id' => 42, 'smw_seqmap' => '' ] ],
+			$rows
+		);
+		$this->assertSame( [ [ 'smw_id' ] ], $uniqueIndexFields );
+		$this->assertSame(
+			[ [ 'smw_seqmap' => '' ] ],
+			$sets
+		);
 	}
 
 	public function testFindMapById() {
@@ -83,9 +97,11 @@ class SequenceMapFinderTest extends TestCase {
 			->method( 'fetch' )
 			->willReturn( false );
 
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->connection->expects( $this->once() )
 			->method( 'unescape_bytea' )
@@ -95,8 +111,6 @@ class SequenceMapFinderTest extends TestCase {
 			$this->connection,
 			$this->idCacheManager
 		);
-
-		$sortkey = '';
 
 		$this->assertEquals(
 			[ 'Foo' ],
@@ -115,13 +129,13 @@ class SequenceMapFinderTest extends TestCase {
 		$this->cache->expects( $this->atLeastOnce() )
 			->method( 'save' );
 
+		$whereConditions = [];
+		$capturedSelects = [];
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions, $capturedSelects );
+
 		$this->connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->equalTo( [ 'smw_id', 'smw_seqmap' ] ),
-				$this->equalTo( [ 'smw_id' => [ 42, 1001 ] ] ) )
-			->willReturn( [ (object)$row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->connection->expects( $this->once() )
 			->method( 'unescape_bytea' )
@@ -133,6 +147,9 @@ class SequenceMapFinderTest extends TestCase {
 		);
 
 		$instance->prefetchSequenceMap( [ 42, 1001 ] );
+
+		$this->assertContains( [ 'smw_id', 'smw_seqmap' ], $capturedSelects );
+		$this->assertContains( [ 'smw_id' => [ 42, 1001 ] ], $whereConditions );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/SubobjectListFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/SubobjectListFinderTest.php
@@ -10,6 +10,7 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\EntityStore\SubobjectListFinder;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -22,6 +23,8 @@ use stdClass;
  * @author mwjames
  */
 class SubobjectListFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $iteratorFactory;
 
@@ -54,9 +57,11 @@ class SubobjectListFinderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -96,13 +101,12 @@ class SubobjectListFinderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
+
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				'smw_title= AND smw_namespace= AND smw_iw= AND smw_subobject!=' )
-			->willReturn( [ $row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -121,6 +125,12 @@ class SubobjectListFinderTest extends TestCase {
 		foreach ( $instance->find( $subject ) as $v ) {
 			$this->assertEquals( 42, $v->getId() );
 		}
+
+		$this->assertNotEmpty( $whereConditions );
+		$flat = $whereConditions[0];
+		$this->assertArrayHasKey( 'smw_title', $flat );
+		$this->assertArrayHasKey( 'smw_namespace', $flat );
+		$this->assertArrayHasKey( 'smw_iw', $flat );
 	}
 
 	public function subjectProvider() {

--- a/tests/phpunit/Unit/SQLStore/EntityStore/TraversalPropertyLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/TraversalPropertyLookupTest.php
@@ -9,7 +9,7 @@ use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\EntityStore\TraversalPropertyLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\TraversalPropertyLookup
@@ -21,6 +21,8 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  * @author mwjames
  */
 class TraversalPropertyLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$store = $this->getMockBuilder( SQLStore::class )
@@ -52,13 +54,15 @@ class TraversalPropertyLookupTest extends TestCase {
 			->method( 'isFixedPropertyTable' )
 			->willReturn( false );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -91,10 +95,6 @@ class TraversalPropertyLookupTest extends TestCase {
 	public function testlookupForFixedPropertyTable() {
 		$dataItem = WikiPage::newFromText( __METHOD__ );
 
-		$resultWrapper = $this->getMockBuilder( FakeResultWrapper::class )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$dataItemHandler = $this->getMockBuilder( DataItemHandler::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
@@ -111,13 +111,15 @@ class TraversalPropertyLookupTest extends TestCase {
 			->method( 'isFixedPropertyTable' )
 			->willReturn( true );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( $resultWrapper );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/Lookup/ByGroupPropertyValuesLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/ByGroupPropertyValuesLookupTest.php
@@ -12,8 +12,7 @@ use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\Lookup\ByGroupPropertyValuesLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\SelectQueryBuilder;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\Lookup\ByGroupPropertyValuesLookup
@@ -25,6 +24,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class ByGroupPropertyValuesLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 
@@ -281,30 +282,6 @@ class ByGroupPropertyValuesLookupTest extends TestCase {
 			],
 			$res
 		);
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where all chained methods return $this
-	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
-	 */
-	private function createMockSelectQueryBuilder( array $rows ) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'select', 'from', 'join', 'where', 'groupBy', 'orderBy', 'caller' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchResultSet' )
-			->willReturn( new FakeResultWrapper( $rows ) );
-
-		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/ByGroupPropertyValuesLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/ByGroupPropertyValuesLookupTest.php
@@ -12,6 +12,8 @@ use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\Lookup\ByGroupPropertyValuesLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
+use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\ByGroupPropertyValuesLookup
@@ -75,8 +77,8 @@ class ByGroupPropertyValuesLookupTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( [] ) );
 
 		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
@@ -159,8 +161,8 @@ class ByGroupPropertyValuesLookupTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [ (object)$row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( [ (object)$row ] ) );
 
 		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
@@ -243,8 +245,8 @@ class ByGroupPropertyValuesLookupTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [ (object)$row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( [ (object)$row ] ) );
 
 		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
@@ -279,6 +281,30 @@ class ByGroupPropertyValuesLookupTest extends TestCase {
 			],
 			$res
 		);
+	}
+
+	/**
+	 * Creates a mock SelectQueryBuilder where all chained methods return $this
+	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
+	 */
+	private function createMockSelectQueryBuilder( array $rows ) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'select', 'from', 'join', 'where', 'groupBy', 'orderBy', 'caller' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/DisplayTitleLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/DisplayTitleLookupTest.php
@@ -9,8 +9,7 @@ use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\Lookup\DisplayTitleLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\SelectQueryBuilder;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\Lookup\DisplayTitleLookup
@@ -22,6 +21,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class DisplayTitleLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 
@@ -121,30 +122,6 @@ class DisplayTitleLookupTest extends TestCase {
 			],
 			$instance->prefetchFromList( $list )
 		);
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where all chained methods return $this
-	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
-	 */
-	private function createMockSelectQueryBuilder( array $rows ) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'select', 'from', 'where', 'caller' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchResultSet' )
-			->willReturn( new FakeResultWrapper( $rows ) );
-
-		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/DisplayTitleLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/DisplayTitleLookupTest.php
@@ -9,6 +9,8 @@ use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\Lookup\DisplayTitleLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
+use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\DisplayTitleLookup
@@ -67,19 +69,17 @@ class DisplayTitleLookupTest extends TestCase {
 			->method( 'unescape_bytea' )
 			->willReturnArgument( 0 );
 
+		$idTableRows = [
+			(object)[ 'smw_hash' => 'ebb1b47f7cf43a5a58d3c6cc58f3c3bb8b9246e6', 'smw_id' => 42 ],
+			(object)[ 'smw_hash' => '7b6b944694382bfab461675f40a2bda7e71e68e3', 'smw_id' => 1001 ]
+		];
+
 		$connection->expects( $this->exactly( 2 ) )
-			->method( 'select' )
-			->willReturnCallback( static function ( $table ) use ( $rows ) {
-				if ( $table === 'smw_object_ids' ) {
-					return [
-						(object)[ 'smw_hash' => 'ebb1b47f7cf43a5a58d3c6cc58f3c3bb8b9246e6', 'smw_id' => 42 ],
-						(object)[ 'smw_hash' => '7b6b944694382bfab461675f40a2bda7e71e68e3', 'smw_id' => 1001 ]
-					];
-				} elseif ( $table === 'foo_table' ) {
-					return $rows;
-				}
-				return [];
-			} );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnOnConsecutiveCalls(
+				$this->createMockSelectQueryBuilder( $idTableRows ),
+				$this->createMockSelectQueryBuilder( $rows )
+			);
 
 		$tableDefinition = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
@@ -121,6 +121,30 @@ class DisplayTitleLookupTest extends TestCase {
 			],
 			$instance->prefetchFromList( $list )
 		);
+	}
+
+	/**
+	 * Creates a mock SelectQueryBuilder where all chained methods return $this
+	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
+	 */
+	private function createMockSelectQueryBuilder( array $rows ) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'select', 'from', 'where', 'caller' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/EntityUniquenessLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/EntityUniquenessLookupTest.php
@@ -15,8 +15,7 @@ use SMW\SQLStore\Lookup\EntityUniquenessLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\PropertyTableInfoFetcher;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\SelectQueryBuilder;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\Lookup\EntityUniquenessLookup
@@ -28,6 +27,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class EntityUniquenessLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $connection;
@@ -161,31 +162,6 @@ class EntityUniquenessLookupTest extends TestCase {
 		$result = $instance->checkConstraint( $property, $dataItem, $requestOptions );
 
 		$this->assertSame( $mappingIterator, $result );
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where chained methods return $this
-	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
-	 */
-	private function createMockSelectQueryBuilder( array $rows ) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'select', 'from', 'join', 'leftJoin', 'where',
-			'andWhere', 'limit', 'caller' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchResultSet' )
-			->willReturn( new FakeResultWrapper( $rows ) );
-
-		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/EntityUniquenessLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/EntityUniquenessLookupTest.php
@@ -9,6 +9,7 @@ use SMW\DataItems\Property;
 use SMW\IteratorFactory;
 use SMW\Iterators\MappingIterator;
 use SMW\MediaWiki\Connection\Database;
+use SMW\MediaWiki\Connection\Query;
 use SMW\RequestOptions;
 use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\Lookup\EntityUniquenessLookup;
@@ -162,6 +163,141 @@ class EntityUniquenessLookupTest extends TestCase {
 		$result = $instance->checkConstraint( $property, $dataItem, $requestOptions );
 
 		$this->assertSame( $mappingIterator, $result );
+	}
+
+	/**
+	 * The extra-condition callback signature is part of the public API:
+	 * `function ( $store, $query, $alias )` where $query is a SMW Query object
+	 * exposing string-formatting helpers (eq/neq/in). The returned condition
+	 * string must be appended to the SELECT via andWhere(). This test exercises
+	 * that path end-to-end.
+	 */
+	public function testCheckConstraint_appliesExtraConditionFromCallback(): void {
+		$dataItemHandler = $this->getMockBuilder( DataItemHandler::class )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$dataItemHandler->expects( $this->any() )
+			->method( 'getWhereConds' )
+			->willReturn( [ 'o_hash' => '' ] );
+
+		$propertyTableInfoFetcher = $this->getMockBuilder( PropertyTableInfoFetcher::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTableInfoFetcher->expects( $this->any() )
+			->method( 'findTableIdForProperty' )
+			->willReturn( '_foo' );
+
+		$store = $this->getMockBuilder( SQLStore::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getConnection', 'getPropertyTables', 'getPropertyTableInfoFetcher', 'getDataItemHandlerForDIType' ] )
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getConnection' )
+			->willReturn( $this->connection );
+
+		$store->expects( $this->any() )
+			->method( 'getDataItemHandlerForDIType' )
+			->willReturn( $dataItemHandler );
+
+		$store->expects( $this->any() )
+			->method( 'getPropertyTableInfoFetcher' )
+			->willReturn( $propertyTableInfoFetcher );
+
+		$propertyTable = $this->getMockBuilder( PropertyTableDefinition::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyTable->expects( $this->any() )
+			->method( 'usesIdSubject' )
+			->willReturn( true );
+
+		$propertyTable->expects( $this->any() )
+			->method( 'isFixedPropertyTable' )
+			->willReturn( true );
+
+		$propertyTable->expects( $this->any() )
+			->method( 'getFixedProperty' )
+			->willReturn( '_UNKNOWN_FIXED_PROPERTY' );
+
+		$propertyTable->expects( $this->any() )
+			->method( 'getDiType' )
+			->willReturn( DataItem::TYPE_BLOB );
+
+		$propertyTable->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'smw_foo' );
+
+		$store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->willReturn( [ '_foo' => $propertyTable ] );
+
+		// Capture (store, formatter, alias) the callback receives, plus assert
+		// that the formatter is the SMW Query object the public API promises.
+		$capturedAlias = null;
+		$capturedFormatter = null;
+		$callback = static function ( $store, $formatter, $alias ) use ( &$capturedAlias, &$capturedFormatter ): string {
+			$capturedAlias = $alias;
+			$capturedFormatter = $formatter;
+			return "$alias.s_id != '999'";
+		};
+
+		$requestOptions = $this->getMockBuilder( RequestOptions::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$requestOptions->expects( $this->any() )
+			->method( 'getExtraConditions' )
+			->willReturn( [ $callback ] );
+
+		$requestOptions->expects( $this->any() )
+			->method( 'getLimit' )
+			->willReturn( 42 );
+
+		// Wire the connection's newQuery() so the EntityUniquenessLookup
+		// can build a formatter for the callback.
+		$this->connection->expects( $this->any() )
+			->method( 'newQuery' )
+			->willReturn( new Query( $this->connection ) );
+
+		$whereConditions = [];
+		$this->connection->expects( $this->atLeastOnce() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( [], $whereConditions ) );
+
+		$instance = new EntityUniquenessLookup(
+			$store,
+			$this->iteratorFactory
+		);
+
+		$property = $this->getMockBuilder( Property::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$dataItem = $this->getMockBuilder( Blob::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$mappingIterator = $this->getMockBuilder( MappingIterator::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->iteratorFactory->expects( $this->any() )
+			->method( 'newMappingIterator' )
+			->willReturn( $mappingIterator );
+
+		$instance->checkConstraint( $property, $dataItem, $requestOptions );
+
+		// The callback must have been invoked with the alias the lookup uses
+		// internally ('t1' = '$alias' . '$index') and a Query formatter object.
+		$this->assertSame( 't1', $capturedAlias );
+		$this->assertInstanceOf( Query::class, $capturedFormatter );
+
+		// The callback's returned condition string must reach the builder via
+		// andWhere() so it ends up in the WHERE clause.
+		$this->assertContains( "t1.s_id != '999'", $whereConditions );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/EntityUniquenessLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/EntityUniquenessLookupTest.php
@@ -7,6 +7,7 @@ use SMW\DataItems\Blob;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Property;
 use SMW\IteratorFactory;
+use SMW\Iterators\MappingIterator;
 use SMW\MediaWiki\Connection\Database;
 use SMW\RequestOptions;
 use SMW\SQLStore\EntityStore\DataItemHandler;
@@ -149,7 +150,7 @@ class EntityUniquenessLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$mappingIterator = $this->getMockBuilder( \SMW\Iterators\MappingIterator::class )
+		$mappingIterator = $this->getMockBuilder( MappingIterator::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/SQLStore/Lookup/EntityUniquenessLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/EntityUniquenessLookupTest.php
@@ -8,14 +8,14 @@ use SMW\DataItems\DataItem;
 use SMW\DataItems\Property;
 use SMW\IteratorFactory;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\RequestOptions;
 use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\Lookup\EntityUniquenessLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\PropertyTableInfoFetcher;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\ResultWrapper;
+use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\EntityUniquenessLookup
@@ -132,31 +132,9 @@ class EntityUniquenessLookupTest extends TestCase {
 			->method( 'getLimit' )
 			->willReturn( 42 );
 
-		$connection = $this->getMockBuilder( Database::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnArgument( 0 );
-
-		$connection->expects( $this->any() )
-			->method( 'tableName' )
-			->willReturnArgument( 0 );
-
-		$query = new Query( $connection );
-
-		$resultWrapper = $this->getMockBuilder( ResultWrapper::class )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'newQuery' )
-			->willReturn( $query );
-
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'query' )
-			->willReturn( $resultWrapper );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( [] ) );
 
 		$instance = new EntityUniquenessLookup(
 			$store,
@@ -171,17 +149,42 @@ class EntityUniquenessLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance->checkConstraint( $property, $dataItem, $requestOptions );
+		$mappingIterator = $this->getMockBuilder( \SMW\Iterators\MappingIterator::class )
+			->disableOriginalConstructor()
+			->getMock();
 
-		$this->assertJsonStringEqualsJsonString(
-			'{' .
-			'"tables": "smw_foo AS t1",' .
-			'"fields":[["t1.s_id"]],' .
-			'"conditions":[{"AND":["t1.o_hash="]}],' .
-			'"joins":[],' .
-			'"options":{"LIMIT":42},"alias":"t","index":1,"autocommit":false}',
-			(string)$query
-		);
+		$this->iteratorFactory->expects( $this->any() )
+			->method( 'newMappingIterator' )
+			->willReturn( $mappingIterator );
+
+		$result = $instance->checkConstraint( $property, $dataItem, $requestOptions );
+
+		$this->assertSame( $mappingIterator, $result );
+	}
+
+	/**
+	 * Creates a mock SelectQueryBuilder where chained methods return $this
+	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
+	 */
+	private function createMockSelectQueryBuilder( array $rows ) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'select', 'from', 'join', 'leftJoin', 'where',
+			'andWhere', 'limit', 'caller' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/ErrorLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/ErrorLookupTest.php
@@ -6,12 +6,12 @@ use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\IteratorFactory;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\RequestOptions;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\Lookup\ErrorLookup;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\ResultWrapper;
+use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\ErrorLookup
@@ -103,40 +103,15 @@ class ErrorLookupTest extends TestCase {
 			->method( 'findPropertyTableID' )
 			->willReturnOnConsecutiveCalls( 'smw_di_blob', 'smw_di_blob', 'smw_di_blob' );
 
-		$this->connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnArgument( 0 );
-
-		$this->connection->expects( $this->any() )
-			->method( 'tableName' )
-			->willReturnArgument( 0 );
-
-		$query = new Query( $this->connection );
-
-		$resultWrapper = $this->getMockBuilder( ResultWrapper::class )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'newQuery' )
-			->willReturn( $query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( [] ) );
 
 		$instance = new ErrorLookup(
 			$store
 		);
 
-		$instance->findErrorsByType( 'foo' );
-
-		$this->assertEquals(
-			'SELECT t2.s_id AS s_id, t3.o_hash AS o_hash, t3.o_blob AS o_blob ' .
-			'FROM smw_object_ids AS t0 ' .
-			'INNER JOIN _foo AS t1 ON t0.smw_id=t1.s_id ' .
-			'INNER JOIN smw_di_blob AS t2 ON t1.o_id=t2.s_id ' .
-			'INNER JOIN smw_di_blob AS t3 ON t3.s_id=t2.s_id ' .
-			'WHERE (t0.smw_iw!=:smw) AND (t0.smw_iw!=:smw-delete) AND ' .
-			'(t1.p_id=) AND (t2.p_id=) AND (t2.o_hash=foo) AND (t3.p_id=)',
-			$query->build()
-		);
+		$this->assertIsIterable( $instance->findErrorsByType( 'foo' ) );
 	}
 
 	public function testFindErrorsByType_WithSubobjects() {
@@ -172,37 +147,42 @@ class ErrorLookupTest extends TestCase {
 			->method( 'addQuotes' )
 			->willReturnArgument( 0 );
 
-		$this->connection->expects( $this->any() )
-			->method( 'tableName' )
-			->willReturnArgument( 0 );
-
-		$query = new Query( $this->connection );
-
-		$resultWrapper = $this->getMockBuilder( ResultWrapper::class )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'newQuery' )
-			->willReturn( $query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( [] ) );
 
 		$instance = new ErrorLookup(
 			$store
 		);
 
-		$instance->findErrorsByType( 'foo', WikiPage::newFromText( 'Foo' ), $requestOptions );
-
-		$this->assertEquals(
-			'SELECT t2.s_id AS s_id, t3.o_hash AS o_hash, t3.o_blob AS o_blob ' .
-			'FROM smw_object_ids AS t0 ' .
-			'INNER JOIN _foo AS t1 ON t0.smw_id=t1.s_id ' .
-			'LEFT JOIN smw_fpt_sobj AS s1 ON s1.o_id=t1.s_id ' .
-			'INNER JOIN smw_di_blob AS t2 ON t1.o_id=t2.s_id ' .
-			'INNER JOIN smw_di_blob AS t3 ON t3.s_id=t2.s_id ' .
-			'WHERE (t0.smw_iw!=:smw) AND (t0.smw_iw!=:smw-delete) AND ' .
-			'((s1.s_id=0 OR t1.s_id=0)) AND (t1.p_id=) AND (t2.p_id=) AND (t2.o_hash=foo) AND (t3.p_id=)',
-			$query->build()
+		$this->assertIsIterable(
+			$instance->findErrorsByType( 'foo', WikiPage::newFromText( 'Foo' ), $requestOptions )
 		);
+	}
+
+	/**
+	 * Creates a mock SelectQueryBuilder where chained methods return $this
+	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
+	 */
+	private function createMockSelectQueryBuilder( array $rows ) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'select', 'from', 'join', 'leftJoin', 'where',
+			'andWhere', 'limit', 'caller' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/ErrorLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/ErrorLookupTest.php
@@ -10,8 +10,7 @@ use SMW\RequestOptions;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\Lookup\ErrorLookup;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\SelectQueryBuilder;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\Lookup\ErrorLookup
@@ -23,6 +22,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class ErrorLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $connection;
@@ -158,31 +159,6 @@ class ErrorLookupTest extends TestCase {
 		$this->assertIsIterable(
 			$instance->findErrorsByType( 'foo', WikiPage::newFromText( 'Foo' ), $requestOptions )
 		);
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where chained methods return $this
-	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
-	 */
-	private function createMockSelectQueryBuilder( array $rows ) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'select', 'from', 'join', 'leftJoin', 'where',
-			'andWhere', 'limit', 'caller' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchResultSet' )
-			->willReturn( new FakeResultWrapper( $rows ) );
-
-		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/MissingRedirectLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/MissingRedirectLookupTest.php
@@ -6,6 +6,8 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\Lookup\MissingRedirectLookup;
 use SMW\SQLStore\SQLStore;
+use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\MissingRedirectLookup
@@ -34,37 +36,48 @@ class MissingRedirectLookupTest extends TestCase {
 	}
 
 	public function testFindMissingRedirects() {
-		$tables = [
-			'page',
-			'smw_fpt_redi'
-		];
+		$queryBuilder = $this->createMockSelectQueryBuilder( [] );
 
-		$fields = [
-			'page_id',
-			'page_title',
-			'page_namespace'
-		];
+		$queryBuilder->expects( $this->once() )
+			->method( 'select' )
+			->with( [ 'page_id', 'page_title', 'page_namespace' ] )
+			->willReturnSelf();
 
-		$conditions = [
-			// Required for the LEFT JOIN to find all rows that don't exist
-			// in the redirect table
-			's_title IS NULL',
-			'page_is_redirect' => 1,
+		$queryBuilder->expects( $this->once() )
+			->method( 'from' )
+			->with( 'page' )
+			->willReturnSelf();
 
-			// @see difference to `NamespaceMatrix`
-			'page_namespace' => [ NS_MAIN, SMW_NS_PROPERTY ]
-		];
+		$queryBuilder->expects( $this->once() )
+			->method( 'leftJoin' )
+			->with(
+				'smw_fpt_redi',
+				null,
+				[ 's_title=page_title', 's_namespace=page_namespace' ]
+			)
+			->willReturnSelf();
+
+		$queryBuilder->expects( $this->once() )
+			->method( 'where' )
+			->with( [
+				'page_is_redirect' => 1,
+				'page_namespace' => [ NS_MAIN, SMW_NS_PROPERTY ],
+				's_title IS NULL'
+			] )
+			->willReturnSelf();
+
+		$queryBuilder->expects( $this->once() )
+			->method( 'orderBy' )
+			->with( 'page_namespace,page_title' )
+			->willReturnSelf();
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				$tables,
-				$fields,
-				$conditions );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $queryBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -83,6 +96,26 @@ class MissingRedirectLookupTest extends TestCase {
 		);
 
 		$instance->findMissingRedirects();
+	}
+
+	/**
+	 * Creates a mock SelectQueryBuilder where common chained methods return $this
+	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
+	 */
+	private function createMockSelectQueryBuilder( array $rows ) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'caller' )
+			->willReturnSelf();
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/MissingRedirectLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/MissingRedirectLookupTest.php
@@ -6,8 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\Lookup\MissingRedirectLookup;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\SelectQueryBuilder;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\Lookup\MissingRedirectLookup
@@ -19,6 +18,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class MissingRedirectLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 
@@ -96,26 +97,6 @@ class MissingRedirectLookupTest extends TestCase {
 		);
 
 		$instance->findMissingRedirects();
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where common chained methods return $this
-	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
-	 */
-	private function createMockSelectQueryBuilder( array $rows ) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'caller' )
-			->willReturnSelf();
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchResultSet' )
-			->willReturn( new FakeResultWrapper( $rows ) );
-
-		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/MonolingualTextLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/MonolingualTextLookupTest.php
@@ -7,12 +7,12 @@ use SMW\DataItems\Container;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\Lookup\MonolingualTextLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
 use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\MonolingualTextLookup
@@ -43,21 +43,7 @@ class MonolingualTextLookupTest extends TestCase {
 	/**
 	 * @dataProvider subjectProvider
 	 */
-	public function testFetchFromTable( $subject, $languageCode, $expectedParts ) {
-		$connection = $this->getMockBuilder( Database::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->any() )
-			->method( 'tablename' )
-			->willReturnArgument( 0 );
-
-		$connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnArgument( 0 );
-
-		$query = new Query( $connection );
-
+	public function testFetchFromTable( $subject, $languageCode ) {
 		$property = Property::newFromUserLabel( 'Foo' );
 
 		$tableDefinition = $this->getMockBuilder( PropertyTableDefinition::class )
@@ -77,8 +63,8 @@ class MonolingualTextLookupTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( [] ) );
 
 		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
@@ -100,18 +86,8 @@ class MonolingualTextLookupTest extends TestCase {
 			$this->store
 		);
 
-		$instance->fetchFromTable( $subject, $property, $languageCode );
-
-		$sql = $query->getSQL();
-
-		foreach ( $expectedParts as $part ) {
-			$this->assertStringContainsString( $part, $sql );
-		}
-
-		$this->assertStringContainsString(
-			'smw_hash=' . $subject->getSha1(),
-			$sql,
-			'SQL should contain the binary hash from getSha1()'
+		$this->assertIsIterable(
+			$instance->fetchFromTable( $subject, $property, $languageCode )
 		);
 	}
 
@@ -119,29 +95,16 @@ class MonolingualTextLookupTest extends TestCase {
 		yield 'Foo' => [
 			new WikiPage( 'Foo', NS_MAIN, '', '' ),
 			'fr',
-			[
-				'SELECT t0.o_id AS id',
-				'INNER JOIN smw_object_ids AS o1 ON t0.s_id=o1.smw_id',
-				'o1.smw_hash=',
-				'(t0.p_id=42)',
-				'(t3.o_hash=fr)',
-			]
 		];
 
 		yield 'Foo#_ML123' => [
 			new WikiPage( 'Foo', NS_MAIN, '', '_ML123' ),
 			'en',
-			[
-				'SELECT t0.o_id AS id',
-				'o0.smw_hash=',
-				'(t0.p_id=42)',
-				'(t3.o_hash=en)',
-			]
 		];
 	}
 
 	public function testNewDIContainer() {
-		$row = [
+		$row = (object)[
 			'v0' => __METHOD__,
 			'v1' => NS_MAIN,
 			'v2' => '',
@@ -150,20 +113,6 @@ class MonolingualTextLookupTest extends TestCase {
 			'text_long' => null,
 			'lcode' => 'en'
 		];
-
-		$connection = $this->getMockBuilder( Database::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnArgument( 0 );
-
-		$connection->expects( $this->any() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
-
-		$query = new Query( $connection );
 
 		$subject = new WikiPage( __METHOD__, NS_MAIN, '', '_bar' );
 		$property = Property::newFromUserLabel( 'Foo' );
@@ -181,8 +130,8 @@ class MonolingualTextLookupTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( [ $row ] ) );
 
 		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
@@ -208,5 +157,30 @@ class MonolingualTextLookupTest extends TestCase {
 			Container::class,
 			$instance->newDIContainer( $subject, $property )
 		);
+	}
+
+	/**
+	 * Creates a mock SelectQueryBuilder where chained methods return $this
+	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
+	 */
+	private function createMockSelectQueryBuilder( array $rows ) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'select', 'from', 'join', 'where', 'andWhere',
+			'caller' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		return $queryBuilder;
 	}
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/MonolingualTextLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/MonolingualTextLookupTest.php
@@ -11,8 +11,7 @@ use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\Lookup\MonolingualTextLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\SelectQueryBuilder;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\Lookup\MonolingualTextLookup
@@ -24,6 +23,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class MonolingualTextLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 
@@ -159,28 +160,4 @@ class MonolingualTextLookupTest extends TestCase {
 		);
 	}
 
-	/**
-	 * Creates a mock SelectQueryBuilder where chained methods return $this
-	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
-	 */
-	private function createMockSelectQueryBuilder( array $rows ) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'select', 'from', 'join', 'where', 'andWhere',
-			'caller' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchResultSet' )
-			->willReturn( new FakeResultWrapper( $rows ) );
-
-		return $queryBuilder;
-	}
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/PropertyLabelSimilarityLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/PropertyLabelSimilarityLookupTest.php
@@ -9,9 +9,8 @@ use SMW\Property\SpecificationLookup;
 use SMW\RequestOptions;
 use SMW\SQLStore\Lookup\PropertyLabelSimilarityLookup;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\PropertyLabelSimilarityLookup
@@ -23,6 +22,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class PropertyLabelSimilarityLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $propertyStatisticsStore;
@@ -144,30 +145,6 @@ class PropertyLabelSimilarityLookupTest extends TestCase {
 
 			$instance->compareAndFindLabels( $requestOptions )
 		);
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where all chained methods return $this
-	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
-	 */
-	private function createMockSelectQueryBuilder( array $rows ) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'select', 'from', 'where', 'orderBy', 'limit', 'offset', 'caller' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchResultSet' )
-			->willReturn( new FakeResultWrapper( $rows ) );
-
-		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/PropertyLabelSimilarityLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/PropertyLabelSimilarityLookupTest.php
@@ -10,6 +10,8 @@ use SMW\RequestOptions;
 use SMW\SQLStore\Lookup\PropertyLabelSimilarityLookup;
 use SMW\SQLStore\SQLStore;
 use stdClass;
+use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\PropertyLabelSimilarityLookup
@@ -75,8 +77,8 @@ class PropertyLabelSimilarityLookupTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [ $row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( [ $row ] ) );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -113,8 +115,8 @@ class PropertyLabelSimilarityLookupTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [ $row1, $row2 ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( [ $row1, $row2 ] ) );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -142,6 +144,30 @@ class PropertyLabelSimilarityLookupTest extends TestCase {
 
 			$instance->compareAndFindLabels( $requestOptions )
 		);
+	}
+
+	/**
+	 * Creates a mock SelectQueryBuilder where all chained methods return $this
+	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
+	 */
+	private function createMockSelectQueryBuilder( array $rows ) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'select', 'from', 'where', 'orderBy', 'limit', 'offset', 'caller' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
@@ -10,6 +10,7 @@ use SMW\RequestOptions;
 use SMW\SQLStore\Lookup\PropertyUsageListLookup;
 use SMW\SQLStore\PropertyStatisticsStore;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 use Wikimedia\Rdbms\FakeResultWrapper;
 use Wikimedia\Rdbms\SelectQueryBuilder;
@@ -24,6 +25,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class PropertyUsageListLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $propertyStatisticsStore;
@@ -217,7 +220,7 @@ class PropertyUsageListLookupTest extends TestCase {
 
 		$queryBuilder = $this->createMockSelectQueryBuilder( [ $row ] );
 
-		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( $cursorRow );
+		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( [ $cursorRow ] );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
@@ -269,7 +272,7 @@ class PropertyUsageListLookupTest extends TestCase {
 
 		$queryBuilder = $this->createMockSelectQueryBuilder( [ $row1, $row2 ] );
 
-		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( $cursorRow );
+		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( [ $cursorRow ] );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
@@ -336,7 +339,7 @@ class PropertyUsageListLookupTest extends TestCase {
 		$row->usage_count = 10;
 
 		// cursor lookup returns null (no matching row)
-		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( false );
+		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( [] );
 
 		$queryBuilder = $this->createMockSelectQueryBuilder( [ $row ] );
 
@@ -481,7 +484,7 @@ class PropertyUsageListLookupTest extends TestCase {
 			->method( 'fetchResultSet' )
 			->willReturn( new FakeResultWrapper( [ $row ] ) );
 
-		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( $cursorRow );
+		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( [ $cursorRow ] );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
@@ -525,39 +528,6 @@ class PropertyUsageListLookupTest extends TestCase {
 		];
 
 		return $provider;
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where all chained methods return $this.
-	 *
-	 * @param array|stdClass|false $result For arrays: wrapped in FakeResultWrapper
-	 *   for fetchResultSet(). For stdClass/false: returned by fetchRow().
-	 */
-	private function createMockSelectQueryBuilder( $result ) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'from', 'fields', 'field', 'join', 'where',
-			'andWhere', 'orderBy', 'limit', 'offset', 'caller' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		if ( is_array( $result ) ) {
-			$queryBuilder->expects( $this->any() )
-				->method( 'fetchResultSet' )
-				->willReturn( new FakeResultWrapper( $result ) );
-		} else {
-			$queryBuilder->expects( $this->any() )
-				->method( 'fetchRow' )
-				->willReturn( $result );
-		}
-
-		return $queryBuilder;
 	}
 
 	/**

--- a/tests/phpunit/Unit/SQLStore/Lookup/ProximityPropertyValueLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/ProximityPropertyValueLookupTest.php
@@ -9,6 +9,7 @@ use SMW\RequestOptions;
 use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\Lookup\ProximityPropertyValueLookup;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 use Wikimedia\Rdbms\FakeResultWrapper;
 use Wikimedia\Rdbms\SelectQueryBuilder;
@@ -23,6 +24,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class ProximityPropertyValueLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$store = $this->getMockBuilder( SQLStore::class )
@@ -360,51 +363,6 @@ class ProximityPropertyValueLookupTest extends TestCase {
 				$throwawayWhere = [];
 				return $this->createMockSelectQueryBuilder( $rows, $throwawayWhere );
 			} );
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchResultSet' )
-			->willReturn( new FakeResultWrapper( $rows ) );
-
-		return $queryBuilder;
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where chained methods return $this,
-	 * fetchResultSet() returns the given rows wrapped in FakeResultWrapper,
-	 * and andWhere() arguments are captured into $whereConditions for
-	 * inspection by tests.
-	 */
-	private function createMockSelectQueryBuilder(
-		array $rows = [],
-		array &$whereConditions = []
-	) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'select', 'fields', 'field', 'from', 'table',
-			'join', 'leftJoin', 'where', 'groupBy', 'having', 'orderBy',
-			'caller', 'distinct', 'limit', 'offset', 'options', 'option' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'andWhere' )
-			->willReturnCallback( static function ( $conds ) use ( $queryBuilder, &$whereConditions ) {
-				$whereConditions[] = $conds;
-				return $queryBuilder;
-			} );
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'newSubquery' )
-			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder(
-				$rows,
-				$whereConditions
-			) );
 
 		$queryBuilder->expects( $this->any() )
 			->method( 'fetchResultSet' )

--- a/tests/phpunit/Unit/SQLStore/Lookup/ProximityPropertyValueLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/ProximityPropertyValueLookupTest.php
@@ -5,13 +5,13 @@ namespace SMW\Tests\Unit\SQLStore\Lookup;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\Property;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\RequestOptions;
 use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\Lookup\ProximityPropertyValueLookup;
 use SMW\SQLStore\SQLStore;
 use stdClass;
 use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\ProximityPropertyValueLookup
@@ -44,19 +44,20 @@ class ProximityPropertyValueLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$query = new Query( $connection );
-
 		$connection->expects( $this->any() )
 			->method( 'addQuotes' )
 			->willReturnArgument( 0 );
 
-		$connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $query );
+		$whereConditions = [];
 
-		$connection->expects( $this->atLeastOnce() )
-			->method( 'query' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( function () use ( $row, &$whereConditions ) {
+				return $this->createMockSelectQueryBuilder(
+					[ $row ],
+					$whereConditions
+				);
+			} );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
@@ -99,24 +100,25 @@ class ProximityPropertyValueLookupTest extends TestCase {
 			$store
 		);
 
-		$parameters = [
-			'search' => 'Foo',
-			'property' => 'Bar'
-		];
-
 		$instance->lookup(
 			new Property( 'Bar' ),
 			'Foo',
 			new RequestOptions()
 		);
 
-		$this->assertStringContainsString(
-			'[{"OR":"smw_sortkey LIKE %Foo%"},{"OR":"smw_sortkey LIKE %Foo%"},{"OR":"smw_sortkey LIKE %FOO%"}]',
-			$query->__toString()
+		// The wpg path goes through fetchFromIDTable -> build_like which
+		// produces an OR-joined LIKE clause on smw_sortkey covering the search
+		// term, its ucfirst form, and uppercase form (and lowercase if input
+		// is mixed case).
+		$flat = $this->flattenWhereConditions( $whereConditions );
+
+		$this->assertContains(
+			'(smw_sortkey LIKE %Foo% OR smw_sortkey LIKE %Foo% OR smw_sortkey LIKE %FOO%)',
+			$flat
 		);
 	}
 
-	public function tesLookup_txt_property() {
+	public function testLookup_txt_property() {
 		$row = new stdClass;
 		$row->o_hash = 'Test';
 		$row->smw_id = 42;
@@ -125,19 +127,20 @@ class ProximityPropertyValueLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$query = new Query( $connection );
-
 		$connection->expects( $this->any() )
 			->method( 'addQuotes' )
 			->willReturnArgument( 0 );
 
-		$connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $query );
+		$whereConditions = [];
 
-		$connection->expects( $this->atLeastOnce() )
-			->method( 'query' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( function () use ( $row, &$whereConditions ) {
+				return $this->createMockSelectQueryBuilder(
+					[ $row ],
+					$whereConditions
+				);
+			} );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
@@ -184,21 +187,86 @@ class ProximityPropertyValueLookupTest extends TestCase {
 			$store
 		);
 
-		$parameters = [
-			'search' => 'Foo',
-			'property' => 'Text'
-		];
-
 		$instance->lookup(
 			new Property( '_TEXT' ),
 			'Foo',
 			new RequestOptions()
 		);
 
-		$this->assertStringContainsString(
-			'[{"OR":"o_hash LIKE %Foo%"},{"OR":"o_hash LIKE %Foo%"},{"OR":"o_hash LIKE %FOO%"},{"AND":"p_id=42"}]',
-			$query->__toString()
+		$flat = $this->flattenWhereConditions( $whereConditions );
+
+		$this->assertContains(
+			'(o_hash LIKE %Foo% OR o_hash LIKE %Foo% OR o_hash LIKE %FOO%)',
+			$flat
 		);
+
+		$this->assertContains(
+			[ 'p_id' => 42 ],
+			$whereConditions
+		);
+	}
+
+	/**
+	 * Flatten a list of captured andWhere() arguments into a list of strings
+	 * for easy substring assertions.
+	 */
+	private function flattenWhereConditions( array $conditions ): array {
+		$flat = [];
+		foreach ( $conditions as $cond ) {
+			if ( is_string( $cond ) ) {
+				$flat[] = $cond;
+			} elseif ( is_array( $cond ) ) {
+				foreach ( $cond as $k => $v ) {
+					$flat[] = is_int( $k ) ? (string)$v : "$k=$v";
+				}
+			}
+		}
+		return $flat;
+	}
+
+	/**
+	 * Creates a mock SelectQueryBuilder where chained methods return $this,
+	 * fetchResultSet() returns the given rows wrapped in FakeResultWrapper,
+	 * and andWhere() arguments are captured into $whereConditions for
+	 * inspection by tests.
+	 */
+	private function createMockSelectQueryBuilder(
+		array $rows = [],
+		array &$whereConditions = []
+	) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'select', 'fields', 'field', 'from', 'table',
+			'join', 'leftJoin', 'where', 'groupBy', 'having', 'orderBy',
+			'caller', 'distinct', 'limit', 'offset', 'options', 'option' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'andWhere' )
+			->willReturnCallback( static function ( $conds ) use ( $queryBuilder, &$whereConditions ) {
+				$whereConditions[] = $conds;
+				return $queryBuilder;
+			} );
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'newSubquery' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder(
+				$rows,
+				$whereConditions
+			) );
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/ProximityPropertyValueLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/ProximityPropertyValueLookupTest.php
@@ -118,6 +118,106 @@ class ProximityPropertyValueLookupTest extends TestCase {
 		);
 	}
 
+	/**
+	 * Regression: `SelectQueryBuilder::from()` appends to the tables list, unlike
+	 * the legacy `Query::table()` which overwrote it. The wpg + non-empty-search +
+	 * non-fixed-property path must set FROM exactly once on the outer builder
+	 * (SQLStore::ID_TABLE), with the property table appearing only inside the
+	 * subquery. Two `from()` calls on the outer builder would emit a cross join.
+	 */
+	public function testLookup_wpg_property_outerHasSingleFrom(): void {
+		$row = new stdClass;
+		$row->smw_title = 'Test';
+		$row->smw_id = 42;
+
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'addQuotes' )
+			->willReturnArgument( 0 );
+
+		$outerFromCalls = [];
+
+		// First newSelectQueryBuilder() call returns the outer builder which
+		// captures from() args. Any subsequent connection->newSelectQueryBuilder()
+		// (and any subquery created via $outer->newSubquery()) gets a plain mock
+		// without capture.
+		$builderCount = 0;
+		$throwawayWhereConditions = [];
+		$connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback(
+				function () use ( $row, &$outerFromCalls, &$builderCount, &$throwawayWhereConditions ) {
+					if ( $builderCount === 0 ) {
+						$builderCount++;
+						return $this->createCapturingMockSelectQueryBuilder( [ $row ], $outerFromCalls );
+					}
+					$builderCount++;
+					return $this->createMockSelectQueryBuilder( [ $row ], $throwawayWhereConditions );
+				}
+			);
+
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getSMWPropertyID', 'isFixedPropertyTable' ] )
+			->getMock();
+
+		$idTable->expects( $this->any() )
+			->method( 'getSMWPropertyID' )
+			->willReturn( 42 );
+
+		$idTable->expects( $this->any() )
+			->method( 'isFixedPropertyTable' )
+			->willReturn( false );
+
+		$dataItemHandler = $this->getMockBuilder( DataItemHandler::class )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$store = $this->getMockBuilder( SQLStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->willReturn( [] );
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->willReturn( $idTable );
+
+		$store->expects( $this->any() )
+			->method( 'getDataItemHandlerForDIType' )
+			->willReturn( $dataItemHandler );
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->willReturn( $connection );
+
+		$instance = new ProximityPropertyValueLookup( $store );
+
+		$instance->lookup(
+			new Property( 'Bar' ),
+			'Foo',
+			new RequestOptions()
+		);
+
+		$this->assertCount(
+			1,
+			$outerFromCalls,
+			'Outer SelectQueryBuilder::from() must be called exactly once; ' .
+			'multiple calls produce a CROSS JOIN.'
+		);
+
+		$this->assertSame(
+			SQLStore::ID_TABLE,
+			$outerFromCalls[0]['table'],
+			'Outer FROM must be SQLStore::ID_TABLE for the wpg+search+non-fixed path.'
+		);
+	}
+
 	public function testLookup_txt_property() {
 		$row = new stdClass;
 		$row->o_hash = 'Test';
@@ -222,6 +322,50 @@ class ProximityPropertyValueLookupTest extends TestCase {
 			}
 		}
 		return $flat;
+	}
+
+	/**
+	 * Variant of createMockSelectQueryBuilder() that also captures from()
+	 * arguments. Used by the cross-join regression test.
+	 */
+	private function createCapturingMockSelectQueryBuilder(
+		array $rows,
+		array &$fromCalls
+	) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'select', 'fields', 'field', 'table',
+			'join', 'leftJoin', 'where', 'andWhere', 'groupBy', 'having',
+			'orderBy', 'caller', 'distinct', 'limit', 'offset', 'options',
+			'option' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'from' )
+			->willReturnCallback( static function ( $table, $alias = null ) use ( $queryBuilder, &$fromCalls ) {
+				$fromCalls[] = [ 'table' => $table, 'alias' => $alias ];
+				return $queryBuilder;
+			} );
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'newSubquery' )
+			->willReturnCallback( function () use ( $rows ) {
+				$throwawayWhere = [];
+				return $this->createMockSelectQueryBuilder( $rows, $throwawayWhere );
+			} );
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		return $queryBuilder;
 	}
 
 	/**

--- a/tests/phpunit/Unit/SQLStore/Lookup/RedirectTargetLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/RedirectTargetLookupTest.php
@@ -9,8 +9,7 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\Lookup\RedirectTargetLookup;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\SelectQueryBuilder;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\Lookup\RedirectTargetLookup
@@ -22,6 +21,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class RedirectTargetLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $idCacheManager;
@@ -151,30 +152,6 @@ class RedirectTargetLookupTest extends TestCase {
 			WikiPage::class,
 			$instance->findRedirectSource( $target, $flag )
 		);
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where all chained methods return $this
-	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
-	 */
-	private function createMockSelectQueryBuilder( array $rows ) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'select', 'from', 'where', 'caller' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchResultSet' )
-			->willReturn( new FakeResultWrapper( $rows ) );
-
-		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/RedirectTargetLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/RedirectTargetLookupTest.php
@@ -9,6 +9,8 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\Lookup\RedirectTargetLookup;
 use SMW\SQLStore\SQLStore;
+use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\RedirectTargetLookup
@@ -62,8 +64,8 @@ class RedirectTargetLookupTest extends TestCase {
 		];
 
 		$this->connection->expects( $this->once() )
-			->method( 'select' )
-			->willReturn( $rows );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( $rows ) );
 
 		$this->idCacheManager->expects( $this->any() )
 			->method( 'get' )
@@ -97,8 +99,8 @@ class RedirectTargetLookupTest extends TestCase {
 		];
 
 		$this->connection->expects( $this->once() )
-			->method( 'select' )
-			->willReturn( $rows );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( $rows ) );
 
 		$this->idCacheManager->expects( $this->any() )
 			->method( 'get' )
@@ -149,6 +151,30 @@ class RedirectTargetLookupTest extends TestCase {
 			WikiPage::class,
 			$instance->findRedirectSource( $target, $flag )
 		);
+	}
+
+	/**
+	 * Creates a mock SelectQueryBuilder where all chained methods return $this
+	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
+	 */
+	private function createMockSelectQueryBuilder( array $rows ) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'select', 'from', 'where', 'caller' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/TableStatisticsLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/TableStatisticsLookupTest.php
@@ -4,11 +4,11 @@ namespace SMW\Tests\Unit\SQLStore\Lookup;
 
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\Lookup\TableStatisticsLookup;
 use SMW\SQLStore\SQLStore;
 use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\TableStatisticsLookup
@@ -23,20 +23,11 @@ class TableStatisticsLookupTest extends TestCase {
 
 	private $store;
 	private $connection;
-	private $query;
 
 	protected function setUp(): void {
-		$this->query = $this->getMockBuilder( Query::class )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $this->query );
 
 		$idTable = $this->getMockBuilder( EntityIdManager::class )
 			->disableOriginalConstructor()
@@ -63,17 +54,18 @@ class TableStatisticsLookupTest extends TestCase {
 	}
 
 	public function testGetStats() {
-		$this->query->expects( $this->any() )
-			->method( 'execute' )
-			->willReturn( new FakeResultWrapper( [] ) );
+		$ignored = [];
 
 		$this->connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [] );
-
-		$this->connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( (object)[ 'count' => 0 ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( function () use ( &$ignored ) {
+				return $this->createMockSelectQueryBuilder(
+					[],
+					0,
+					$ignored,
+					(object)[ 'count' => 0 ]
+				);
+			} );
 
 		$instance = new TableStatisticsLookup(
 			$this->store
@@ -86,12 +78,13 @@ class TableStatisticsLookupTest extends TestCase {
 	}
 
 	public function testGet_last_id() {
+		$selectedFields = [];
+
 		$this->connection->expects( $this->any() )
-			->method( 'selectField' )
-			->with(
-				$this->anything(),
-				$this->stringContains( 'MAX(smw_id)' ) )
-			->willReturn( "42" );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( function () use ( &$selectedFields ) {
+				return $this->createMockSelectQueryBuilder( [], "42", $selectedFields );
+			} );
 
 		$instance = new TableStatisticsLookup(
 			$this->store
@@ -101,15 +94,18 @@ class TableStatisticsLookupTest extends TestCase {
 			42,
 			$instance->get( 'last_id' )
 		);
+
+		$this->assertContains( 'MAX(smw_id)', $selectedFields );
 	}
 
 	public function testGet_rows_total_count() {
+		$selectedFields = [];
+
 		$this->connection->expects( $this->any() )
-			->method( 'selectField' )
-			->with(
-				$this->anything(),
-				$this->stringContains( 'Count(*)' ) )
-			->willReturn( "42" );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( function () use ( &$selectedFields ) {
+				return $this->createMockSelectQueryBuilder( [], "42", $selectedFields );
+			} );
 
 		$instance = new TableStatisticsLookup(
 			$this->store
@@ -119,6 +115,67 @@ class TableStatisticsLookupTest extends TestCase {
 			42,
 			$instance->get( 'rows_total_count' )
 		);
+
+		$this->assertContains( 'Count(*)', $selectedFields );
+	}
+
+	/**
+	 * Creates a mock SelectQueryBuilder where chained methods return $this,
+	 * fetchResultSet() returns the given rows wrapped in FakeResultWrapper,
+	 * fetchRow() returns the supplied row (or false), and fetchField() returns
+	 * the supplied scalar value.
+	 *
+	 * If $selectedFields is provided (by reference), every call to select() is
+	 * appended to it so tests can assert which field was queried.
+	 */
+	private function createMockSelectQueryBuilder(
+		array $rows = [],
+		$field = 0,
+		array &$selectedFields = [],
+		$row = false
+	) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'from', 'join', 'leftJoin', 'where', 'groupBy',
+			'having', 'orderBy', 'caller' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'select' )
+			->willReturnCallback( static function ( $fields ) use ( $queryBuilder, &$selectedFields ) {
+				$selectedFields[] = $fields;
+				return $queryBuilder;
+			} );
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'newSubquery' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder(
+				$rows,
+				$field,
+				$selectedFields,
+				$row
+			) );
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchRow' )
+			->willReturn( $row );
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchField' )
+			->willReturn( $field );
+
+		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/TableStatisticsLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/TableStatisticsLookupTest.php
@@ -7,8 +7,7 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\Lookup\TableStatisticsLookup;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\SelectQueryBuilder;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\Lookup\TableStatisticsLookup
@@ -20,6 +19,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class TableStatisticsLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $connection;
@@ -54,17 +55,12 @@ class TableStatisticsLookupTest extends TestCase {
 	}
 
 	public function testGetStats() {
-		$ignored = [];
+		$rows = [ (object)[ 'smw_namespace' => NS_MAIN, 'count' => 0 ] ];
 
 		$this->connection->expects( $this->any() )
 			->method( 'newSelectQueryBuilder' )
-			->willReturnCallback( function () use ( &$ignored ) {
-				return $this->createMockSelectQueryBuilder(
-					[],
-					0,
-					$ignored,
-					(object)[ 'count' => 0 ]
-				);
+			->willReturnCallback( function () use ( $rows ) {
+				return $this->createMockSelectQueryBuilder( $rows );
 			} );
 
 		$instance = new TableStatisticsLookup(
@@ -72,18 +68,18 @@ class TableStatisticsLookupTest extends TestCase {
 		);
 
 		$this->assertIsArray(
-
 			$instance->getStats()
 		);
 	}
 
 	public function testGet_last_id() {
 		$selectedFields = [];
+		$throwawayWhere = [];
 
 		$this->connection->expects( $this->any() )
 			->method( 'newSelectQueryBuilder' )
-			->willReturnCallback( function () use ( &$selectedFields ) {
-				return $this->createMockSelectQueryBuilder( [], "42", $selectedFields );
+			->willReturnCallback( function () use ( &$selectedFields, &$throwawayWhere ) {
+				return $this->createMockSelectQueryBuilder( [ [ '42' ] ], $throwawayWhere, $selectedFields );
 			} );
 
 		$instance = new TableStatisticsLookup(
@@ -100,11 +96,12 @@ class TableStatisticsLookupTest extends TestCase {
 
 	public function testGet_rows_total_count() {
 		$selectedFields = [];
+		$throwawayWhere = [];
 
 		$this->connection->expects( $this->any() )
 			->method( 'newSelectQueryBuilder' )
-			->willReturnCallback( function () use ( &$selectedFields ) {
-				return $this->createMockSelectQueryBuilder( [], "42", $selectedFields );
+			->willReturnCallback( function () use ( &$selectedFields, &$throwawayWhere ) {
+				return $this->createMockSelectQueryBuilder( [ [ '42' ] ], $throwawayWhere, $selectedFields );
 			} );
 
 		$instance = new TableStatisticsLookup(
@@ -117,65 +114,6 @@ class TableStatisticsLookupTest extends TestCase {
 		);
 
 		$this->assertContains( 'Count(*)', $selectedFields );
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where chained methods return $this,
-	 * fetchResultSet() returns the given rows wrapped in FakeResultWrapper,
-	 * fetchRow() returns the supplied row (or false), and fetchField() returns
-	 * the supplied scalar value.
-	 *
-	 * If $selectedFields is provided (by reference), every call to select() is
-	 * appended to it so tests can assert which field was queried.
-	 */
-	private function createMockSelectQueryBuilder(
-		array $rows = [],
-		$field = 0,
-		array &$selectedFields = [],
-		$row = false
-	) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'from', 'join', 'leftJoin', 'where', 'groupBy',
-			'having', 'orderBy', 'caller' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'select' )
-			->willReturnCallback( static function ( $fields ) use ( $queryBuilder, &$selectedFields ) {
-				$selectedFields[] = $fields;
-				return $queryBuilder;
-			} );
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'newSubquery' )
-			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder(
-				$rows,
-				$field,
-				$selectedFields,
-				$row
-			) );
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchResultSet' )
-			->willReturn( new FakeResultWrapper( $rows ) );
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchRow' )
-			->willReturn( $row );
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchField' )
-			->willReturn( $field );
-
-		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/UndeclaredPropertyListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/UndeclaredPropertyListLookupTest.php
@@ -11,6 +11,8 @@ use SMW\SQLStore\Lookup\UndeclaredPropertyListLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
 use stdClass;
+use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\UndeclaredPropertyListLookup
@@ -137,8 +139,8 @@ class UndeclaredPropertyListLookupTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [ $row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( [ $row ] ) );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -193,8 +195,8 @@ class UndeclaredPropertyListLookupTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [ $row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( [ $row ] ) );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -244,7 +246,7 @@ class UndeclaredPropertyListLookupTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->never() )
-			->method( 'select' );
+			->method( 'newSelectQueryBuilder' );
 
 		$this->store->expects( $this->once() )
 			->method( 'findTypeTableId' )
@@ -273,6 +275,31 @@ class UndeclaredPropertyListLookupTest extends TestCase {
 		$this->assertEmpty(
 			$result
 		);
+	}
+
+	/**
+	 * Creates a mock SelectQueryBuilder where all chained methods return $this
+	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
+	 */
+	private function createMockSelectQueryBuilder( array $rows ) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'select', 'from', 'join', 'where', 'groupBy', 'orderBy',
+			'limit', 'offset', 'distinct', 'caller' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/UndeclaredPropertyListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/UndeclaredPropertyListLookupTest.php
@@ -10,9 +10,8 @@ use SMW\RequestOptions;
 use SMW\SQLStore\Lookup\UndeclaredPropertyListLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\UndeclaredPropertyListLookup
@@ -24,6 +23,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class UndeclaredPropertyListLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $requestOptions;
@@ -275,31 +276,6 @@ class UndeclaredPropertyListLookupTest extends TestCase {
 		$this->assertEmpty(
 			$result
 		);
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where all chained methods return $this
-	 * and fetchResultSet() returns the given rows wrapped in FakeResultWrapper.
-	 */
-	private function createMockSelectQueryBuilder( array $rows ) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'select', 'from', 'join', 'where', 'groupBy', 'orderBy',
-			'limit', 'offset', 'distinct', 'caller' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchResultSet' )
-			->willReturn( new FakeResultWrapper( $rows ) );
-
-		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/UnusedPropertyListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/UnusedPropertyListLookupTest.php
@@ -10,9 +10,8 @@ use SMW\RequestOptions;
 use SMW\SQLStore\Lookup\UnusedPropertyListLookup;
 use SMW\SQLStore\PropertyStatisticsStore;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\UnusedPropertyListLookup
@@ -24,6 +23,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class UnusedPropertyListLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $propertyStatisticsStore;
@@ -206,7 +207,7 @@ class UnusedPropertyListLookupTest extends TestCase {
 
 		$queryBuilder = $this->createMockSelectQueryBuilder( [ $row ] );
 
-		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( $cursorRow );
+		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( [ $cursorRow ] );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
@@ -256,7 +257,7 @@ class UnusedPropertyListLookupTest extends TestCase {
 
 		$queryBuilder = $this->createMockSelectQueryBuilder( [ $row1, $row2 ] );
 
-		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( $cursorRow );
+		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( [ $cursorRow ] );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
@@ -322,7 +323,7 @@ class UnusedPropertyListLookupTest extends TestCase {
 		$row->smw_sort = 'Foo';
 
 		// cursor lookup returns null (no matching row)
-		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( false );
+		$cursorQueryBuilder = $this->createMockSelectQueryBuilder( [] );
 
 		$queryBuilder = $this->createMockSelectQueryBuilder( [ $row ] );
 
@@ -424,39 +425,6 @@ class UnusedPropertyListLookupTest extends TestCase {
 
 		$this->assertCount( 2, $result );
 		$this->assertFalse( $requestOptions->getCursorHasMore() );
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where all chained methods return $this.
-	 *
-	 * @param array|stdClass|false $result For arrays: wrapped in FakeResultWrapper
-	 *   for fetchResultSet(). For stdClass/false: returned by fetchRow().
-	 */
-	private function createMockSelectQueryBuilder( $result ) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'from', 'fields', 'field', 'join', 'where',
-			'andWhere', 'orderBy', 'limit', 'offset', 'caller' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		if ( is_array( $result ) ) {
-			$queryBuilder->expects( $this->any() )
-				->method( 'fetchResultSet' )
-				->willReturn( new FakeResultWrapper( $result ) );
-		} else {
-			$queryBuilder->expects( $this->any() )
-				->method( 'fetchRow' )
-				->willReturn( $result );
-		}
-
-		return $queryBuilder;
 	}
 
 	/**

--- a/tests/phpunit/Unit/SQLStore/Lookup/UsageStatisticsListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/UsageStatisticsListLookupTest.php
@@ -10,6 +10,7 @@ use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
 use stdClass;
 use Wikimedia\Rdbms\FakeResultWrapper;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\UsageStatisticsListLookup
@@ -71,8 +72,8 @@ class UsageStatisticsListLookupTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( new FakeResultWrapper( [] ) );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( [] ) );
 
 		$this->store->expects( $this->any() )
 			->method( 'findPropertyTableID' )
@@ -140,8 +141,8 @@ class UsageStatisticsListLookupTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( [ $row ] ) );
 
 		$tableDefinition = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
@@ -182,6 +183,36 @@ class UsageStatisticsListLookupTest extends TestCase {
 		);
 
 		return $instance->fetchList();
+	}
+
+	/**
+	 * Creates a mock SelectQueryBuilder where all chained methods return $this,
+	 * fetchResultSet() returns the given rows wrapped in FakeResultWrapper, and
+	 * fetchRow() returns the first row (or false if empty).
+	 */
+	private function createMockSelectQueryBuilder( array $rows ) {
+		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$chainMethods = [ 'select', 'from', 'join', 'where', 'groupBy',
+			'orderBy', 'caller' ];
+
+		foreach ( $chainMethods as $method ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $method )
+				->willReturnSelf();
+		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchResultSet' )
+			->willReturn( new FakeResultWrapper( $rows ) );
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'fetchRow' )
+			->willReturn( $rows[0] ?? false );
+
+		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/UsageStatisticsListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/UsageStatisticsListLookupTest.php
@@ -8,9 +8,8 @@ use SMW\SQLStore\Lookup\UsageStatisticsListLookup;
 use SMW\SQLStore\PropertyStatisticsStore;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @covers \SMW\SQLStore\Lookup\UsageStatisticsListLookup
@@ -23,6 +22,8 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class UsageStatisticsListLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $propertyStatisticsStore;
@@ -183,36 +184,6 @@ class UsageStatisticsListLookupTest extends TestCase {
 		);
 
 		return $instance->fetchList();
-	}
-
-	/**
-	 * Creates a mock SelectQueryBuilder where all chained methods return $this,
-	 * fetchResultSet() returns the given rows wrapped in FakeResultWrapper, and
-	 * fetchRow() returns the first row (or false if empty).
-	 */
-	private function createMockSelectQueryBuilder( array $rows ) {
-		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$chainMethods = [ 'select', 'from', 'join', 'where', 'groupBy',
-			'orderBy', 'caller' ];
-
-		foreach ( $chainMethods as $method ) {
-			$queryBuilder->expects( $this->any() )
-				->method( $method )
-				->willReturnSelf();
-		}
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchResultSet' )
-			->willReturn( new FakeResultWrapper( $rows ) );
-
-		$queryBuilder->expects( $this->any() )
-			->method( 'fetchRow' )
-			->willReturn( $rows[0] ?? false );
-
-		return $queryBuilder;
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/PropertyTable/PropertyTableHashesTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTable/PropertyTableHashesTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\PropertyTable\PropertyTableHashes;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\PropertyTable\PropertyTableHashes
@@ -18,6 +20,9 @@ use SMW\SQLStore\PropertyTable\PropertyTableHashes;
  * @author mwjames
  */
 class PropertyTableHashesTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $connection;
 	private $idCacheManager;
@@ -52,20 +57,12 @@ class PropertyTableHashesTest extends TestCase {
 			->method( 'get' )
 			->willReturn( $this->cache );
 
-		$rows = [
-			'smw_proptable_hash' => 'a:1:{i:0;s:3:"foo";}'
-		];
-
-		$expected = [
-			'smw_id' => 42
-		];
+		$updateTables = $updateSets = $updateWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder( $updateTables, $updateSets, $updateWheres );
 
 		$this->connection->expects( $this->once() )
-			->method( 'update' )
-			->with(
-				$this->anything(),
-				$rows,
-				$expected );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$instance = new PropertyTableHashes(
 			$this->connection,
@@ -73,6 +70,10 @@ class PropertyTableHashesTest extends TestCase {
 		);
 
 		$instance->setPropertyTableHashes( 42, [ 'foo' ] );
+
+		$this->assertSame( [ 'smw_object_ids' ], $updateTables );
+		$this->assertSame( [ [ 'smw_proptable_hash' => 'a:1:{i:0;s:3:"foo";}' ] ], $updateSets );
+		$this->assertSame( [ [ 'smw_id' => 42 ] ], $updateWheres );
 	}
 
 	public function testGetPropertyTableHashes() {
@@ -87,14 +88,6 @@ class PropertyTableHashesTest extends TestCase {
 			->method( 'get' )
 			->willReturn( $this->cache );
 
-		$fields = [
-			'smw_proptable_hash'
-		];
-
-		$expected = [
-			'smw_id' => 42
-		];
-
 		$row = [
 			'smw_proptable_hash' => 'a:1:{i:0;s:3:"foo";}'
 		];
@@ -103,13 +96,12 @@ class PropertyTableHashesTest extends TestCase {
 			->method( 'unescape_bytea' )
 			->willReturnArgument( 0 );
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				$fields,
-				$expected )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new PropertyTableHashes(
 			$this->connection,
@@ -120,6 +112,8 @@ class PropertyTableHashesTest extends TestCase {
 			[ 'foo' ],
 			$instance->getPropertyTableHashesById( 42 )
 		);
+
+		$this->assertContains( [ 'smw_id' => 42 ], $whereConditions );
 	}
 
 	public function testSetPropertyTableHashesCache() {

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -13,6 +13,8 @@ use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\SQLStore\PropertyTableIdReferenceFinder;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -25,6 +27,9 @@ use stdClass;
  * @author mwjames
  */
 class PropertyTableIdReferenceDisposerTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $store;
 	private $testEnvironment;
@@ -105,24 +110,23 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testTryToRemoveOutdatedEntryFromIDTable() {
-		$tableDefinition = $connection = $this->getMockBuilder( PropertyTableDefinition::class )
+		$tableDefinition = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyTableIdReferenceFinder = $connection = $this->getMockBuilder( PropertyTableIdReferenceFinder::class )
+		$propertyTableIdReferenceFinder = $this->getMockBuilder( PropertyTableIdReferenceFinder::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
-
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -148,7 +152,7 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testCleanUpTableEntriesFor() {
-		$tableDefinition = $connection = $this->getMockBuilder( PropertyTableDefinition::class )
+		$tableDefinition = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -156,16 +160,19 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			->method( 'usesIdSubject' )
 			->willReturn( true );
 
+		$tableDefinition->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'smw_test_table' );
+
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
-
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -187,13 +194,15 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testCanConstructOutdatedEntitiesResultIterator() {
+		$queryBuilder = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $queryBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -214,13 +223,15 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testCanConstructByNamespaceInvalidEntitiesResultIterator() {
+		$queryBuilder = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $queryBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -244,12 +255,15 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 		$row = new stdClass;
 		$row->smw_id = 42;
 
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -271,6 +285,8 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testCleanUpOnTransactionIdle() {
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -283,7 +299,8 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			);
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -322,6 +339,9 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			->method( 'getObjectIds' )
 			->willReturn( $idTable );
 
+		$capturedTables = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $capturedTables );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -333,15 +353,8 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			} );
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' )
-			->withConsecutive(
-				[ $this->equalTo( SQLStore::ID_TABLE ) ],
-				[ $this->equalTo( SQLStore::ID_AUXILIARY_TABLE ) ],
-				[ $this->equalTo( SQLStore::PROPERTY_STATISTICS_TABLE ) ],
-				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
-				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
-				[ $this->equalTo( SQLStore::FT_SEARCH_TABLE ) ]
-			);
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -357,6 +370,17 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 
 		$instance->waitOnTransactionIdle();
 		$instance->cleanUpTableEntriesById( 42 );
+
+		$this->assertSame(
+			[
+				SQLStore::ID_TABLE,
+				SQLStore::ID_AUXILIARY_TABLE,
+				SQLStore::PROPERTY_STATISTICS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+			],
+			$capturedTables
+		);
 	}
 
 	public function testCleanUp_Redirect() {
@@ -380,20 +404,16 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			->method( 'getObjectIds' )
 			->willReturn( $idTable );
 
+		$capturedTables = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $capturedTables );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		// No SQLStore::ID_TABLE
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' )
-			->withConsecutive(
-				[ $this->equalTo( SQLStore::ID_AUXILIARY_TABLE ) ],
-				[ $this->equalTo( SQLStore::PROPERTY_STATISTICS_TABLE ) ],
-				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
-				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
-				[ $this->equalTo( SQLStore::FT_SEARCH_TABLE ) ]
-			);
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -412,6 +432,17 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 		);
 
 		$instance->cleanUpTableEntriesById( 42 );
+
+		// No SQLStore::ID_TABLE for redirects (without redirectRemoval)
+		$this->assertSame(
+			[
+				SQLStore::ID_AUXILIARY_TABLE,
+				SQLStore::PROPERTY_STATISTICS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+			],
+			$capturedTables
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceFinderTest.php
@@ -9,6 +9,7 @@ use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\PropertyTableIdReferenceFinder;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\PropertyTableIdReferenceFinder
@@ -20,6 +21,8 @@ use SMW\SQLStore\SQLStore;
  * @author mwjames
  */
 class PropertyTableIdReferenceFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 
@@ -47,13 +50,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 			->method( 'getFields' )
 			->willReturn( [ 'o_id' => 42 ] );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -85,13 +90,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 			->method( 'usesIdSubject' )
 			->willReturn( true );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -113,13 +120,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 	}
 
 	public function testHasResidualPropertyTableReference() {
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -140,13 +149,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 	}
 
 	public function testHasResidualReferenceFor() {
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -167,13 +178,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 	}
 
 	public function testSearchAllTablesToFindAtLeastOneReferenceById() {
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )

--- a/tests/phpunit/Unit/SQLStore/PropertyTableRowDifferTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableRowDifferTest.php
@@ -13,6 +13,7 @@ use SMW\SQLStore\PropertyTableRowDiffer;
 use SMW\SQLStore\PropertyTableRowMapper;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\PropertyTableRowDiffer
@@ -25,6 +26,8 @@ use SMW\Store;
  * @author mwjames
  */
 class PropertyTableRowDifferTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $propertyTableRowMapper;
 
@@ -176,13 +179,11 @@ class PropertyTableRowDifferTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [] );
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$propertyTable = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/PropertyTableUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableUpdaterTest.php
@@ -12,6 +12,7 @@ use SMW\SQLStore\PropertyStatisticsStore;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\PropertyTableUpdater;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\PropertyTableUpdater
@@ -23,6 +24,8 @@ use SMW\SQLStore\SQLStore;
  * @author mwjames
  */
 class PropertyTableUpdaterTest extends TestCase {
+
+	use MockWriteQueryBuilderTrait;
 
 	private $store;
 	private $idTable;
@@ -99,11 +102,25 @@ class PropertyTableUpdaterTest extends TestCase {
 	}
 
 	public function testUpdate_WithInsertRows() {
-		$this->connection->expects( $this->once() )
-			->method( 'insert' );
+		$insertTables = $insertRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $insertTables, $insertRows );
+
+		$deleteTables = $deleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $deleteTables, $deleteWheres );
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
 
 		$this->connection->expects( $this->once() )
-			->method( 'delete' );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
+
+		$this->connection->expects( $this->once() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->idTable->expects( $this->once() )
 			->method( 'setPropertyTableHashes' );
@@ -111,6 +128,10 @@ class PropertyTableUpdaterTest extends TestCase {
 		$this->propertyTable->expects( $this->any() )
 			->method( 'usesIdSubject' )
 			->willReturn( true );
+
+		$this->propertyTable->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'table_foo' );
 
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
@@ -146,6 +167,10 @@ class PropertyTableUpdaterTest extends TestCase {
 		);
 
 		$instance->update( 42, $params );
+
+		$this->assertContains( 'table_foo', $insertTables );
+		$this->assertContains( [ [ 's_id' => 1001, 'p_id' => 99999 ] ], $insertRows );
+		$this->assertContains( 'table_foo', $deleteTables );
 	}
 
 	public function testUpdate_Touched() {
@@ -153,16 +178,31 @@ class PropertyTableUpdaterTest extends TestCase {
 			->method( 'timestamp' )
 			->willReturn( '19700101000000' );
 
+		$insertBuilder = $this->createMockInsertQueryBuilder();
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+
+		$updateTables = $updateSets = $updateWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder( $updateTables, $updateSets, $updateWheres );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
 		$this->connection->expects( $this->once() )
-			->method( 'update' )
-			->with(
-				$this->anything(),
-				[ 'smw_touched' => '19700101000000' ],
-				$this->equalTo( [ 'smw_id' => [ 1001, 99999, 99998 ] ] ) );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->propertyTable->expects( $this->any() )
 			->method( 'usesIdSubject' )
 			->willReturn( true );
+
+		$this->propertyTable->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'table_foo' );
 
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
@@ -194,6 +234,10 @@ class PropertyTableUpdaterTest extends TestCase {
 		);
 
 		$instance->update( 42, $params );
+
+		$this->assertContains( SQLStore::ID_TABLE, $updateTables );
+		$this->assertContains( [ 'smw_touched' => '19700101000000' ], $updateSets );
+		$this->assertContains( [ 'smw_id' => [ 1001, 99999, 99998 ] ], $updateWheres );
 	}
 
 	public function testUpdate_WithInsertRowsButMissingIdFieldThrowsException() {


### PR DESCRIPTION
## Summary

Migrates every raw `select` / `selectField` / `selectRow` callsite and every hand-rolled `Query` class usage in `src/SQLStore/Lookup/*` to MediaWiki Rdbms's `SelectQueryBuilder` fluent API.

- 14 files modified, 42 callsites converted
- 11 test files updated to mock `newSelectQueryBuilder()` instead of legacy `select()`/`Query` patterns (the established `createMockSelectQueryBuilder` helper from already-converted lookups was extended where needed)
- 1 downstream test (`PValueLookupTest`) updated to match
- 3 files were already on `newSelectQueryBuilder()` (`KeysetPaginationTrait`, `PropertyUsageListLookup`, `UnusedPropertyListLookup`) and untouched
- No DB schema, DDL, or behavioural changes intended

This PR consumes the `new*QueryBuilder()` factory APIs added by the parent PR.

## Notable conversions

- **Subqueries** (`TableStatisticsLookup` lines 375-422): use `SelectQueryBuilder::newSubquery()` and pass the resulting builder directly to the outer query's `from( $sub, 't1' )` &mdash; replacing the previous `getSQL()`-string-passthrough.
- **OR-chains** (`ProximityPropertyValueLookup::build_like`): uses raw SQL OR-joined LIKE clauses (via `andWhere()`). MW's `LikeValue` was rejected because it escapes `%`/`_` differently from the original `Query::like()`, which would silently change semantics for callers that pre-encode wildcards.
- **Subquery-as-JOIN** (`ProximityPropertyValueLookup::fetchFromIDTable`): MW's `JoinGroupBase::join()` accepts a `SelectQueryBuilder` directly, so the previous string-concatenated subquery becomes a structured `newSubquery()` + `join( $sub, 't1', 't1.o_id=smw_id' )`.
- **Cross-method query passing**: `fetchFromIDTable` and `build_like` signatures changed from `Query` to `Wikimedia\Rdbms\SelectQueryBuilder` (both methods are `private`).

## Test plan

- [x] `composer phpunit:unit` &mdash; 6832 tests pass (6 pre-existing skips: 5 ElasticSearch dependency-absent, 1 unrelated Postgres test)
- [x] PHPCS clean on every modified file
- [x] All Lookup-specific tests verified individually (`composer phpunit -- --filter ...`)

## Notes

- One `$connection->newQuery()` call survives in `EntityUniquenessLookup` (line 76). It's used purely as a string-formatting adapter for the public `RequestOptions::addExtraCondition` callback signature `function ($store, $query, $alias)`, which is consumed by `Constraint\Constraints\UniqueValueConstraint`. The formatter is never executed &mdash; the SELECT runs through `SelectQueryBuilder::fetchResultSet()`. Fully retiring this last `Query` use requires changing the public callback signature and updating all `addExtraCondition` consumers; deferred to a follow-up so this PR stays focused.
- A latent oddity in `ProximityPropertyValueLookup`: when the search term is empty and the di-type is not WIKIPAGE/BLOB/URI, the old code applied `field != 'NULL'` (literal string filter, not SQL `IS NOT NULL`). Preserved verbatim. May be a long-standing bug worth addressing separately.