### PR TITLE
Migrate SQLStore/EntityStore callsites to MW Rdbms QueryBuilder

### DIFF
--- a/src/SQLStore/EntityStore/AuxiliaryFields.php
+++ b/src/SQLStore/EntityStore/AuxiliaryFields.php
@@ -117,7 +117,7 @@ class AuxiliaryFields {
 		return $this->connection->newSelectQueryBuilder()
 			->select( [ 't.smw_id', 't.smw_hash', 'p.smw_countmap' ] )
 			->from( SQLStore::ID_TABLE, 't' )
-			->join( SQLStore::ID_AUXILIARY_TABLE, 'p', [ 'p.smw_id=t.smw_id' ] )
+			->join( SQLStore::ID_AUXILIARY_TABLE, 'p', 'p.smw_id=t.smw_id' )
 			->where( [ 't.smw_hash' => $hashes ] )
 			->caller( __METHOD__ )
 			->fetchResultSet();

--- a/src/SQLStore/EntityStore/AuxiliaryFields.php
+++ b/src/SQLStore/EntityStore/AuxiliaryFields.php
@@ -94,44 +94,33 @@ class AuxiliaryFields {
 			$countmap = null;
 		}
 
-		$this->connection->upsert(
-			SQLStore::ID_AUXILIARY_TABLE,
-			[
+		$this->connection->newInsertQueryBuilder()
+			->insertInto( SQLStore::ID_AUXILIARY_TABLE )
+			->row( [
 				'smw_id' => $sid,
 				'smw_seqmap' => $seqmap,
 				'smw_countmap' => $countmap
-			],
-			'smw_id',
-			[
+			] )
+			->onDuplicateKeyUpdate()
+			->uniqueIndexFields( [ 'smw_id' ] )
+			->set( [
 				'smw_seqmap' => $seqmap,
 				'smw_countmap' => $countmap
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$cache->save( $sid, $countmap );
 	}
 
 	private function fetchCountMap( array $hashes ) {
-		return $this->connection->select(
-			[
-				't' => SQLStore::ID_TABLE,
-				'p' => SQLStore::ID_AUXILIARY_TABLE
-			],
-			[
-				't.smw_id',
-				't.smw_hash',
-				'p.smw_countmap',
-			],
-			[
-				't.smw_hash' => $hashes
-			],
-			__METHOD__,
-			[],
-			[
-				'p' => [ 'INNER JOIN', [ 'p.smw_id=t.smw_id' ] ],
-			]
-		);
+		return $this->connection->newSelectQueryBuilder()
+			->select( [ 't.smw_id', 't.smw_hash', 'p.smw_countmap' ] )
+			->from( SQLStore::ID_TABLE, 't' )
+			->join( SQLStore::ID_AUXILIARY_TABLE, 'p', [ 'p.smw_id=t.smw_id' ] )
+			->where( [ 't.smw_hash' => $hashes ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 	}
 
 }

--- a/src/SQLStore/EntityStore/CacheWarmer.php
+++ b/src/SQLStore/EntityStore/CacheWarmer.php
@@ -138,9 +138,8 @@ class CacheWarmer {
 
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$rows = $connection->select(
-			SQLStore::ID_TABLE,
-			[
+		$rows = $connection->newSelectQueryBuilder()
+			->select( [
 				'smw_id',
 				'smw_title',
 				'smw_namespace',
@@ -148,12 +147,11 @@ class CacheWarmer {
 				'smw_subobject',
 				'smw_sortkey',
 				'smw_sort'
-			],
-			[
-				'smw_hash' => $hashList
-			],
-			__METHOD__
-		);
+			] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_hash' => $hashList ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 		foreach ( $rows as $row ) {
 			$sortkey = $row->smw_sort === null ? '' : $row->smw_sortkey;
 
@@ -191,9 +189,8 @@ class CacheWarmer {
 			return;
 		}
 
-		$rows = $connection->select(
-			SQLStore::ID_TABLE,
-			[
+		$rows = $connection->newSelectQueryBuilder()
+			->select( [
 				'smw_id',
 				'smw_title',
 				'smw_namespace',
@@ -201,12 +198,11 @@ class CacheWarmer {
 				'smw_subobject',
 				'smw_sortkey',
 				'smw_sort'
-			],
-			[
-				'smw_id' => $idList
-			],
-			__METHOD__
-		);
+			] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $idList ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		foreach ( $rows as $row ) {
 			$sortkey = $row->smw_sort === null ? '' : $row->smw_sortkey;

--- a/src/SQLStore/EntityStore/DuplicateFinder.php
+++ b/src/SQLStore/EntityStore/DuplicateFinder.php
@@ -11,6 +11,7 @@ use SMW\SQLStore\PropertyTableInfoFetcher;
 use SMW\SQLStore\RedirectStore;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @license GPL-2.0-or-later
@@ -44,36 +45,31 @@ class DuplicateFinder {
 		}
 
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
 
-		$query->type( 'SELECT' );
-		$query->options( [ 'LIMIT' => 2 ] );
-
-		$query->table( SQLStore::ID_TABLE );
-
-		// Only find entities
-		$query->fields( [ 'smw_id', 'smw_sortkey' ] );
+		$qb = $connection->newSelectQueryBuilder()
+			->from( SQLStore::ID_TABLE )
+			->select( [ 'smw_id', 'smw_sortkey' ] )
+			->limit( 2 );
 
 		if ( $type === DataItem::TYPE_WIKIPAGE ) {
-			$query->condition( $query->eq( 'smw_title', $dataItem->getDBKey() ) );
-			$query->condition( $query->eq( 'smw_namespace', $dataItem->getNamespace() ) );
-			$query->condition( $query->eq( 'smw_subobject', $dataItem->getSubobjectName() ) );
+			$qb->where( [
+				'smw_title' => $dataItem->getDBKey(),
+				'smw_namespace' => $dataItem->getNamespace(),
+				'smw_subobject' => $dataItem->getSubobjectName(),
+			] );
 		} else {
-			$query->condition( $query->eq( 'smw_sortkey', $dataItem->getCanonicalLabel() ) );
-			$query->condition( $query->eq( 'smw_namespace', SMW_NS_PROPERTY ) );
-			$query->condition( $query->eq( 'smw_subobject', '' ) );
+			$qb->where( [
+				'smw_sortkey' => $dataItem->getCanonicalLabel(),
+				'smw_namespace' => SMW_NS_PROPERTY,
+				'smw_subobject' => '',
+			] );
 		}
 
-		$query->condition( $query->neq( 'smw_iw', SMW_SQL3_SMWIW_OUTDATED ) );
-		$query->condition( $query->neq( 'smw_iw', SMW_SQL3_SMWDELETEIW ) );
-		$query->condition( $query->neq( 'smw_iw', SMW_SQL3_SMWREDIIW ) );
+		foreach ( [ SMW_SQL3_SMWIW_OUTDATED, SMW_SQL3_SMWDELETEIW, SMW_SQL3_SMWREDIIW ] as $iw ) {
+			$qb->andWhere( $connection->expr( 'smw_iw', '!=', $iw ) );
+		}
 
-		$res = $connection->readQuery(
-			$query,
-			__METHOD__
-		);
-
-		return $res->numRows() > 1;
+		return $qb->caller( __METHOD__ )->fetchResultSet()->numRows() > 1;
 	}
 
 	/**
@@ -85,26 +81,25 @@ class DuplicateFinder {
 	 */
 	public function findDuplicates( $table = null ): Iterator|array {
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
-
-		$query->type( 'SELECT' );
 
 		if ( $table === null ) {
 			$table = SQLStore::ID_TABLE;
 		}
 
+		$qb = $connection->newSelectQueryBuilder()->from( $table );
+
 		if ( $table === SQLStore::ID_TABLE ) {
-			$this->id_table( $table, $query );
+			$this->id_table( $table, $qb );
 		} elseif ( $table === PropertyTableInfoFetcher::findTableIdForDataItemTypeId( DataItem::TYPE_WIKIPAGE ) ) {
-			$this->common_table( $table, $query );
+			$this->common_table( $table, $qb );
 		} elseif ( $table === RedirectStore::TABLE_NAME ) {
-			$this->common_table( $table, $query );
+			$this->common_table( $table, $qb );
 		}
 
-		$rows = $query->execute( __METHOD__ );
+		$rows = $qb->caller( __METHOD__ )->fetchResultSet();
 		$fname = __METHOD__;
 
-		if ( $rows === false ) {
+		if ( $rows->numRows() === 0 ) {
 			return [];
 		}
 
@@ -113,12 +108,12 @@ class DuplicateFinder {
 			$map = [ 'count' => $row->count ] + $map;
 
 			if ( $table === PropertyTableInfoFetcher::findTableIdForDataItemTypeId( DataItem::TYPE_WIKIPAGE ) ) {
-				$row = $connection->selectRow(
-					SQLStore::ID_TABLE,
-					[ 'smw_id', 'smw_title', 'smw_namespace', 'smw_iw', 'smw_subobject' ],
-					[ 'smw_id' => $row->s_id ],
-					$fname
-				);
+				$row = $connection->newSelectQueryBuilder()
+					->select( [ 'smw_id', 'smw_title', 'smw_namespace', 'smw_iw', 'smw_subobject' ] )
+					->from( SQLStore::ID_TABLE )
+					->where( [ 'smw_id' => $row->s_id ] )
+					->caller( $fname )
+					->fetchRow();
 
 				$map += [
 					'entity' => [
@@ -134,43 +129,29 @@ class DuplicateFinder {
 			return $map;
 		};
 
-		$mappingIterator = $this->iteratorFactory->newMappingIterator(
+		return $this->iteratorFactory->newMappingIterator(
 			$this->iteratorFactory->newResultIterator( $rows ),
 			$callback
 		);
-
-		return $mappingIterator;
 	}
 
-	private function id_table( string $table, $query ): void {
+	private function id_table( string $table, SelectQueryBuilder $qb ): void {
 		$fields = self::fields( $table );
+		$connection = $this->store->getConnection( 'mw.db' );
 
-		$query->table( $table );
-		$query->fields( array_merge( [ 'COUNT(*) as count' ], $fields ) );
-
-		$query->condition( $query->neq( 'smw_iw', SMW_SQL3_SMWIW_OUTDATED ) );
-		$query->condition( $query->neq( 'smw_iw', SMW_SQL3_SMWDELETEIW ) );
-
-		$query->options(
-			[
-				'GROUP BY' => implode( ',', $fields ),
-				'HAVING' => 'count(*) > 1'
-			]
-		);
+		$qb->select( array_merge( [ 'count' => 'COUNT(*)' ], $fields ) )
+			->andWhere( $connection->expr( 'smw_iw', '!=', SMW_SQL3_SMWIW_OUTDATED ) )
+			->andWhere( $connection->expr( 'smw_iw', '!=', SMW_SQL3_SMWDELETEIW ) )
+			->groupBy( $fields )
+			->having( 'count(*) > 1' );
 	}
 
-	private function common_table( string $table, $query ): void {
+	private function common_table( string $table, SelectQueryBuilder $qb ): void {
 		$fields = self::fields( $table );
 
-		$query->table( $table );
-		$query->fields( array_merge( [ 'COUNT(*) as count' ], $fields ) );
-
-		$query->options(
-			[
-				'GROUP BY' => implode( ',', $fields ),
-				'HAVING' => 'count(*) > 1'
-			]
-		);
+		$qb->select( array_merge( [ 'count' => 'COUNT(*)' ], $fields ) )
+			->groupBy( $fields )
+			->having( 'count(*) > 1' );
 	}
 
 	private static function fields( string $tableName ) {

--- a/src/SQLStore/EntityStore/EntityIdFinder.php
+++ b/src/SQLStore/EntityStore/EntityIdFinder.php
@@ -56,19 +56,17 @@ class EntityIdFinder {
 
 		$id = 0;
 
-		$row = $this->connection->selectRow(
-			SQLStore::ID_TABLE,
-			[
-				'smw_id'
-			],
-			[
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_id' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				'smw_title' => $dataItem->getDBKey(),
 				'smw_namespace' => $dataItem->getNamespace(),
 				'smw_iw' => $dataItem->getInterWiki(),
 				'smw_subobject' => $dataItem->getSubobjectName()
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row !== false ) {
 			$id = (int)$row->smw_id;
@@ -118,14 +116,12 @@ class EntityIdFinder {
 			$fields = [ 'smw_sortkey', 'smw_sort', 'smw_hash' ];
 		}
 
-		$row = $this->connection->selectRow(
-			SQLStore::ID_TABLE,
-			$fields,
-			[
-				'smw_id' => $id
-			],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( $fields )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row !== false ) {
 			// Make sure that smw_sort is being re-computed in case it is null
@@ -194,17 +190,17 @@ class EntityIdFinder {
 			$subobjectName = mb_substr( $subobjectName, 0, 255 );
 		}
 
-		$row = $this->connection->selectRow(
-			SQLStore::ID_TABLE,
-			$fields,
-			[
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( $fields )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				'smw_title' => $title,
 				'smw_namespace' => $namespace,
 				'smw_iw' => $iw,
 				'smw_subobject' => $subobjectName
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row !== false ) {
 			$id = $row->smw_id;
@@ -261,14 +257,12 @@ class EntityIdFinder {
 			unset( $conditions['smw_iw'] );
 		}
 
-		$rows = $this->connection->select(
-			SQLStore::ID_TABLE,
-			[
-				'smw_id'
-			],
-			$conditions,
-			__METHOD__
-		);
+		$rows = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_id' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( $conditions )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		foreach ( $rows as $row ) {
 			$matches[] = (int)$row->smw_id;

--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -621,9 +621,9 @@ class EntityIdManager {
 			// #2089 (MySQL 5.7 complained with "Data too long for column")
 			$sortkey = mb_substr( $sortkey, 0, 254 );
 
-			$db->insert(
-				SQLStore::ID_TABLE,
-				[
+			$db->newInsertQueryBuilder()
+				->insertInto( SQLStore::ID_TABLE )
+				->row( [
 					'smw_id' => $sequenceValue,
 					'smw_title' => $title,
 					'smw_namespace' => $namespace,
@@ -632,10 +632,10 @@ class EntityIdManager {
 					'smw_sortkey' => $sortkey,
 					'smw_sort' => $collator->getSortKey( $sortkey ),
 					'smw_hash' => $this->computeSha1( [ $title, (int)$namespace, $iw, $subobjectName ] ),
-					'smw_touched' => $db->timestamp()
-				],
-				__METHOD__
-			);
+					'smw_touched' => $db->timestamp(),
+				] )
+				->caller( __METHOD__ )
+				->execute();
 
 			$id = $db->insertId();
 
@@ -733,27 +733,27 @@ class EntityIdManager {
 
 		if ( $title instanceof WikiPage ) {
 			$cond = [
-				"smw_hash" => $title->getSha1()
+				'smw_hash' => $title->getSha1(),
 			];
 		} elseif ( is_int( $title ) ) {
 			$cond = [
-				"smw_id" => $title
+				'smw_id' => $title,
 			];
 		} else {
 			$cond = [
-				"smw_title =" . $connection->addQuotes( $title ),
-				"smw_namespace =" . $connection->addQuotes( $namespace ),
-				"smw_iw =" . $connection->addQuotes( $iw ),
-				"smw_subobject =''"
+				'smw_title' => $title,
+				'smw_namespace' => $namespace,
+				'smw_iw' => $iw,
+				'smw_subobject' => '',
 			];
 		}
 
-		$row = $connection->selectRow(
-			SQLStore::ID_TABLE,
-			'smw_rev',
-			$cond,
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( 'smw_rev' )
+			->from( SQLStore::ID_TABLE )
+			->where( $cond )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return $row === false ? 0 : (int)$row->smw_rev;
 	}

--- a/src/SQLStore/EntityStore/IdChanger.php
+++ b/src/SQLStore/EntityStore/IdChanger.php
@@ -47,14 +47,12 @@ class IdChanger {
 	public function move( $curid, $targetid = 0 ) {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$row = $connection->selectRow(
-			SQLStore::ID_TABLE,
-			'*',
-			[
-				'smw_id' => $curid
-			],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( '*' )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $curid ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		// No id at current position, ignore
 		if ( $row === false ) {
@@ -74,9 +72,9 @@ class IdChanger {
 			$row->smw_subobject
 		];
 
-		$connection->insert(
-			SQLStore::ID_TABLE,
-			[
+		$connection->newInsertQueryBuilder()
+			->insertInto( SQLStore::ID_TABLE )
+			->row( [
 				'smw_id' => $id,
 				'smw_title' => $row->smw_title,
 				'smw_namespace' => $row->smw_namespace,
@@ -85,27 +83,23 @@ class IdChanger {
 				'smw_sortkey' => $row->smw_sortkey,
 				'smw_sort' => $row->smw_sort,
 				'smw_hash' => IdCacheManager::computeSha1( $hash )
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$targetid = $targetid == 0 ? $connection->insertId() : $targetid;
 
-		$connection->delete(
-			SQLStore::ID_AUXILIARY_TABLE,
-			[
-				'smw_id' => $curid
-			],
-			__METHOD__
-		);
+		$connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::ID_AUXILIARY_TABLE )
+			->where( [ 'smw_id' => $curid ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$connection->delete(
-			SQLStore::ID_TABLE,
-			[
-				'smw_id' => $curid
-			],
-			__METHOD__
-		);
+		$connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $curid ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$row->smw_id = $targetid;
 
@@ -158,40 +152,40 @@ class IdChanger {
 
 			if ( $s_data && $proptable->usesIdSubject() ) {
 
-				$row = $connection->selectRow(
-					$proptable->getName(),
-					[ 's_id' ],
-					[ 's_id' => $old_id ],
-					__METHOD__
-				);
+				$row = $connection->newSelectQueryBuilder()
+					->select( [ 's_id' ] )
+					->from( $proptable->getName() )
+					->where( [ 's_id' => $old_id ] )
+					->caller( __METHOD__ )
+					->fetchRow();
 
 				if ( $row === false ) {
 					continue;
 				}
 
-				$connection->update(
-					$proptable->getName(),
-					[ 's_id' => $new_id ],
-					[ 's_id' => $old_id ],
-					__METHOD__
-				);
+				$connection->newUpdateQueryBuilder()
+					->update( $proptable->getName() )
+					->set( [ 's_id' => $new_id ] )
+					->where( [ 's_id' => $old_id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 
 			if ( $po_data ) {
 				if ( ( ( $old_ns == -1 ) || ( $old_ns == SMW_NS_PROPERTY ) ) && ( !$proptable->isFixedPropertyTable() ) ) {
 					if ( ( $new_ns == -1 ) || ( $new_ns == SMW_NS_PROPERTY ) ) {
-						$connection->update(
-							$proptable->getName(),
-							[ 'p_id' => $new_id ],
-							[ 'p_id' => $old_id ],
-							__METHOD__
-						);
+						$connection->newUpdateQueryBuilder()
+							->update( $proptable->getName() )
+							->set( [ 'p_id' => $new_id ] )
+							->where( [ 'p_id' => $old_id ] )
+							->caller( __METHOD__ )
+							->execute();
 					} else {
-						$connection->delete(
-							$proptable->getName(),
-							[ 'p_id' => $old_id ],
-							__METHOD__
-						);
+						$connection->newDeleteQueryBuilder()
+							->deleteFrom( $proptable->getName() )
+							->where( [ 'p_id' => $old_id ] )
+							->caller( __METHOD__ )
+							->execute();
 					}
 				}
 
@@ -201,23 +195,23 @@ class IdChanger {
 						continue;
 					}
 
-					$row = $connection->selectRow(
-						$proptable->getName(),
-						[ $fieldName ],
-						[ $fieldName => $old_id ],
-						__METHOD__
-					);
+					$row = $connection->newSelectQueryBuilder()
+						->select( [ $fieldName ] )
+						->from( $proptable->getName() )
+						->where( [ $fieldName => $old_id ] )
+						->caller( __METHOD__ )
+						->fetchRow();
 
 					if ( $row === false ) {
 						continue;
 					}
 
-					$connection->update(
-						$proptable->getName(),
-						[ $fieldName => $new_id ],
-						[ $fieldName => $old_id ],
-						__METHOD__
-					);
+					$connection->newUpdateQueryBuilder()
+						->update( $proptable->getName() )
+						->set( [ $fieldName => $new_id ] )
+						->where( [ $fieldName => $old_id ] )
+						->caller( __METHOD__ )
+						->execute();
 				}
 			}
 		}
@@ -230,41 +224,41 @@ class IdChanger {
 
 		if ( $s_data && ( ( $old_ns == -1 ) || ( $old_ns == SMW_NS_CONCEPT ) ) ) {
 			if ( ( $new_ns == -1 ) || ( $new_ns == SMW_NS_CONCEPT ) ) {
-				$connection->update(
-					SQLStore::CONCEPT_TABLE,
-					[ 's_id' => $new_id ],
-					[ 's_id' => $old_id ],
-					__METHOD__
-				);
+				$connection->newUpdateQueryBuilder()
+					->update( SQLStore::CONCEPT_TABLE )
+					->set( [ 's_id' => $new_id ] )
+					->where( [ 's_id' => $old_id ] )
+					->caller( __METHOD__ )
+					->execute();
 
-				$connection->update(
-					SQLStore::CONCEPT_CACHE_TABLE,
-					[ 's_id' => $new_id ],
-					[ 's_id' => $old_id ],
-					__METHOD__
-				);
+				$connection->newUpdateQueryBuilder()
+					->update( SQLStore::CONCEPT_CACHE_TABLE )
+					->set( [ 's_id' => $new_id ] )
+					->where( [ 's_id' => $old_id ] )
+					->caller( __METHOD__ )
+					->execute();
 			} else {
-				$connection->delete(
-					SQLStore::CONCEPT_TABLE,
-					[ 's_id' => $old_id ],
-					__METHOD__
-				);
+				$connection->newDeleteQueryBuilder()
+					->deleteFrom( SQLStore::CONCEPT_TABLE )
+					->where( [ 's_id' => $old_id ] )
+					->caller( __METHOD__ )
+					->execute();
 
-				$connection->delete(
-					SQLStore::CONCEPT_CACHE_TABLE,
-					[ 's_id' => $old_id ],
-					__METHOD__
-				);
+				$connection->newDeleteQueryBuilder()
+					->deleteFrom( SQLStore::CONCEPT_CACHE_TABLE )
+					->where( [ 's_id' => $old_id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 		}
 
 		if ( $po_data ) {
-			$connection->update(
-				SQLStore::CONCEPT_CACHE_TABLE,
-				[ 'o_id' => $new_id ],
-				[ 'o_id' => $old_id ],
-				__METHOD__
-			);
+			$connection->newUpdateQueryBuilder()
+				->update( SQLStore::CONCEPT_CACHE_TABLE )
+				->set( [ 'o_id' => $new_id ] )
+				->where( [ 'o_id' => $old_id ] )
+				->caller( __METHOD__ )
+				->execute();
 		}
 	}
 

--- a/src/SQLStore/EntityStore/IdEntityFinder.php
+++ b/src/SQLStore/EntityStore/IdEntityFinder.php
@@ -156,11 +156,17 @@ class IdEntityFinder {
 			'smw_hash'
 		];
 
+		$queryBuilder = $connection->newSelectQueryBuilder()
+			->select( $fields )
+			->from( SQLStore::ID_TABLE )
+			->where( $conditions )
+			->caller( __METHOD__ );
+
 		if ( $selectRow ) {
-			return $connection->selectRow( SQLStore::ID_TABLE, $fields, $conditions, __METHOD__ );
+			return $queryBuilder->fetchRow();
 		}
 
-		return $connection->select( SQLStore::ID_TABLE, $fields, $conditions, __METHOD__ );
+		return $queryBuilder->fetchResultSet();
 	}
 
 }

--- a/src/SQLStore/EntityStore/PropertiesLookup.php
+++ b/src/SQLStore/EntityStore/PropertiesLookup.php
@@ -3,9 +3,11 @@
 namespace SMW\SQLStore\EntityStore;
 
 use SMW\DataItems\WikiPage;
+use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\RequestOptions;
 use SMW\SQLStore\PropertyTableDefinition as TableDefinition;
 use SMW\SQLStore\SQLStore;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @license GPL-2.0-or-later
@@ -47,57 +49,56 @@ class PropertiesLookup {
 	 */
 	public function fetchFromTable( WikiPage $subject, TableDefinition $propertyTable, ?RequestOptions $requestOptions = null ) {
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
 
-		$query->type( 'SELECT' );
-		$query->table( $propertyTable->getName() );
+		$qb = $connection->newSelectQueryBuilder()
+			->from( $propertyTable->getName() );
 
 		if ( $propertyTable->usesIdSubject() ) {
-			$query->condition( $query->eq( 's_id', $subject->getId() ) );
+			$qb->where( [ 's_id' => $subject->getId() ] );
 		} elseif ( $subject->getInterwiki() === '' ) {
-			$query->condition( $query->eq( 's_title', $subject->getDBkey() ) );
-			$query->condition( $query->eq( 's_namespace', $subject->getNamespace() ) );
+			$qb->where( [
+				's_title' => $subject->getDBkey(),
+				's_namespace' => $subject->getNamespace(),
+			] );
 		} else {
 			// subjects with non-empty interwiki cannot have properties
 			return [];
 		}
 
 		if ( $propertyTable->isFixedPropertyTable() ) {
-			return $this->fetchFromFixedTable( $query, $propertyTable->getFixedProperty() );
+			return $this->fetchFromFixedTable( $qb, $propertyTable->getFixedProperty() );
 		}
 
-		$query->join(
-			'INNER JOIN',
-			[ SQLStore::ID_TABLE => "ON smw_id=p_id" ]
-		);
-
-		$query->fields( [ 'smw_title', 'smw_sortkey' ] );
+		$qb->join( SQLStore::ID_TABLE, null, 'smw_id=p_id' )
+			->select( [ 'smw_title', 'smw_sortkey' ] );
 
 		// (select sortkey since it might be used in ordering (needed by Postgres))
-		$query->condition( $this->store->getSQLConditions(
+		$sqlConds = $this->store->getSQLConditions(
 			$requestOptions,
 			'smw_sortkey',
 			'smw_sortkey'
-		) );
-
-		$opt = $this->store->getSQLOptions(
-			$requestOptions,
-			'smw_sortkey'
 		);
 
-		$query->options( $opt + [ 'DISTINCT' => true ] );
+		if ( $sqlConds !== '' ) {
+			$qb->andWhere( $sqlConds );
+		}
 
-		return $query->execute( __METHOD__ );
+		$qb->distinct();
+
+		LegacyOptionsApplier::applyTo(
+			$qb,
+			$this->store->getSQLOptions( $requestOptions, 'smw_sortkey' )
+		);
+
+		return $qb->caller( __METHOD__ )->fetchResultSet();
 	}
 
-	private function fetchFromFixedTable( $query, $title ): array {
+	private function fetchFromFixedTable( SelectQueryBuilder $qb, string $title ): array {
 		// just check if subject occurs in table
-		$query->options(
-			[ 'LIMIT' => 1 ]
-		);
-
-		$query->field( '*' );
-		$res = $query->execute( __METHOD__ );
+		$res = $qb->select( '*' )
+			->limit( 1 )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		if ( $res->numRows() > 0 ) {
 			return [ $title ];

--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -7,6 +7,7 @@ use SMW\DataItems\Container;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Property;
 use SMW\IteratorFactory;
+use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\Options;
 use SMW\RequestOptions;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -14,6 +15,7 @@ use SMW\SQLStore\EntityStore\Exception\DataItemHandlerException;
 use SMW\SQLStore\PropertyTableDefinition as TableDefinition;
 use SMW\SQLStore\SQLStore;
 use stdClass;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @license GPL-2.0-or-later
@@ -157,8 +159,6 @@ class PropertySubjectsLookup {
 		);
 
 		$sortField = $dataItemHandler->getSortField();
-		$query = $connection->newQuery();
-		$query->type( 'SELECT' );
 
 		if ( $requestOptions === null ) {
 			$requestOptions = new RequestOptions();
@@ -178,74 +178,67 @@ class PropertySubjectsLookup {
 		// and causes an unacceptable query time therefore force an index for
 		// those tables where the behaviour has been observed.
 		$index = $this->getIndexHint( $dataItemHandler, $pid, $dataItem );
-		$result = [];
+
+		$qb = $connection->newSelectQueryBuilder();
 
 		if ( $proptable->usesIdSubject() ) {
 			$group = true;
 
-			$query->table( SQLStore::ID_TABLE );
-
-			$query->join(
-				'INNER JOIN',
-				[ $proptable->getName() => "t1 $index ON t1.s_id=smw_id" ]
-			);
-
-			$query->fields(
-				[
+			$qb->from( SQLStore::ID_TABLE )
+				->join( $proptable->getName(), 't1', 't1.s_id=smw_id' )
+				->select( [
 					'smw_id',
 					'smw_title',
 					'smw_namespace',
 					'smw_iw',
 					'smw_subobject',
 					'smw_sortkey',
-					'smw_sort'
-				]
-			);
+					'smw_sort',
+				] );
 
-		} else { // no join needed, title+namespace as given in proptable
-			$query->table( $proptable->getName(), "t1" );
-
-			$query->fields(
-				[
+			// Preserve the FORCE INDEX(...) hint by translating to useIndex( [ 't1' => $name ] ).
+			// This emits USE INDEX on MySQL (vs the original FORCE INDEX). Both restrict the
+			// optimizer to the named index; on Postgres/SQLite both are no-ops. The semantic
+			// difference is documented in the PR description.
+			if ( $index !== '' && preg_match( '/^FORCE INDEX\(([^)]+)\)$/', $index, $m ) ) {
+				$qb->useIndex( [ 't1' => $m[1] ] );
+			}
+		} else {
+			// no join needed, title+namespace as given in proptable
+			$qb->from( $proptable->getName(), 't1' )
+				->select( [
 					's_title AS smw_title',
 					's_namespace AS smw_namespace',
-					'\'\' AS smw_iw',
-					'\'\' AS smw_subobject',
+					"'' AS smw_iw",
+					"'' AS smw_subobject",
 					's_title AS smw_sortkey',
-					's_title AS smw_sort'
-				]
-			);
+					's_title AS smw_sort',
+				] );
 
 			$requestOptions->setOption( 'ORDER BY', false );
 		}
 
 		if ( !$proptable->isFixedPropertyTable() ) {
-			$query->condition( $query->eq( "t1.p_id", $pid ) );
+			$qb->where( [ 't1.p_id' => $pid ] );
 		}
 
 		// Specified by the prefetch
 		if ( is_array( $dataItem ) ) {
-
-			$fieldname = 's_id';
-
-			if ( $proptable->getDiType() === DataItem::TYPE_WIKIPAGE ) {
-				$fieldname = 'o_id';
-			}
-
-			$query->condition( $query->in( "t1.$fieldname", $dataItem ) );
-			$query->field( "t1.$fieldname AS id" );
+			$fieldname = ( $proptable->getDiType() === DataItem::TYPE_WIKIPAGE ) ? 'o_id' : 's_id';
+			$qb->andWhere( [ "t1.$fieldname" => $dataItem ] )
+				->select( [ 'id' => "t1.$fieldname" ] );
 		} else {
-			$this->getWhereConds( $query, $dataItem );
+			$this->getWhereConds( $qb, $dataItem );
 		}
 
 		if ( $requestOptions !== null ) {
 			foreach ( $requestOptions->getExtraConditions() as $extraCondition ) {
 				if ( isset( $extraCondition['o_id'] ) ) {
-					$query->condition( $query->eq( 't1.o_id', $extraCondition['o_id'] ) );
+					$qb->andWhere( [ 't1.o_id' => $extraCondition['o_id'] ] );
 				}
 
 				if ( is_callable( $extraCondition ) ) {
-					$extraCondition( $query );
+					$extraCondition( $qb );
 				}
 			}
 
@@ -254,8 +247,8 @@ class PropertySubjectsLookup {
 		}
 
 		if ( $proptable->usesIdSubject() ) {
-			foreach ( [ SMW_SQL3_SMWIW_OUTDATED, SMW_SQL3_SMWDELETEIW, SMW_SQL3_SMWREDIIW ] as $v ) {
-				$query->condition( $query->neq( "smw_iw", $v ) );
+			foreach ( [ SMW_SQL3_SMWIW_OUTDATED, SMW_SQL3_SMWDELETEIW, SMW_SQL3_SMWREDIIW ] as $iw ) {
+				$qb->andWhere( $connection->expr( 'smw_iw', '!=', $iw ) );
 			}
 		}
 
@@ -290,30 +283,35 @@ class PropertySubjectsLookup {
 			false
 		);
 
-		$query->condition( $cond );
+		if ( $cond !== '' ) {
+			$qb->andWhere( $cond );
+		}
 
 		$opts = $this->store->getSQLOptions(
 			$requestOptions,
 			$sortField
 		);
 
-		$query->options( $opts );
+		// Preserve Postgres-specific `DISTINCT ON (...)` (a string DISTINCT value),
+		// which the legacy options array supports but `->distinct()` does not.
+		if ( isset( $opts['DISTINCT'] ) && is_string( $opts['DISTINCT'] ) ) {
+			$qb->option( 'DISTINCT', $opts['DISTINCT'] );
+			unset( $opts['DISTINCT'] );
+		}
 
 		if ( $requestOptions->exclude_limit ) {
-			$query->option( 'LIMIT', null );
-			$query->option( 'OFFSET', null );
+			unset( $opts['LIMIT'], $opts['OFFSET'] );
 		}
+
+		LegacyOptionsApplier::applyTo( $qb, $opts );
 
 		$caller = $this->caller;
 
 		if ( strval( $requestOptions->getCaller() ) !== '' ) {
-			$caller .= " (for " . $requestOptions->getCaller() . ")";
+			$caller .= ' (for ' . $requestOptions->getCaller() . ')';
 		}
 
-		$res = $connection->readQuery(
-			$query,
-			$caller
-		);
+		$res = $qb->caller( $caller )->fetchResultSet();
 
 		$this->dataItemHandler = $this->store->getDataItemHandlerForDIType(
 			DataItem::TYPE_WIKIPAGE
@@ -360,21 +358,21 @@ class PropertySubjectsLookup {
 		return $this->dataItemHandler->dataItemFromDBKeys( [ 'Blankpage/' . $title, NS_SPECIAL, '', '', '' ] );
 	}
 
-	private function getWhereConds( $query, DataItem|array|null $dataItem ): void {
-		$conds = '';
-
+	private function getWhereConds( SelectQueryBuilder $qb, ?DataItem $dataItem ): void {
 		if ( $dataItem instanceof Container ) {
 			throw new RuntimeException( '\SMW\DataItems\Container support is missing!' );
 		}
 
-		if ( $dataItem !== null ) {
-			$dataItemHandler = $this->store->getDataItemHandlerForDIType(
-				$dataItem->getDIType()
-			);
+		if ( $dataItem === null ) {
+			return;
+		}
 
-			foreach ( $dataItemHandler->getWhereConds( $dataItem ) as $fieldname => $value ) {
-				$query->condition( $query->eq( "t1.$fieldname", $value ) );
-			}
+		$dataItemHandler = $this->store->getDataItemHandlerForDIType(
+			$dataItem->getDIType()
+		);
+
+		foreach ( $dataItemHandler->getWhereConds( $dataItem ) as $fieldname => $value ) {
+			$qb->andWhere( [ "t1.$fieldname" => $value ] );
 		}
 	}
 
@@ -418,12 +416,12 @@ class PropertySubjectsLookup {
 		//
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$row = $connection->selectRow(
-			SQLStore::PROPERTY_STATISTICS_TABLE,
-			[ 'usage_count' ],
-			[ 'p_id' => $pid ],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'usage_count' ] )
+			->from( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->where( [ 'p_id' => $pid ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		// 5000? It just showed to be a sweet spot while doing some
 		// exploratory queries

--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -9,11 +9,13 @@ use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\DataModel\SequenceMap;
+use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\RequestOptions;
 use SMW\SQLStore\Lookup\RedirectTargetLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder\FieldType;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @license GPL-2.0-or-later
@@ -315,7 +317,6 @@ class SemanticDataLookup {
 			return [];
 		}
 
-		$result = [];
 		$connection = $this->store->getConnection( 'mw.db' );
 		$this->caller = __METHOD__;
 
@@ -334,26 +335,24 @@ class SemanticDataLookup {
 		// INNER JOIN `smw_object_ids` AS p ON p_id=p.smw_id
 		// WHERE s_id='80' AND p.smw_iw!=':smw' AND p.smw_iw!=':smw-delete'
 
-		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
-
-		$query->type( 'select' );
-		$query->table( $propTable->getName() );
+		$qb = $connection->newSelectQueryBuilder()->from( $propTable->getName() );
 
 		// Restrict to property
 		if ( !$isSubject && !$propTable->isFixedPropertyTable() ) {
-			$query->condition( $query->eq( 'p_id', $id ) );
+			$qb->where( [ 'p_id' => $id ] );
 		}
 
 		// Restrict subject, select property
 		if ( $isSubject && $propTable->usesIdSubject() ) {
-			$query->condition( $query->eq( 's_id', $id ) );
+			$qb->where( [ 's_id' => $id ] );
 		} elseif ( $isSubject ) {
-			$query->condition( $query->eq( 's_title', $dataItem->getDBkey() ) );
-			$query->condition( $query->eq( 's_namespace', $dataItem->getNamespace() ) );
+			$qb->where( [
+				's_title' => $dataItem->getDBkey(),
+				's_namespace' => $dataItem->getNamespace(),
+			] );
 		}
 
-		return $this->fetchFromTable( $query, $propTable, $isSubject, $requestOptions );
+		return $this->fetchFromTable( $qb, $propTable, $isSubject, $requestOptions );
 	}
 
 	/**
@@ -365,56 +364,52 @@ class SemanticDataLookup {
 		}
 
 		$isSubject = true;
-		$result = [];
 
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
-
-		$query->type( 'select' );
-		$query->table( $propTable->getName() );
+		$qb = $connection->newSelectQueryBuilder()->from( $propTable->getName() );
 
 		// Restrict property only
 		if ( !$propTable->isFixedPropertyTable() ) {
-			$query->condition( $query->eq( 'p_id', $pid ) );
+			$qb->where( [ 'p_id' => $pid ] );
 		}
+
+		$seedFields = [];
 
 		// Restrict subject, select property
 		if ( $propTable->usesIdSubject() ) {
-			$query->condition( $query->in( 's_id', $list ) );
-			$query->field( 's_id' );
+			$qb->where( [ 's_id' => $list ] );
+			$seedFields[] = 's_id';
 		} else {
 			throw new RuntimeException( "Need a table that has an ID subject column (ID: " . $pid . ')!' );
 		}
 
-		return $this->fetchFromTable( $query, $propTable, $isSubject, $requestOptions );
+		return $this->fetchFromTable( $qb, $propTable, $isSubject, $requestOptions, '', $seedFields );
 	}
 
 	/**
 	 * @return mixed[]
 	 */
-	private function fetchFromTable( $query, PropertyTableDefinition $propTable, bool $isSubject, ?RequestOptions $requestOptions, $field = '' ): array {
+	private function fetchFromTable( SelectQueryBuilder $qb, PropertyTableDefinition $propTable, bool $isSubject, ?RequestOptions $requestOptions, $field = '', array $selectFields = [] ): array {
 		$result = [];
 		$connection = $this->store->getConnection( 'mw.db' );
 
 		// Select property name
 		// In case of a fixed property, no select needed
 		if ( $isSubject && !$propTable->isFixedPropertyTable() ) {
-			$query->join(
-				'INNER JOIN',
-				[ SQLStore::ID_TABLE => 'p ON p_id=p.smw_id' ]
-			);
+			$qb->join( SQLStore::ID_TABLE, 'p', 'p_id=p.smw_id' );
 
-			$query->field( 'p.smw_title', 'prop' );
+			// Equivalent of `$query->field( 'p.smw_title', 'prop' )`.
+			$selectFields['prop'] = 'p.smw_title';
 
 			// Avoid displaying any property that has been marked deleted or outdated
-			$query->condition( $query->neq( "p.smw_iw", SMW_SQL3_SMWIW_OUTDATED ) );
-			$query->condition( $query->neq( "p.smw_iw", SMW_SQL3_SMWDELETEIW ) );
+			$qb->andWhere( $connection->expr( 'p.smw_iw', '!=', SMW_SQL3_SMWIW_OUTDATED ) )
+				->andWhere( $connection->expr( 'p.smw_iw', '!=', SMW_SQL3_SMWDELETEIW ) );
 		}
 
 		if ( $requestOptions !== null ) {
 			foreach ( $requestOptions->getExtraConditions() as $extraCondition ) {
 				if ( isset( $extraCondition['p_id'] ) ) {
-					$query->condition( $query->eq( 'p_id', $extraCondition['p_id'] ) );
+					$qb->andWhere( [ 'p_id' => $extraCondition['p_id'] ] );
 				}
 			}
 		} else {
@@ -436,7 +431,8 @@ class SemanticDataLookup {
 		$map = [];
 
 		$this->addFields(
-			$query,
+			$qb,
+			$selectFields,
 			$map,
 			$fields,
 			$valueField,
@@ -504,35 +500,41 @@ class SemanticDataLookup {
 				false
 			);
 
-			$query->condition( $conds );
+			if ( $conds !== '' ) {
+				$qb->andWhere( $conds );
+			}
 		} else {
 			$valueField = '';
 		}
 
 		if ( $field !== '' ) {
-			$query->field( $field );
+			$selectFields[] = $field;
 		}
 
-		$query->options(
-			$this->store->getSQLOptions( $requestOptions, $valueField )
-		);
+		$opts = $this->store->getSQLOptions( $requestOptions, $valueField );
 
-		if (
-			$requestOptions->getOption( RequestOptions::CONDITION_CONSTRAINT_RESULT, false ) ||
-			$requestOptions->getOption( RequestOptions::CONDITION_CONSTRAINT, false ) ) {
-			$sort = 'ASC';
-
-			if ( $requestOptions->sort ) {
-				$sort = $requestOptions->ascending ? 'ASC' : 'DESC';
-				$query->option( 'ORDER BY', $map[$sortField] . " $sort" );
-			}
+		// Preserve Postgres-specific `DISTINCT ON (...)` (a string DISTINCT value),
+		// which the legacy options array supports but `->distinct()` does not.
+		if ( isset( $opts['DISTINCT'] ) && is_string( $opts['DISTINCT'] ) ) {
+			$qb->option( 'DISTINCT', $opts['DISTINCT'] );
+			unset( $opts['DISTINCT'] );
 		}
 
 		// `exclude_limit` indicates an unrestricted query due to use of `WHERE IN`
 		// that is required by the prefetch mode
 		if ( $requestOptions->exclude_limit ) {
-			$query->option( 'LIMIT', null );
-			$query->option( 'OFFSET', null );
+			unset( $opts['LIMIT'], $opts['OFFSET'] );
+		}
+
+		LegacyOptionsApplier::applyTo( $qb, $opts );
+
+		if (
+			$requestOptions->getOption( RequestOptions::CONDITION_CONSTRAINT_RESULT, false ) ||
+			$requestOptions->getOption( RequestOptions::CONDITION_CONSTRAINT, false ) ) {
+			if ( $requestOptions->sort ) {
+				$sort = $requestOptions->ascending ? 'ASC' : 'DESC';
+				$qb->orderBy( $map[$sortField] . " $sort" );
+			}
 		}
 
 		$caller = $this->caller;
@@ -541,10 +543,9 @@ class SemanticDataLookup {
 			$caller .= " (for " . $requestOptions->getCaller() . ")";
 		}
 
-		$res = $connection->readQuery(
-			$query,
-			$caller
-		);
+		$qb->select( $selectFields );
+
+		$res = $qb->caller( $caller )->fetchResultSet();
 
 		$warmupCache = [];
 
@@ -610,31 +611,28 @@ class SemanticDataLookup {
 		return $result;
 	}
 
-	private function addFields( &$query, array &$map, $fields, $valueField, $labelField, int &$valueCount, string &$fieldname ): void {
+	private function addFields( SelectQueryBuilder $qb, array &$selectFields, array &$map, $fields, $valueField, $labelField, int &$valueCount, string &$fieldname ): void {
 		// Select dataItem column(s)
 		foreach ( $fields as $fieldname => $fieldType ) {
 
 			// Get data from ID table
 			if ( $fieldType === FieldType::FIELD_ID ) {
-				$query->join(
-					'INNER JOIN',
-					[ SQLStore::ID_TABLE => "o$valueCount ON $fieldname=o$valueCount.smw_id" ]
-				);
+				$qb->join( SQLStore::ID_TABLE, "o$valueCount", "$fieldname=o$valueCount.smw_id" );
 
-				$query->field( "$fieldname AS id$valueCount" );
-				$query->field( "o$valueCount.smw_title AS v$valueCount" );
-				$query->field( "o$valueCount.smw_namespace AS v" . ( $valueCount + 1 ) );
-				$query->field( "o$valueCount.smw_iw AS v" . ( $valueCount + 2 ) );
-				$query->field( "o$valueCount.smw_sortkey AS v" . ( $valueCount + 3 ) );
+				$selectFields[ "id$valueCount" ] = $fieldname;
+				$selectFields[ "v$valueCount" ] = "o$valueCount.smw_title";
+				$selectFields[ 'v' . ( $valueCount + 1 ) ] = "o$valueCount.smw_namespace";
+				$selectFields[ 'v' . ( $valueCount + 2 ) ] = "o$valueCount.smw_iw";
+				$selectFields[ 'v' . ( $valueCount + 3 ) ] = "o$valueCount.smw_sortkey";
 				$map[$fieldname] = "v" . ( $valueCount + 3 );
 
 				// In case of switching the position of v3/v4 (subobject, sortkey/sort)
 				// see below the position reassignment of sort
 				// Row position is important when building an instance using
 				// `DIWikiPageHandler::newDiWikiPage`
-				$query->field( "o$valueCount.smw_subobject AS v" . ( $valueCount + 4 ) );
+				$selectFields[ 'v' . ( $valueCount + 4 ) ] = "o$valueCount.smw_subobject";
 
-				$query->field( "o$valueCount.smw_sort AS v" . ( $valueCount + 5 ) );
+				$selectFields[ 'v' . ( $valueCount + 5 ) ] = "o$valueCount.smw_sort";
 				$map[$fieldname] = "v" . ( $valueCount + 5 );
 
 				if ( $valueField == $fieldname ) {
@@ -647,7 +645,7 @@ class SemanticDataLookup {
 				$valueCount += 5;
 			} else {
 				$map[$fieldname] = "v$valueCount";
-				$query->field( $fieldname, "v$valueCount" );
+				$selectFields[ "v$valueCount" ] = $fieldname;
 			}
 
 			$valueCount += 1;
@@ -656,9 +654,12 @@ class SemanticDataLookup {
 		// Postgres
 		// Function: SMWSQLStore3Readers::fetchSemanticData
 		// Error: 42P10 ERROR: for SELECT DISTINCT, ORDER BY expressions must appear in select list
-		if ( !$query->hasField( $valueField ) ) {
+		// Replicates the legacy `Query::hasField()` check by testing whether the
+		// field already appears either as a select expression (value) or as an
+		// alias (key) in the in-progress select list.
+		if ( !in_array( $valueField, $selectFields, true ) && !array_key_exists( $valueField, $selectFields ) ) {
 			$map[$valueField] = "v" . ( $valueCount + 1 );
-			$query->field( $valueField, "v" . ( $valueCount + 1 ) );
+			$selectFields[ 'v' . ( $valueCount + 1 ) ] = $valueField;
 		}
 	}
 
@@ -747,27 +748,17 @@ class SemanticDataLookup {
 
 	private function fetchPropertiesFromTable( $id, PropertyTableDefinition $propTable ) {
 		$connection = $this->store->getConnection( 'mw.db' );
-		$query = $connection->newQuery();
 
-		$query->type( 'select' );
-		$query->table( $propTable->getName() );
-
-		$query->condition( $query->eq( 's_id', $id ) );
-
-		$query->join(
-			'INNER JOIN',
-			[ SQLStore::ID_TABLE => 'p ON p_id=p.smw_id' ]
-		);
-
-		$query->field( 'p_id' );
-
-		// Avoid displaying any property that have been marked deleted or outdated
-		$query->condition( $query->neq( "p.smw_iw", SMW_SQL3_SMWIW_OUTDATED ) );
-		$query->condition( $query->neq( "p.smw_iw", SMW_SQL3_SMWDELETEIW ) );
-
-		$query->option( 'DISTINCT', true );
-
-		return $query->execute( __METHOD__ );
+		return $connection->newSelectQueryBuilder()
+			->from( $propTable->getName() )
+			->join( SQLStore::ID_TABLE, 'p', 'p_id=p.smw_id' )
+			->select( 'p_id' )
+			->where( [ 's_id' => $id ] )
+			->andWhere( $connection->expr( 'p.smw_iw', '!=', SMW_SQL3_SMWIW_OUTDATED ) )
+			->andWhere( $connection->expr( 'p.smw_iw', '!=', SMW_SQL3_SMWDELETEIW ) )
+			->distinct()
+			->caller( __METHOD__ )
+			->fetchResultSet();
 	}
 
 	private function reportDuplicate( array $params ): void {

--- a/src/SQLStore/EntityStore/SequenceMapFinder.php
+++ b/src/SQLStore/EntityStore/SequenceMapFinder.php
@@ -49,18 +49,19 @@ class SequenceMapFinder {
 			$map = null;
 		}
 
-		$this->connection->upsert(
-			SQLStore::ID_AUXILIARY_TABLE,
-			[
+		$this->connection->newInsertQueryBuilder()
+			->insertInto( SQLStore::ID_AUXILIARY_TABLE )
+			->row( [
 				'smw_id' => $sid,
 				'smw_seqmap' => $map
-			],
-			'smw_id',
-			[
+			] )
+			->onDuplicateKeyUpdate()
+			->uniqueIndexFields( [ 'smw_id' ] )
+			->set( [
 				'smw_seqmap' => $map
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 	/**
@@ -79,16 +80,12 @@ class SequenceMapFinder {
 			return $map;
 		}
 
-		$row = $this->connection->selectRow(
-			SQLStore::ID_AUXILIARY_TABLE,
-			[
-				'smw_seqmap'
-			],
-			[
-				'smw_id' => $sid
-			],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_seqmap' ] )
+			->from( SQLStore::ID_AUXILIARY_TABLE )
+			->where( [ 'smw_id' => $sid ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row !== false ) {
 			$omap = $row->smw_seqmap;
@@ -124,17 +121,12 @@ class SequenceMapFinder {
 
 		$cache = $this->idCacheManager->get( 'sequence.map' );
 
-		$rows = $this->connection->select(
-			SQLStore::ID_AUXILIARY_TABLE,
-			[
-				'smw_id',
-				'smw_seqmap'
-			],
-			[
-				'smw_id' => $ids
-			],
-			__METHOD__
-		);
+		$rows = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_id', 'smw_seqmap' ] )
+			->from( SQLStore::ID_AUXILIARY_TABLE )
+			->where( [ 'smw_id' => $ids ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		$inverted_ids = array_flip( $ids );
 

--- a/src/SQLStore/EntityStore/SubobjectListFinder.php
+++ b/src/SQLStore/EntityStore/SubobjectListFinder.php
@@ -108,26 +108,26 @@ class SubobjectListFinder {
 		}
 
 		$conditions = [
-			'smw_title=' . $connection->addQuotes( $key ),
-			'smw_namespace=' . $connection->addQuotes( $subject->getNamespace() ),
-			'smw_iw=' . $connection->addQuotes( $subject->getInterwiki() ),
-			'smw_subobject!=' . $connection->addQuotes( '' )
+			'smw_title' => $key,
+			'smw_namespace' => $subject->getNamespace(),
+			'smw_iw' => $subject->getInterwiki(),
+			$connection->expr( 'smw_subobject', '!=', '' ),
 		];
 
 		foreach ( $this->skipConditions as $skipOn ) {
-			$conditions[] = 'smw_subobject!=' . $connection->addQuotes( $skipOn );
+			$conditions[] = $connection->expr( 'smw_subobject', '!=', $skipOn );
 		}
 
-		$res = $connection->select(
-			SQLStore::ID_TABLE,
-			[
+		$res = $connection->newSelectQueryBuilder()
+			->select( [
 				'smw_id',
 				'smw_subobject',
 				'smw_sortkey'
-			],
-			implode( ' AND ', $conditions ),
-			__METHOD__
-		);
+			] )
+			->from( SQLStore::ID_TABLE )
+			->where( $conditions )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		return $this->iteratorFactory->newResultIterator( $res );
 	}

--- a/src/SQLStore/EntityStore/TraversalPropertyLookup.php
+++ b/src/SQLStore/EntityStore/TraversalPropertyLookup.php
@@ -5,6 +5,7 @@ namespace SMW\SQLStore\EntityStore;
 use RuntimeException;
 use SMW\DataItems\DataItem;
 use SMW\DIContainer;
+use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\MediaWiki\Connection\OptionsBuilder;
 use SMW\RequestOptions;
 use SMW\SQLStore\PropertyTableDefinition as PropertyTableDef;
@@ -55,28 +56,26 @@ class TraversalPropertyLookup {
 			$conditions = '';
 
 			// No sorting
-			$options = $this->store->getSQLOptions( $subOptions, '' );
+			$subQueryOptions = $this->store->getSQLOptions( $subOptions, '' );
 
 			// Avoid any limit or offset for the sub-query in order to find all
 			// incoming properties
-			unset( $options['LIMIT'] );
-			unset( $options['OFFSET'] );
+			unset( $subQueryOptions['LIMIT'] );
+			unset( $subQueryOptions['OFFSET'] );
 
 			// Ensure to group same IDs to reduce the amount of data transferred
 			// from the inner join
-			$options['GROUP BY'] = 'p_id';
+			$subQueryOptions['GROUP BY'] = 'p_id';
 
-			$opt = OptionsBuilder::toString( $options );
+			$opt = OptionsBuilder::toString( $subQueryOptions );
 
 			$cond = ( $cond !== '' ? ' WHERE ' : '' ) . $cond;
 
 			// Use a subquery to match all possible IDs, no ORDER BY or DISTINCT to avoid
 			// a filesort
-			$from = [
-				SQLStore::ID_TABLE,
-				't1' => new Subquery( 'SELECT p_id FROM ' . $connection->tableName( $propertyTableDef->getName() ) . " $cond $opt" ),
-			];
-			$join = [ 't1' => [ 'INNER JOIN', 't1.p_id=smw_id' ] ];
+			$subquery = new Subquery(
+				'SELECT p_id FROM ' . $connection->tableName( $propertyTableDef->getName() ) . " $cond $opt"
+			);
 
 			$conditions .= ( $conditions ? ' AND ' : ' ' ) .
 				" smw_iw!=" . $connection->addQuotes( SMW_SQL3_SMWIW_OUTDATED ) .
@@ -84,28 +83,35 @@ class TraversalPropertyLookup {
 
 			$conditions .= $this->store->getSQLConditions( $subOptions, 'smw_sortkey', 'smw_sortkey', $conditions !== '' );
 
-			$options = $this->store->getSQLOptions( $subOptions, '' ) + [ 'DISTINCT' ];
+			$outerOptions = $this->store->getSQLOptions( $subOptions, '' ) + [ 'DISTINCT' ];
 
-			$result = $connection->select(
-				$from,
-				[ 'smw_title', 'smw_sortkey', 'smw_iw' ],
-				$conditions,
-				__METHOD__,
-				$options,
-				$join
-			);
+			$qb = $connection->newSelectQueryBuilder()
+				->rawTables( [ SQLStore::ID_TABLE, 't1' => $subquery ] )
+				->joinConds( [ 't1' => [ 'INNER JOIN', 't1.p_id=smw_id' ] ] )
+				->select( [ 'smw_title', 'smw_sortkey', 'smw_iw' ] );
+
+			if ( trim( $conditions ) !== '' ) {
+				$qb->andWhere( $conditions );
+			}
+
+			LegacyOptionsApplier::applyTo( $qb, $outerOptions );
+
+			$result = $qb->caller( __METHOD__ )->fetchResultSet();
 
 		} else {
 			$where = $this->getWhereConds( $dataItem );
 			$fields = $propertyTableDef->usesIdSubject() ? 's_id' : '*';
 
-			$result = $connection->select(
-				[ 't1' => $propertyTableDef->getName() ],
-				$fields,
-				$where,
-				__METHOD__,
-				[ 'LIMIT' => 1 ]
-			);
+			$qb = $connection->newSelectQueryBuilder()
+				->from( $propertyTableDef->getName(), 't1' )
+				->select( $fields )
+				->limit( 1 );
+
+			if ( $where !== '' ) {
+				$qb->where( $where );
+			}
+
+			$result = $qb->caller( __METHOD__ )->fetchResultSet();
 
 			if ( $result->numRows() > 0 ) {
 				$res = new stdClass;

--- a/src/SQLStore/PropertyTable/PropertyTableHashes.php
+++ b/src/SQLStore/PropertyTable/PropertyTableHashes.php
@@ -45,14 +45,12 @@ class PropertyTableHashes {
 			throw new RuntimeException( "Expected a null or an array as value!" );
 		}
 
-		$this->connection->update(
-			SQLStore::ID_TABLE,
-			$update,
-			[
-				'smw_id' => $id
-			],
-			__METHOD__
-		);
+		$this->connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( $update )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
 /*
 		$smw_proptable = $hash === null ? null : serialize( $hash );
@@ -100,16 +98,12 @@ class PropertyTableHashes {
 			return $hash;
 		}
 
-		$row = $this->connection->selectRow(
-			SQLStore::ID_TABLE,
-			[
-				'smw_proptable_hash'
-			],
-			[
-				'smw_id' => $id
-			],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_proptable_hash' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row !== false ) {
 			$hash = $row->smw_proptable_hash;

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -7,6 +7,7 @@ use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\DataItems\WikiPage;
 use SMW\Iterators\ResultIterator;
 use SMW\MediaWiki\Connection\Database;
+use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\RequestOptions;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use stdClass;
@@ -131,19 +132,18 @@ class PropertyTableIdReferenceDisposer {
 		if ( $requestOptions !== null ) {
 			$options = [
 				'LIMIT'  => $requestOptions->getLimit(),
-				'OFFSET' => $requestOptions->getOffset()
+				'OFFSET' => $requestOptions->getOffset(),
 			];
 		}
 
-		$res = $this->connection->select(
-			SQLStore::ID_TABLE,
-			[ 'smw_id' ],
-			[ 'smw_iw' => SMW_SQL3_SMWDELETEIW ],
-			__METHOD__,
-			$options
-		);
+		$qb = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_id' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_iw' => SMW_SQL3_SMWDELETEIW ] );
 
-		return new ResultIterator( $res );
+		LegacyOptionsApplier::applyTo( $qb, $options );
+
+		return new ResultIterator( $qb->caller( __METHOD__ )->fetchResultSet() );
 	}
 
 	/**
@@ -159,21 +159,18 @@ class PropertyTableIdReferenceDisposer {
 		if ( $requestOptions !== null ) {
 			$options = [
 				'LIMIT'  => $requestOptions->getLimit(),
-				'OFFSET' => $requestOptions->getOffset()
+				'OFFSET' => $requestOptions->getOffset(),
 			];
 		}
 
-		$res = $this->connection->select(
-			SQLStore::ID_TABLE,
-			[ 'smw_id' ],
-			[
-				'smw_namespace NOT IN (' . $this->connection->makeList( array_keys( $this->namespacesWithSemanticLinks ) ) . ')'
-			],
-			__METHOD__,
-			$options
-		);
+		$qb = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_id' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( 'smw_namespace NOT IN (' . $this->connection->makeList( array_keys( $this->namespacesWithSemanticLinks ) ) . ')' );
 
-		return new ResultIterator( $res );
+		LegacyOptionsApplier::applyTo( $qb, $options );
+
+		return new ResultIterator( $qb->caller( __METHOD__ )->fetchResultSet() );
 	}
 
 	/**
@@ -229,30 +226,30 @@ class PropertyTableIdReferenceDisposer {
 
 		foreach ( $this->store->getPropertyTables() as $proptable ) {
 			if ( $proptable->usesIdSubject() ) {
-				$this->connection->delete(
-					$proptable->getName(),
-					[ 's_id' => $id ],
-					__METHOD__
-				);
+				$this->connection->newDeleteQueryBuilder()
+					->deleteFrom( $proptable->getName() )
+					->where( [ 's_id' => $id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 
 			if ( !$proptable->isFixedPropertyTable() ) {
-				$this->connection->delete(
-					$proptable->getName(),
-					[ 'p_id' => $id ],
-					__METHOD__
-				);
+				$this->connection->newDeleteQueryBuilder()
+					->deleteFrom( $proptable->getName() )
+					->where( [ 'p_id' => $id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 
 			$fields = $proptable->getFields( $this->store );
 
 			// Match tables (including ftp_redi) that contain an object reference
 			if ( isset( $fields['o_id'] ) ) {
-				$this->connection->delete(
-					$proptable->getName(),
-					[ 'o_id' => $id ],
-					__METHOD__
-				);
+				$this->connection->newDeleteQueryBuilder()
+					->deleteFrom( $proptable->getName() )
+					->where( [ 'o_id' => $id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 		}
 
@@ -270,36 +267,36 @@ class PropertyTableIdReferenceDisposer {
 	private function cleanUpSecondaryReferencesById( $id, bool $isRedirect ): void {
 		// When marked as redirect, don't remove the reference
 		if ( !$isRedirect || $this->redirectRemoval ) {
-			$this->connection->delete(
-				SQLStore::ID_TABLE,
-				[ 'smw_id' => $id ],
-				__METHOD__
-			);
+			$this->connection->newDeleteQueryBuilder()
+				->deleteFrom( SQLStore::ID_TABLE )
+				->where( [ 'smw_id' => $id ] )
+				->caller( __METHOD__ )
+				->execute();
 		}
 
-		$this->connection->delete(
-			SQLStore::ID_AUXILIARY_TABLE,
-			[ 'smw_id' => $id ],
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::ID_AUXILIARY_TABLE )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$this->connection->delete(
-			SQLStore::PROPERTY_STATISTICS_TABLE,
-			[ 'p_id' => $id ],
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->where( [ 'p_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$this->connection->delete(
-			SQLStore::QUERY_LINKS_TABLE,
-			[ 's_id' => $id ],
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 's_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$this->connection->delete(
-			SQLStore::QUERY_LINKS_TABLE,
-			[ 'o_id' => $id ],
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 'o_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$tableExists = false;
 
@@ -314,7 +311,11 @@ class PropertyTableIdReferenceDisposer {
 		}
 
 		if ( $tableExists ) {
-			$this->connection->delete( SQLStore::FT_SEARCH_TABLE, [ 's_id' => $id ], __METHOD__ );
+			$this->connection->newDeleteQueryBuilder()
+				->deleteFrom( SQLStore::FT_SEARCH_TABLE )
+				->where( [ 's_id' => $id ] )
+				->caller( __METHOD__ )
+				->execute();
 		}
 	}
 

--- a/src/SQLStore/PropertyTableIdReferenceFinder.php
+++ b/src/SQLStore/PropertyTableIdReferenceFinder.php
@@ -187,12 +187,12 @@ class PropertyTableIdReferenceFinder {
 		$row = false;
 
 		if ( $proptable->usesIdSubject() ) {
-			$row = $this->connection->selectRow(
-				$proptable->getName(),
-				[ 's_id' ],
-				[ 's_id' => $id ],
-				__METHOD__
-			);
+			$row = $this->connection->newSelectQueryBuilder()
+				->select( [ 's_id' ] )
+				->from( $proptable->getName() )
+				->where( [ 's_id' => $id ] )
+				->caller( __METHOD__ )
+				->fetchRow();
 		}
 
 		if ( $row !== false ) {
@@ -207,12 +207,12 @@ class PropertyTableIdReferenceFinder {
 			// This next time someone ... I'm going to Alaska
 			$field = preg_match( '/redi$/', $proptable->getName() ?? '' ) ? [ 's_title', 's_namespace' ] : [ 's_id' ];
 
-			$row = $this->connection->selectRow(
-				$proptable->getName(),
-				$field,
-				[ 'o_id' => $id ],
-				__METHOD__
-			);
+			$row = $this->connection->newSelectQueryBuilder()
+				->select( $field )
+				->from( $proptable->getName() )
+				->where( [ 'o_id' => $id ] )
+				->caller( __METHOD__ )
+				->fetchRow();
 
 			if ( $row !== false && strpos( $proptable->getName(), 'redi' ) ) {
 				$row->s_id = $this->store->getObjectIds()->findRedirect( $row->s_title, $row->s_namespace );
@@ -223,12 +223,12 @@ class PropertyTableIdReferenceFinder {
 		// table to a specific property with the p_id column being suppressed)
 		// then check for the p_id field
 		if ( $row === false && !$proptable->isFixedPropertyTable() ) {
-			$row = $this->connection->selectRow(
-				$proptable->getName(),
-				[ 's_id' ],
-				[ 'p_id' => $id ],
-				__METHOD__
-			);
+			$row = $this->connection->newSelectQueryBuilder()
+				->select( [ 's_id' ] )
+				->from( $proptable->getName() )
+				->where( [ 'p_id' => $id ] )
+				->caller( __METHOD__ )
+				->fetchRow();
 		}
 
 		return $row;
@@ -238,12 +238,12 @@ class PropertyTableIdReferenceFinder {
 		// If the query table contains a reference then we keep the object (could
 		// be a subject, property, or printrequest) where in case the query is
 		// removed the object will also loose its reference
-		$row = $this->connection->selectRow(
-			SQLStore::QUERY_LINKS_TABLE,
-			[ 's_id' ],
-			[ 'o_id' => $id ],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 's_id' ] )
+			->from( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 'o_id' => $id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return $row;
 	}

--- a/src/SQLStore/PropertyTableRowDiffer.php
+++ b/src/SQLStore/PropertyTableRowDiffer.php
@@ -193,14 +193,12 @@ class PropertyTableRowDiffer {
 
 				// #3849
 				// Check the table that wasn't part of the old and new hash
-				$row = $connection->selectRow(
-					$propertyTable->getName(),
-					's_id',
-					[
-						's_id' => $sid
-					],
-					__METHOD__
-				);
+				$row = $connection->newSelectQueryBuilder()
+					->select( 's_id' )
+					->from( $propertyTable->getName() )
+					->where( [ 's_id' => $sid ] )
+					->caller( __METHOD__ )
+					->fetchRow();
 
 				// Find and remove any remnants (ghosts) from possible failed
 				// updates that weren't rollback correctly
@@ -272,12 +270,12 @@ class PropertyTableRowDiffer {
 		$contents = [];
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$result = $connection->select(
-			$propertyTable->getName(),
-			'*',
-			[ 's_id' => $sid ],
-			__METHOD__
-		);
+		$result = $connection->newSelectQueryBuilder()
+			->select( '*' )
+			->from( $propertyTable->getName() )
+			->where( [ 's_id' => $sid ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		foreach ( $result as $row ) {
 			if ( is_object( $row ) ) {

--- a/src/SQLStore/PropertyTableRowMapper.php
+++ b/src/SQLStore/PropertyTableRowMapper.php
@@ -281,12 +281,12 @@ class PropertyTableRowMapper {
 		}
 
 		// Add existing cache status data to this row:
-		$row = $connection->selectRow(
-			'smw_fpt_conc',
-			[ 'cache_date', 'cache_count' ],
-			[ 's_id' => $sid ],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'cache_date', 'cache_count' ] )
+			->from( 'smw_fpt_conc' )
+			->where( [ 's_id' => $sid ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row === false ) {
 			$insertValues['cache_date'] = null;

--- a/src/SQLStore/PropertyTableUpdater.php
+++ b/src/SQLStore/PropertyTableUpdater.php
@@ -173,11 +173,11 @@ class PropertyTableUpdater {
 		$connection = $this->store->getConnection( 'mw.db' );
 		$tableName = $propertyTable->getName();
 
-		$connection->insert(
-			$tableName,
-			$rows,
-			__METHOD__ . "-$tableName"
-		);
+		$connection->newInsertQueryBuilder()
+			->insertInto( $tableName )
+			->rows( $rows )
+			->caller( __METHOD__ . "-$tableName" )
+			->execute();
 	}
 
 	private function delete( PropertyTableDefinition $propertyTable, array $rows ): void {
@@ -215,11 +215,11 @@ class PropertyTableUpdater {
 
 		$condition = "s_id=" . $connection->addQuotes( $sid ) . " AND ($condition)";
 
-		$connection->delete(
-			$tableName,
-			[ $condition ],
-			__METHOD__ . "-$tableName"
-		);
+		$connection->newDeleteQueryBuilder()
+			->deleteFrom( $tableName )
+			->where( $condition )
+			->caller( __METHOD__ . "-$tableName" )
+			->execute();
 	}
 
 	private function aggregate_ids( array &$ids, $propertyTable, $rows ): void {
@@ -261,16 +261,12 @@ class PropertyTableUpdater {
 		// onTransctionIdle( ... ) to avoid locking the rows for succeeding
 		// updates?
 
-		$connection->update(
-			SQLStore::ID_TABLE,
-			[
-				'smw_touched' => $touched
-			],
-			[
-				'smw_id' => $ids
-			],
-			__METHOD__
-		);
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( [ 'smw_touched' => $touched ] )
+			->where( [ 'smw_id' => $ids ] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 }

--- a/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticMediaWikiProvidedHookInterfaceIntegrationTest.php
@@ -34,6 +34,8 @@ use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\SQLStoreFactory;
 use SMW\SQLStore\SQLStoreUpdater;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @group semantic-mediawiki
@@ -44,6 +46,9 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $mwHooksHandler;
@@ -118,6 +123,22 @@ class SemanticMediaWikiProvidedHookInterfaceIntegrationTest extends TestCase {
 			$connection->expects( $this->any() )
 				->method( 'selectRow' )
 				->willReturn( false );
+
+			$connection->expects( $this->any() )
+				->method( 'newSelectQueryBuilder' )
+				->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
+
+			$connection->expects( $this->any() )
+				->method( 'newInsertQueryBuilder' )
+				->willReturnCallback( fn () => $this->createMockInsertQueryBuilder() );
+
+			$connection->expects( $this->any() )
+				->method( 'newUpdateQueryBuilder' )
+				->willReturnCallback( fn () => $this->createMockUpdateQueryBuilder() );
+
+			$connection->expects( $this->any() )
+				->method( 'newDeleteQueryBuilder' )
+				->willReturnCallback( fn () => $this->createMockDeleteQueryBuilder() );
 		}
 
 		return $connection;

--- a/tests/phpunit/Unit/Elastic/ElasticStoreTest.php
+++ b/tests/phpunit/Unit/Elastic/ElasticStoreTest.php
@@ -19,6 +19,8 @@ use SMW\Options;
 use SMW\SetupFile;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -31,6 +33,9 @@ use stdClass;
  * @author mwjames
  */
 class ElasticStoreTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $elasticFactory;
@@ -309,9 +314,15 @@ class ElasticStoreTest extends TestCase {
 			->method( 'getType' )
 			->willReturn( 'mysql' );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
 		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
+
+		$insertBuilder = $this->createMockInsertQueryBuilder();
+		$connection->expects( $this->any() )
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Connection/MockSelectQueryBuilderTrait.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/MockSelectQueryBuilderTrait.php
@@ -37,7 +37,7 @@ trait MockSelectQueryBuilderTrait {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$chainMethods = [ 'fields', 'field', 'from', 'table', 'tables',
+		$chainMethods = [ 'fields', 'field', 'from', 'table', 'tables', 'rawTables',
 			'join', 'leftJoin', 'straightJoin', 'joinConds',
 			'groupBy', 'having', 'orderBy', 'caller', 'distinct',
 			'limit', 'offset', 'options', 'option', 'conds',

--- a/tests/phpunit/Unit/MediaWiki/Connection/MockWriteQueryBuilderTrait.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/MockWriteQueryBuilderTrait.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace SMW\Tests\Unit\MediaWiki\Connection;
+
+use Wikimedia\Rdbms\DeleteQueryBuilder;
+use Wikimedia\Rdbms\InsertQueryBuilder;
+use Wikimedia\Rdbms\ReplaceQueryBuilder;
+use Wikimedia\Rdbms\UpdateQueryBuilder;
+
+/**
+ * Test helper for mocking the write-side QueryBuilder chains
+ * (`InsertQueryBuilder`, `UpdateQueryBuilder`, `DeleteQueryBuilder`,
+ * `ReplaceQueryBuilder`). Each helper returns a chainable mock that
+ * captures the most relevant arguments into shared arrays so individual
+ * tests can assert on the row data, set clause, where conditions etc.
+ *
+ * `execute()` is stubbed (does nothing). Tests still need to wire the
+ * mock into the `Database` mock via `expects()->method('new*QueryBuilder')
+ * ->willReturn( $mock )`.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+trait MockWriteQueryBuilderTrait {
+
+	private function createMockInsertQueryBuilder(
+		array &$tables = [],
+		array &$rows = [],
+		array &$sets = [],
+		array &$uniqueIndexFields = []
+	): InsertQueryBuilder {
+		$builder = $this->getMockBuilder( InsertQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$captureTable = static function ( $table ) use ( $builder, &$tables ) {
+			$tables[] = $table;
+			return $builder;
+		};
+		$builder->method( 'insertInto' )->willReturnCallback( $captureTable );
+		$builder->method( 'insert' )->willReturnCallback( $captureTable );
+		$builder->method( 'table' )->willReturnCallback( $captureTable );
+
+		$captureRow = static function ( $row ) use ( $builder, &$rows ) {
+			$rows[] = $row;
+			return $builder;
+		};
+		$builder->method( 'row' )->willReturnCallback( $captureRow );
+		$builder->method( 'rows' )->willReturnCallback( $captureRow );
+
+		$captureSet = static function ( $set ) use ( $builder, &$sets ) {
+			$sets[] = $set;
+			return $builder;
+		};
+		$builder->method( 'set' )->willReturnCallback( $captureSet );
+		$builder->method( 'andSet' )->willReturnCallback( $captureSet );
+
+		$captureUnique = static function ( $fields ) use ( $builder, &$uniqueIndexFields ) {
+			$uniqueIndexFields[] = $fields;
+			return $builder;
+		};
+		$builder->method( 'uniqueIndexFields' )->willReturnCallback( $captureUnique );
+
+		foreach ( [ 'onDuplicateKeyUpdate', 'ignore', 'caller', 'option', 'options' ] as $passthrough ) {
+			$builder->method( $passthrough )->willReturn( $builder );
+		}
+
+		$builder->method( 'execute' );
+
+		return $builder;
+	}
+
+	private function createMockUpdateQueryBuilder(
+		array &$tables = [],
+		array &$sets = [],
+		array &$wheres = []
+	): UpdateQueryBuilder {
+		$builder = $this->getMockBuilder( UpdateQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$captureTable = static function ( $table ) use ( $builder, &$tables ) {
+			$tables[] = $table;
+			return $builder;
+		};
+		$builder->method( 'update' )->willReturnCallback( $captureTable );
+		$builder->method( 'table' )->willReturnCallback( $captureTable );
+
+		$captureSet = static function ( $set ) use ( $builder, &$sets ) {
+			$sets[] = $set;
+			return $builder;
+		};
+		$builder->method( 'set' )->willReturnCallback( $captureSet );
+		$builder->method( 'andSet' )->willReturnCallback( $captureSet );
+
+		$captureWhere = static function ( $cond ) use ( $builder, &$wheres ) {
+			$wheres[] = $cond;
+			return $builder;
+		};
+		$builder->method( 'where' )->willReturnCallback( $captureWhere );
+		$builder->method( 'andWhere' )->willReturnCallback( $captureWhere );
+		$builder->method( 'conds' )->willReturnCallback( $captureWhere );
+
+		foreach ( [ 'ignore', 'caller', 'option', 'options' ] as $passthrough ) {
+			$builder->method( $passthrough )->willReturn( $builder );
+		}
+
+		$builder->method( 'execute' );
+
+		return $builder;
+	}
+
+	private function createMockDeleteQueryBuilder(
+		array &$tables = [],
+		array &$wheres = []
+	): DeleteQueryBuilder {
+		$builder = $this->getMockBuilder( DeleteQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$captureTable = static function ( $table ) use ( $builder, &$tables ) {
+			$tables[] = $table;
+			return $builder;
+		};
+		$builder->method( 'deleteFrom' )->willReturnCallback( $captureTable );
+		$builder->method( 'delete' )->willReturnCallback( $captureTable );
+		$builder->method( 'table' )->willReturnCallback( $captureTable );
+
+		$captureWhere = static function ( $cond ) use ( $builder, &$wheres ) {
+			$wheres[] = $cond;
+			return $builder;
+		};
+		$builder->method( 'where' )->willReturnCallback( $captureWhere );
+		$builder->method( 'andWhere' )->willReturnCallback( $captureWhere );
+		$builder->method( 'conds' )->willReturnCallback( $captureWhere );
+
+		$builder->method( 'caller' )->willReturn( $builder );
+		$builder->method( 'execute' );
+
+		return $builder;
+	}
+
+	private function createMockReplaceQueryBuilder(
+		array &$tables = [],
+		array &$rows = [],
+		array &$uniqueIndexFields = []
+	): ReplaceQueryBuilder {
+		$builder = $this->getMockBuilder( ReplaceQueryBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$captureTable = static function ( $table ) use ( $builder, &$tables ) {
+			$tables[] = $table;
+			return $builder;
+		};
+		$builder->method( 'replaceInto' )->willReturnCallback( $captureTable );
+		$builder->method( 'table' )->willReturnCallback( $captureTable );
+
+		$captureRow = static function ( $row ) use ( $builder, &$rows ) {
+			$rows[] = $row;
+			return $builder;
+		};
+		$builder->method( 'row' )->willReturnCallback( $captureRow );
+		$builder->method( 'rows' )->willReturnCallback( $captureRow );
+
+		$captureUnique = static function ( $fields ) use ( $builder, &$uniqueIndexFields ) {
+			$uniqueIndexFields[] = $fields;
+			return $builder;
+		};
+		$builder->method( 'uniqueIndexFields' )->willReturnCallback( $captureUnique );
+
+		$builder->method( 'caller' )->willReturn( $builder );
+		$builder->method( 'execute' );
+
+		return $builder;
+	}
+}

--- a/tests/phpunit/Unit/MediaWiki/Connection/MockWriteQueryBuilderTrait.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/MockWriteQueryBuilderTrait.php
@@ -23,6 +23,17 @@ use Wikimedia\Rdbms\UpdateQueryBuilder;
  */
 trait MockWriteQueryBuilderTrait {
 
+	/**
+	 * @param array &$tables Captures `insertInto()`/`insert()`/`table()`
+	 *   arguments in call order. Successive calls append.
+	 * @param array &$rows Captures `row()` and `rows()` arguments in call
+	 *   order. `row($a)` followed by `rows([$b, $c])` yields
+	 *   `[$a, [$b, $c]]`.
+	 * @param array &$sets Captures `set()`/`andSet()` arguments in call
+	 *   order. Successive calls append.
+	 * @param array &$uniqueIndexFields Captures `uniqueIndexFields()`
+	 *   arguments in call order. Successive calls append.
+	 */
 	private function createMockInsertQueryBuilder(
 		array &$tables = [],
 		array &$rows = [],
@@ -70,6 +81,14 @@ trait MockWriteQueryBuilderTrait {
 		return $builder;
 	}
 
+	/**
+	 * @param array &$tables Captures `update()`/`table()` arguments in call
+	 *   order. Successive calls append.
+	 * @param array &$sets Captures `set()`/`andSet()` arguments in call
+	 *   order. Successive calls append.
+	 * @param array &$wheres Captures `where()`/`andWhere()`/`conds()`
+	 *   arguments in call order. Successive calls append.
+	 */
 	private function createMockUpdateQueryBuilder(
 		array &$tables = [],
 		array &$sets = [],
@@ -110,6 +129,12 @@ trait MockWriteQueryBuilderTrait {
 		return $builder;
 	}
 
+	/**
+	 * @param array &$tables Captures `deleteFrom()`/`delete()`/`table()`
+	 *   arguments in call order. Successive calls append.
+	 * @param array &$wheres Captures `where()`/`andWhere()`/`conds()`
+	 *   arguments in call order. Successive calls append.
+	 */
 	private function createMockDeleteQueryBuilder(
 		array &$tables = [],
 		array &$wheres = []
@@ -140,6 +165,15 @@ trait MockWriteQueryBuilderTrait {
 		return $builder;
 	}
 
+	/**
+	 * @param array &$tables Captures `replaceInto()`/`table()` arguments in
+	 *   call order. Successive calls append.
+	 * @param array &$rows Captures `row()` and `rows()` arguments in call
+	 *   order. `row($a)` followed by `rows([$b, $c])` yields
+	 *   `[$a, [$b, $c]]`.
+	 * @param array &$uniqueIndexFields Captures `uniqueIndexFields()`
+	 *   arguments in call order. Successive calls append.
+	 */
 	private function createMockReplaceQueryBuilder(
 		array &$tables = [],
 		array &$rows = [],

--- a/tests/phpunit/Unit/MediaWiki/Connection/MockWriteQueryBuilderTraitTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/MockWriteQueryBuilderTraitTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace SMW\Tests\Unit\MediaWiki\Connection;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait
+ *
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class MockWriteQueryBuilderTraitTest extends TestCase {
+
+	use MockWriteQueryBuilderTrait;
+
+	public function testInsertCapturesTableRowsAndUniqueIndex(): void {
+		$tables = $rows = $sets = $uniqueIndexFields = [];
+
+		$builder = $this->createMockInsertQueryBuilder( $tables, $rows, $sets, $uniqueIndexFields );
+
+		$builder
+			->insertInto( 'smw_test' )
+			->row( [ 'a' => 1 ] )
+			->onDuplicateKeyUpdate()
+			->uniqueIndexFields( [ 'a' ] )
+			->set( [ 'a' => 2 ] )
+			->caller( __METHOD__ )
+			->execute();
+
+		$this->assertSame( [ 'smw_test' ], $tables );
+		$this->assertSame( [ [ 'a' => 1 ] ], $rows );
+		$this->assertSame( [ [ 'a' => 2 ] ], $sets );
+		$this->assertSame( [ [ 'a' ] ], $uniqueIndexFields );
+	}
+
+	public function testUpdateCapturesTableSetAndWhere(): void {
+		$tables = $sets = $wheres = [];
+
+		$builder = $this->createMockUpdateQueryBuilder( $tables, $sets, $wheres );
+
+		$builder
+			->update( 'smw_test' )
+			->set( [ 'a' => 2 ] )
+			->where( [ 'id' => 1 ] )
+			->caller( __METHOD__ )
+			->execute();
+
+		$this->assertSame( [ 'smw_test' ], $tables );
+		$this->assertSame( [ [ 'a' => 2 ] ], $sets );
+		$this->assertSame( [ [ 'id' => 1 ] ], $wheres );
+	}
+
+	public function testDeleteCapturesTableAndWhere(): void {
+		$tables = $wheres = [];
+
+		$builder = $this->createMockDeleteQueryBuilder( $tables, $wheres );
+
+		$builder
+			->deleteFrom( 'smw_test' )
+			->where( [ 'id' => 1 ] )
+			->caller( __METHOD__ )
+			->execute();
+
+		$this->assertSame( [ 'smw_test' ], $tables );
+		$this->assertSame( [ [ 'id' => 1 ] ], $wheres );
+	}
+
+	public function testReplaceCapturesTableRowsAndUniqueIndex(): void {
+		$tables = $rows = $uniqueIndexFields = [];
+
+		$builder = $this->createMockReplaceQueryBuilder( $tables, $rows, $uniqueIndexFields );
+
+		$builder
+			->replaceInto( 'smw_test' )
+			->uniqueIndexFields( [ 'id' ] )
+			->row( [ 'id' => 1 ] )
+			->caller( __METHOD__ )
+			->execute();
+
+		$this->assertSame( [ 'smw_test' ], $tables );
+		$this->assertSame( [ [ 'id' => 1 ] ], $rows );
+		$this->assertSame( [ [ 'id' ] ], $uniqueIndexFields );
+	}
+}

--- a/tests/phpunit/Unit/MediaWiki/Connection/MockWriteQueryBuilderTraitTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/MockWriteQueryBuilderTraitTest.php
@@ -36,6 +36,26 @@ class MockWriteQueryBuilderTraitTest extends TestCase {
 		$this->assertSame( [ [ 'a' ] ], $uniqueIndexFields );
 	}
 
+	public function testInsertAppendsAcrossMultipleCalls(): void {
+		$tables = $rows = $sets = $uniqueIndexFields = [];
+
+		$builder = $this->createMockInsertQueryBuilder( $tables, $rows, $sets, $uniqueIndexFields );
+
+		$builder
+			->insertInto( 'smw_test' )
+			->row( [ 'a' => 1 ] )
+			->row( [ 'a' => 2 ] )
+			->rows( [ [ 'a' => 3 ], [ 'a' => 4 ] ] )
+			->caller( __METHOD__ )
+			->execute();
+
+		$this->assertSame( [ 'smw_test' ], $tables );
+		$this->assertSame(
+			[ [ 'a' => 1 ], [ 'a' => 2 ], [ [ 'a' => 3 ], [ 'a' => 4 ] ] ],
+			$rows
+		);
+	}
+
 	public function testUpdateCapturesTableSetAndWhere(): void {
 		$tables = $sets = $wheres = [];
 

--- a/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
@@ -11,6 +11,7 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\MediaWiki\Jobs\EntityIdDisposerJob
@@ -22,6 +23,8 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class EntityIdDisposerJobTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $connection;
@@ -138,9 +141,10 @@ class EntityIdDisposerJobTest extends TestCase {
 			'smw_hash' => ''
 		];
 
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
 		$this->connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$subject = WikiPage::newFromText( __METHOD__ );
 

--- a/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
@@ -42,6 +42,10 @@ class EntityIdDisposerJobTest extends TestCase {
 			->method( 'select' )
 			->willReturn( [ 'Foo' ] );
 
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
+
 		$store = $this->getMockBuilder( SQLStore::class )
 			->getMockForAbstractClass();
 

--- a/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
@@ -23,6 +23,8 @@ use SMW\SQLStore\RedirectStore;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\SQLStoreFactory;
 use SMW\SQLStore\TableFieldUpdater;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -35,6 +37,9 @@ use stdClass;
  * @author mwjames
  */
 class EntityIdManagerTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $store;
 	private $cache;
@@ -212,9 +217,10 @@ class EntityIdManagerTest extends TestCase {
 		$selectRow->smw_sortkey = 'Foo';
 		$selectRow->smw_hash = '___hash___';
 
-		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( $selectRow );
+		$qb = $this->createMockSelectQueryBuilder( [ $selectRow ] );
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -245,9 +251,10 @@ class EntityIdManagerTest extends TestCase {
 		$selectRow->smw_proptable_hash = serialize( 'Foo' );
 		$selectRow->smw_hash = '___hash___';
 
-		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( $selectRow );
+		$qb = $this->createMockSelectQueryBuilder( [ $selectRow ] );
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -289,9 +296,16 @@ class EntityIdManagerTest extends TestCase {
 		$selectRow->smw_proptable_hash = serialize( 'Foo' );
 		$selectRow->smw_hash = '___hash___';
 
+		$qb = $this->createMockSelectQueryBuilder( [ $selectRow ] );
 		$this->connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( $selectRow );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
+
+		$insertTables = $insertRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $insertTables, $insertRows );
+		$this->connection->expects( $this->once() )
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$this->connection->expects( $this->once() )
 			->method( 'insertId' )
@@ -325,6 +339,8 @@ class EntityIdManagerTest extends TestCase {
 		);
 
 		$this->assertEquals( 9999, $result );
+		$this->assertSame( [ SQLStore::ID_TABLE ], $insertTables );
+		$this->assertCount( 1, $insertRows );
 	}
 
 	public function testGetDataItemById() {
@@ -418,9 +434,10 @@ class EntityIdManagerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( $row );
+		$qb = $this->createMockSelectQueryBuilder( [ $row ] );
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -519,9 +536,11 @@ class EntityIdManagerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions );
+		$connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -539,6 +558,16 @@ class EntityIdManagerTest extends TestCase {
 		$this->assertEquals(
 			1001,
 			$instance->findAssociatedRev( 'Foo', NS_MAIN, '', '' )
+		);
+
+		$this->assertSame(
+			[ [
+				'smw_title' => 'Foo',
+				'smw_namespace' => NS_MAIN,
+				'smw_iw' => '',
+				'smw_subobject' => '',
+			] ],
+			$whereConditions
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/EntityStore/AuxiliaryFieldsTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/AuxiliaryFieldsTest.php
@@ -10,6 +10,8 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\AuxiliaryFields;
 use SMW\SQLStore\EntityStore\FieldList;
 use SMW\SQLStore\EntityStore\IdCacheManager;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use SMW\Utils\HmacSerializer;
 
 /**
@@ -22,6 +24,9 @@ use SMW\Utils\HmacSerializer;
  * @author mwjames
  */
 class AuxiliaryFieldsTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $connection;
 	private $idCacheManager;
@@ -60,13 +65,12 @@ class AuxiliaryFieldsTest extends TestCase {
 			'smw_countmap' => 0
 		];
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions );
+
 		$this->connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 't.smw_hash' => [ sha1( json_encode( [ 'Foo', 0, '', '' ] ), true ) ] ] )
-			->willReturn( [ (object)$row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new AuxiliaryFields(
 			$this->connection,
@@ -77,6 +81,11 @@ class AuxiliaryFieldsTest extends TestCase {
 			FieldList::class,
 			$instance->prefetchFieldList( $subjects )
 		);
+
+		$this->assertContains(
+			[ 't.smw_hash' => [ sha1( json_encode( [ 'Foo', 0, '', '' ] ), true ) ] ],
+			$whereConditions
+		);
 	}
 
 	public function testSetFieldMaps_Empty() {
@@ -85,14 +94,12 @@ class AuxiliaryFieldsTest extends TestCase {
 			->with( AuxiliaryFields::COUNTMAP_CACHE_ID )
 			->willReturn( $this->cache );
 
+		$tables = $rows = $sets = $uniqueIndexFields = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $tables, $rows, $sets, $uniqueIndexFields );
+
 		$this->connection->expects( $this->once() )
-			->method( 'upsert' )
-			->with(
-				$this->anything(),
-				$this->equalTo( [
-					'smw_id' => 42,
-					'smw_seqmap' => null,
-					'smw_countmap' => null ] ) );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$instance = new AuxiliaryFields(
 			$this->connection,
@@ -100,6 +107,17 @@ class AuxiliaryFieldsTest extends TestCase {
 		);
 
 		$instance->setFieldMaps( 42, [], [] );
+
+		$this->assertSame( [ 'smw_object_aux' ], $tables );
+		$this->assertSame(
+			[ [ 'smw_id' => 42, 'smw_seqmap' => null, 'smw_countmap' => null ] ],
+			$rows
+		);
+		$this->assertSame( [ [ 'smw_id' ] ], $uniqueIndexFields );
+		$this->assertSame(
+			[ [ 'smw_seqmap' => null, 'smw_countmap' => null ] ],
+			$sets
+		);
 	}
 
 	public function testSetFieldMaps() {
@@ -112,14 +130,12 @@ class AuxiliaryFieldsTest extends TestCase {
 			->method( 'escape_bytea' )
 			->willReturnArgument( 0 );
 
+		$tables = $rows = $sets = $uniqueIndexFields = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $tables, $rows, $sets, $uniqueIndexFields );
+
 		$this->connection->expects( $this->once() )
-			->method( 'upsert' )
-			->with(
-				$this->anything(),
-				$this->equalTo( [
-					'smw_id' => 42,
-					'smw_seqmap' => HmacSerializer::compress( [ 'seqmap' ] ),
-					'smw_countmap' => HmacSerializer::compress( [ 'countmap' ] ) ] ) );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$instance = new AuxiliaryFields(
 			$this->connection,
@@ -127,6 +143,24 @@ class AuxiliaryFieldsTest extends TestCase {
 		);
 
 		$instance->setFieldMaps( 42, [ 'seqmap' ], [ 'countmap' ] );
+
+		$this->assertSame( [ 'smw_object_aux' ], $tables );
+		$this->assertSame(
+			[ [
+				'smw_id' => 42,
+				'smw_seqmap' => HmacSerializer::compress( [ 'seqmap' ] ),
+				'smw_countmap' => HmacSerializer::compress( [ 'countmap' ] )
+			] ],
+			$rows
+		);
+		$this->assertSame( [ [ 'smw_id' ] ], $uniqueIndexFields );
+		$this->assertSame(
+			[ [
+				'smw_seqmap' => HmacSerializer::compress( [ 'seqmap' ] ),
+				'smw_countmap' => HmacSerializer::compress( [ 'countmap' ] )
+			] ],
+			$sets
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/CacheWarmerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/CacheWarmerTest.php
@@ -11,6 +11,7 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\CacheWarmer;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\CacheWarmer
@@ -22,6 +23,8 @@ use SMW\SQLStore\SQLStore;
  * @author mwjames
  */
 class CacheWarmerTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $idCacheManager;
 	private $store;
@@ -72,13 +75,12 @@ class CacheWarmerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions );
+
 		$connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 'smw_hash' => [ sha1( json_encode( [ 'Bar', 0, '', '' ] ), true ) ] ] )
-			->willReturn( [ (object)$row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -95,6 +97,11 @@ class CacheWarmerTest extends TestCase {
 
 		$instance->setThresholdLimit( 1 );
 		$instance->prepareCache( $list );
+
+		$this->assertContains(
+			[ 'smw_hash' => [ sha1( json_encode( [ 'Bar', 0, '', '' ] ), true ) ] ],
+			$whereConditions
+		);
 	}
 
 	public function testPrepareCache_DisplayTitleFinder() {
@@ -144,13 +151,12 @@ class CacheWarmerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions );
+
 		$connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 'smw_hash' => [ sha1( json_encode( [ 'Foo', 102, '', '' ] ), true ) ] ] )
-			->willReturn( [ (object)$row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -167,6 +173,11 @@ class CacheWarmerTest extends TestCase {
 
 		$instance->setThresholdLimit( 1 );
 		$instance->prepareCache( $list );
+
+		$this->assertContains(
+			[ 'smw_hash' => [ sha1( json_encode( [ 'Foo', 102, '', '' ] ), true ) ] ],
+			$whereConditions
+		);
 	}
 
 	public function testPrepareCache_UnknownPredefinedProperty() {

--- a/tests/phpunit/Unit/SQLStore/EntityStore/DuplicateFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/DuplicateFinderTest.php
@@ -7,13 +7,11 @@ use SMW\DataItems\WikiPage;
 use SMW\IteratorFactory;
 use SMW\Iterators\MappingIterator;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\SQLStore\EntityStore\DuplicateFinder;
 use SMW\SQLStore\RedirectStore;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
-use Wikimedia\Rdbms\FakeResultWrapper;
-use Wikimedia\Rdbms\ResultWrapper;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\DuplicateFinder
@@ -25,6 +23,8 @@ use Wikimedia\Rdbms\ResultWrapper;
  * @author mwjames
  */
 class DuplicateFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $connection;
@@ -57,47 +57,32 @@ class DuplicateFinderTest extends TestCase {
 	}
 
 	public function testHasDuplicate() {
-		$connection = $this->getMockBuilder( Database::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnArgument( 0 );
-
-		$connection->expects( $this->any() )
-			->method( 'tableName' )
-			->willReturnArgument( 0 );
-
-		$query = new Query( $connection );
-
-		$resultWrapper = $this->getMockBuilder( ResultWrapper::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder(
+			[ (object)[ 'smw_id' => 1 ], (object)[ 'smw_id' => 2 ] ],
+			$whereConditions
+		);
 
 		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'newQuery' )
-			->willReturn( $query );
-
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'readQuery' )
-			->willReturn( $resultWrapper );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new DuplicateFinder(
 			$this->store,
 			$this->iteratorFactory
 		);
 
-		$instance->hasDuplicate( WikiPage::newFromText( 'Foo' ) );
+		$this->assertTrue(
+			$instance->hasDuplicate( WikiPage::newFromText( 'Foo' ) )
+		);
 
-		$this->assertJsonStringEqualsJsonString(
-			'{' .
-			'"tables": "smw_object_ids",' .
-			'"fields":["smw_id","smw_sortkey"],' .
-			'"conditions":[["smw_title=Foo"],["smw_namespace=0"],["smw_subobject="],["smw_iw!=:smw"],["smw_iw!=:smw-delete"],["smw_iw!=:smw-redi"]],' .
-			'"joins":[],' .
-			'"options":{"LIMIT":2},"alias":"","index":0,"autocommit":false}',
-			(string)$query
+		$this->assertContains(
+			[
+				'smw_title' => 'Foo',
+				'smw_namespace' => 0,
+				'smw_subobject' => '',
+			],
+			$whereConditions
 		);
 	}
 
@@ -117,15 +102,11 @@ class DuplicateFinderTest extends TestCase {
 			'smw_subobject' => ''
 		];
 
-		$query = new Query( $this->connection );
+		$qb = $this->createMockSelectQueryBuilder( [ $row ] );
 
-		$this->connection->expects( $this->once() )
-			->method( 'newQuery' )
-			->willReturn( $query );
-
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$this->connection->expects( $this->atLeastOnce() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new DuplicateFinder(
 			$this->store,
@@ -137,11 +118,6 @@ class DuplicateFinderTest extends TestCase {
 		$this->assertInstanceOf(
 			MappingIterator::class,
 			$res
-		);
-
-		$this->assertStringContainsString(
-			'HAVING":"count(*) > 1',
-			$query->__toString()
 		);
 
 		$this->assertEquals(
@@ -164,15 +140,11 @@ class DuplicateFinderTest extends TestCase {
 			'o_id' => 1001
 		];
 
-		$query = new Query( $this->connection );
+		$qb = $this->createMockSelectQueryBuilder( [ $row ] );
 
-		$this->connection->expects( $this->once() )
-			->method( 'newQuery' )
-			->willReturn( $query );
-
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$this->connection->expects( $this->atLeastOnce() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new DuplicateFinder(
 			$this->store,
@@ -186,11 +158,6 @@ class DuplicateFinderTest extends TestCase {
 		$this->assertInstanceOf(
 			MappingIterator::class,
 			$res
-		);
-
-		$this->assertStringContainsString(
-			'HAVING":"count(*) > 1',
-			$query->__toString()
 		);
 
 		$this->assertEquals(

--- a/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdFinderTest.php
@@ -10,6 +10,7 @@ use SMW\SQLStore\EntityStore\EntityIdFinder;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\PropertyTable\PropertyTableHashes;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\EntityIdFinder
@@ -21,6 +22,8 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class EntityIdFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $cache;
@@ -75,9 +78,11 @@ class EntityIdFinderTest extends TestCase {
 		$this->idCacheManager->expects( $this->once() )
 			->method( 'setCache' );
 
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new EntityIdFinder(
 			$this->connection,
@@ -106,9 +111,11 @@ class EntityIdFinderTest extends TestCase {
 		$this->idCacheManager->expects( $this->once() )
 			->method( 'setCache' );
 
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new EntityIdFinder(
 			$this->connection,
@@ -139,9 +146,11 @@ class EntityIdFinderTest extends TestCase {
 		$this->idCacheManager->expects( $this->once() )
 			->method( 'setCache' );
 
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new EntityIdFinder(
 			$this->connection,
@@ -167,9 +176,11 @@ class EntityIdFinderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$qb = $this->createMockSelectQueryBuilder( $rows );
+
 		$this->connection->expects( $this->once() )
-			->method( 'select' )
-			->willReturn( $rows );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new EntityIdFinder(
 			$this->connection,

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdChangerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdChangerTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Unit\SQLStore\EntityStore;
 
-use PHPUnit\Framework\MockObject\Builder\InvocationMocker;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\JobFactory;
@@ -12,6 +11,8 @@ use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder\FieldType;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\IdChanger
@@ -23,6 +24,9 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class IdChangerTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $store;
@@ -63,26 +67,26 @@ class IdChangerTest extends TestCase {
 	}
 
 	public function testMove_NoMatch() {
+		$selectWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [], $selectWheres );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				'*',
-				[ 'smw_id' => 42 ] )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new IdChanger(
 			$this->store
 		);
 
 		$instance->move( 42 );
+
+		$this->assertSame(
+			[ [ 'smw_id' => 42 ] ],
+			$selectWheres
+		);
 	}
 
 	public function testMove_ZeroTarget() {
-		if ( !method_exists( InvocationMocker::class, 'withConsecutive' ) ) {
-			$this->markTestSkipped( 'PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive requires PHPUnit 5.7+.' );
-		}
-
 		$row = [
 			'smw_id' => 42,
 			'smw_title' => 'Foo',
@@ -94,33 +98,39 @@ class IdChangerTest extends TestCase {
 			'smw_hash' => sha1( json_encode( [ 'Foo', 0, '', '' ] ), true )
 		];
 
-		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				'*',
-				[ 'smw_id' => 42 ] )
-			->willReturn( (object)$row );
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)$row ] );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$this->connection->expects( $this->once() )
 			->method( 'nextSequenceValue' )
 			->willReturn( 1 );
 
+		$insertTables = $insertRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $insertTables, $insertRows );
+
 		$this->connection->expects( $this->once() )
-			->method( 'insert' )
-			->with(
-				$this->anything(),
-				[ 'smw_id' => 1 ] + $row );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$this->connection->expects( $this->once() )
 			->method( 'insertId' )
 			->willReturn( 9999 );
 
+		$deleteTables = $deleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $deleteTables, $deleteWheres );
+
 		$this->connection->expects( $this->any() )
-			->method( 'delete' )
-			->withConsecutive(
-				[ $this->equalTo( 'smw_object_aux' ), $this->equalTo( [ 'smw_id' => 42 ] ) ],
-				[ $this->equalTo( 'smw_object_ids' ), $this->equalTo( [ 'smw_id' => 42 ] ) ] );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
@@ -141,13 +151,22 @@ class IdChangerTest extends TestCase {
 			(object)$expected,
 			$instance->move( 42, 0 )
 		);
+
+		$this->assertSame(
+			[ [ 'smw_id' => 1 ] + $row ],
+			$insertRows
+		);
+		$this->assertSame(
+			[ SQLStore::ID_AUXILIARY_TABLE, SQLStore::ID_TABLE ],
+			$deleteTables
+		);
+		$this->assertSame(
+			[ [ 'smw_id' => 42 ], [ 'smw_id' => 42 ] ],
+			$deleteWheres
+		);
 	}
 
 	public function testMove_Target() {
-		if ( !method_exists( InvocationMocker::class, 'withConsecutive' ) ) {
-			$this->markTestSkipped( 'PHPUnit\Framework\MockObject\Builder\InvocationMocker::withConsecutive requires PHPUnit 5.7+.' );
-		}
-
 		$row = [
 			'smw_id' => 42,
 			'smw_title' => 'Foo',
@@ -159,25 +178,31 @@ class IdChangerTest extends TestCase {
 			'smw_hash' => sha1( json_encode( [ 'Foo', 0, '', '' ] ), true )
 		];
 
-		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				'*',
-				[ 'smw_id' => 42 ] )
-			->willReturn( (object)$row );
-
-		$this->connection->expects( $this->once() )
-			->method( 'insert' )
-			->with(
-				$this->anything(),
-				[ 'smw_id' => 1001 ] + $row );
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)$row ] );
 
 		$this->connection->expects( $this->any() )
-			->method( 'delete' )
-			->withConsecutive(
-				[ $this->equalTo( 'smw_object_aux' ), $this->equalTo( [ 'smw_id' => 42 ] ) ],
-				[ $this->equalTo( 'smw_object_ids' ), $this->equalTo( [ 'smw_id' => 42 ] ) ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$insertTables = $insertRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $insertTables, $insertRows );
+
+		$this->connection->expects( $this->once() )
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
+
+		$deleteTables = $deleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $deleteTables, $deleteWheres );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
@@ -198,6 +223,19 @@ class IdChangerTest extends TestCase {
 			(object)$expected,
 			$instance->move( 42, 1001 )
 		);
+
+		$this->assertSame(
+			[ [ 'smw_id' => 1001 ] + $row ],
+			$insertRows
+		);
+		$this->assertSame(
+			[ SQLStore::ID_AUXILIARY_TABLE, SQLStore::ID_TABLE ],
+			$deleteTables
+		);
+		$this->assertSame(
+			[ [ 'smw_id' => 42 ], [ 'smw_id' => 42 ] ],
+			$deleteWheres
+		);
 	}
 
 	public function testChange_IdSubject_Fields_NotFixedPropertyTable() {
@@ -206,6 +244,10 @@ class IdChangerTest extends TestCase {
 			->getMock();
 
 		$table->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'smw_foo' );
+
+		$table->expects( $this->any() )
 			->method( 'usesIdSubject' )
 			->willReturn( true );
 
@@ -221,26 +263,28 @@ class IdChangerTest extends TestCase {
 			->method( 'getPropertyTables' )
 			->willReturnOnConsecutiveCalls( [ $table ] );
 
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'selectRow' )
-			->willReturnCallback( static function ( $table, $vars, $conds ) {
-				if ( isset( $conds['s_id'] ) && $conds['s_id'] === 42 ) {
-					return true;
-				}
-				return false;
-			} );
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)[] ] );
 
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'update' )
-			->willReturnCallback( static function ( $table, $set, $conds ) {
-				// Accepts calls for s_id, p_id, _foo updates
-			} );
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$updateTables = $updateSets = $updateWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder( $updateTables, $updateSets, $updateWheres );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$instance = new IdChanger(
 			$this->store
 		);
 
 		$instance->change( 42, 1001 );
+
+		$this->assertContains( [ 's_id' => 1001 ], $updateSets );
+		$this->assertContains( [ 'p_id' => 1001 ], $updateSets );
+		$this->assertContains( [ '_foo' => 1001 ], $updateSets );
 	}
 
 	public function testChange_IdSubject_PropertyNS_Fields_NotFixedPropertyTable() {
@@ -249,6 +293,10 @@ class IdChangerTest extends TestCase {
 			->getMock();
 
 		$table->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'smw_foo' );
+
+		$table->expects( $this->any() )
 			->method( 'usesIdSubject' )
 			->willReturn( true );
 
@@ -264,38 +312,45 @@ class IdChangerTest extends TestCase {
 			->method( 'getPropertyTables' )
 			->willReturnOnConsecutiveCalls( [ $table ] );
 
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'selectRow' )
-			->willReturnCallback( static function ( $table, $vars, $conds ) {
-				if ( isset( $conds['s_id'] ) && $conds['s_id'] === 42 ) {
-					return true;
-				}
-				return false;
-			} );
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)[] ] );
 
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'update' )
-			->willReturnCallback( static function ( $table, $set, $conds ) {
-				// Accepts calls for s_id and _foo updates
-			} );
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
+
+		$deleteTables = $deleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $deleteTables, $deleteWheres );
 
 		$this->connection->expects( $this->once() )
-			->method( 'delete' )
-			->with(
-				$this->anything(),
-				[ 'p_id' => 42 ] );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$instance = new IdChanger(
 			$this->store
 		);
 
 		$instance->change( 42, 1001, SMW_NS_PROPERTY, NS_MAIN );
+
+		$this->assertSame(
+			[ [ 'p_id' => 42 ] ],
+			$deleteWheres
+		);
 	}
 
 	public function testChange_IdSubject_ConceptNS_Fields_NotFixedPropertyTable() {
 		$table = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$table->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'smw_foo' );
 
 		$table->expects( $this->any() )
 			->method( 'usesIdSubject' )
@@ -313,31 +368,40 @@ class IdChangerTest extends TestCase {
 			->method( 'getPropertyTables' )
 			->willReturnOnConsecutiveCalls( [ $table ] );
 
-		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 's_id' => 42 ] )
-			->willReturn( true );
+		$selectWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)[] ], $selectWheres );
 
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'update' )
-			->willReturnCallback( static function ( $table, $set, $conds ) {
-				// Accepts calls for s_id and o_id updates
-			} );
+		$this->connection->expects( $this->once() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
+
+		$deleteTables = $deleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $deleteTables, $deleteWheres );
 
 		$this->connection->expects( $this->exactly( 2 ) )
-			->method( 'delete' )
-			->with(
-				$this->anything(),
-				[ 's_id' => 42 ] );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$instance = new IdChanger(
 			$this->store
 		);
 
 		$instance->change( 42, 1001, SMW_NS_CONCEPT, NS_MAIN );
+
+		$this->assertSame(
+			[ [ 's_id' => 42 ] ],
+			$selectWheres
+		);
+		$this->assertSame(
+			[ [ 's_id' => 42 ], [ 's_id' => 42 ] ],
+			$deleteWheres
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdEntityFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdEntityFinderTest.php
@@ -11,6 +11,7 @@ use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\EntityStore\IdEntityFinder;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -23,6 +24,8 @@ use stdClass;
  * @author mwjames
  */
 class IdEntityFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $cache;
@@ -92,13 +95,12 @@ class IdEntityFinderTest extends TestCase {
 			->method( 'fetch' )
 			->willReturn( false );
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 'smw_id' => 42 ] )
-			->willReturn( $row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new IdEntityFinder(
 			$this->store,
@@ -110,6 +112,8 @@ class IdEntityFinderTest extends TestCase {
 			WikiPage::class,
 			$instance->getDataItemById( 42 )
 		);
+
+		$this->assertContains( [ 'smw_id' => 42 ], $whereConditions );
 	}
 
 	public function testGetDataItemForCachedId() {
@@ -118,7 +122,7 @@ class IdEntityFinderTest extends TestCase {
 			->willReturn( new WikiPage( 'Foo', NS_MAIN ) );
 
 		$this->connection->expects( $this->never() )
-			->method( 'selectRow' );
+			->method( 'newSelectQueryBuilder' );
 
 		$instance = new IdEntityFinder(
 			$this->store,
@@ -152,13 +156,12 @@ class IdEntityFinderTest extends TestCase {
 			->method( 'fetch' )
 			->willReturn( false );
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 'smw_id' => 42 ] )
-			->willReturn( $row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new IdEntityFinder(
 			$this->store,
@@ -170,6 +173,8 @@ class IdEntityFinderTest extends TestCase {
 			$dataItem,
 			$instance->getDataItemById( 42 )
 		);
+
+		$this->assertContains( [ 'smw_id' => 42 ], $whereConditions );
 	}
 
 	public function testNullForUnknownId() {
@@ -177,9 +182,11 @@ class IdEntityFinderTest extends TestCase {
 			->method( 'fetch' )
 			->willReturn( false );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new IdEntityFinder(
 			$this->store,
@@ -208,13 +215,12 @@ class IdEntityFinderTest extends TestCase {
 		$row->smw_sort = '...';
 		$row->smw_hash = 'x99w';
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
+
 		$this->connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 'smw_id' => [ 42 ] ] )
-			->willReturn( [ $row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new IdEntityFinder(
 			$this->store,
@@ -228,6 +234,8 @@ class IdEntityFinderTest extends TestCase {
 				$value
 			);
 		}
+
+		$this->assertContains( [ 'smw_id' => [ 42 ] ], $whereConditions );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PropertiesLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PropertiesLookupTest.php
@@ -5,11 +5,10 @@ namespace SMW\Tests\Unit\SQLStore\EntityStore;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\SQLStore\EntityStore\PropertiesLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\PropertiesLookup
@@ -21,6 +20,8 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  * @author mwjames
  */
 class PropertiesLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$store = $this->getMockBuilder( SQLStore::class )
@@ -37,33 +38,28 @@ class PropertiesLookupTest extends TestCase {
 		$dataItem = WikiPage::newFromText( __METHOD__ );
 		$dataItem->setId( 42 );
 
-		$resultWrapper = $this->getMockBuilder( FakeResultWrapper::class )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$propertyTableDef = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$propertyTableDef->expects( $this->atLeastOnce() )
+			->method( 'usesIdSubject' )
+			->willReturn( true );
+
+		$propertyTableDef->expects( $this->atLeastOnce() )
 			->method( 'isFixedPropertyTable' )
 			->willReturn( false );
 
-		$query = $this->getMockBuilder( Query::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$query->expects( $this->atLeastOnce() )
-			->method( 'execute' )
-			->willReturn( $resultWrapper );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [], $whereConditions );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'newQuery' )
-			->willReturn( $query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -87,13 +83,13 @@ class PropertiesLookupTest extends TestCase {
 		);
 
 		$instance->fetchFromTable( $dataItem, $propertyTableDef );
+
+		$this->assertContains( [ 's_id' => 42 ], $whereConditions );
 	}
 
 	public function testLookupForFixedPropertyTable() {
 		$dataItem = WikiPage::newFromText( __METHOD__ );
 		$dataItem->setId( 1001 );
-
-		$resultWrapper = new FakeResultWrapper( [] );
 
 		$propertyTableDef = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
@@ -103,21 +99,15 @@ class PropertiesLookupTest extends TestCase {
 			->method( 'isFixedPropertyTable' )
 			->willReturn( true );
 
-		$query = $this->getMockBuilder( Query::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$query->expects( $this->atLeastOnce() )
-			->method( 'execute' )
-			->willReturn( $resultWrapper );
+		$qb = $this->createMockSelectQueryBuilder( [] );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'newQuery' )
-			->willReturn( $query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PropertySubjectsLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PropertySubjectsLookupTest.php
@@ -5,12 +5,11 @@ namespace SMW\Tests\Unit\SQLStore\EntityStore;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\EntityStore\PropertySubjectsLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\PropertySubjectsLookup
@@ -22,6 +21,8 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  * @author mwjames
  */
 class PropertySubjectsLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$store = $this->getMockBuilder( SQLStore::class )
@@ -53,21 +54,15 @@ class PropertySubjectsLookupTest extends TestCase {
 			->method( 'isFixedPropertyTable' )
 			->willReturn( false );
 
-		$query = $this->getMockBuilder( Query::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$qb = $this->createMockSelectQueryBuilder( [] );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'newQuery' )
-			->willReturn( $query );
-
-		$connection->expects( $this->atLeastOnce() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [] ) );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -100,8 +95,6 @@ class PropertySubjectsLookupTest extends TestCase {
 	public function testLookupForFixedPropertyTable() {
 		$dataItem = WikiPage::newFromText( __METHOD__ );
 
-		$resultWrapper = new FakeResultWrapper( [] );
-
 		$dataItemHandler = $this->getMockBuilder( DataItemHandler::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
@@ -118,21 +111,15 @@ class PropertySubjectsLookupTest extends TestCase {
 			->method( 'isFixedPropertyTable' )
 			->willReturn( true );
 
-		$query = $this->getMockBuilder( Query::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$qb = $this->createMockSelectQueryBuilder( [] );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'newQuery' )
-			->willReturn( $query );
-
-		$connection->expects( $this->atLeastOnce() )
-			->method( 'readQuery' )
-			->willReturn( $resultWrapper );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/EntityStore/SemanticDataLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/SemanticDataLookupTest.php
@@ -9,7 +9,6 @@ use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\Connection\Query;
 use SMW\RequestOptions;
 use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\EntityStore\EntityIdManager;
@@ -17,8 +16,8 @@ use SMW\SQLStore\EntityStore\SemanticDataLookup;
 use SMW\SQLStore\EntityStore\StubSemanticData;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
-use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\SemanticDataLookup
@@ -31,10 +30,11 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  */
 class SemanticDataLookupTest extends TestCase {
 
+	use MockSelectQueryBuilderTrait;
+
 	private $store;
 	private $connection;
 	private $dataItemHandler;
-	private $query;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -59,8 +59,6 @@ class SemanticDataLookupTest extends TestCase {
 		$this->connection->expects( $this->any() )
 			->method( 'tableName' )
 			->willReturnArgument( 0 );
-
-		$this->query = new Query( $this->connection );
 
 		$connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()
@@ -210,13 +208,12 @@ class SemanticDataLookupTest extends TestCase {
 			->method( 'getDIType' )
 			->willReturn( 'Foo' );
 
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
 		$this->connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $this->query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new SemanticDataLookup(
 			$this->store
@@ -224,11 +221,13 @@ class SemanticDataLookupTest extends TestCase {
 
 		$subject = WikiPage::newFromText( __METHOD__ );
 
-		$semanticData = $instance->fetchSemanticDataFromTable(
+		$instance->fetchSemanticDataFromTable(
 			42,
 			$subject,
 			$propertyTable
 		);
+
+		$this->assertContainsEquals( [ 's_id' => 42 ], $whereConditions );
 	}
 
 	public function testSemanticDataFromTable_WithConstraint() {
@@ -269,18 +268,12 @@ class SemanticDataLookupTest extends TestCase {
 			->method( 'getDIType' )
 			->willReturn( 'Foo' );
 
-		$this->connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnCallback( static function ( $value ) { return "'$value'";
-			} );
-
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
 		$this->connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $this->query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$subject = WikiPage::newFromText( __METHOD__ );
 
@@ -300,13 +293,10 @@ class SemanticDataLookupTest extends TestCase {
 
 		$instance->fetchSemanticDataFromTable( 42, $subject, $propertyTable, $requestOptions );
 
-		$this->assertEquals(
-			"SELECT p.smw_title AS prop, fooField AS v0 FROM  " .
-			"INNER JOIN smw_object_ids AS p ON p_id=p.smw_id " .
-			"WHERE (s_id='42') AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete') AND (p_id='9999') " .
-			"LIMIT 4",
-			$this->query->build()
-		);
+		// `s_id` from the subject restriction and `p_id` from the extra-condition
+		// constraint must both be present in the captured where conditions.
+		$this->assertContainsEquals( [ 's_id' => 42 ], $whereConditions );
+		$this->assertContainsEquals( [ 'p_id' => 9999 ], $whereConditions );
 	}
 
 	public function testFetchSemanticDataFromTable_NoDataItem() {
@@ -330,18 +320,12 @@ class SemanticDataLookupTest extends TestCase {
 			->method( 'getDIType' )
 			->willReturn( 'Foo' );
 
-		$this->connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnCallback( static function ( $value ) { return "'$value'";
-			} );
-
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
 		$this->connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $this->query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new SemanticDataLookup(
 			$this->store
@@ -349,12 +333,7 @@ class SemanticDataLookupTest extends TestCase {
 
 		$instance->fetchSemanticDataFromTable( 42, null, $propertyTable );
 
-		$this->assertEquals(
-			"SELECT p.smw_title AS prop, fooField AS v0 FROM  " .
-			"INNER JOIN smw_object_ids AS p ON p_id=p.smw_id " .
-			"WHERE (s_id='42') AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete')",
-			$this->query->build()
-		);
+		$this->assertContainsEquals( [ 's_id' => 42 ], $whereConditions );
 	}
 
 	public function testFetchSemanticDataFromTable_NoIdSubject() {
@@ -382,18 +361,12 @@ class SemanticDataLookupTest extends TestCase {
 			->method( 'getName' )
 			->willReturn( 'bar_table' );
 
-		$this->connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnCallback( static function ( $value ) { return "'$value'";
-			} );
-
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
 		$this->connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $this->query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$dataItem = WikiPage::newFromText( 'no_id_subject' );
 
@@ -403,11 +376,13 @@ class SemanticDataLookupTest extends TestCase {
 
 		$instance->fetchSemanticDataFromTable( 42, $dataItem, $propertyTable );
 
-		$this->assertEquals(
-			"SELECT p.smw_title AS prop, fooField AS v0 FROM bar_table " .
-			"INNER JOIN smw_object_ids AS p ON p_id=p.smw_id " .
-			"WHERE (s_title='no_id_subject') AND (s_namespace='0') AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete')",
-			$this->query->build()
+		// Subject without idSubject column → restriction by title+namespace.
+		$this->assertContainsEquals(
+			[
+				's_title' => 'no_id_subject',
+				's_namespace' => 0,
+			],
+			$whereConditions
 		);
 	}
 
@@ -489,18 +464,12 @@ class SemanticDataLookupTest extends TestCase {
 			->method( 'getName' )
 			->willReturn( 'bar_table' );
 
-		$this->connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnCallback( static function ( $value ) { return "'$value'";
-			} );
-
-		$this->connection->expects( $this->once() )
-			->method( 'readQuery' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
 		$this->connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturn( $this->query );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$dataItem = new Blob( __METHOD__ );
 
@@ -511,12 +480,12 @@ class SemanticDataLookupTest extends TestCase {
 			$this->store
 		);
 
+		// Non-WikiPage `Blob` data item → property branch (isSubject=false), which
+		// applies DISTINCT and a `p_id` restriction. `distinct()` on the trait mock
+		// is a `willReturnSelf()` no-op; assert the restriction made it through.
 		$instance->fetchSemanticDataFromTable( 42, $dataItem, $propertyTable, $requestOptions );
 
-		$this->assertEquals(
-			"SELECT DISTINCT fooField AS v0 FROM bar_table WHERE (p_id='42') LIMIT 4",
-			$this->query->build()
-		);
+		$this->assertContainsEquals( [ 'p_id' => 42 ], $whereConditions );
 	}
 
 	public function testGetSemanticData_OnLimit() {
@@ -527,9 +496,6 @@ class SemanticDataLookupTest extends TestCase {
 		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
 			->willReturn( $idTable );
-
-		$query_1 = new Query( $this->connection );
-		$query_2 = new Query( $this->connection );
 
 		$row = new stdClass;
 		$row->p_id = 9000;
@@ -560,18 +526,13 @@ class SemanticDataLookupTest extends TestCase {
 			->method( 'getName' )
 			->willReturn( 'bar_table' );
 
-		$this->connection->expects( $this->any() )
-			->method( 'addQuotes' )
-			->willReturnCallback( static function ( $value ) { return "'$value'";
-			} );
+		$whereConditions = [];
+		$qb1 = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
+		$qb2 = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
 		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'readQuery' )
-			->willReturnOnConsecutiveCalls( new FakeResultWrapper( [ $row ] ), new FakeResultWrapper( [ $row ] ) );
-
-		$this->connection->expects( $this->any() )
-			->method( 'newQuery' )
-			->willReturnOnConsecutiveCalls( $query_1, $query_2 );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnOnConsecutiveCalls( $qb1, $qb2 );
 
 		$dataItem = WikiPage::newFromText( 'Bar' );
 
@@ -584,17 +545,11 @@ class SemanticDataLookupTest extends TestCase {
 
 		$instance->getSemanticData( 42, $dataItem, $propertyTable, $requestOptions );
 
-		$this->assertEquals(
-			"SELECT DISTINCT p_id FROM bar_table INNER JOIN smw_object_ids " .
-			"AS p ON p_id=p.smw_id WHERE (s_id='42') AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete')",
-			$query_1->build()
-		);
-
-		$this->assertEquals(
-			"SELECT p.smw_title AS prop, fooField AS v0 FROM bar_table INNER JOIN smw_object_ids " .
-			"AS p ON p_id=p.smw_id WHERE (s_id='42') AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete') AND (p_id='9000') LIMIT 4",
-			$query_2->build()
-		);
+		// First query: `fetchPropertiesFromTable` restricts on `s_id`.
+		// Second query: `fetchSemanticDataFromTable` re-applies `s_id` and adds the
+		// extra-condition `p_id` discovered from the first query's row.
+		$this->assertContainsEquals( [ 's_id' => 42 ], $whereConditions );
+		$this->assertContainsEquals( [ 'p_id' => 9000 ], $whereConditions );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/SequenceMapFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/SequenceMapFinderTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\EntityStore\SequenceMapFinder;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use SMW\Utils\HmacSerializer;
 
 /**
@@ -19,6 +21,9 @@ use SMW\Utils\HmacSerializer;
  * @author mwjames
  */
 class SequenceMapFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $cache;
 	private $idCacheManager;
@@ -50,18 +55,16 @@ class SequenceMapFinderTest extends TestCase {
 	}
 
 	public function testSetMap() {
-		$row = [
-			'smw_id' => 42,
-			'smw_seqmap' => null
-		];
+		$this->connection->expects( $this->any() )
+			->method( 'escape_bytea' )
+			->willReturn( '' );
+
+		$tables = $rows = $sets = $uniqueIndexFields = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $tables, $rows, $sets, $uniqueIndexFields );
 
 		$this->connection->expects( $this->once() )
-			->method( 'upsert' )
-			->with(
-				$this->anything(),
-				$row,
-				'smw_id',
-				[ 'smw_seqmap' => null ] );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$instance = new SequenceMapFinder(
 			$this->connection,
@@ -69,6 +72,17 @@ class SequenceMapFinderTest extends TestCase {
 		);
 
 		$instance->setMap( 42, [ 'Foo' ] );
+
+		$this->assertSame( [ 'smw_object_aux' ], $tables );
+		$this->assertSame(
+			[ [ 'smw_id' => 42, 'smw_seqmap' => '' ] ],
+			$rows
+		);
+		$this->assertSame( [ [ 'smw_id' ] ], $uniqueIndexFields );
+		$this->assertSame(
+			[ [ 'smw_seqmap' => '' ] ],
+			$sets
+		);
 	}
 
 	public function testFindMapById() {
@@ -83,9 +97,11 @@ class SequenceMapFinderTest extends TestCase {
 			->method( 'fetch' )
 			->willReturn( false );
 
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->connection->expects( $this->once() )
 			->method( 'unescape_bytea' )
@@ -95,8 +111,6 @@ class SequenceMapFinderTest extends TestCase {
 			$this->connection,
 			$this->idCacheManager
 		);
-
-		$sortkey = '';
 
 		$this->assertEquals(
 			[ 'Foo' ],
@@ -115,13 +129,13 @@ class SequenceMapFinderTest extends TestCase {
 		$this->cache->expects( $this->atLeastOnce() )
 			->method( 'save' );
 
+		$whereConditions = [];
+		$capturedSelects = [];
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions, $capturedSelects );
+
 		$this->connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->equalTo( [ 'smw_id', 'smw_seqmap' ] ),
-				$this->equalTo( [ 'smw_id' => [ 42, 1001 ] ] ) )
-			->willReturn( [ (object)$row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->connection->expects( $this->once() )
 			->method( 'unescape_bytea' )
@@ -133,6 +147,9 @@ class SequenceMapFinderTest extends TestCase {
 		);
 
 		$instance->prefetchSequenceMap( [ 42, 1001 ] );
+
+		$this->assertContains( [ 'smw_id', 'smw_seqmap' ], $capturedSelects );
+		$this->assertContains( [ 'smw_id' => [ 42, 1001 ] ], $whereConditions );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/SubobjectListFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/SubobjectListFinderTest.php
@@ -10,6 +10,7 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\EntityStore\SubobjectListFinder;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -22,6 +23,8 @@ use stdClass;
  * @author mwjames
  */
 class SubobjectListFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $iteratorFactory;
 
@@ -54,9 +57,11 @@ class SubobjectListFinderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -96,13 +101,12 @@ class SubobjectListFinderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
+
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				'smw_title= AND smw_namespace= AND smw_iw= AND smw_subobject!=' )
-			->willReturn( [ $row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -121,6 +125,12 @@ class SubobjectListFinderTest extends TestCase {
 		foreach ( $instance->find( $subject ) as $v ) {
 			$this->assertEquals( 42, $v->getId() );
 		}
+
+		$this->assertNotEmpty( $whereConditions );
+		$flat = $whereConditions[0];
+		$this->assertArrayHasKey( 'smw_title', $flat );
+		$this->assertArrayHasKey( 'smw_namespace', $flat );
+		$this->assertArrayHasKey( 'smw_iw', $flat );
 	}
 
 	public function subjectProvider() {

--- a/tests/phpunit/Unit/SQLStore/EntityStore/TraversalPropertyLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/TraversalPropertyLookupTest.php
@@ -9,7 +9,7 @@ use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\EntityStore\TraversalPropertyLookup;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
-use Wikimedia\Rdbms\FakeResultWrapper;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\TraversalPropertyLookup
@@ -21,6 +21,8 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  * @author mwjames
  */
 class TraversalPropertyLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$store = $this->getMockBuilder( SQLStore::class )
@@ -52,13 +54,15 @@ class TraversalPropertyLookupTest extends TestCase {
 			->method( 'isFixedPropertyTable' )
 			->willReturn( false );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -91,10 +95,6 @@ class TraversalPropertyLookupTest extends TestCase {
 	public function testlookupForFixedPropertyTable() {
 		$dataItem = WikiPage::newFromText( __METHOD__ );
 
-		$resultWrapper = $this->getMockBuilder( FakeResultWrapper::class )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$dataItemHandler = $this->getMockBuilder( DataItemHandler::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
@@ -111,13 +111,15 @@ class TraversalPropertyLookupTest extends TestCase {
 			->method( 'isFixedPropertyTable' )
 			->willReturn( true );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( $resultWrapper );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/PropertyTable/PropertyTableHashesTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTable/PropertyTableHashesTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\PropertyTable\PropertyTableHashes;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\PropertyTable\PropertyTableHashes
@@ -18,6 +20,9 @@ use SMW\SQLStore\PropertyTable\PropertyTableHashes;
  * @author mwjames
  */
 class PropertyTableHashesTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $connection;
 	private $idCacheManager;
@@ -52,20 +57,12 @@ class PropertyTableHashesTest extends TestCase {
 			->method( 'get' )
 			->willReturn( $this->cache );
 
-		$rows = [
-			'smw_proptable_hash' => 'a:1:{i:0;s:3:"foo";}'
-		];
-
-		$expected = [
-			'smw_id' => 42
-		];
+		$updateTables = $updateSets = $updateWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder( $updateTables, $updateSets, $updateWheres );
 
 		$this->connection->expects( $this->once() )
-			->method( 'update' )
-			->with(
-				$this->anything(),
-				$rows,
-				$expected );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$instance = new PropertyTableHashes(
 			$this->connection,
@@ -73,6 +70,10 @@ class PropertyTableHashesTest extends TestCase {
 		);
 
 		$instance->setPropertyTableHashes( 42, [ 'foo' ] );
+
+		$this->assertSame( [ 'smw_object_ids' ], $updateTables );
+		$this->assertSame( [ [ 'smw_proptable_hash' => 'a:1:{i:0;s:3:"foo";}' ] ], $updateSets );
+		$this->assertSame( [ [ 'smw_id' => 42 ] ], $updateWheres );
 	}
 
 	public function testGetPropertyTableHashes() {
@@ -87,14 +88,6 @@ class PropertyTableHashesTest extends TestCase {
 			->method( 'get' )
 			->willReturn( $this->cache );
 
-		$fields = [
-			'smw_proptable_hash'
-		];
-
-		$expected = [
-			'smw_id' => 42
-		];
-
 		$row = [
 			'smw_proptable_hash' => 'a:1:{i:0;s:3:"foo";}'
 		];
@@ -103,13 +96,12 @@ class PropertyTableHashesTest extends TestCase {
 			->method( 'unescape_bytea' )
 			->willReturnArgument( 0 );
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				$fields,
-				$expected )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new PropertyTableHashes(
 			$this->connection,
@@ -120,6 +112,8 @@ class PropertyTableHashesTest extends TestCase {
 			[ 'foo' ],
 			$instance->getPropertyTableHashesById( 42 )
 		);
+
+		$this->assertContains( [ 'smw_id' => 42 ], $whereConditions );
 	}
 
 	public function testSetPropertyTableHashesCache() {

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -13,6 +13,8 @@ use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\SQLStore\PropertyTableIdReferenceFinder;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -25,6 +27,9 @@ use stdClass;
  * @author mwjames
  */
 class PropertyTableIdReferenceDisposerTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $store;
 	private $testEnvironment;
@@ -105,24 +110,23 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testTryToRemoveOutdatedEntryFromIDTable() {
-		$tableDefinition = $connection = $this->getMockBuilder( PropertyTableDefinition::class )
+		$tableDefinition = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyTableIdReferenceFinder = $connection = $this->getMockBuilder( PropertyTableIdReferenceFinder::class )
+		$propertyTableIdReferenceFinder = $this->getMockBuilder( PropertyTableIdReferenceFinder::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
-
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -148,7 +152,7 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testCleanUpTableEntriesFor() {
-		$tableDefinition = $connection = $this->getMockBuilder( PropertyTableDefinition::class )
+		$tableDefinition = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -156,16 +160,19 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			->method( 'usesIdSubject' )
 			->willReturn( true );
 
+		$tableDefinition->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'smw_test_table' );
+
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
-
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -187,13 +194,15 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testCanConstructOutdatedEntitiesResultIterator() {
+		$queryBuilder = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $queryBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -214,13 +223,15 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testCanConstructByNamespaceInvalidEntitiesResultIterator() {
+		$queryBuilder = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $queryBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -244,12 +255,15 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 		$row = new stdClass;
 		$row->smw_id = 42;
 
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -271,6 +285,8 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testCleanUpOnTransactionIdle() {
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -283,7 +299,8 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			);
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -322,6 +339,9 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			->method( 'getObjectIds' )
 			->willReturn( $idTable );
 
+		$capturedTables = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $capturedTables );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -333,15 +353,8 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			} );
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' )
-			->withConsecutive(
-				[ $this->equalTo( SQLStore::ID_TABLE ) ],
-				[ $this->equalTo( SQLStore::ID_AUXILIARY_TABLE ) ],
-				[ $this->equalTo( SQLStore::PROPERTY_STATISTICS_TABLE ) ],
-				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
-				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
-				[ $this->equalTo( SQLStore::FT_SEARCH_TABLE ) ]
-			);
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -357,6 +370,17 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 
 		$instance->waitOnTransactionIdle();
 		$instance->cleanUpTableEntriesById( 42 );
+
+		$this->assertSame(
+			[
+				SQLStore::ID_TABLE,
+				SQLStore::ID_AUXILIARY_TABLE,
+				SQLStore::PROPERTY_STATISTICS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+			],
+			$capturedTables
+		);
 	}
 
 	public function testCleanUp_Redirect() {
@@ -380,20 +404,16 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			->method( 'getObjectIds' )
 			->willReturn( $idTable );
 
+		$capturedTables = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $capturedTables );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		// No SQLStore::ID_TABLE
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' )
-			->withConsecutive(
-				[ $this->equalTo( SQLStore::ID_AUXILIARY_TABLE ) ],
-				[ $this->equalTo( SQLStore::PROPERTY_STATISTICS_TABLE ) ],
-				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
-				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
-				[ $this->equalTo( SQLStore::FT_SEARCH_TABLE ) ]
-			);
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -412,6 +432,17 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 		);
 
 		$instance->cleanUpTableEntriesById( 42 );
+
+		// No SQLStore::ID_TABLE for redirects (without redirectRemoval)
+		$this->assertSame(
+			[
+				SQLStore::ID_AUXILIARY_TABLE,
+				SQLStore::PROPERTY_STATISTICS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+			],
+			$capturedTables
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceFinderTest.php
@@ -9,6 +9,7 @@ use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\PropertyTableIdReferenceFinder;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\PropertyTableIdReferenceFinder
@@ -20,6 +21,8 @@ use SMW\SQLStore\SQLStore;
  * @author mwjames
  */
 class PropertyTableIdReferenceFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 
@@ -47,13 +50,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 			->method( 'getFields' )
 			->willReturn( [ 'o_id' => 42 ] );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -85,13 +90,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 			->method( 'usesIdSubject' )
 			->willReturn( true );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -113,13 +120,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 	}
 
 	public function testHasResidualPropertyTableReference() {
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -140,13 +149,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 	}
 
 	public function testHasResidualReferenceFor() {
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -167,13 +178,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 	}
 
 	public function testSearchAllTablesToFindAtLeastOneReferenceById() {
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )

--- a/tests/phpunit/Unit/SQLStore/PropertyTableRowDifferTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableRowDifferTest.php
@@ -13,6 +13,7 @@ use SMW\SQLStore\PropertyTableRowDiffer;
 use SMW\SQLStore\PropertyTableRowMapper;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\PropertyTableRowDiffer
@@ -25,6 +26,8 @@ use SMW\Store;
  * @author mwjames
  */
 class PropertyTableRowDifferTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $propertyTableRowMapper;
 
@@ -176,13 +179,11 @@ class PropertyTableRowDifferTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [] );
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$propertyTable = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/PropertyTableUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableUpdaterTest.php
@@ -12,6 +12,7 @@ use SMW\SQLStore\PropertyStatisticsStore;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\PropertyTableUpdater;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\PropertyTableUpdater
@@ -23,6 +24,8 @@ use SMW\SQLStore\SQLStore;
  * @author mwjames
  */
 class PropertyTableUpdaterTest extends TestCase {
+
+	use MockWriteQueryBuilderTrait;
 
 	private $store;
 	private $idTable;
@@ -99,11 +102,25 @@ class PropertyTableUpdaterTest extends TestCase {
 	}
 
 	public function testUpdate_WithInsertRows() {
-		$this->connection->expects( $this->once() )
-			->method( 'insert' );
+		$insertTables = $insertRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $insertTables, $insertRows );
+
+		$deleteTables = $deleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $deleteTables, $deleteWheres );
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
 
 		$this->connection->expects( $this->once() )
-			->method( 'delete' );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
+
+		$this->connection->expects( $this->once() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->idTable->expects( $this->once() )
 			->method( 'setPropertyTableHashes' );
@@ -111,6 +128,10 @@ class PropertyTableUpdaterTest extends TestCase {
 		$this->propertyTable->expects( $this->any() )
 			->method( 'usesIdSubject' )
 			->willReturn( true );
+
+		$this->propertyTable->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'table_foo' );
 
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
@@ -146,6 +167,10 @@ class PropertyTableUpdaterTest extends TestCase {
 		);
 
 		$instance->update( 42, $params );
+
+		$this->assertContains( 'table_foo', $insertTables );
+		$this->assertContains( [ [ 's_id' => 1001, 'p_id' => 99999 ] ], $insertRows );
+		$this->assertContains( 'table_foo', $deleteTables );
 	}
 
 	public function testUpdate_Touched() {
@@ -153,16 +178,31 @@ class PropertyTableUpdaterTest extends TestCase {
 			->method( 'timestamp' )
 			->willReturn( '19700101000000' );
 
+		$insertBuilder = $this->createMockInsertQueryBuilder();
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+
+		$updateTables = $updateSets = $updateWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder( $updateTables, $updateSets, $updateWheres );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
 		$this->connection->expects( $this->once() )
-			->method( 'update' )
-			->with(
-				$this->anything(),
-				[ 'smw_touched' => '19700101000000' ],
-				$this->equalTo( [ 'smw_id' => [ 1001, 99999, 99998 ] ] ) );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->propertyTable->expects( $this->any() )
 			->method( 'usesIdSubject' )
 			->willReturn( true );
+
+		$this->propertyTable->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'table_foo' );
 
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
@@ -194,6 +234,10 @@ class PropertyTableUpdaterTest extends TestCase {
 		);
 
 		$instance->update( 42, $params );
+
+		$this->assertContains( SQLStore::ID_TABLE, $updateTables );
+		$this->assertContains( [ 'smw_touched' => '19700101000000' ], $updateSets );
+		$this->assertContains( [ 'smw_id' => [ 1001, 99999, 99998 ] ], $updateWheres );
 	}
 
 	public function testUpdate_WithInsertRowsButMissingIdFieldThrowsException() {


### PR DESCRIPTION
## Summary

Migrates every raw `select` / `selectRow` / `selectField` / `insert` / `update` / `delete` / `upsert` / `newQuery` callsite under `src/SQLStore/EntityStore/*` to MediaWiki Rdbms's `SelectQueryBuilder` / `InsertQueryBuilder` / `UpdateQueryBuilder` / `DeleteQueryBuilder` fluent APIs.

- 13 production files modified, ~42 callsites converted
- Adds `tests/phpunit/Unit/MediaWiki/Connection/MockWriteQueryBuilderTrait.php` (mirror of the existing `MockSelectQueryBuilderTrait`) so unit tests can stub Insert/Update/Delete/Replace builder chains and capture the table, row data, set values, where conditions, and unique-index fields. Companion self-test included.
- One small addition to `MockSelectQueryBuilderTrait`: `rawTables` added to the chain-method passthrough list (needed by `TraversalPropertyLookup`).
- No DB schema or DDL changes. No behavioural changes intended for the typical paths. See "Notes for reviewers" below for the two documented translations.
- Targeted at the `SQLStore/Lookup` migration PR rather than `master` so the diff reads cleanly. Will retarget to `master` once the parent merges.

## Notes for reviewers

- **`upsert()` mapping.** `Database::upsert( table, row, uniqueIndexes, set, fname )` becomes `newInsertQueryBuilder()->insertInto( table )->row( row )->onDuplicateKeyUpdate()->uniqueIndexFields( [ ... ] )->set( set )->caller( fname )->execute()`. Bare-string unique-index args are wrapped in arrays for clarity. Verified equivalent against `InsertQueryBuilder::execute()` — it ultimately calls `$db->upsert( table, rows, [ uniqueIndexFields ], $set, caller )`.
- **`PropertySubjectsLookup` index hint.** Original code emitted raw `FORCE INDEX(s_id)` on MySQL via a string fragment in the legacy join array. Converted code uses `$qb->useIndex( [ 't1' => 's_id' ] )`, which emits `USE INDEX` on MySQL and is a no-op on Postgres / SQLite (same as `FORCE INDEX` on those dialects). Both `FORCE` and `USE` restrict the optimizer to the named index; the practical difference is minor and either keeps the underlying query plan stable for the populated tables this hint targets.
- **Postgres `DISTINCT ON ( ... )` preservation.** `PropertySubjectsLookup` and `SemanticDataLookup` previously merged `'DISTINCT' => 'ON (smw_sort, smw_id)'` into the legacy options array (string DISTINCT value) on Postgres. `LegacyOptionsApplier::applyTo` only emits `->distinct()` (boolean), so a local `is_string` special-case before the applier preserves the prior shape: `$qb->option( 'DISTINCT', \$opts['DISTINCT'] ); unset( \$opts['DISTINCT'] );`.
- **`SemanticDataLookup::addFields` redesign.** The hand-rolled `Query::hasField()` check has no equivalent on `SelectQueryBuilder`. Replaced by passing a parallel `array &\$selectFields` accumulator through `addFields()`; field expressions are pushed into the array (string keys for `AS` aliases, integer keys for raw fragments) and the caller applies `\$qb->select( \$selectFields )` once at the end of `fetchFromTable`.
- **`TraversalPropertyLookup` subquery.** The outer SELECT now goes through `newSelectQueryBuilder()->rawTables( [ ID_TABLE, 't1' => \$subquery ] )->joinConds( [ 't1' => [ 'INNER JOIN', 't1.p_id=smw_id' ] ] )`. The inner subquery's raw SQL string (built via `OptionsBuilder::toString` for portable `GROUP BY` / `LIMIT` emission) is preserved as a planner concern.
- **`addExtraCondition` callable contract.** Where `RequestOptions::getExtraConditions()` returns a callable, the callable now receives a `SelectQueryBuilder` instead of the hand-rolled `Query`. Audited callers — only one callable producer exists (`src/Constraint/Constraints/UniqueValueConstraint.php`), and it's consumed by an unrelated lookup; no production regression risk.
- **Test rewrites.** Where the previous tests asserted on `\$query->build()` SQL strings or `\$connection->expects()->method('selectRow'/'insert'/...)`, the converted tests use `MockSelectQueryBuilderTrait` and the new `MockWriteQueryBuilderTrait` to capture chain arguments and assert on the captured arrays. SQL-string assertions were dropped where they couldn't be preserved verbatim — captured-conditions assertions cover the most useful where-clause regressions, and the `Integration/Query/SemanticDataLookupTest` integration suite covers the field-aliasing path that unit tests cannot.

## Test plan

- [x] `composer analyze` clean (lint 2117 files, PHPCS 16/16)
- [x] `composer phpunit` on `tests/phpunit/Unit/SQLStore/EntityStore/` and `tests/phpunit/Unit/MediaWiki/Connection/`: 159 tests / 352 assertions green
- [x] `composer phpunit` on full `tests/phpunit/Unit/SQLStore/`: 873 tests / 1755 assertions green (1 unrelated pre-existing skip on `PostgresTableBuilderTest::testDoCheckOnAfterCreate`)
- [x] `Integration/Query/SemanticDataLookupTest` against the local MySQL dev DB: 5 cases green (covers the field-aliasing path most affected by `addFields` rewrite)
- [x] API-level smoke against the seeded dev wiki: identical Ask result counts on this branch vs. parent vs. `master` across page-literal, MW-category, property-exists, property-equality, LIKE-wildcard, and modification-date queries — no regression introduced by this PR
- [x] CI matrix on MySQL / Postgres / SQLite — promote from draft once green