### PR TITLE
Migrate SQLStore/PropertyTable callsites to MW Rdbms QueryBuilder

### DIFF
--- a/src/SQLStore/PropertyTable/PropertyTableHashes.php
+++ b/src/SQLStore/PropertyTable/PropertyTableHashes.php
@@ -45,14 +45,12 @@ class PropertyTableHashes {
 			throw new RuntimeException( "Expected a null or an array as value!" );
 		}
 
-		$this->connection->update(
-			SQLStore::ID_TABLE,
-			$update,
-			[
-				'smw_id' => $id
-			],
-			__METHOD__
-		);
+		$this->connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( $update )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
 /*
 		$smw_proptable = $hash === null ? null : serialize( $hash );
@@ -100,16 +98,12 @@ class PropertyTableHashes {
 			return $hash;
 		}
 
-		$row = $this->connection->selectRow(
-			SQLStore::ID_TABLE,
-			[
-				'smw_proptable_hash'
-			],
-			[
-				'smw_id' => $id
-			],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_proptable_hash' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row !== false ) {
 			$hash = $row->smw_proptable_hash;

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -7,6 +7,7 @@ use Onoi\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\DataItems\WikiPage;
 use SMW\Iterators\ResultIterator;
 use SMW\MediaWiki\Connection\Database;
+use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\RequestOptions;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use stdClass;
@@ -131,19 +132,18 @@ class PropertyTableIdReferenceDisposer {
 		if ( $requestOptions !== null ) {
 			$options = [
 				'LIMIT'  => $requestOptions->getLimit(),
-				'OFFSET' => $requestOptions->getOffset()
+				'OFFSET' => $requestOptions->getOffset(),
 			];
 		}
 
-		$res = $this->connection->select(
-			SQLStore::ID_TABLE,
-			[ 'smw_id' ],
-			[ 'smw_iw' => SMW_SQL3_SMWDELETEIW ],
-			__METHOD__,
-			$options
-		);
+		$qb = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_id' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_iw' => SMW_SQL3_SMWDELETEIW ] );
 
-		return new ResultIterator( $res );
+		LegacyOptionsApplier::applyTo( $qb, $options );
+
+		return new ResultIterator( $qb->caller( __METHOD__ )->fetchResultSet() );
 	}
 
 	/**
@@ -159,21 +159,18 @@ class PropertyTableIdReferenceDisposer {
 		if ( $requestOptions !== null ) {
 			$options = [
 				'LIMIT'  => $requestOptions->getLimit(),
-				'OFFSET' => $requestOptions->getOffset()
+				'OFFSET' => $requestOptions->getOffset(),
 			];
 		}
 
-		$res = $this->connection->select(
-			SQLStore::ID_TABLE,
-			[ 'smw_id' ],
-			[
-				'smw_namespace NOT IN (' . $this->connection->makeList( array_keys( $this->namespacesWithSemanticLinks ) ) . ')'
-			],
-			__METHOD__,
-			$options
-		);
+		$qb = $this->connection->newSelectQueryBuilder()
+			->select( [ 'smw_id' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( 'smw_namespace NOT IN (' . $this->connection->makeList( array_keys( $this->namespacesWithSemanticLinks ) ) . ')' );
 
-		return new ResultIterator( $res );
+		LegacyOptionsApplier::applyTo( $qb, $options );
+
+		return new ResultIterator( $qb->caller( __METHOD__ )->fetchResultSet() );
 	}
 
 	/**
@@ -229,30 +226,30 @@ class PropertyTableIdReferenceDisposer {
 
 		foreach ( $this->store->getPropertyTables() as $proptable ) {
 			if ( $proptable->usesIdSubject() ) {
-				$this->connection->delete(
-					$proptable->getName(),
-					[ 's_id' => $id ],
-					__METHOD__
-				);
+				$this->connection->newDeleteQueryBuilder()
+					->deleteFrom( $proptable->getName() )
+					->where( [ 's_id' => $id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 
 			if ( !$proptable->isFixedPropertyTable() ) {
-				$this->connection->delete(
-					$proptable->getName(),
-					[ 'p_id' => $id ],
-					__METHOD__
-				);
+				$this->connection->newDeleteQueryBuilder()
+					->deleteFrom( $proptable->getName() )
+					->where( [ 'p_id' => $id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 
 			$fields = $proptable->getFields( $this->store );
 
 			// Match tables (including ftp_redi) that contain an object reference
 			if ( isset( $fields['o_id'] ) ) {
-				$this->connection->delete(
-					$proptable->getName(),
-					[ 'o_id' => $id ],
-					__METHOD__
-				);
+				$this->connection->newDeleteQueryBuilder()
+					->deleteFrom( $proptable->getName() )
+					->where( [ 'o_id' => $id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 		}
 
@@ -270,36 +267,36 @@ class PropertyTableIdReferenceDisposer {
 	private function cleanUpSecondaryReferencesById( $id, bool $isRedirect ): void {
 		// When marked as redirect, don't remove the reference
 		if ( !$isRedirect || $this->redirectRemoval ) {
-			$this->connection->delete(
-				SQLStore::ID_TABLE,
-				[ 'smw_id' => $id ],
-				__METHOD__
-			);
+			$this->connection->newDeleteQueryBuilder()
+				->deleteFrom( SQLStore::ID_TABLE )
+				->where( [ 'smw_id' => $id ] )
+				->caller( __METHOD__ )
+				->execute();
 		}
 
-		$this->connection->delete(
-			SQLStore::ID_AUXILIARY_TABLE,
-			[ 'smw_id' => $id ],
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::ID_AUXILIARY_TABLE )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$this->connection->delete(
-			SQLStore::PROPERTY_STATISTICS_TABLE,
-			[ 'p_id' => $id ],
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->where( [ 'p_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$this->connection->delete(
-			SQLStore::QUERY_LINKS_TABLE,
-			[ 's_id' => $id ],
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 's_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$this->connection->delete(
-			SQLStore::QUERY_LINKS_TABLE,
-			[ 'o_id' => $id ],
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 'o_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$tableExists = false;
 
@@ -314,7 +311,11 @@ class PropertyTableIdReferenceDisposer {
 		}
 
 		if ( $tableExists ) {
-			$this->connection->delete( SQLStore::FT_SEARCH_TABLE, [ 's_id' => $id ], __METHOD__ );
+			$this->connection->newDeleteQueryBuilder()
+				->deleteFrom( SQLStore::FT_SEARCH_TABLE )
+				->where( [ 's_id' => $id ] )
+				->caller( __METHOD__ )
+				->execute();
 		}
 	}
 

--- a/src/SQLStore/PropertyTableIdReferenceFinder.php
+++ b/src/SQLStore/PropertyTableIdReferenceFinder.php
@@ -187,12 +187,12 @@ class PropertyTableIdReferenceFinder {
 		$row = false;
 
 		if ( $proptable->usesIdSubject() ) {
-			$row = $this->connection->selectRow(
-				$proptable->getName(),
-				[ 's_id' ],
-				[ 's_id' => $id ],
-				__METHOD__
-			);
+			$row = $this->connection->newSelectQueryBuilder()
+				->select( [ 's_id' ] )
+				->from( $proptable->getName() )
+				->where( [ 's_id' => $id ] )
+				->caller( __METHOD__ )
+				->fetchRow();
 		}
 
 		if ( $row !== false ) {
@@ -207,12 +207,12 @@ class PropertyTableIdReferenceFinder {
 			// This next time someone ... I'm going to Alaska
 			$field = preg_match( '/redi$/', $proptable->getName() ?? '' ) ? [ 's_title', 's_namespace' ] : [ 's_id' ];
 
-			$row = $this->connection->selectRow(
-				$proptable->getName(),
-				$field,
-				[ 'o_id' => $id ],
-				__METHOD__
-			);
+			$row = $this->connection->newSelectQueryBuilder()
+				->select( $field )
+				->from( $proptable->getName() )
+				->where( [ 'o_id' => $id ] )
+				->caller( __METHOD__ )
+				->fetchRow();
 
 			if ( $row !== false && strpos( $proptable->getName(), 'redi' ) ) {
 				$row->s_id = $this->store->getObjectIds()->findRedirect( $row->s_title, $row->s_namespace );
@@ -223,12 +223,12 @@ class PropertyTableIdReferenceFinder {
 		// table to a specific property with the p_id column being suppressed)
 		// then check for the p_id field
 		if ( $row === false && !$proptable->isFixedPropertyTable() ) {
-			$row = $this->connection->selectRow(
-				$proptable->getName(),
-				[ 's_id' ],
-				[ 'p_id' => $id ],
-				__METHOD__
-			);
+			$row = $this->connection->newSelectQueryBuilder()
+				->select( [ 's_id' ] )
+				->from( $proptable->getName() )
+				->where( [ 'p_id' => $id ] )
+				->caller( __METHOD__ )
+				->fetchRow();
 		}
 
 		return $row;
@@ -238,12 +238,12 @@ class PropertyTableIdReferenceFinder {
 		// If the query table contains a reference then we keep the object (could
 		// be a subject, property, or printrequest) where in case the query is
 		// removed the object will also loose its reference
-		$row = $this->connection->selectRow(
-			SQLStore::QUERY_LINKS_TABLE,
-			[ 's_id' ],
-			[ 'o_id' => $id ],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 's_id' ] )
+			->from( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 'o_id' => $id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return $row;
 	}

--- a/src/SQLStore/PropertyTableRowDiffer.php
+++ b/src/SQLStore/PropertyTableRowDiffer.php
@@ -193,14 +193,12 @@ class PropertyTableRowDiffer {
 
 				// #3849
 				// Check the table that wasn't part of the old and new hash
-				$row = $connection->selectRow(
-					$propertyTable->getName(),
-					's_id',
-					[
-						's_id' => $sid
-					],
-					__METHOD__
-				);
+				$row = $connection->newSelectQueryBuilder()
+					->select( 's_id' )
+					->from( $propertyTable->getName() )
+					->where( [ 's_id' => $sid ] )
+					->caller( __METHOD__ )
+					->fetchRow();
 
 				// Find and remove any remnants (ghosts) from possible failed
 				// updates that weren't rollback correctly
@@ -272,12 +270,12 @@ class PropertyTableRowDiffer {
 		$contents = [];
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$result = $connection->select(
-			$propertyTable->getName(),
-			'*',
-			[ 's_id' => $sid ],
-			__METHOD__
-		);
+		$result = $connection->newSelectQueryBuilder()
+			->select( '*' )
+			->from( $propertyTable->getName() )
+			->where( [ 's_id' => $sid ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		foreach ( $result as $row ) {
 			if ( is_object( $row ) ) {

--- a/src/SQLStore/PropertyTableRowMapper.php
+++ b/src/SQLStore/PropertyTableRowMapper.php
@@ -281,12 +281,12 @@ class PropertyTableRowMapper {
 		}
 
 		// Add existing cache status data to this row:
-		$row = $connection->selectRow(
-			'smw_fpt_conc',
-			[ 'cache_date', 'cache_count' ],
-			[ 's_id' => $sid ],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'cache_date', 'cache_count' ] )
+			->from( 'smw_fpt_conc' )
+			->where( [ 's_id' => $sid ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row === false ) {
 			$insertValues['cache_date'] = null;

--- a/src/SQLStore/PropertyTableUpdater.php
+++ b/src/SQLStore/PropertyTableUpdater.php
@@ -173,11 +173,11 @@ class PropertyTableUpdater {
 		$connection = $this->store->getConnection( 'mw.db' );
 		$tableName = $propertyTable->getName();
 
-		$connection->insert(
-			$tableName,
-			$rows,
-			__METHOD__ . "-$tableName"
-		);
+		$connection->newInsertQueryBuilder()
+			->insertInto( $tableName )
+			->rows( $rows )
+			->caller( __METHOD__ . "-$tableName" )
+			->execute();
 	}
 
 	private function delete( PropertyTableDefinition $propertyTable, array $rows ): void {
@@ -215,11 +215,11 @@ class PropertyTableUpdater {
 
 		$condition = "s_id=" . $connection->addQuotes( $sid ) . " AND ($condition)";
 
-		$connection->delete(
-			$tableName,
-			[ $condition ],
-			__METHOD__ . "-$tableName"
-		);
+		$connection->newDeleteQueryBuilder()
+			->deleteFrom( $tableName )
+			->where( $condition )
+			->caller( __METHOD__ . "-$tableName" )
+			->execute();
 	}
 
 	private function aggregate_ids( array &$ids, $propertyTable, $rows ): void {
@@ -261,16 +261,12 @@ class PropertyTableUpdater {
 		// onTransctionIdle( ... ) to avoid locking the rows for succeeding
 		// updates?
 
-		$connection->update(
-			SQLStore::ID_TABLE,
-			[
-				'smw_touched' => $touched
-			],
-			[
-				'smw_id' => $ids
-			],
-			__METHOD__
-		);
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( [ 'smw_touched' => $touched ] )
+			->where( [ 'smw_id' => $ids ] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
@@ -42,6 +42,10 @@ class EntityIdDisposerJobTest extends TestCase {
 			->method( 'select' )
 			->willReturn( [ 'Foo' ] );
 
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
+
 		$store = $this->getMockBuilder( SQLStore::class )
 			->getMockForAbstractClass();
 

--- a/tests/phpunit/Unit/SQLStore/PropertyTable/PropertyTableHashesTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTable/PropertyTableHashesTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\PropertyTable\PropertyTableHashes;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\PropertyTable\PropertyTableHashes
@@ -18,6 +20,9 @@ use SMW\SQLStore\PropertyTable\PropertyTableHashes;
  * @author mwjames
  */
 class PropertyTableHashesTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $connection;
 	private $idCacheManager;
