### PR TITLE
Convert SQLStore/TableBuilder/Examiner DML to QueryBuilder

### DIFF
--- a/src/SQLStore/TableBuilder/Examiner/FixedProperties.php
+++ b/src/SQLStore/TableBuilder/Examiner/FixedProperties.php
@@ -83,18 +83,16 @@ class FixedProperties {
 		$connection = $this->store->getConnection( DB_PRIMARY );
 		$this->messageReporter->reportMessage( "   ... reading `$prop` ...\n" );
 
-		$row = $connection->selectRow(
-			SQLStore::ID_TABLE,
-			[
-				'smw_id'
-			],
-			[
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'smw_id' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				'smw_title' => $prop,
 				'smw_namespace' => SMW_NS_PROPERTY,
 				'smw_subobject' => ''
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row === false || (int)$row->smw_id == $target_id ) {
 			return $this->messageReporter->reportMessage( "   ... done.\n" );
@@ -105,40 +103,30 @@ class FixedProperties {
 		$this->messageReporter->reportMessage( "   ... moving from $current_id to $target_id ...\n" );
 
 		// Avoid "Error: 1062 Duplicate entry '52' for key 'PRIMARY' ..." before moving
-		$connection->delete(
-			SQLStore::ID_TABLE,
-			[
-				'smw_id' => $target_id
-			],
-			__METHOD__
-		);
+		$connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $target_id ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$this->store->getObjectIds()->moveSMWPageID(
 			$current_id,
 			$target_id
 		);
 
-		$connection->update(
-			SQLStore::QUERY_LINKS_TABLE,
-			[
-				'o_id' => $target_id
-			],
-			[
-				'o_id' => $current_id
-			],
-			__METHOD__
-		);
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::QUERY_LINKS_TABLE )
+			->set( [ 'o_id' => $target_id ] )
+			->where( [ 'o_id' => $current_id ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$connection->update(
-			SQLStore::PROPERTY_STATISTICS_TABLE,
-			[
-				'p_id' => $target_id
-			],
-			[
-				'p_id' => $current_id
-			],
-			__METHOD__
-		);
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->set( [ 'p_id' => $target_id ] )
+			->where( [ 'p_id' => $current_id ] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 }

--- a/src/SQLStore/TableBuilder/Examiner/HashField.php
+++ b/src/SQLStore/TableBuilder/Examiner/HashField.php
@@ -61,12 +61,12 @@ class HashField {
 		$cliMsgFormatter = new CliMsgFormatter();
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$count = (int)$connection->selectField(
-			SQLStore::ID_TABLE,
-			'COUNT(*)',
-			'LENGTH(smw_hash) = 40',
-			__METHOD__
-		);
+		$count = (int)$connection->newSelectQueryBuilder()
+			->select( 'COUNT(*)' )
+			->from( SQLStore::ID_TABLE )
+			->where( 'LENGTH(smw_hash) = 40' )
+			->caller( __METHOD__ )
+			->fetchField();
 
 		if ( $count === 0 ) {
 			return;
@@ -128,20 +128,20 @@ class HashField {
 	 * Row-by-row hex-to-binary conversion for databases without UNHEX().
 	 */
 	private function migrateHexHashesViaPHP( $connection ): void {
-		$rows = $connection->select(
-			SQLStore::ID_TABLE,
-			[ 'smw_id', 'smw_hash' ],
-			'LENGTH(smw_hash) = 40',
-			__METHOD__
-		);
+		$rows = $connection->newSelectQueryBuilder()
+			->select( [ 'smw_id', 'smw_hash' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( 'LENGTH(smw_hash) = 40' )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		foreach ( $rows as $row ) {
-			$connection->update(
-				SQLStore::ID_TABLE,
-				[ 'smw_hash' => hex2bin( $row->smw_hash ) ],
-				[ 'smw_id' => $row->smw_id ],
-				__METHOD__
-			);
+			$connection->newUpdateQueryBuilder()
+				->update( SQLStore::ID_TABLE )
+				->set( [ 'smw_hash' => hex2bin( $row->smw_hash ) ] )
+				->where( [ 'smw_id' => $row->smw_id ] )
+				->caller( __METHOD__ )
+				->execute();
 		}
 	}
 

--- a/src/SQLStore/TableBuilder/Examiner/IdBorder.php
+++ b/src/SQLStore/TableBuilder/Examiner/IdBorder.php
@@ -64,28 +64,22 @@ class IdBorder {
 		$row = false;
 		$hasUpperBound = false;
 
-		$rows = $connection->select(
-			SQLStore::ID_TABLE,
-			[
-				'smw_id'
-			],
-			[
-				'smw_iw' => SMW_SQL3_SMWBORDERIW
-			],
-			__METHOD__
-		);
+		$rows = $connection->newSelectQueryBuilder()
+			->select( [ 'smw_id' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_iw' => SMW_SQL3_SMWBORDERIW ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		foreach ( $rows as $row ) {
 			if ( $row->smw_id == $upperbound ) {
 				$hasUpperBound = true;
 			} else {
-				$connection->delete(
-					SQLStore::ID_TABLE,
-					[
-						'smw_id' => $row->smw_id
-					],
-					__METHOD__
-				);
+				$connection->newDeleteQueryBuilder()
+					->deleteFrom( SQLStore::ID_TABLE )
+					->where( [ 'smw_id' => $row->smw_id ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 		}
 
@@ -111,18 +105,18 @@ class IdBorder {
 			$cliMsgFormatter->secondCol( CliMsgFormatter::OK )
 		);
 
-		$connection->insert(
-			SQLStore::ID_TABLE,
-			[
+		$connection->newInsertQueryBuilder()
+			->insertInto( SQLStore::ID_TABLE )
+			->row( [
 				'smw_id' => $upperbound,
 				'smw_title' => '',
 				'smw_namespace' => 0,
 				'smw_iw' => SMW_SQL3_SMWBORDERIW,
 				'smw_subobject' => '',
 				'smw_sortkey' => ''
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->execute();
 
 		if ( $currentUpperbound < $upperbound ) {
 			$this->move( $currentUpperbound, $upperbound );

--- a/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
+++ b/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
@@ -78,18 +78,16 @@ class PredefinedProperties {
 
 		// Try to find the ID for a non-fixed predefined property
 		if ( $id === null ) {
-			$row = $connection->selectRow(
-				SQLStore::ID_TABLE,
-				[
-					'smw_id'
-				],
-				[
+			$row = $connection->newSelectQueryBuilder()
+				->select( [ 'smw_id' ] )
+				->from( SQLStore::ID_TABLE )
+				->where( [
 					'smw_title' => $property->getKey(),
 					'smw_namespace' => SMW_NS_PROPERTY,
 					'smw_subobject' => ''
-				],
-				__METHOD__
-			);
+				] )
+				->caller( __METHOD__ )
+				->fetchRow();
 
 			if ( $row !== false ) {
 				$id = $row->smw_id;
@@ -106,19 +104,17 @@ class PredefinedProperties {
 			$property
 		);
 
-		$row = $connection->selectRow(
-			SQLStore::ID_TABLE,
-			[
+		$row = $connection->newSelectQueryBuilder()
+			->select( [
 				'smw_proptable_hash',
 				'smw_hash',
 				'smw_rev',
 				'smw_touched'
-			],
-			[
-				'smw_id' => $id
-			],
-			__METHOD__
-		);
+			] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row === false ) {
 			$row = (object)[
@@ -129,10 +125,10 @@ class PredefinedProperties {
 			];
 		}
 
-		$connection->replace(
-			SQLStore::ID_TABLE,
-			'smw_id',
-			[
+		$connection->newReplaceQueryBuilder()
+			->replaceInto( SQLStore::ID_TABLE )
+			->uniqueIndexFields( [ 'smw_id' ] )
+			->row( [
 				'smw_id' => $id,
 				'smw_title' => $property->getKey(),
 				'smw_namespace' => SMW_NS_PROPERTY,
@@ -144,20 +140,20 @@ class PredefinedProperties {
 				'smw_hash' => $row->smw_hash,
 				'smw_rev' => $row->smw_rev,
 				'smw_touched' => $row->smw_touched
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->execute();
 
 		if ( $id === null ) {
 			return;
 		}
 
-		$row = $connection->selectRow(
-			SQLStore::PROPERTY_STATISTICS_TABLE,
-			[ 'p_id' ],
-			[ 'p_id' => $id ],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'p_id' ] )
+			->from( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->where( [ 'p_id' => $id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		// Entry is available therefore don't try to override the count
 		// value
@@ -165,15 +161,15 @@ class PredefinedProperties {
 			return;
 		}
 
-		$connection->insert(
-			SQLStore::PROPERTY_STATISTICS_TABLE,
-			[
+		$connection->newInsertQueryBuilder()
+			->insertInto( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->row( [
 				'p_id' => $id,
 				'usage_count' => 0,
 				'null_count' => 0
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 }

--- a/src/SQLStore/TableBuilder/Examiner/TouchedField.php
+++ b/src/SQLStore/TableBuilder/Examiner/TouchedField.php
@@ -30,17 +30,15 @@ class TouchedField {
 		$this->messageReporter->reportMessage( "Checking smw_touched field ...\n" );
 		$connection = $this->store->getConnection( DB_PRIMARY );
 
-		$row = $connection->selectRow(
-			SQLStore::ID_TABLE,
-			[
-				'COUNT(smw_id) as count'
-			],
-			[
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'COUNT(smw_id) as count' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				'smw_touched IS NULL',
 				'smw_iw!=' . $connection->addQuotes( SMW_SQL3_SMWBORDERIW )
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row === false || $row->count == 0 ) {
 			return $this->messageReporter->reportMessage( "   ... done.\n" );
@@ -48,27 +46,19 @@ class TouchedField {
 
 		$this->messageReporter->reportMessage( "   ... updating {$row->count} rows with default date ...\n" );
 
-		$connection->update(
-			SQLStore::ID_TABLE,
-			[
-				'smw_touched' => $connection->timestamp( '1970-01-01 00:00:00' )
-			],
-			[
-				'smw_touched IS NULL'
-			],
-			__METHOD__
-		);
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( [ 'smw_touched' => $connection->timestamp( '1970-01-01 00:00:00' ) ] )
+			->where( [ 'smw_touched IS NULL' ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$connection->update(
-			SQLStore::ID_TABLE,
-			[
-				'smw_touched' => null
-			],
-			[
-				'smw_iw' => SMW_SQL3_SMWBORDERIW
-			],
-			__METHOD__
-		);
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( [ 'smw_touched' => null ] )
+			->where( [ 'smw_iw' => SMW_SQL3_SMWBORDERIW ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$this->messageReporter->reportMessage( "   ... done.\n" );
 	}

--- a/tests/phpunit/Unit/Elastic/ElasticStoreTest.php
+++ b/tests/phpunit/Unit/Elastic/ElasticStoreTest.php
@@ -122,6 +122,26 @@ class ElasticStoreTest extends TestCase {
 			->method( 'selectRow' )
 			->willReturn( $row );
 
+		$database->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( [ $row ] ) );
+
+		$database->expects( $this->any() )
+			->method( 'newInsertQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockInsertQueryBuilder() );
+
+		$database->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockUpdateQueryBuilder() );
+
+		$database->expects( $this->any() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockDeleteQueryBuilder() );
+
+		$database->expects( $this->any() )
+			->method( 'newReplaceQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockReplaceQueryBuilder() );
+
 		$connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/FixedPropertiesTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/FixedPropertiesTest.php
@@ -8,6 +8,8 @@ use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder\Examiner\FixedProperties;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\TableBuilder\Examiner\FixedProperties
@@ -19,6 +21,9 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class FixedPropertiesTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $spyMessageReporter;
 	private $store;
@@ -49,11 +54,43 @@ class FixedPropertiesTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$selectBuilderFoo = $this->createMockSelectQueryBuilder(
+			[ (object)[ 'smw_id' => 99999 ] ]
+		);
+		$selectBuilderBar = $this->createMockSelectQueryBuilder(
+			[ (object)[ 'smw_id' => 11111 ] ]
+		);
+
+		$capturedDeleteTables = [];
+		$capturedDeleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder(
+			$capturedDeleteTables,
+			$capturedDeleteWheres
+		);
+
+		$capturedUpdateTables = [];
+		$capturedUpdateSets = [];
+		$capturedUpdateWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder(
+			$capturedUpdateTables,
+			$capturedUpdateSets,
+			$capturedUpdateWheres
+		);
+
 		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'selectRow' )
+			->method( 'newSelectQueryBuilder' )
 			->willReturnOnConsecutiveCalls(
-				(object)[ 'smw_id' => 99999 ],
-				(object)[ 'smw_id' => 11111 ] );
+				$selectBuilderFoo,
+				$selectBuilderBar
+			);
+
+		$this->connection->expects( $this->any() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -72,6 +109,46 @@ class FixedPropertiesTest extends TestCase {
 		$instance->setProperties( [ '_FOO', '_BAR' ] );
 
 		$instance->check();
+
+		$this->assertSame(
+			[ SQLStore::ID_TABLE, SQLStore::ID_TABLE ],
+			$capturedDeleteTables
+		);
+
+		$this->assertSame(
+			[ [ 'smw_id' => 51 ], [ 'smw_id' => 52 ] ],
+			$capturedDeleteWheres
+		);
+
+		$this->assertSame(
+			[
+				SQLStore::QUERY_LINKS_TABLE,
+				SQLStore::PROPERTY_STATISTICS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+				SQLStore::PROPERTY_STATISTICS_TABLE,
+			],
+			$capturedUpdateTables
+		);
+
+		$this->assertSame(
+			[
+				[ 'o_id' => 51 ],
+				[ 'p_id' => 51 ],
+				[ 'o_id' => 52 ],
+				[ 'p_id' => 52 ],
+			],
+			$capturedUpdateSets
+		);
+
+		$this->assertSame(
+			[
+				[ 'o_id' => 99999 ],
+				[ 'p_id' => 99999 ],
+				[ 'o_id' => 11111 ],
+				[ 'p_id' => 11111 ],
+			],
+			$capturedUpdateWheres
+		);
 
 		$expected = $this->spyMessageReporter->getMessagesAsString();
 

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
@@ -8,6 +8,8 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder\Examiner\HashField;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use Wikimedia\Rdbms\DBError;
 use Wikimedia\Rdbms\ResultWrapper;
 
@@ -22,6 +24,9 @@ use Wikimedia\Rdbms\ResultWrapper;
  */
 class HashFieldTest extends TestCase {
 
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
+
 	private $spyMessageReporter;
 	private $store;
 	private $populateHashField;
@@ -34,9 +39,6 @@ class HashFieldTest extends TestCase {
 		$this->connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->connection->method( 'selectField' )
-			->willReturn( 0 );
 
 		$this->store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -96,8 +98,12 @@ class HashFieldTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->connection->method( 'selectField' )
-			->willReturn( HashField::threshold() + 1 );
+		$selectBuilder = $this->createMockSelectQueryBuilder(
+			[ (object)[ 'count' => HashField::threshold() + 1 ] ]
+		);
+
+		$this->connection->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$this->connection->method( 'tableName' )
 			->willReturn( 'smw_object_ids' );
@@ -131,8 +137,12 @@ class HashFieldTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->connection->method( 'selectField' )
-			->willReturn( 1 );
+		$selectBuilder = $this->createMockSelectQueryBuilder(
+			[ (object)[ 'count' => 1 ] ]
+		);
+
+		$this->connection->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$this->connection->method( 'tableName' )
 			->willReturn( 'smw_object_ids' );
@@ -170,6 +180,13 @@ class HashFieldTest extends TestCase {
 	}
 
 	public function testMigrateHexHashes_NoOpWhenCountIsZero() {
+		$selectBuilder = $this->createMockSelectQueryBuilder(
+			[ (object)[ 'count' => 0 ] ]
+		);
+
+		$this->connection->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
 		$this->connection->expects( $this->never() )
 			->method( 'query' );
 

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/IdBorderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/IdBorderTest.php
@@ -7,6 +7,8 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder\Examiner\IdBorder;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\TableBuilder\Examiner\IdBorder
@@ -18,6 +20,9 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class IdBorderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $spyMessageReporter;
 	private $store;
@@ -39,17 +44,19 @@ class IdBorderTest extends TestCase {
 	}
 
 	public function testCheckBorder_HasBorder() {
-		$row = [
-			'smw_id' => 100
+		$rows = [
+			(object)[ 'smw_id' => 100 ]
 		];
+
+		$selectBuilder = $this->createMockSelectQueryBuilder( $rows );
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( [ (object)$row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -80,19 +87,23 @@ class IdBorderTest extends TestCase {
 			(object)[ 'smw_id' => 9999 ]
 		];
 
+		$selectBuilder = $this->createMockSelectQueryBuilder( $rows );
+
+		$capturedTables = [];
+		$capturedWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $capturedTables, $capturedWheres );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( $rows );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$connection->expects( $this->once() )
-			->method( 'delete' )
-			->with(
-				$this->anything(),
-				[ 'smw_id' => 9999 ] );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -110,6 +121,13 @@ class IdBorderTest extends TestCase {
 				IdBorder::LEGACY_BOUND => 42
 			]
 		);
+
+		$this->assertSame(
+			[ [ 'smw_id' => 9999 ] ],
+			$capturedWheres
+		);
+
+		$this->assertSame( [ SQLStore::ID_TABLE ], $capturedTables );
 
 		$this->assertStringContainsString(
 			'space for internal properties allocated',
@@ -133,19 +151,23 @@ class IdBorderTest extends TestCase {
 			->setMethods( [ 'moveSMWPageID' ] )
 			->getMock();
 
+		$selectBuilder = $this->createMockSelectQueryBuilder( $rows );
+
+		$capturedTables = [];
+		$capturedRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $capturedTables, $capturedRows );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( $rows );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$connection->expects( $this->once() )
-			->method( 'insert' )
-			->with(
-				$this->anything(),
-				$expected );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
@@ -167,6 +189,13 @@ class IdBorderTest extends TestCase {
 				IdBorder::LEGACY_BOUND => 42
 			]
 		);
+
+		$this->assertSame(
+			[ $expected ],
+			$capturedRows
+		);
+
+		$this->assertSame( [ SQLStore::ID_TABLE ], $capturedTables );
 
 		$this->assertStringContainsString(
 			'allocating space for internal properties',

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/PredefinedPropertiesTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/PredefinedPropertiesTest.php
@@ -7,6 +7,8 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder\Examiner\PredefinedProperties;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\TableBuilder\Examiner\PredefinedProperties
@@ -18,6 +20,9 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class PredefinedPropertiesTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $spyMessageReporter;
 	private $store;
@@ -56,16 +61,28 @@ class PredefinedPropertiesTest extends TestCase {
 			->method( 'getPropertyInterwiki' )
 			->willReturn( 'Foo' );
 
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)$row ] );
+
+		$capturedReplaceTables = [];
+		$capturedReplaceRows = [];
+		$capturedReplaceUniqueIndexFields = [];
+		$replaceBuilder = $this->createMockReplaceQueryBuilder(
+			$capturedReplaceTables,
+			$capturedReplaceRows,
+			$capturedReplaceUniqueIndexFields
+		);
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'replace' );
+			->method( 'newReplaceQueryBuilder' )
+			->willReturn( $replaceBuilder );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -90,6 +107,9 @@ class PredefinedPropertiesTest extends TestCase {
 
 		$instance->setMessageReporter( $this->spyMessageReporter );
 		$instance->check();
+
+		$this->assertSame( [ SQLStore::ID_TABLE ], $capturedReplaceTables );
+		$this->assertSame( [ [ 'smw_id' ] ], $capturedReplaceUniqueIndexFields );
 	}
 
 	public function testCheckOnValidProperty_NotFixed() {
@@ -106,20 +126,22 @@ class PredefinedPropertiesTest extends TestCase {
 			->setMethods( [ 'moveSMWPageID', 'getPropertyInterwiki' ] )
 			->getMock();
 
+		$capturedWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)$row ], $capturedWheres );
+
+		$replaceBuilder = $this->createMockReplaceQueryBuilder();
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'selectRow' )
-			->willReturnCallback( static function ( $table, $vars, $conds ) use ( $row ) {
-				if ( is_array( $conds ) && isset( $conds['smw_title'] ) && $conds['smw_title'] === 'Foo'
-					&& isset( $conds['smw_namespace'] ) && $conds['smw_namespace'] === SMW_NS_PROPERTY
-					&& isset( $conds['smw_subobject'] ) && $conds['smw_subobject'] === '' ) {
-					return (object)$row;
-				}
-				return (object)$row;
-			} );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newReplaceQueryBuilder' )
+			->willReturn( $replaceBuilder );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -144,6 +166,15 @@ class PredefinedPropertiesTest extends TestCase {
 
 		$instance->setMessageReporter( $this->spyMessageReporter );
 		$instance->check();
+
+		$this->assertContains(
+			[
+				'smw_title' => 'Foo',
+				'smw_namespace' => SMW_NS_PROPERTY,
+				'smw_subobject' => ''
+			],
+			$capturedWheres
+		);
 	}
 
 	public function testCheckOnInvalidProperty() {

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/TouchedFieldTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/TouchedFieldTest.php
@@ -7,6 +7,8 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder\Examiner\TouchedField;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\TableBuilder\Examiner\TouchedField
@@ -18,6 +20,9 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class TouchedFieldTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $spyMessageReporter;
 	private $store;
@@ -43,16 +48,31 @@ class TouchedFieldTest extends TestCase {
 			'count' => 42
 		];
 
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)$row ] );
+
+		$capturedTables = [];
+		$capturedSets = [];
+		$capturedWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder(
+			$capturedTables,
+			$capturedSets,
+			$capturedWheres
+		);
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
+		$connection->method( 'timestamp' )
+			->willReturnArgument( 0 );
+
 		$connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)$row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'update' );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -64,6 +84,21 @@ class TouchedFieldTest extends TestCase {
 
 		$instance->setMessageReporter( $this->spyMessageReporter );
 		$instance->check();
+
+		$this->assertSame( [ SQLStore::ID_TABLE, SQLStore::ID_TABLE ], $capturedTables );
+
+		$this->assertSame(
+			[ [ 'smw_touched IS NULL' ], [ 'smw_iw' => SMW_SQL3_SMWBORDERIW ] ],
+			$capturedWheres
+		);
+
+		$this->assertSame(
+			[
+				[ 'smw_touched' => '1970-01-01 00:00:00' ],
+				[ 'smw_touched' => null ],
+			],
+			$capturedSets
+		);
 
 		$this->assertStringContainsString(
 			'updating 42 rows with',


### PR DESCRIPTION
## Summary

Migrates the QueryBuilder-eligible DML in `src/SQLStore/TableBuilder/Examiner/` (18 callsites across 5 files) onto the SMW `Database` wrapper's `newSelectQueryBuilder()` / `newInsertQueryBuilder()` / `newUpdateQueryBuilder()` / `newDeleteQueryBuilder()` / `newReplaceQueryBuilder()` factories. Mechanical, no behaviour change intended.

Files converted (one commit per file):

- `IdBorder.php` — 3 callsites (`select`, `delete`, `insert`)
- `PredefinedProperties.php` — 5 callsites (3× `selectRow`, `replace`, `insert`)
- `TouchedField.php` — 3 callsites (`selectRow`, 2× `update`)
- `FixedProperties.php` — 4 callsites (`selectRow`, `delete`, 2× `update`)
- `HashField.php` — 3 callsites (`selectField`, `select`, `update`)

Each converted chain ends with `->caller( __METHOD__ )`. Writes go through the SMW `Database` wrapper's factories so the existing `Muted*QueryBuilder` profiler-mute on `execute()` is preserved.

Tests are updated in lockstep using the existing `MockSelectQueryBuilderTrait` / `MockWriteQueryBuilderTrait` helpers, with captured-argument assertions in place of legacy `with(...)` arg matchers.

A sixth commit updates `ElasticStoreTest::testSetup` to stub the QueryBuilder factories on its raw-IDatabase mock — that test exercises real production code through to `TableBuildExaminer::checkOnPostCreation`, which runs the converted Examiner classes end-to-end.

### Out of scope (intentionally kept on `$db->query()`)

- DDL in `MySQLTableBuilder.php` / `PostgresTableBuilder.php` / `SQLiteTableBuilder.php` / `TemporaryTableBuilder.php` — `CREATE`, `ALTER`, `DROP`, `ANALYZE`, `VACUUM`, `PRAGMA`, the SQLite table-rebuild block. DDL has no QueryBuilder counterpart.
- The column-to-column `UPDATE smw_object_ids SET smw_sort = smw_sortkey` in `TableBuildExaminer.php` — column-self-assignment isn't a clean fit for `UpdateQueryBuilder::set()`.
- Two dialect-specific UPDATEs in `HashField.php` (lines 84, 92) emitting `decode(smw_hash, 'hex')` (Postgres) and `UNHEX(smw_hash)` (MySQL). Already platform-aware and the SET right-hand side is a SQL function applied to the column itself, which is awkward to express through the QueryBuilder API. Left raw with the existing `getType()`-dispatch.

### Representative before / after

`PredefinedProperties::doUpdate()`, `replace` callsite:

```php
// Before
$connection->replace(
    SQLStore::ID_TABLE,
    'smw_id',
    [ /* row payload */ ],
    __METHOD__
);

// After
$connection->newReplaceQueryBuilder()
    ->replaceInto( SQLStore::ID_TABLE )
    ->uniqueIndexFields( [ 'smw_id' ] )
    ->row( [ /* same payload */ ] )
    ->caller( __METHOD__ )
    ->execute();
```

Note the legacy bare-string `'smw_id'` (3rd positional arg) becomes the array `[ 'smw_id' ]` on `uniqueIndexFields()`.

`HashField::migrateHexHashes()`, count guard:

```php
// Before
$count = (int)$connection->selectField(
    SQLStore::ID_TABLE,
    'COUNT(*)',
    'LENGTH(smw_hash) = 40',
    __METHOD__
);

// After
$count = (int)$connection->newSelectQueryBuilder()
    ->select( 'COUNT(*)' )
    ->from( SQLStore::ID_TABLE )
    ->where( 'LENGTH(smw_hash) = 40' )
    ->caller( __METHOD__ )
    ->fetchField();
```

## Test plan

- [x] `composer analyze` clean (PHP lint: 2117/2117 OK; PHPCS clean on changed files)
- [x] Filtered tests pass: `IdBorderTest`, `PredefinedPropertiesTest`, `TouchedFieldTest`, `FixedPropertiesTest`, `HashFieldTest` — 20 tests, 52 assertions
- [x] Full `semantic-mediawiki-unit` testsuite green: 6843 tests, 12172 assertions, 6 pre-existing skips — equivalent to CI's invocation
- [x] `php maintenance/update.php --quick` against the dev wiki completes cleanly — the Examiner classes are invoked from `TableBuildExaminer` during the "Post-creation examination" phase. All five Examiner phases run without DB errors.
- [ ] CI matrix green on MySQL + Postgres + SQLite (will verify before promoting from draft)
