### PR TITLE
Convert SQLStore/QueryDependency DML to QueryBuilder

### DIFF
--- a/src/SQLStore/QueryDependency/DependencyLinksTableUpdater.php
+++ b/src/SQLStore/QueryDependency/DependencyLinksTableUpdater.php
@@ -89,13 +89,11 @@ class DependencyLinksTableUpdater {
 		$connection = $this->store->getConnection( 'mw.db' );
 		$connection->beginAtomicTransaction( __METHOD__ );
 
-		$connection->delete(
-			SQLStore::QUERY_LINKS_TABLE,
-			[
-				's_id' => $deleteIdList
-			],
-			__METHOD__
-		);
+		$connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 's_id' => $deleteIdList ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$connection->endAtomicTransaction( __METHOD__ );
 	}
@@ -112,27 +110,21 @@ class DependencyLinksTableUpdater {
 		$connection = $this->store->getConnection( 'mw.db' );
 		$connection->beginAtomicTransaction( __METHOD__ );
 
-		$connection->update(
-			SQLStore::ID_TABLE,
-			[
-				'smw_touched' => $connection->timestamp()
-			],
-			[
-				'smw_id' => $sid
-			],
-			__METHOD__
-		);
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( [ 'smw_touched' => $connection->timestamp() ] )
+			->where( [ 'smw_id' => $sid ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		// Before an insert, delete all entries that for the criteria which is
 		// cheaper then doing an individual upsert or selectRow, this also ensures
 		// that entries are self-corrected for dependencies matched
-		$connection->delete(
-			SQLStore::QUERY_LINKS_TABLE,
-			[
-				's_id' => $sid
-			],
-			__METHOD__
-		);
+		$connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 's_id' => $sid ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		if ( $sid == 0 ) {
 			$connection->endAtomicTransaction( __METHOD__ );
@@ -182,11 +174,11 @@ class DependencyLinksTableUpdater {
 			[ 'method' => __METHOD__, 'role' => 'developer', 'id' => $sid ]
 		);
 
-		$connection->insert(
-			SQLStore::QUERY_LINKS_TABLE,
-			$inserts,
-			__METHOD__
-		);
+		$connection->newInsertQueryBuilder()
+			->insertInto( SQLStore::QUERY_LINKS_TABLE )
+			->rows( $inserts )
+			->caller( __METHOD__ )
+			->execute();
 
 		$connection->endAtomicTransaction( __METHOD__ );
 	}

--- a/src/SQLStore/QueryDependency/DependencyLinksValidator.php
+++ b/src/SQLStore/QueryDependency/DependencyLinksValidator.php
@@ -105,25 +105,18 @@ class DependencyLinksValidator {
 		// INNER JOIN smw_object_ids AS p ON ((s_id=p.smw_id))
 		// INNER JOIN smw_object_ids AS v ON ((o_id=v.smw_id))
 		// WHERE p.smw_hash = 'xxx' AND (p.smw_iw!=':smw') AND (p.smw_iw!=':smw-delete')
-		$rows = $connection->select(
-			[ $proptables[$tableid]->getName(), "p" => SQLStore::ID_TABLE, "v" => SQLStore::ID_TABLE ],
-			[
-				'v.smw_id', 'v.smw_subobject', 'v.smw_touched'
-			],
-			[
+		$rows = $connection->newSelectQueryBuilder()
+			->select( [ 'v.smw_id', 'v.smw_subobject', 'v.smw_touched' ] )
+			->from( $proptables[$tableid]->getName() )
+			->join( SQLStore::ID_TABLE, 'p', [ 's_id=p.smw_id' ] )
+			->join( SQLStore::ID_TABLE, 'v', [ 'o_id=v.smw_id' ] )
+			->where( [
 				'p.smw_hash' => $subject->getSha1(),
 				'p.smw_iw!=' . $connection->addQuotes( SMW_SQL3_SMWIW_OUTDATED ),
 				'p.smw_iw!=' . $connection->addQuotes( SMW_SQL3_SMWDELETEIW ),
-			],
-			__METHOD__,
-			[
-			// 'ORDER BY' => 'v.smw_touched'
-			],
-			[
-				"p" => [ 'INNER JOIN', [ 's_id=p.smw_id' ] ],
-				"v" => [ 'INNER JOIN', [ 'o_id=v.smw_id' ] ]
-			]
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		$list = [];
 		$touched = 0;
@@ -153,21 +146,16 @@ class DependencyLinksValidator {
 		// INNER JOIN smw_query_links AS p ON ((p.o_id=smw_id))
 		// WHERE p.s_id = '18341' AND (smw_touched > '2019-01-08 17:45:03')
 		// LIMIT 1
-		$row = $connection->selectRow(
-			[ SQLStore::ID_TABLE, "p" => SQLStore::QUERY_LINKS_TABLE ],
-			[
-				'smw_id'
-			],
-			[
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'smw_id' ] )
+			->from( SQLStore::ID_TABLE )
+			->join( SQLStore::QUERY_LINKS_TABLE, 'p', [ 'p.o_id=smw_id' ] )
+			->where( [
 				'p.s_id' => $list,
 				'smw_touched > ' . $connection->addQuotes( $touched ),
-			],
-			__METHOD__,
-			[],
-			[
-				"p" => [ 'INNER JOIN', [ 'p.o_id=smw_id' ] ],
-			]
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		// Something matched? If yes, an outdated reference was detected and we
 		// use this as a decision parameter to declare a "archaic" dependency (or

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -209,16 +209,12 @@ class QueryDependencyLinksStore {
 
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$row = $connection->selectRow(
-			SQLStore::QUERY_LINKS_TABLE,
-			[
-				'COUNT(s_id) AS count'
-			],
-			[
-				'o_id' => $ids
-			],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'COUNT(s_id) AS count' ] )
+			->from( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 'o_id' => $ids ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		$count = $row ? $row->count : $count;
 
@@ -253,11 +249,6 @@ class QueryDependencyLinksStore {
 			return [];
 		}
 
-		$options = [
-			'LIMIT'     => $requestOptions->getLimit(),
-			'OFFSET'    => $requestOptions->getOffset(),
-		] + [ 'DISTINCT' ];
-
 		$conditions = [
 			'o_id' => $idlist
 		];
@@ -268,13 +259,15 @@ class QueryDependencyLinksStore {
 
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$rows = $connection->select(
-			SQLStore::QUERY_LINKS_TABLE,
-			[ 's_id' ],
-			$conditions,
-			__METHOD__,
-			$options
-		);
+		$rows = $connection->newSelectQueryBuilder()
+			->select( [ 's_id' ] )
+			->distinct()
+			->from( SQLStore::QUERY_LINKS_TABLE )
+			->where( $conditions )
+			->limit( $requestOptions->getLimit() )
+			->offset( $requestOptions->getOffset() )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		$targetLinksIdList = [];
 
@@ -477,14 +470,12 @@ class QueryDependencyLinksStore {
 
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$row = $connection->selectRow(
-			SQLStore::QUERY_LINKS_TABLE,
-			[
-				's_id'
-			],
-			[ 's_id' => $sid ],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 's_id' ] )
+			->from( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 's_id' => $sid ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		$title = $subject->getTitle();
 

--- a/src/SQLStore/QueryDependency/QueryLinksTableDisposer.php
+++ b/src/SQLStore/QueryDependency/QueryLinksTableDisposer.php
@@ -58,18 +58,13 @@ class QueryLinksTableDisposer {
 	 * @return ResultIterator
 	 */
 	public function newOutdatedQueryLinksResultIterator(): ResultIterator {
-		$res = $this->connection->select(
-			[ SQLStore::QUERY_LINKS_TABLE, SQLStore::ID_TABLE ],
-			's_id as id',
-			[
-				"smw_subobject=''"
-			],
-			__METHOD__,
-			[],
-			[
-				SQLStore::QUERY_LINKS_TABLE => [ 'INNER JOIN', "s_id=smw_id" ]
-			]
-		);
+		$res = $this->connection->newSelectQueryBuilder()
+			->select( [ 'id' => 's_id' ] )
+			->from( SQLStore::QUERY_LINKS_TABLE )
+			->join( SQLStore::ID_TABLE, null, [ 's_id=smw_id' ] )
+			->where( [ "smw_subobject=''" ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		return $this->iteratorFactory->newResultIterator( $res );
 	}
@@ -83,18 +78,13 @@ class QueryLinksTableDisposer {
 	 * @return ResultIterator
 	 */
 	public function newUnassignedQueryLinksResultIterator(): ResultIterator {
-		$res = $this->connection->select(
-			[ SQLStore::QUERY_LINKS_TABLE, SQLStore::ID_TABLE ],
-			's_id as id',
-			[
-				"smw_id IS NULL"
-			],
-			__METHOD__,
-			[],
-			[
-				SQLStore::ID_TABLE => [ 'LEFT JOIN', "smw_id=s_id" ]
-			]
-		);
+		$res = $this->connection->newSelectQueryBuilder()
+			->select( [ 'id' => 's_id' ] )
+			->from( SQLStore::QUERY_LINKS_TABLE )
+			->leftJoin( SQLStore::ID_TABLE, null, [ 'smw_id=s_id' ] )
+			->where( [ 'smw_id IS NULL' ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		return $this->iteratorFactory->newResultIterator( $res );
 	}
@@ -113,23 +103,19 @@ class QueryLinksTableDisposer {
 
 		if ( $this->onTransactionIdle ) {
 			return $this->connection->onTransactionCommitOrIdle( function () use ( $id, $fname ): void {
-				$this->connection->delete(
-					SQLStore::QUERY_LINKS_TABLE,
-					[
-						's_id' => $id
-					],
-					$fname
-				);
+				$this->connection->newDeleteQueryBuilder()
+					->deleteFrom( SQLStore::QUERY_LINKS_TABLE )
+					->where( [ 's_id' => $id ] )
+					->caller( $fname )
+					->execute();
 			} );
 		}
 
-		$this->connection->delete(
-			SQLStore::QUERY_LINKS_TABLE,
-			[
-				's_id' => $id
-			],
-			$fname
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::QUERY_LINKS_TABLE )
+			->where( [ 's_id' => $id ] )
+			->caller( $fname )
+			->execute();
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksTableUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksTableUpdaterTest.php
@@ -10,6 +10,8 @@ use SMW\SQLStore\QueryDependency\DependencyLinksTableUpdater;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\QueryDependency\DependencyLinksTableUpdater
@@ -21,6 +23,9 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class DependencyLinksTableUpdaterTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $spyLogger;
@@ -60,26 +65,37 @@ class DependencyLinksTableUpdaterTest extends TestCase {
 			->method( 'getId' )
 			->willReturnOnConsecutiveCalls( 1001 );
 
+		$capturedDeleteTables = [];
+		$capturedDeleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder(
+			$capturedDeleteTables,
+			$capturedDeleteWheres
+		);
+
+		$capturedInsertTables = [];
+		$capturedInsertRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder(
+			$capturedInsertTables,
+			$capturedInsertRows
+		);
+
+		$capturedUpdateTables = [];
+		$capturedUpdateSets = [];
+		$capturedUpdateWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder(
+			$capturedUpdateTables,
+			$capturedUpdateSets,
+			$capturedUpdateWheres
+		);
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->once() )
-			->method( 'delete' )
-			->with(
-				SQLStore::QUERY_LINKS_TABLE,
-				[ 's_id' => 42 ] );
-
-		$insert[] = [
-			's_id' => 42,
-			'o_id' => 1001
-		];
-
-		$connection->expects( $this->once() )
-			->method( 'insert' )
-			->with(
-				SQLStore::QUERY_LINKS_TABLE,
-				$insert );
+		$connection->method( 'timestamp' )->willReturn( '20260503000000' );
+		$connection->method( 'newDeleteQueryBuilder' )->willReturn( $deleteBuilder );
+		$connection->method( 'newInsertQueryBuilder' )->willReturn( $insertBuilder );
+		$connection->method( 'newUpdateQueryBuilder' )->willReturn( $updateBuilder );
 
 		$connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()
@@ -112,6 +128,19 @@ class DependencyLinksTableUpdaterTest extends TestCase {
 
 		$instance->addToUpdateList( 42, [ WikiPage::newFromText( 'Bar' ) ] );
 		$instance->doUpdate();
+
+		$this->assertSame( [ SQLStore::QUERY_LINKS_TABLE ], $capturedDeleteTables );
+		$this->assertSame( [ [ 's_id' => 42 ] ], $capturedDeleteWheres );
+
+		$this->assertSame( [ SQLStore::QUERY_LINKS_TABLE ], $capturedInsertTables );
+		$this->assertSame(
+			[ [ [ 's_id' => 42, 'o_id' => 1001 ] ] ],
+			$capturedInsertRows
+		);
+
+		$this->assertSame( [ SQLStore::ID_TABLE ], $capturedUpdateTables );
+		$this->assertSame( [ [ 'smw_touched' => '20260503000000' ] ], $capturedUpdateSets );
+		$this->assertSame( [ [ 'smw_id' => 42 ] ], $capturedUpdateWheres );
 	}
 
 	public function testAddToUpdateListOnNull_List() {
@@ -157,26 +186,37 @@ class DependencyLinksTableUpdaterTest extends TestCase {
 			->method( 'makeSMWPageID' )
 			->willReturn( 1001 );
 
+		$capturedDeleteTables = [];
+		$capturedDeleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder(
+			$capturedDeleteTables,
+			$capturedDeleteWheres
+		);
+
+		$capturedInsertTables = [];
+		$capturedInsertRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder(
+			$capturedInsertTables,
+			$capturedInsertRows
+		);
+
+		$capturedUpdateTables = [];
+		$capturedUpdateSets = [];
+		$capturedUpdateWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder(
+			$capturedUpdateTables,
+			$capturedUpdateSets,
+			$capturedUpdateWheres
+		);
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->once() )
-			->method( 'delete' )
-			->with(
-				SQLStore::QUERY_LINKS_TABLE,
-				[ 's_id' => 42 ] );
-
-		$insert[] = [
-			's_id' => 42,
-			'o_id' => 1001
-		];
-
-		$connection->expects( $this->once() )
-			->method( 'insert' )
-			->with(
-				SQLStore::QUERY_LINKS_TABLE,
-				$insert );
+		$connection->method( 'timestamp' )->willReturn( '20260503000000' );
+		$connection->method( 'newDeleteQueryBuilder' )->willReturn( $deleteBuilder );
+		$connection->method( 'newInsertQueryBuilder' )->willReturn( $insertBuilder );
+		$connection->method( 'newUpdateQueryBuilder' )->willReturn( $updateBuilder );
 
 		$connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()
@@ -209,6 +249,19 @@ class DependencyLinksTableUpdaterTest extends TestCase {
 
 		$instance->addToUpdateList( 42, [ WikiPage::newFromText( 'Bar', SMW_NS_PROPERTY ) ] );
 		$instance->doUpdate();
+
+		$this->assertSame( [ SQLStore::QUERY_LINKS_TABLE ], $capturedDeleteTables );
+		$this->assertSame( [ [ 's_id' => 42 ] ], $capturedDeleteWheres );
+
+		$this->assertSame( [ SQLStore::QUERY_LINKS_TABLE ], $capturedInsertTables );
+		$this->assertSame(
+			[ [ [ 's_id' => 42, 'o_id' => 1001 ] ] ],
+			$capturedInsertRows
+		);
+
+		$this->assertSame( [ SQLStore::ID_TABLE ], $capturedUpdateTables );
+		$this->assertSame( [ [ 'smw_touched' => '20260503000000' ] ], $capturedUpdateSets );
+		$this->assertSame( [ [ 'smw_id' => 42 ] ], $capturedUpdateWheres );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksValidatorTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksValidatorTest.php
@@ -9,6 +9,7 @@ use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\PropertyTableInfoFetcher;
 use SMW\SQLStore\QueryDependency\DependencyLinksValidator;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\QueryDependency\DependencyLinksValidator
@@ -20,6 +21,8 @@ use SMW\SQLStore\SQLStore;
  * @author mwjames
  */
 class DependencyLinksValidatorTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $dataItemFactory;
@@ -70,17 +73,25 @@ class DependencyLinksValidatorTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$firstSelectBuilder = $this->createMockSelectQueryBuilder(
+			[ (object)[ 'smw_id' => 42, 'smw_subobject' => '_foo', 'smw_touched' => '99999' ] ]
+		);
+
+		$secondSelectBuilder = $this->createMockSelectQueryBuilder(
+			[ (object)[ 'smw_id' => 42 ] ]
+		);
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)[ 'smw_id' => 42 ] );
+		$connection->expects( $this->exactly( 2 ) )
+			->method( 'newSelectQueryBuilder' )
+			->willReturnOnConsecutiveCalls( $firstSelectBuilder, $secondSelectBuilder );
 
-		$connection->expects( $this->once() )
-			->method( 'select' )
-			->willReturn( [ (object)[ 'smw_id' => 42, 'smw_subobject' => '_foo', 'smw_touched' => '99999' ] ] );
+		$connection->method( 'addQuotes' )->willReturnCallback(
+			static fn ( $v ) => "'" . $v . "'"
+		);
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -20,6 +20,7 @@ use SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -33,6 +34,8 @@ use stdClass;
  * @author mwjames
  */
 class QueryDependencyLinksStoreTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $spyLogger;
@@ -224,17 +227,20 @@ class QueryDependencyLinksStoreTest extends TestCase {
 		$idTable->expects( $this->once() )
 			->method( 'getDataItemPoolHashListFor' );
 
+		$capturedWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ $row ], $capturedWheres );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				SQLStore::QUERY_LINKS_TABLE,
-				$this->anything(),
-				[ 'o_id' => [ 42 ] ] )
-			->willReturn( [ $row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$connection->method( 'addQuotes' )->willReturnCallback(
+			static fn ( $v ) => "'" . $v . "'"
+		);
 
 		$connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()
@@ -277,6 +283,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 		$requestOptions->setOffset( 200 );
 
 		$instance->findDependencyTargetLinks( [ 42 ], $requestOptions );
+
+		$this->assertSame( [ [ 'o_id' => [ 42 ] ] ], $capturedWheres );
 	}
 
 	public function testFindEmbeddedQueryTargetLinksHashListBySubject() {
@@ -290,17 +298,20 @@ class QueryDependencyLinksStoreTest extends TestCase {
 		$idTable->expects( $this->once() )
 			->method( 'getDataItemPoolHashListFor' );
 
+		$capturedWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ $row ], $capturedWheres );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				SQLStore::QUERY_LINKS_TABLE,
-				$this->anything(),
-				[ 'o_id' => [ 42 ] ] )
-			->willReturn( [ $row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$connection->method( 'addQuotes' )->willReturnCallback(
+			static fn ( $v ) => "'" . $v . "'"
+		);
 
 		$connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()
@@ -347,6 +358,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 		$requestOptions->setOffset( 200 );
 
 		$instance->findDependencyTargetLinksForSubject( WikiPage::newFromText( 'Foo' ), $requestOptions );
+
+		$this->assertSame( [ [ 'o_id' => [ 42 ] ] ], $capturedWheres );
 	}
 
 	public function testCountDependencies() {
@@ -361,17 +374,16 @@ class QueryDependencyLinksStoreTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$capturedWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ $row ], $capturedWheres );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				SQLStore::QUERY_LINKS_TABLE,
-				$this->anything(),
-				[ 'o_id' => [ 42 ] ] )
-			->willReturn( $row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -392,6 +404,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 		);
 
 		$instance->countDependencies( 42 );
+
+		$this->assertSame( [ [ 'o_id' => [ 42 ] ] ], $capturedWheres );
 	}
 
 	public function testTryDoUpdateDependenciesByWhileBeingDisabled() {
@@ -654,6 +668,9 @@ class QueryDependencyLinksStoreTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$connection->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
+
 		$connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -833,6 +850,12 @@ class QueryDependencyLinksStoreTest extends TestCase {
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		// isRegistered() only checks `$row !== false`, so returning any
+		// non-empty row preserves the "already registered, skip update"
+		// branch this test was originally exercising.
+		$connection->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( [ (object)[ 's_id' => 1 ] ] ) );
 
 		$connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()


### PR DESCRIPTION
## Summary

Migrates the QueryBuilder-eligible DML in `src/SQLStore/QueryDependency/` (13 callsites across 4 files) onto the SMW `Database` wrapper's `new*QueryBuilder()` factories. Mechanical, no behaviour change intended.

Files converted (one commit per file):

- `DependencyLinksTableUpdater.php` — 4 callsites (2× `delete`, `update`, `insert`)
- `QueryDependencyLinksStore.php` — 3 callsites (2× `selectRow`, `select` with `DISTINCT`/`LIMIT`/`OFFSET`)
- `DependencyLinksValidator.php` — 2 callsites (multi-join `select`, multi-join `selectRow`)
- `QueryLinksTableDisposer.php` — 4 callsites (2× join `select`, 2× `delete` — one inside an `onTransactionCommitOrIdle` closure)

Each converted chain ends with `->caller( __METHOD__ )`. Writes go through the SMW `Database` wrapper's factories so the existing `Muted*QueryBuilder` profiler-mute on `execute()` is preserved on both the eager and the deferred (`onTransactionCommitOrIdle`) write paths.

Tests are updated in lockstep using the existing `MockSelectQueryBuilderTrait` / `MockWriteQueryBuilderTrait` helpers, with captured-argument assertions in place of the legacy `with(...)` arg matchers. `QueryLinksTableDisposer` has no pre-existing Unit test and this PR does not add one (out of scope — the broader Unit suite check confirms no collection-level regression).

### Representative before / after

`DependencyLinksTableUpdater::updateDependencyList()`, the `update` callsite:

```php
// Before
$connection->update(
    SQLStore::ID_TABLE,
    [ 'smw_touched' => $connection->timestamp() ],
    [ 'smw_id' => $sid ],
    __METHOD__
);

// After
$connection->newUpdateQueryBuilder()
    ->update( SQLStore::ID_TABLE )
    ->set( [ 'smw_touched' => $connection->timestamp() ] )
    ->where( [ 'smw_id' => $sid ] )
    ->caller( __METHOD__ )
    ->execute();
```

`QueryDependencyLinksStore::findDependencyTargetLinks()`, the `select` with options-array `DISTINCT`/`LIMIT`/`OFFSET`:

```php
// Before — DISTINCT/LIMIT/OFFSET via the legacy options array
$options = [
    'LIMIT'  => $requestOptions->getLimit(),
    'OFFSET' => $requestOptions->getOffset(),
] + [ 'DISTINCT' ];

$rows = $connection->select(
    SQLStore::QUERY_LINKS_TABLE,
    [ 's_id' ],
    $conditions,
    __METHOD__,
    $options
);

// After
$rows = $connection->newSelectQueryBuilder()
    ->select( [ 's_id' ] )
    ->distinct()
    ->from( SQLStore::QUERY_LINKS_TABLE )
    ->where( $conditions )
    ->limit( $requestOptions->getLimit() )
    ->offset( $requestOptions->getOffset() )
    ->caller( __METHOD__ )
    ->fetchResultSet();
```

`DependencyLinksValidator::hasArchaicDependencies()`, the multi-join `select`:

```php
// Before
$rows = $connection->select(
    [ $proptables[$tableid]->getName(), "p" => SQLStore::ID_TABLE, "v" => SQLStore::ID_TABLE ],
    [ 'v.smw_id', 'v.smw_subobject', 'v.smw_touched' ],
    [
        'p.smw_hash' => $subject->getSha1(),
        'p.smw_iw!=' . $connection->addQuotes( SMW_SQL3_SMWIW_OUTDATED ),
        'p.smw_iw!=' . $connection->addQuotes( SMW_SQL3_SMWDELETEIW ),
    ],
    __METHOD__,
    [],
    [
        "p" => [ 'INNER JOIN', [ 's_id=p.smw_id' ] ],
        "v" => [ 'INNER JOIN', [ 'o_id=v.smw_id' ] ],
    ]
);

// After
$rows = $connection->newSelectQueryBuilder()
    ->select( [ 'v.smw_id', 'v.smw_subobject', 'v.smw_touched' ] )
    ->from( $proptables[$tableid]->getName() )
    ->join( SQLStore::ID_TABLE, 'p', [ 's_id=p.smw_id' ] )
    ->join( SQLStore::ID_TABLE, 'v', [ 'o_id=v.smw_id' ] )
    ->where( [
        'p.smw_hash' => $subject->getSha1(),
        'p.smw_iw!=' . $connection->addQuotes( SMW_SQL3_SMWIW_OUTDATED ),
        'p.smw_iw!=' . $connection->addQuotes( SMW_SQL3_SMWDELETEIW ),
    ] )
    ->caller( __METHOD__ )
    ->fetchResultSet();
```

The inline `addQuotes()` calls on the `p.smw_iw!=` predicates are intentionally retained — minimising semantic surface area for a mechanical conversion. Tightening the predicate style (move to ``$db->expr( 'p.smw_iw', '!=', ... )``) is for follow-up cleanup.

`QueryLinksTableDisposer::cleanUpTableEntriesById()`, the deferred-write inside `onTransactionCommitOrIdle`:

```php
// Before
return $this->connection->onTransactionCommitOrIdle( function () use ( $id, $fname ): void {
    $this->connection->delete(
        SQLStore::QUERY_LINKS_TABLE,
        [ 's_id' => $id ],
        $fname
    );
} );

// After
return $this->connection->onTransactionCommitOrIdle( function () use ( $id, $fname ): void {
    $this->connection->newDeleteQueryBuilder()
        ->deleteFrom( SQLStore::QUERY_LINKS_TABLE )
        ->where( [ 's_id' => $id ] )
        ->caller( $fname )
        ->execute();
} );
```

The `MutedDeleteQueryBuilder::execute()` plumbs ``muteTransactionProfiler()`` through to the underlying write, so the deferred path picks up the same profiler-mute behaviour as before with no extra wrapping.

## Test plan

- [x] ``composer analyze`` clean (PHP lint OK on 2117 files; PHPCS 0 errors / 0 warnings on the 16 changed files)
- [x] Filtered tests pass: ``DependencyLinksTableUpdaterTest`` (6 / 18), ``QueryDependencyLinksStoreTest`` (14 / 26), ``DependencyLinksValidatorTest`` (3 / 7), QueryDependency Unit subdir (45 / 95)
- [x] Broader Unit cross-impact suite green: ``Unit/SQLStore`` + ``Unit/MediaWiki`` + ``Unit/Elastic`` + ``Unit/Maintenance`` — 873 tests / 1797 assertions / 1 pre-existing skip (``PostgresTableBuilderTest::testDoCheckOnAfterCreate``, unrelated)
- [x] Local browser smoke against the dev wiki at ``localhost:8080`` (after ``runJobs.php --maxjobs=500`` drained the queue) with a temporarily-enabled ``\$smwgEnabledQueryDependencyLinksStore`` to actually exercise the conversion paths: ``Special:Browse``, ``Special:Ask``, ``Special:SearchByProperty`` and a saved page with an embedded ``#ask`` render without ``smw-error`` markers; saving the ``#ask``-bearing page writes rows into ``smw_query_links`` as expected; ``disposeOutdatedEntities.php`` runs end-to-end through the converted iterator/delete paths in ``QueryLinksTableDisposer`` against MySQL with no errors
- [ ] CI matrix green on MySQL + Postgres + SQLite (will verify before promoting from draft)