### PR TITLE
NamespaceManager: Merge standard namespace defaults for partial overrides

### DIFF
--- a/src/NamespaceManager.php
+++ b/src/NamespaceManager.php
@@ -237,18 +237,17 @@ class NamespaceManager {
 			SMW_NS_SCHEMA_TALK => false,
 		];
 
-		// When the CanonicalNamespaces hook fires before src/DefaultSettings.php
-		// has been applied, smwgNamespacesWithSemanticLinks may be empty.
-		// Load the defaults from src/DefaultSettings.php to ensure standard MW
-		// namespaces (NS_MAIN, NS_USER, etc.) are preserved. (#6302)
-		if ( $vars['smwgNamespacesWithSemanticLinks'] === [] ) {
-			$defaults = SemanticMediaWiki::getDefaultSettings();
-			$vars['smwgNamespacesWithSemanticLinks'] = $defaults['smwgNamespacesWithSemanticLinks'];
-		}
+		// Always merge in the standard MW namespace defaults from
+		// src/DefaultSettings.php. Without this, a LocalSettings.php that
+		// only sets entries for custom namespaces — e.g.
+		// `$smwgNamespacesWithSemanticLinks[NS_AUTHORITY] = true;` — would
+		// leave NS_MAIN, NS_USER, etc. unset because `setupGlobals()` skips
+		// any global already touched by the user. User-set keys still win
+		// via `array_replace`'s right-most precedence. (#6302, #6726)
+		$defaults = SemanticMediaWiki::getDefaultSettings();
 
-		// Combine default values with values specified in other places
-		// (LocalSettings etc.)
 		$vars['smwgNamespacesWithSemanticLinks'] = array_replace(
+			$defaults['smwgNamespacesWithSemanticLinks'],
 			$smwNamespacesSettings,
 			$vars['smwgNamespacesWithSemanticLinks']
 		);

--- a/tests/phpunit/Unit/NamespaceManagerTest.php
+++ b/tests/phpunit/Unit/NamespaceManagerTest.php
@@ -263,6 +263,42 @@ class NamespaceManagerTest extends TestCase {
 		);
 	}
 
+	public function testInitMergesStandardDefaultsWhenUserSetsOnlyCustomNamespaces() {
+		// Simulates a LocalSettings.php that opts a custom namespace into
+		// semantic processing, which causes setupGlobals() to skip seeding
+		// $smwgNamespacesWithSemanticLinks. The standard MW namespace
+		// defaults must still be merged in. (#6726)
+		$customNamespace = 3000;
+
+		$vars = $this->default + [
+			'wgExtraNamespaces'  => '',
+			'wgNamespaceAliases' => '',
+		];
+
+		$vars['smwgNamespacesWithSemanticLinks'] = [
+			$customNamespace => true,
+		];
+
+		$instance = new NamespaceManager( $this->localLanguage );
+		$vars = $instance->init( $vars );
+
+		$this->assertTrue(
+			$vars['smwgNamespacesWithSemanticLinks'][$customNamespace]
+		);
+
+		$this->assertTrue(
+			$vars['smwgNamespacesWithSemanticLinks'][NS_MAIN]
+		);
+
+		$this->assertTrue(
+			$vars['smwgNamespacesWithSemanticLinks'][NS_HELP]
+		);
+
+		$this->assertTrue(
+			$vars['smwgNamespacesWithSemanticLinks'][SMW_NS_PROPERTY]
+		);
+	}
+
 	public function testInitCustomNamespace_NamespaceAliases() {
 		$localLanguage = $this->getMockBuilder( LocalLanguage::class )
 			->disableOriginalConstructor()


### PR DESCRIPTION
## Summary

- `$smwgNamespacesWithSemanticLinks[NS_FOO] = true;` in `LocalSettings.php` was silently dropping all standard MW namespace defaults (NS_MAIN, NS_USER, etc.), which disabled the "Browse properties" toolbox link, the entity issue panel, and other namespace-gated SMW UI on existing wikis after upgrade.
- `SemanticMediaWiki::setupGlobals()` only seeds a global when it's unset, so a single nested-key write from the user's settings skipped seeding. The empty-array shortcut from #6302 didn't catch the partial-override case.
- `addNamespaceSettings()` now always merges the defaults underneath user values via `array_replace`'s right-most precedence, so user-set keys still win.

Reproduction steps (worked SMW 6.0.1, broke on dev-master) reported in #6726:

```php
$smwgNamespacesWithSemanticLinks[NS_AUTHORITY] = true;
$smwgNamespacesWithSemanticLinks[NS_AUTHORITY_TALK] = false;
```

Fixes #6726.

## Test plan

- [x] New unit test `testInitMergesStandardDefaultsWhenUserSetsOnlyCustomNamespaces` — fails on master with "Undefined array key 0", passes with the fix.
- [x] Existing `NamespaceManagerTest`, `SetupTest`, `HooksTest` — all green (103 tests, 254 assertions).
- [x] Manual browser repro: added the user's namespace pattern to the dev wiki's `LocalSettings.php`. Without the fix, `t-smwbrowselink` and `smw-entity-examiner` are missing from `Main_Page`. With the fix, both render. (`<link rel="alternate" type="application/rdf+xml">` is unaffected — `BeforePageDisplay` doesn't gate on namespace.)
- [x] `composer analyze` — clean (lint + PHPCS).