@@ -52,20 +57,12 @@ class PropertyTableHashesTest extends TestCase {
 			->method( 'get' )
 			->willReturn( $this->cache );
 
-		$rows = [
-			'smw_proptable_hash' => 'a:1:{i:0;s:3:"foo";}'
-		];
-
-		$expected = [
-			'smw_id' => 42
-		];
+		$updateTables = $updateSets = $updateWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder( $updateTables, $updateSets, $updateWheres );
 
 		$this->connection->expects( $this->once() )
-			->method( 'update' )
-			->with(
-				$this->anything(),
-				$rows,
-				$expected );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$instance = new PropertyTableHashes(
 			$this->connection,
@@ -73,6 +70,10 @@ class PropertyTableHashesTest extends TestCase {
 		);
 
 		$instance->setPropertyTableHashes( 42, [ 'foo' ] );
+
+		$this->assertSame( [ 'smw_object_ids' ], $updateTables );
+		$this->assertSame( [ [ 'smw_proptable_hash' => 'a:1:{i:0;s:3:"foo";}' ] ], $updateSets );
+		$this->assertSame( [ [ 'smw_id' => 42 ] ], $updateWheres );
 	}
 
 	public function testGetPropertyTableHashes() {
@@ -87,14 +88,6 @@ class PropertyTableHashesTest extends TestCase {
 			->method( 'get' )
 			->willReturn( $this->cache );
 
-		$fields = [
-			'smw_proptable_hash'
-		];
-
-		$expected = [
-			'smw_id' => 42
-		];
-
 		$row = [
 			'smw_proptable_hash' => 'a:1:{i:0;s:3:"foo";}'
 		];
@@ -103,13 +96,12 @@ class PropertyTableHashesTest extends TestCase {
 			->method( 'unescape_bytea' )
 			->willReturnArgument( 0 );
 
+		$whereConditions = [];
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				$fields,
-				$expected )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$instance = new PropertyTableHashes(
 			$this->connection,
@@ -120,6 +112,8 @@ class PropertyTableHashesTest extends TestCase {
 			[ 'foo' ],
 			$instance->getPropertyTableHashesById( 42 )
 		);
+
+		$this->assertContains( [ 'smw_id' => 42 ], $whereConditions );
 	}
 
 	public function testSetPropertyTableHashesCache() {

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -13,6 +13,8 @@ use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\SQLStore\PropertyTableIdReferenceFinder;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -25,6 +27,9 @@ use stdClass;
  * @author mwjames
  */
 class PropertyTableIdReferenceDisposerTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $store;
 	private $testEnvironment;
@@ -105,24 +110,23 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testTryToRemoveOutdatedEntryFromIDTable() {
-		$tableDefinition = $connection = $this->getMockBuilder( PropertyTableDefinition::class )
+		$tableDefinition = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$propertyTableIdReferenceFinder = $connection = $this->getMockBuilder( PropertyTableIdReferenceFinder::class )
+		$propertyTableIdReferenceFinder = $this->getMockBuilder( PropertyTableIdReferenceFinder::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
-
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -148,7 +152,7 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testCleanUpTableEntriesFor() {
-		$tableDefinition = $connection = $this->getMockBuilder( PropertyTableDefinition::class )
+		$tableDefinition = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -156,16 +160,19 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			->method( 'usesIdSubject' )
 			->willReturn( true );
 
+		$tableDefinition->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'smw_test_table' );
+
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
-
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -187,13 +194,15 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testCanConstructOutdatedEntitiesResultIterator() {
+		$queryBuilder = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $queryBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -214,13 +223,15 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testCanConstructByNamespaceInvalidEntitiesResultIterator() {
+		$queryBuilder = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $queryBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -244,12 +255,15 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 		$row = new stdClass;
 		$row->smw_id = 42;
 
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -271,6 +285,8 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	}
 
 	public function testCleanUpOnTransactionIdle() {
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -283,7 +299,8 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			);
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -322,6 +339,9 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			->method( 'getObjectIds' )
 			->willReturn( $idTable );
 
+		$capturedTables = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $capturedTables );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -333,15 +353,8 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			} );
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' )
-			->withConsecutive(
-				[ $this->equalTo( SQLStore::ID_TABLE ) ],
-				[ $this->equalTo( SQLStore::ID_AUXILIARY_TABLE ) ],
-				[ $this->equalTo( SQLStore::PROPERTY_STATISTICS_TABLE ) ],
-				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
-				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
-				[ $this->equalTo( SQLStore::FT_SEARCH_TABLE ) ]
-			);
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -357,6 +370,17 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 
 		$instance->waitOnTransactionIdle();
 		$instance->cleanUpTableEntriesById( 42 );
+
+		$this->assertSame(
+			[
+				SQLStore::ID_TABLE,
+				SQLStore::ID_AUXILIARY_TABLE,
+				SQLStore::PROPERTY_STATISTICS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+			],
+			$capturedTables
+		);
 	}
 
 	public function testCleanUp_Redirect() {
@@ -380,20 +404,16 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 			->method( 'getObjectIds' )
 			->willReturn( $idTable );
 
+		$capturedTables = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $capturedTables );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		// No SQLStore::ID_TABLE
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'delete' )
-			->withConsecutive(
-				[ $this->equalTo( SQLStore::ID_AUXILIARY_TABLE ) ],
-				[ $this->equalTo( SQLStore::PROPERTY_STATISTICS_TABLE ) ],
-				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
-				[ $this->equalTo( SQLStore::QUERY_LINKS_TABLE ) ],
-				[ $this->equalTo( SQLStore::FT_SEARCH_TABLE ) ]
-			);
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -412,6 +432,17 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 		);
 
 		$instance->cleanUpTableEntriesById( 42 );
+
+		// No SQLStore::ID_TABLE for redirects (without redirectRemoval)
+		$this->assertSame(
+			[
+				SQLStore::ID_AUXILIARY_TABLE,
+				SQLStore::PROPERTY_STATISTICS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+			],
+			$capturedTables
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceFinderTest.php
@@ -9,6 +9,7 @@ use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\PropertyTableIdReferenceFinder;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\PropertyTableIdReferenceFinder
@@ -20,6 +21,8 @@ use SMW\SQLStore\SQLStore;
  * @author mwjames
  */
 class PropertyTableIdReferenceFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 
@@ -47,13 +50,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 			->method( 'getFields' )
 			->willReturn( [ 'o_id' => 42 ] );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -85,13 +90,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 			->method( 'usesIdSubject' )
 			->willReturn( true );
 
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -113,13 +120,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 	}
 
 	public function testHasResidualPropertyTableReference() {
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -140,13 +149,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 	}
 
 	public function testHasResidualReferenceFor() {
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -167,13 +178,15 @@ class PropertyTableIdReferenceFinderTest extends TestCase {
 	}
 
 	public function testSearchAllTablesToFindAtLeastOneReferenceById() {
+		$qb = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )

--- a/tests/phpunit/Unit/SQLStore/PropertyTableRowDifferTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableRowDifferTest.php
@@ -13,6 +13,7 @@ use SMW\SQLStore\PropertyTableRowDiffer;
 use SMW\SQLStore\PropertyTableRowMapper;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\PropertyTableRowDiffer
@@ -25,6 +26,8 @@ use SMW\Store;
  * @author mwjames
  */
 class PropertyTableRowDifferTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $propertyTableRowMapper;
 
@@ -176,13 +179,11 @@ class PropertyTableRowDifferTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [] );
+		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
 
 		$propertyTable = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/PropertyTableUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableUpdaterTest.php
@@ -12,6 +12,7 @@ use SMW\SQLStore\PropertyStatisticsStore;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\PropertyTableUpdater;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\PropertyTableUpdater
@@ -23,6 +24,8 @@ use SMW\SQLStore\SQLStore;
  * @author mwjames
  */
 class PropertyTableUpdaterTest extends TestCase {
+
+	use MockWriteQueryBuilderTrait;
 
 	private $store;
 	private $idTable;
@@ -99,11 +102,25 @@ class PropertyTableUpdaterTest extends TestCase {
 	}
 
 	public function testUpdate_WithInsertRows() {
-		$this->connection->expects( $this->once() )
-			->method( 'insert' );
+		$insertTables = $insertRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $insertTables, $insertRows );
+
+		$deleteTables = $deleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $deleteTables, $deleteWheres );
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
 
 		$this->connection->expects( $this->once() )
-			->method( 'delete' );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
+
+		$this->connection->expects( $this->once() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->idTable->expects( $this->once() )
 			->method( 'setPropertyTableHashes' );
@@ -111,6 +128,10 @@ class PropertyTableUpdaterTest extends TestCase {
 		$this->propertyTable->expects( $this->any() )
 			->method( 'usesIdSubject' )
 			->willReturn( true );
+
+		$this->propertyTable->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'table_foo' );
 
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
@@ -146,6 +167,10 @@ class PropertyTableUpdaterTest extends TestCase {
 		);
 
 		$instance->update( 42, $params );
+
+		$this->assertContains( 'table_foo', $insertTables );
+		$this->assertContains( [ [ 's_id' => 1001, 'p_id' => 99999 ] ], $insertRows );
+		$this->assertContains( 'table_foo', $deleteTables );
 	}
 
 	public function testUpdate_Touched() {
@@ -153,16 +178,31 @@ class PropertyTableUpdaterTest extends TestCase {
 			->method( 'timestamp' )
 			->willReturn( '19700101000000' );
 
+		$insertBuilder = $this->createMockInsertQueryBuilder();
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+
+		$updateTables = $updateSets = $updateWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder( $updateTables, $updateSets, $updateWheres );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
 		$this->connection->expects( $this->once() )
-			->method( 'update' )
-			->with(
-				$this->anything(),
-				[ 'smw_touched' => '19700101000000' ],
-				$this->equalTo( [ 'smw_id' => [ 1001, 99999, 99998 ] ] ) );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->propertyTable->expects( $this->any() )
 			->method( 'usesIdSubject' )
 			->willReturn( true );
+
+		$this->propertyTable->expects( $this->any() )
+			->method( 'getName' )
+			->willReturn( 'table_foo' );
 
 		$this->store->expects( $this->any() )
 			->method( 'getPropertyTables' )
@@ -194,6 +234,10 @@ class PropertyTableUpdaterTest extends TestCase {
 		);
 
 		$instance->update( 42, $params );
+
+		$this->assertContains( SQLStore::ID_TABLE, $updateTables );
+		$this->assertContains( [ 'smw_touched' => '19700101000000' ], $updateSets );
+		$this->assertContains( [ 'smw_id' => [ 1001, 99999, 99998 ] ], $updateWheres );
 	}
 
 	public function testUpdate_WithInsertRowsButMissingIdFieldThrowsException() {


### PR DESCRIPTION
## Summary

Migrates every raw `select` / `selectRow` / `insert` / `update` / `delete` callsite in `src/SQLStore/PropertyTable*.php` and `src/SQLStore/PropertyTable/PropertyTableHashes.php` to the MediaWiki Rdbms `SelectQueryBuilder` / `InsertQueryBuilder` / `UpdateQueryBuilder` / `DeleteQueryBuilder` fluent APIs.

- 6 production files modified, 23 callsites converted
- 5 corresponding test files updated
- No new files. No DDL changes. No schema changes. No behavioural changes intended for the typical paths. See "Notes for reviewers" below for the two raw-SQL preservation sites.
- Targeted at the `SQLStore/EntityStore` migration PR rather than `master` so the diff reads cleanly. Will retarget to `master` once the parent merges.

## Notes for reviewers

- **`PropertyTableUpdater::delete`** preserves the existing raw OR-chain SQL fragment (built per-row via `\$connection->makeList(\$row, LIST_AND)` and `\$connection->addQuotes(\$sid)`). The fragment passes through `where(<raw string>)` unchanged. The previous form passed it as a single-element numeric-keyed array `[\$condition]` to `Database::delete`; both produce identical SQL.
- **`PropertyTableIdReferenceDisposer::newByNamespaceInvalidEntitiesResultIterator`** preserves the raw `'smw_namespace NOT IN (…)'` fragment via `where(<raw string>)`. The list is built using `\$connection->makeList()` exactly as before.
- **`LegacyOptionsApplier`** translates `[ 'LIMIT' => …, 'OFFSET' => … ]` options arrays to builder method calls. Used in both `PropertyTableIdReferenceDisposer` SELECT methods.
- **No `Query`-class usage** in any of these files, so no `Query` → `SelectQueryBuilder` translation work.
- **The commented-out `upsert` block** in `src/SQLStore/PropertyTable/PropertyTableHashes.php` (lines 57-72) is intentionally left untouched.
- **Test-side strengthening:** `PropertyTableIdReferenceDisposerTest::testCleanUpOnTransactionIdleAvoidOnSubobject` and `testCleanUp_Redirect` previously listed `FT_SEARCH_TABLE` deletes in their `withConsecutive` argument lists, but `setFulltextTableUsage(true)` was never called in those test setups so the FT_SEARCH branch never executed. The new captured-tables-sequence assertions (via `MockWriteQueryBuilderTrait`) precisely reflect the actually-executing 5- or 6-table sequence — a strengthening, not a weakening.
- **`PropertyTableRowMapperTest` is intentionally not modified.** The converted `selectRow` on `smw_fpt_conc` is gated on a SMW_NS_CONCEPT subject path that none of the file's existing tests exercise; the broader Unit suite passing confirms no regression. Adding a concept-path test would expand scope; deferred to a follow-up.

## Test plan

- [x] `composer analyze` clean (lint 2117 files, PHPCS 16/16)
- [x] `composer phpunit` on `Unit/SQLStore/`, `Unit/MediaWiki/`, `Unit/Maintenance/`, `Unit/Elastic/`: 873 tests / 1767 assertions green (1 unrelated pre-existing skip on `PostgresTableBuilderTest::testDoCheckOnAfterCreate`)
- [x] PHPCS clean on every modified file
- [x] API-level smoke against the seeded dev wiki: identical Ask-query counts on this branch vs. parent across page-literal, MW-category, property-exists, property-equality, single-word property-equality, and modification-date queries — no regression
- [x] Property page (`Border_Collie`) renders with no real `smw-error` markers
- [x] CI matrix on MySQL / Postgres / SQLite — promote from draft once green