### PR TITLE
Convert SQLStore misc-singleton DML to QueryBuilder

### DIFF
--- a/src/SQLStore/ConceptCache.php
+++ b/src/SQLStore/ConceptCache.php
@@ -101,11 +101,11 @@ class ConceptCache {
 		}
 
 		// TODO: catch db exception
-		$db->delete(
-			SQLStore::CONCEPT_CACHE_TABLE,
-			[ 'o_id' => $cid ],
-			__METHOD__
-		);
+		$db->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::CONCEPT_CACHE_TABLE )
+			->where( [ 'o_id' => $cid ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$concCacheTableName = $db->tablename( SQLStore::CONCEPT_CACHE_TABLE );
 
@@ -133,12 +133,15 @@ class ConceptCache {
 			ISQLPlatform::QUERY_CHANGE_ROWS
 		);
 
-		$db->update(
-			'smw_fpt_conc',
-			[ 'cache_date' => strtotime( "now" ), 'cache_count' => $db->affectedRows() ],
-			[ 's_id' => $cid ],
-			__METHOD__
-		);
+		$db->newUpdateQueryBuilder()
+			->update( 'smw_fpt_conc' )
+			->set( [
+				'cache_date'  => strtotime( "now" ),
+				'cache_count' => $db->affectedRows(),
+			] )
+			->where( [ 's_id' => $cid ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		return [];
 	}
@@ -190,18 +193,18 @@ class ConceptCache {
 
 		$db = $this->store->getConnection();
 
-		$db->delete(
-			SQLStore::CONCEPT_CACHE_TABLE,
-			[ 'o_id' => $conceptId ],
-			__METHOD__
-		);
+		$db->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::CONCEPT_CACHE_TABLE )
+			->where( [ 'o_id' => $conceptId ] )
+			->caller( __METHOD__ )
+			->execute();
 
-		$db->update(
-			'smw_fpt_conc',
-			[ 'cache_date' => null, 'cache_count' => null ],
-			[ 's_id' => $conceptId ],
-			__METHOD__
-		);
+		$db->newUpdateQueryBuilder()
+			->update( 'smw_fpt_conc' )
+			->set( [ 'cache_date' => null, 'cache_count' => null ] )
+			->where( [ 's_id' => $conceptId ] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 	/**
@@ -222,12 +225,12 @@ class ConceptCache {
 
 		// TODO: catch db exception
 
-		$row = $db->selectRow(
-			'smw_fpt_conc',
-			[ 'concept_txt', 'concept_features', 'concept_size', 'concept_depth', 'cache_date', 'cache_count' ],
-			[ 's_id' => $cid ],
-			__METHOD__
-		);
+		$row = $db->newSelectQueryBuilder()
+			->select( [ 'concept_txt', 'concept_features', 'concept_size', 'concept_depth', 'cache_date', 'cache_count' ] )
+			->from( 'smw_fpt_conc' )
+			->where( [ 's_id' => $cid ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row === false ) {
 			return null;

--- a/src/SQLStore/PropertyStatisticsStore.php
+++ b/src/SQLStore/PropertyStatisticsStore.php
@@ -5,6 +5,7 @@ namespace SMW\SQLStore;
 use Psr\Log\LoggerAwareTrait;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\Exception\PropertyStatisticsInvalidArgumentException;
+use Wikimedia\Rdbms\IDatabase;
 
 /**
  * Simple implementation of PropertyStatisticsTable using MediaWikis
@@ -86,17 +87,15 @@ class PropertyStatisticsStore {
 			return true;
 		}
 
-		$this->connection->update(
-			SQLStore::PROPERTY_STATISTICS_TABLE,
-			[
+		$this->connection->newUpdateQueryBuilder()
+			->update( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->set( [
 				$this->safeIncrement( 'usage_count', $usageVal ),
-				$this->safeIncrement( 'null_count', $nullVal )
-			],
-			[
-				'p_id' => $pid
-			],
-			__METHOD__
-		);
+				$this->safeIncrement( 'null_count', $nullVal ),
+			] )
+			->where( [ 'p_id' => $pid ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		return true;
 	}
@@ -196,20 +195,21 @@ class PropertyStatisticsStore {
 			throw new PropertyStatisticsInvalidArgumentException( 'The property id to add must be a positive integer' );
 		}
 
-		$this->connection->upsert(
-			SQLStore::PROPERTY_STATISTICS_TABLE,
-			[
+		$this->connection->newInsertQueryBuilder()
+			->insertInto( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->row( [
 				'usage_count' => $usageCount,
-				'null_count' => $nullCount,
-				'p_id' => $propertyId,
-			],
-			[ [ 'p_id' ] ],
-			[
+				'null_count'  => $nullCount,
+				'p_id'        => $propertyId,
+			] )
+			->onDuplicateKeyUpdate()
+			->uniqueIndexFields( [ 'p_id' ] )
+			->set( [
 				'usage_count' => $usageCount,
-				'null_count' => $nullCount,
-			],
-			__METHOD__
-		);
+				'null_count'  => $nullCount,
+			] )
+			->caller( __METHOD__ )
+			->execute();
 
 		return true;
 	}
@@ -228,16 +228,12 @@ class PropertyStatisticsStore {
 			return 0;
 		}
 
-		$row = $this->connection->selectRow(
-			SQLStore::PROPERTY_STATISTICS_TABLE,
-			[
-				'usage_count'
-			],
-			[
-				'p_id' => $propertyId,
-			],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 'usage_count' ] )
+			->from( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->where( [ 'p_id' => $propertyId ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return $row !== false ? (int)$row->usage_count : 0;
 	}
@@ -262,17 +258,12 @@ class PropertyStatisticsStore {
 			return [];
 		}
 
-		$propertyStatistics = $this->connection->select(
-			SQLStore::PROPERTY_STATISTICS_TABLE,
-			[
-				'usage_count',
-				'p_id',
-			],
-			[
-				'p_id' => $propertyIds,
-			],
-			__METHOD__
-		);
+		$propertyStatistics = $this->connection->newSelectQueryBuilder()
+			->select( [ 'usage_count', 'p_id' ] )
+			->from( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->where( [ 'p_id' => $propertyIds ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		$usageCounts = [];
 
@@ -292,15 +283,13 @@ class PropertyStatisticsStore {
 	 * Deletes all rows in the table.
 	 *
 	 * @since 1.9
-	 *
-	 * @return bool Success indicator
 	 */
-	public function deleteAll() {
-		return $this->connection->delete(
-			SQLStore::PROPERTY_STATISTICS_TABLE,
-			'*',
-			__METHOD__
-		);
+	public function deleteAll(): void {
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::PROPERTY_STATISTICS_TABLE )
+			->where( IDatabase::ALL_ROWS )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 	private function log( string $message, array $context = [] ): void {

--- a/src/SQLStore/PropertyTypeFinder.php
+++ b/src/SQLStore/PropertyTypeFinder.php
@@ -49,14 +49,12 @@ class PropertyTypeFinder {
 			$type = 'http://semantic-mediawiki.org/swivt/1.0#' . $type;
 		}
 
-		$row = $this->connection->selectRow(
-			PropertyTableDefinitionBuilder::makeTableName( '_TYPE' ),
-			'COUNT(*) AS count',
-			[
-				'o_serialized' => $type
-			],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 'COUNT(*) AS count' ] )
+			->from( PropertyTableDefinitionBuilder::makeTableName( '_TYPE' ) )
+			->where( [ 'o_serialized' => $type ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return isset( $row->count ) ? (int)$row->count : 0;
 	}
@@ -71,19 +69,17 @@ class PropertyTypeFinder {
 	 */
 	public function findTypeID( Property $property ) {
 		try {
-			$row = $this->connection->selectRow(
-				SQLStore::ID_TABLE,
-				[
-					'smw_id'
-				],
-				[
+			$row = $this->connection->newSelectQueryBuilder()
+				->select( [ 'smw_id' ] )
+				->from( SQLStore::ID_TABLE )
+				->where( [
 					'smw_namespace' => SMW_NS_PROPERTY,
-					'smw_title' => $property->getKey(),
-					'smw_iw' => '',
-					'smw_subobject' => ''
-				],
-				__METHOD__
-			);
+					'smw_title'     => $property->getKey(),
+					'smw_iw'        => '',
+					'smw_subobject' => '',
+				] )
+				->caller( __METHOD__ )
+				->fetchRow();
 		} catch ( Exception ) {
 			$row = false;
 		}
@@ -103,16 +99,12 @@ class PropertyTypeFinder {
 		//
 		// We expect it to be a URI table with `o_serialized` containing the
 		// type string
-		$row = $this->connection->selectRow(
-			$this->typeTableName,
-			[
-				'o_serialized'
-			],
-			[
-				's_id' => $row->smw_id
-			],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 'o_serialized' ] )
+			->from( $this->typeTableName )
+			->where( [ 's_id' => $row->smw_id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row === false ) {
 			return $GLOBALS['smwgPDefaultType'];

--- a/src/SQLStore/Rebuilder/EntityValidator.php
+++ b/src/SQLStore/Rebuilder/EntityValidator.php
@@ -8,7 +8,7 @@ use SMW\NamespaceExaminer;
 use SMW\Query\Query;
 use SMW\SQLStore\SQLStore;
 use stdClass;
-use Wikimedia\Rdbms\ResultWrapper;
+use Wikimedia\Rdbms\IResultWrapper;
 
 /**
  * @private
@@ -244,30 +244,25 @@ class EntityValidator {
 	 *
 	 * @param stdClass $row
 	 *
-	 * @return ResultWrapper
+	 * @return IResultWrapper
 	 */
 	public function findDuplicates( $row ) {
 		$connection = $this->store->getConnection( 'mw.db' );
 
 		// Use the sortkey (comparing the label and not the "_..." key) in order
 		// to match possible duplicate properties by label (not by key)
-		$duplicates = $connection->select(
-			SQLStore::ID_TABLE,
-			[
-				'smw_id',
-				'smw_title'
-			],
-			[
+		$duplicates = $connection->newSelectQueryBuilder()
+			->select( [ 'smw_id', 'smw_title' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				"smw_id !=" . $connection->addQuotes( $row->smw_id ),
 				"smw_sortkey =" . $connection->addQuotes( $row->smw_sortkey ),
 				"smw_namespace =" . $row->smw_namespace,
-				"smw_subobject =" . $connection->addQuotes( $row->smw_subobject )
-			],
-			__METHOD__,
-			[
-				'ORDER BY' => "smw_id ASC"
-			]
-		);
+				"smw_subobject =" . $connection->addQuotes( $row->smw_subobject ),
+			] )
+			->orderBy( 'smw_id', 'ASC' )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		return $duplicates;
 	}

--- a/src/SQLStore/Rebuilder/Rebuilder.php
+++ b/src/SQLStore/Rebuilder/Rebuilder.php
@@ -120,19 +120,17 @@ class Rebuilder {
 	public function getMaxId(): int {
 		$db = $this->store->getConnection( 'mw.db' );
 
-		$maxByPageId = (int)$db->selectField(
-			'page',
-			'MAX(page_id)',
-			'',
-			__METHOD__
-		);
+		$maxByPageId = (int)$db->newSelectQueryBuilder()
+			->select( [ 'MAX(page_id)' ] )
+			->from( 'page' )
+			->caller( __METHOD__ )
+			->fetchField();
 
-		$maxBySmwId = (int)$db->selectField(
-			SQLStore::ID_TABLE,
-			'MAX(smw_id)',
-			'',
-			__METHOD__
-		);
+		$maxBySmwId = (int)$db->newSelectQueryBuilder()
+			->select( [ 'MAX(smw_id)' ] )
+			->from( SQLStore::ID_TABLE )
+			->caller( __METHOD__ )
+			->fetchField();
 
 		return max( $maxByPageId, $maxBySmwId );
 	}
@@ -238,9 +236,8 @@ class Rebuilder {
 		// MWCallableUpdate::doUpdate: transaction round 'SMW\MediaWiki\Jobs\RefreshJob::run' already started"
 		$this->propertyTableIdReferenceDisposer->waitOnTransactionIdle();
 
-		$res = $connection->select(
-			SQLStore::ID_TABLE,
-			[
+		$res = $connection->newSelectQueryBuilder()
+			->select( [
 				'smw_id',
 				'smw_title',
 				'smw_namespace',
@@ -248,14 +245,15 @@ class Rebuilder {
 				'smw_subobject',
 				'smw_sortkey',
 				'smw_proptable_hash',
-				'smw_rev'
-			],
-			[
+				'smw_rev',
+			] )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				"smw_id >= $id ",
-				" smw_id < " . $connection->addQuotes( $id + $this->iterationLimit )
-			],
-			__METHOD__
-		);
+				" smw_id < " . $connection->addQuotes( $id + $this->iterationLimit ),
+			] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		foreach ( $res as $row ) {
 
@@ -400,25 +398,21 @@ class Rebuilder {
 		// nothing found, check if there will be more pages later on
 		if ( $emptyRange && $nextPosition > SQLStore::FIXED_PROPERTY_ID_UPPERBOUND ) {
 
-			$nextByPageId = (int)$db->selectField(
-				'page',
-				'page_id',
-				"page_id >= $nextPosition",
-				__METHOD__,
-				[
-					'ORDER BY' => "page_id ASC"
-				]
-			);
+			$nextByPageId = (int)$db->newSelectQueryBuilder()
+				->select( [ 'page_id' ] )
+				->from( 'page' )
+				->where( [ "page_id >= $nextPosition" ] )
+				->orderBy( 'page_id', 'ASC' )
+				->caller( __METHOD__ )
+				->fetchField();
 
-			$nextBySmwId = (int)$db->selectField(
-				SQLStore::ID_TABLE,
-				'smw_id',
-				"smw_id >= $nextPosition",
-				__METHOD__,
-				[
-					'ORDER BY' => "smw_id ASC"
-				]
-			);
+			$nextBySmwId = (int)$db->newSelectQueryBuilder()
+				->select( [ 'smw_id' ] )
+				->from( SQLStore::ID_TABLE )
+				->where( [ "smw_id >= $nextPosition" ] )
+				->orderBy( 'smw_id', 'ASC' )
+				->caller( __METHOD__ )
+				->fetchField();
 
 			// Next position is determined by the pool with the maxId
 			$nextPosition = $nextBySmwId != 0 && $nextBySmwId > $nextByPageId ? $nextBySmwId : $nextByPageId;

--- a/src/SQLStore/RedirectStore.php
+++ b/src/SQLStore/RedirectStore.php
@@ -232,15 +232,12 @@ class RedirectStore {
 	private function select( $title, $namespace ): int {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$row = $connection->selectRow(
-			self::TABLE_NAME,
-			'o_id',
-			[
-				's_title' => $title,
-				's_namespace' => $namespace
-			],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'o_id' ] )
+			->from( self::TABLE_NAME )
+			->where( [ 's_title' => $title, 's_namespace' => $namespace ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return $row !== false && isset( $row->o_id ) ? (int)$row->o_id : 0;
 	}
@@ -248,18 +245,12 @@ class RedirectStore {
 	private function insert( $id, $title, $namespace ): void {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$row = $connection->selectRow(
-			self::TABLE_NAME,
-			[
-				'o_id'
-			],
-			[
-				's_title' => $title,
-				's_namespace' => $namespace,
-				'o_id' => $id
-			],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'o_id' ] )
+			->from( self::TABLE_NAME )
+			->where( [ 's_title' => $title, 's_namespace' => $namespace, 'o_id' => $id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		// Found a match, avoid duplicates!
 		if ( $row !== false ) {
@@ -269,27 +260,25 @@ class RedirectStore {
 		// Only allow one active redirection from source to target
 		$this->delete( $title, $namespace );
 
-		$connection->insert(
-			self::TABLE_NAME,
-			[
-				's_title' => $title,
+		$connection->newInsertQueryBuilder()
+			->insertInto( self::TABLE_NAME )
+			->row( [
+				's_title'     => $title,
 				's_namespace' => $namespace,
-				'o_id' => $id
-			],
-			__METHOD__
-		);
+				'o_id'        => $id,
+			] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 	private function delete( $title, $namespace ): void {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$connection->delete(
-			self::TABLE_NAME,
-			[
-				's_title' => $title,
-				's_namespace' => $namespace ],
-			__METHOD__
-		);
+		$connection->newDeleteQueryBuilder()
+			->deleteFrom( self::TABLE_NAME )
+			->where( [ 's_title' => $title, 's_namespace' => $namespace ] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 	private function canCreateUpdateJobs(): bool {
@@ -297,14 +286,21 @@ class RedirectStore {
 	}
 
 	private function findUpdateJobs( $connection, array $query, &$jobs ): void {
-		$res = $connection->select(
-			$query['from'],
-			$query['fields'],
-			$query['condition'],
-			__METHOD__,
-			$query['options'],
-			$query['join']
-		);
+		$queryBuilder = $connection->newSelectQueryBuilder()
+			->select( $query['fields'] )
+			->from( $query['from'][0] )
+			->where( $query['condition'] )
+			->caller( __METHOD__ );
+
+		if ( in_array( SQLStore::ID_TABLE, $query['from'], true ) ) {
+			$queryBuilder->join( SQLStore::ID_TABLE, null, [ 's_id=smw_id' ] );
+		}
+
+		if ( in_array( 'DISTINCT', $query['options'], true ) ) {
+			$queryBuilder->distinct();
+		}
+
+		$res = $queryBuilder->fetchResultSet();
 
 		$titleFactory = MediaWikiServices::getInstance()->getTitleFactory();
 		foreach ( $res as $row ) {

--- a/src/SQLStore/RedirectUpdater.php
+++ b/src/SQLStore/RedirectUpdater.php
@@ -11,7 +11,6 @@ use SMW\SQLStore\EntityStore\CachingSemanticDataLookup;
 use SMW\SQLStore\EntityStore\IdChanger;
 use SMW\Store;
 use SMW\Utils\Flag;
-use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
  * @license GPL-2.0-or-later
@@ -442,20 +441,20 @@ class RedirectUpdater {
 		// does too much; fall back to general case below.
 		if ( $sid != 0 ) { // change id entry to refer to the new title
 			// Note that this also changes the reference for internal objects (subobjects)
-			$connection->update(
-				SQLStore::ID_TABLE,
-				[
+			$connection->newUpdateQueryBuilder()
+				->update( SQLStore::ID_TABLE )
+				->set( [
 					'smw_title' => $target->getDBkey(),
 					'smw_namespace' => $target->getNamespace(),
-					'smw_iw' => ''
-				],
-				[
+					'smw_iw' => '',
+				] )
+				->where( [
 					'smw_title' => $source->getDBkey(),
 					'smw_namespace' => $source->getNamespace(),
-					'smw_iw' => ''
-				],
-				__METHOD__
-			);
+					'smw_iw' => '',
+				] )
+				->caller( __METHOD__ )
+				->execute();
 
 			$this->moveSubobjects(
 				$source->getDBkey(),
@@ -539,21 +538,21 @@ class RedirectUpdater {
 		}
 
 		// Associate internal objects (subobjects) with the new title:
-		$table = $connection->tableName( SQLStore::ID_TABLE );
-
-		$values = [
-			'smw_title' => $target->getDBkey(),
-			'smw_namespace' => $target->getNamespace(),
-			'smw_iw' => ''
-		];
-
-		$sql = "UPDATE $table SET " . $connection->makeList( $values, LIST_SET ) .
-			' WHERE smw_title = ' . $connection->addQuotes( $source->getDBkey() ) . ' AND ' .
-			'smw_namespace = ' . $connection->addQuotes( $source->getNamespace() ) . ' AND ' .
-			'smw_iw = ' . $connection->addQuotes( '' ) . ' AND ' .
-			'smw_subobject != ' . $connection->addQuotes( '' ); // The "!=" is why we cannot use MW array syntax here
-
-		$connection->query( $sql, __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( [
+				'smw_title' => $target->getDBkey(),
+				'smw_namespace' => $target->getNamespace(),
+				'smw_iw' => '',
+			] )
+			->where( [
+				'smw_title' => $source->getDBkey(),
+				'smw_namespace' => $source->getNamespace(),
+				'smw_iw' => '',
+				$connection->expr( 'smw_subobject', '!=', '' ),
+			] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$this->moveSubobjects(
 			$source->getDBkey(),

--- a/src/SQLStore/SQLStoreUpdater.php
+++ b/src/SQLStore/SQLStoreUpdater.php
@@ -135,17 +135,17 @@ class SQLStoreUpdater {
 		if ( $subject->getNamespace() === SMW_NS_CONCEPT ) { // make sure to clear caches
 			$db = $this->store->getConnection();
 
-			$db->delete(
-				SQLStore::CONCEPT_TABLE,
-				[ 's_id' => $id ],
-				'SMW::deleteSubject::Conc'
-			);
+			$db->newDeleteQueryBuilder()
+				->deleteFrom( SQLStore::CONCEPT_TABLE )
+				->where( [ 's_id' => $id ] )
+				->caller( 'SMW::deleteSubject::Conc' )
+				->execute();
 
-			$db->delete(
-				SQLStore::CONCEPT_CACHE_TABLE,
-				[ 'o_id' => $id ],
-				'SMW::deleteSubject::Conccache'
-			);
+			$db->newDeleteQueryBuilder()
+				->deleteFrom( SQLStore::CONCEPT_CACHE_TABLE )
+				->where( [ 'o_id' => $id ] )
+				->caller( 'SMW::deleteSubject::Conccache' )
+				->execute();
 		}
 
 		$subject->setId( $id );

--- a/src/SQLStore/TableFieldUpdater.php
+++ b/src/SQLStore/TableFieldUpdater.php
@@ -33,14 +33,14 @@ class TableFieldUpdater {
 		$connection = $this->store->getConnection( 'mw.db' );
 		$connection->beginAtomicTransaction( __METHOD__ );
 
-		$connection->update(
-			SQLStore::ID_TABLE,
-			[
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( [
 				'smw_touched' => $connection->timestamp( $tz )
-			],
-			[ 'smw_id' => $id ],
-			__METHOD__
-		);
+			] )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$connection->endAtomicTransaction( __METHOD__ );
 	}
@@ -61,16 +61,16 @@ class TableFieldUpdater {
 		$connection = $this->store->getConnection( 'mw.db' );
 		$connection->beginAtomicTransaction( __METHOD__ );
 
-		$connection->update(
-			SQLStore::ID_TABLE,
-			[
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( [
 				'smw_sortkey' => mb_strcut( $searchKey, 0, 255 ),
 				'smw_sort'    => substr( $this->collator->getSortKey( $searchKey ), 0, 255 ),
 				'smw_touched' => $connection->timestamp()
-			],
-			[ 'smw_id' => $id ],
-			__METHOD__
-		);
+			] )
+			->where( [ 'smw_id' => $id ] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$connection->endAtomicTransaction( __METHOD__ );
 	}
@@ -86,17 +86,17 @@ class TableFieldUpdater {
 	public function updateRevField( $sid, $rev_id ): void {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$connection->update(
-			SQLStore::ID_TABLE,
-			[
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( [
 				'smw_rev' => $rev_id,
 				'smw_touched' => $connection->timestamp()
-			],
-			[
+			] )
+			->where( [
 				'smw_id' => $sid
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 	/**
@@ -111,17 +111,17 @@ class TableFieldUpdater {
 	public function updateIwField( $sid, $iw, $hash ): void {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$connection->update(
-			SQLStore::ID_TABLE,
-			[
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( [
 				'smw_iw' => $iw,
 				'smw_hash' => $hash
-			],
-			[
+			] )
+			->where( [
 				'smw_id' => $sid
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 }

--- a/tests/phpunit/Integration/SQLStore/PropertyStatisticsStoreTest.php
+++ b/tests/phpunit/Integration/SQLStore/PropertyStatisticsStoreTest.php
@@ -7,6 +7,7 @@ use SMW\SQLStore\Exception\PropertyStatisticsInvalidArgumentException;
 use SMW\SQLStore\PropertyStatisticsStore;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\SMWIntegrationTestCase;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\PropertyStatisticsStore
@@ -21,6 +22,8 @@ use SMW\Tests\SMWIntegrationTestCase;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class PropertyStatisticsStoreTest extends SMWIntegrationTestCase {
+
+	use MockWriteQueryBuilderTrait;
 
 	protected $statsTable = null;
 
@@ -194,7 +197,8 @@ class PropertyStatisticsStoreTest extends SMWIntegrationTestCase {
 			);
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'update' );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockUpdateQueryBuilder() );
 
 		$instance = new PropertyStatisticsStore(
 			$connection
@@ -220,7 +224,8 @@ class PropertyStatisticsStoreTest extends SMWIntegrationTestCase {
 			->method( 'onTransactionCommitOrIdle' );
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'update' );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockUpdateQueryBuilder() );
 
 		$instance = new PropertyStatisticsStore(
 			$connection
@@ -239,34 +244,59 @@ class PropertyStatisticsStoreTest extends SMWIntegrationTestCase {
 	}
 
 	public function testUpsertWithInsertUsageCountWithArrayValue() {
-		$tableName = 'Foo';
+		$capturedTables = [];
+		$capturedRows = [];
+		$capturedSets = [];
+		$capturedUniqueIndexFields = [];
+
+		$insertBuilder = $this->createMockInsertQueryBuilder(
+			$capturedTables,
+			$capturedRows,
+			$capturedSets,
+			$capturedUniqueIndexFields
+		);
 
 		$connection = $this->createMock( Database::class );
-
 		$connection->expects( $this->once() )
-			->method( 'upsert' )
-			->with(
-				$this->stringContains( SQLStore::PROPERTY_STATISTICS_TABLE ),
-				[
-					'usage_count' => 1,
-					'null_count'  => 9999,
-					'p_id' => 42
-				],
-				[ [ 'p_id' ] ],
-				[
-					'usage_count' => 1,
-					'null_count' => 9999,
-				],
-				$this->anything() );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$instance = new PropertyStatisticsStore(
 			$connection
 		);
 
 		$instance->insertUsageCount( 42, [ 1, 9999 ] );
+
+		$this->assertSame( [ SQLStore::PROPERTY_STATISTICS_TABLE ], $capturedTables );
+		$this->assertSame(
+			[ [
+				'usage_count' => 1,
+				'null_count'  => 9999,
+				'p_id'        => 42,
+			] ],
+			$capturedRows
+		);
+		$this->assertSame( [ [ 'p_id' ] ], $capturedUniqueIndexFields );
+		$this->assertSame(
+			[ [
+				'usage_count' => 1,
+				'null_count'  => 9999,
+			] ],
+			$capturedSets
+		);
 	}
 
 	public function testAddToUsageCountsWithArrayValue() {
+		$capturedTables = [];
+		$capturedSets = [];
+		$capturedWheres = [];
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder(
+			$capturedTables,
+			$capturedSets,
+			$capturedWheres
+		);
+
 		$connection = $this->createMock( Database::class );
 
 		$connection->expects( $this->any() )
@@ -274,50 +304,66 @@ class PropertyStatisticsStoreTest extends SMWIntegrationTestCase {
 			->willReturnArgument( 0 );
 
 		$connection->expects( $this->once() )
-			->method( 'update' )
-			->with(
-				$this->stringContains( SQLStore::PROPERTY_STATISTICS_TABLE ),
-				$this->equalTo(
-					[
-						'usage_count = usage_count + 1',
-						'null_count = null_count + 9999'
-					] ),
-				[
-					'p_id' => 42
-				],
-				$this->anything() );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$instance = new PropertyStatisticsStore(
 			$connection
 		);
 
 		$instance->addToUsageCounts( [ 42 => [ 'usage' => 1, 'null' => 9999 ] ] );
+
+		$this->assertSame( [ SQLStore::PROPERTY_STATISTICS_TABLE ], $capturedTables );
+		$this->assertSame(
+			[ [
+				'usage_count = usage_count + 1',
+				'null_count = null_count + 9999',
+			] ],
+			$capturedSets
+		);
+		$this->assertSame( [ [ 'p_id' => 42 ] ], $capturedWheres );
 	}
 
 	public function testUpsertOnInsertUsageCount() {
-		$connection = $this->createMock( Database::class );
+		$capturedTables = [];
+		$capturedRows = [];
+		$capturedSets = [];
+		$capturedUniqueIndexFields = [];
 
+		$insertBuilder = $this->createMockInsertQueryBuilder(
+			$capturedTables,
+			$capturedRows,
+			$capturedSets,
+			$capturedUniqueIndexFields
+		);
+
+		$connection = $this->createMock( Database::class );
 		$connection->expects( $this->once() )
-			->method( 'upsert' )
-			->with(
-				$this->stringContains( SQLStore::PROPERTY_STATISTICS_TABLE ),
-				$this->equalTo(
-					[
-						'usage_count' => 12,
-						'null_count' => 0,
-						'p_id' => 42
-					] ),
-				[ [ 'p_id' ] ],
-				[
-					'usage_count' => 12,
-					'null_count' => 0,
-				],
-				$this->anything() );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$instance = new PropertyStatisticsStore(
 			$connection
 		);
 
 		$instance->insertUsageCount( 42, 12 );
+
+		$this->assertSame( [ SQLStore::PROPERTY_STATISTICS_TABLE ], $capturedTables );
+		$this->assertSame(
+			[ [
+				'usage_count' => 12,
+				'null_count'  => 0,
+				'p_id'        => 42,
+			] ],
+			$capturedRows
+		);
+		$this->assertSame( [ [ 'p_id' ] ], $capturedUniqueIndexFields );
+		$this->assertSame(
+			[ [
+				'usage_count' => 12,
+				'null_count'  => 0,
+			] ],
+			$capturedSets
+		);
 	}
 }

--- a/tests/phpunit/Unit/MediaWiki/Jobs/PropertyStatisticsRebuildJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/PropertyStatisticsRebuildJobTest.php
@@ -9,6 +9,7 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\Jobs\PropertyStatisticsRebuildJob;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
 use Wikimedia\Rdbms\FakeResultWrapper;
 
@@ -22,6 +23,8 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  * @author mwjames
  */
 class PropertyStatisticsRebuildJobTest extends TestCase {
+
+	use MockWriteQueryBuilderTrait;
 
 	private $testEnvironment;
 
@@ -41,6 +44,14 @@ class PropertyStatisticsRebuildJobTest extends TestCase {
 		$connection->expects( $this->any() )
 			->method( 'select' )
 			->willReturn( new FakeResultWrapper( [ $row ] ) );
+
+		// PropertyStatisticsRebuilder::rebuild() calls deleteAll() and
+		// insertUsageCount() on PropertyStatisticsStore, which now route
+		// through newDeleteQueryBuilder() and newInsertQueryBuilder().
+		$connection->method( 'newDeleteQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockDeleteQueryBuilder() );
+		$connection->method( 'newInsertQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockInsertQueryBuilder() );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/ConceptCacheTest.php
+++ b/tests/phpunit/Unit/SQLStore/ConceptCacheTest.php
@@ -9,6 +9,8 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\ConceptCache;
 use SMW\SQLStore\QueryEngine\ConceptQuerySegmentBuilder;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\ConceptCache
@@ -20,6 +22,9 @@ use SMW\SQLStore\SQLStore;
  * @author mwjames
  */
 class ConceptCacheTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $store;
 	private $conceptQuerySegmentBuilder;
@@ -59,16 +64,31 @@ class ConceptCacheTest extends TestCase {
 	}
 
 	public function testDeleteConceptCache() {
+		$capturedDeleteTables = [];
+		$capturedDeleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder(
+			$capturedDeleteTables,
+			$capturedDeleteWheres
+		);
+
+		$capturedUpdateTables = [];
+		$capturedUpdateSets = [];
+		$capturedUpdateWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder(
+			$capturedUpdateTables,
+			$capturedUpdateSets,
+			$capturedUpdateWheres
+		);
+
+		$selectBuilder = $this->createMockSelectQueryBuilder( [] );
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( false );
-
-		$connection->expects( $this->once() )
-			->method( 'delete' );
+		$connection->method( 'newDeleteQueryBuilder' )->willReturn( $deleteBuilder );
+		$connection->method( 'newUpdateQueryBuilder' )->willReturn( $updateBuilder );
+		$connection->method( 'newSelectQueryBuilder' )->willReturn( $selectBuilder );
 
 		$connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()
@@ -88,6 +108,13 @@ class ConceptCacheTest extends TestCase {
 
 		$instance->deleteConceptCache(
 			Title::newFromText( 'Foo', SMW_NS_CONCEPT )
+		);
+
+		$this->assertSame( [ SQLStore::CONCEPT_CACHE_TABLE ], $capturedDeleteTables );
+		$this->assertSame( [ 'smw_fpt_conc' ], $capturedUpdateTables );
+		$this->assertSame(
+			[ [ 'cache_date' => null, 'cache_count' => null ] ],
+			$capturedUpdateSets
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
@@ -178,6 +178,18 @@ class EntityIdManagerTest extends TestCase {
 	public function testRedirectInfoRoundtrip() {
 		$subject = new WikiPage( 'Foo', 9001 );
 
+		// This test exercises real RedirectStore (via EntityIdManager), so
+		// the converted RedirectStore::select()/insert()/delete() chains need
+		// chainable mock builders to avoid NPEing on `null->from(...)` etc.
+		// Returned rows are empty — RedirectStore's cache fronts the DB after
+		// addRedirect(), so the assertions don't depend on DB row content.
+		$this->connection->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
+		$this->connection->method( 'newInsertQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockInsertQueryBuilder() );
+		$this->connection->method( 'newDeleteQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockDeleteQueryBuilder() );
+
 		$instance = new EntityIdManager(
 			$this->store,
 			$this->factory

--- a/tests/phpunit/Unit/SQLStore/PropertyTypeFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTypeFinderTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Unit\SQLStore;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\PropertyTypeFinder;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -17,6 +18,8 @@ use stdClass;
  * @author mwjames
  */
 class PropertyTypeFinderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $connection;
 
@@ -39,13 +42,12 @@ class PropertyTypeFinderTest extends TestCase {
 		$row = new stdClass;
 		$row->count = 42;
 
+		$whereConditions = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				'smw_fpt_type',
-				$this->anything(),
-				[ 'o_serialized' => 'http://semantic-mediawiki.org/swivt/1.0#_txt' ] )
-			->willReturn( $row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new PropertyTypeFinder(
 			$this->connection
@@ -54,6 +56,11 @@ class PropertyTypeFinderTest extends TestCase {
 		$this->assertEquals(
 			42,
 			$instance->countByType( '_txt' )
+		);
+
+		$this->assertSame(
+			[ [ 'o_serialized' => 'http://semantic-mediawiki.org/swivt/1.0#_txt' ] ],
+			$whereConditions
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/Rebuilder/EntityValidatorTest.php
+++ b/tests/phpunit/Unit/SQLStore/Rebuilder/EntityValidatorTest.php
@@ -10,6 +10,9 @@ use SMW\SQLStore\Rebuilder\EntityValidator;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\IResultWrapper;
 
 /**
  * @covers \SMW\SQLStore\Rebuilder\EntityValidator
@@ -21,6 +24,8 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class EntityValidatorTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $testEnvironment;
 	private NamespaceExaminer $namespaceExaminer;
@@ -191,6 +196,49 @@ class EntityValidatorTest extends TestCase {
 			$expected,
 			$instance->isRetiredProperty( $row )
 		);
+	}
+
+	public function testFindDuplicates() {
+		$expectedRows = [
+			(object)[ 'smw_id' => 42, 'smw_title' => 'Foo' ],
+		];
+
+		$connection = $this->getMockBuilder( IDatabase::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'addQuotes' )
+			->willReturnCallback( static fn ( $v ) => "'" . $v . "'" );
+
+		$connection->expects( $this->once() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $this->createMockSelectQueryBuilder( $expectedRows ) );
+
+		$store = $this->getMockBuilder( SQLStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getConnection' )
+			->with( 'mw.db' )
+			->willReturn( $connection );
+
+		$instance = new EntityValidator(
+			$store,
+			$this->namespaceExaminer
+		);
+
+		$row = (object)[
+			'smw_id' => 1,
+			'smw_sortkey' => 'Foo',
+			'smw_namespace' => SMW_NS_PROPERTY,
+			'smw_subobject' => '',
+		];
+
+		$result = $instance->findDuplicates( $row );
+
+		$this->assertInstanceOf( IResultWrapper::class, $result );
 	}
 
 	public function propertyRetiredListProvider() {

--- a/tests/phpunit/Unit/SQLStore/Rebuilder/RebuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/Rebuilder/RebuilderTest.php
@@ -13,6 +13,7 @@ use SMW\SQLStore\Rebuilder\Rebuilder;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\Rebuilder\Rebuilder
@@ -24,6 +25,8 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class RebuilderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $titleFactory;
@@ -112,13 +115,18 @@ class RebuilderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		// matchAsSubject() (the first newSelectQueryBuilder() call) needs
+		// fetchResultSet() to iterate empty so emptyRange stays true. The
+		// remaining callsites in next_position() and getMaxId() use
+		// fetchField() and must return $expected.
+		$callIndex = 0;
 		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [] );
-
-		$connection->expects( $this->any() )
-			->method( 'selectField' )
-			->willReturn( $expected );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( function () use ( $expected, &$callIndex ) {
+				$rows = $callIndex === 0 ? [] : [ [ $expected ] ];
+				$callIndex++;
+				return $this->createMockSelectQueryBuilder( $rows );
+			} );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -196,13 +204,17 @@ class RebuilderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		// matchAsSubject() (the first newSelectQueryBuilder() call) feeds the
+		// row into fetchResultSet(); subsequent getMaxId() callsites use
+		// fetchField() and must return 500.
+		$callIndex = 0;
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( [ (object)$row ] );
-
-		$connection->expects( $this->any() )
-			->method( 'selectField' )
-			->willReturn( 500 );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( function () use ( $row, &$callIndex ) {
+				$rows = $callIndex === 0 ? [ (object)$row ] : [ [ 500 ] ];
+				$callIndex++;
+				return $this->createMockSelectQueryBuilder( $rows );
+			} );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/RedirectStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/RedirectStoreTest.php
@@ -14,8 +14,9 @@ use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder\FieldType;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
-use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
  * @covers \SMW\SQLStore\RedirectStore
@@ -28,6 +29,9 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  * @author mwjames
  */
 class RedirectStoreTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $store;
 	private Database $connection;
@@ -87,15 +91,12 @@ class RedirectStoreTest extends TestCase {
 		$row = new stdClass;
 		$row->o_id = 42;
 
+		$capturedWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ $row ], $capturedWheres );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				$this->equalTo( [
-					's_title' => 'Foo',
-					's_namespace' => 0 ] ) )
-			->willReturn( $row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new RedirectStore(
 			$this->store
@@ -104,6 +105,11 @@ class RedirectStoreTest extends TestCase {
 		$this->assertEquals(
 			42,
 			$instance->findRedirect( 'Foo', 0 )
+		);
+
+		$this->assertSame(
+			[ [ 's_title' => 'Foo', 's_namespace' => 0 ] ],
+			$capturedWheres
 		);
 
 		$stats = InMemoryPoolCache::getInstance()->getStats();
@@ -124,15 +130,12 @@ class RedirectStoreTest extends TestCase {
 	}
 
 	public function testFindRedirectIdForNonCachedNonRedirect() {
+		$capturedWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [], $capturedWheres );
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				$this->equalTo( [
-					's_title' => 'Foo',
-					's_namespace' => 0 ] ) )
-			->willReturn( false );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new RedirectStore(
 			$this->store
@@ -142,27 +145,68 @@ class RedirectStoreTest extends TestCase {
 			0,
 			$instance->findRedirect( 'Foo', 0 )
 		);
+
+		$this->assertSame(
+			[ [ 's_title' => 'Foo', 's_namespace' => 0 ] ],
+			$capturedWheres
+		);
 	}
 
 	public function testAddRedirectInfoRecordToFetchFromCache() {
-		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( false );
+		// insert() does a selectRow duplicate-check (returns false)
+		$capturedSelectWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [], $capturedSelectWheres );
+
+		$capturedDeleteTables = [];
+		$capturedDeleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder(
+			$capturedDeleteTables,
+			$capturedDeleteWheres
+		);
+
+		$capturedInsertTables = [];
+		$capturedInsertRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder(
+			$capturedInsertTables,
+			$capturedInsertRows
+		);
 
 		$this->connection->expects( $this->once() )
-			->method( 'insert' )
-			->with(
-				$this->anything(),
-				$this->equalTo( [
-					's_title' => 'Foo',
-					's_namespace' => 0,
-					'o_id' => 42 ] ) );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$this->connection->expects( $this->once() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$this->connection->expects( $this->once() )
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$instance = new RedirectStore(
 			$this->store
 		);
 
 		$instance->addRedirect( 42, 'Foo', 0 );
+
+		$this->assertSame(
+			[ [ 's_title' => 'Foo', 's_namespace' => 0, 'o_id' => 42 ] ],
+			$capturedSelectWheres
+		);
+
+		$this->assertSame(
+			[ [ 's_title' => 'Foo', 's_namespace' => 0 ] ],
+			$capturedDeleteWheres
+		);
+
+		$this->assertSame(
+			[ [
+				's_title' => 'Foo',
+				's_namespace' => 0,
+				'o_id' => 42,
+			] ],
+			$capturedInsertRows
+		);
 
 		$this->assertEquals(
 			42,
@@ -171,19 +215,37 @@ class RedirectStoreTest extends TestCase {
 	}
 
 	public function testDeleteRedirectInfoRecord() {
+		$capturedDeleteTables = [];
+		$capturedDeleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder(
+			$capturedDeleteTables,
+			$capturedDeleteWheres
+		);
+
+		// findRedirect() after delete() will go to select() (cache was cleared)
+		$selectBuilder = $this->createMockSelectQueryBuilder( [] );
+
 		$this->connection->expects( $this->once() )
-			->method( 'delete' )
-			->with(
-				$this->anything(),
-				$this->equalTo( [
-					's_title' => 'Foo',
-					's_namespace' => 9001 ] ) );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$this->connection->expects( $this->once() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new RedirectStore(
 			$this->store
 		);
 
 		$instance->deleteRedirect( 'Foo', 9001 );
+
+		$this->assertSame(
+			[ [
+				's_title' => 'Foo',
+				's_namespace' => 9001,
+			] ],
+			$capturedDeleteWheres
+		);
 
 		$this->assertSame(
 			0,
@@ -196,13 +258,19 @@ class RedirectStoreTest extends TestCase {
 		$row->ns = NS_MAIN;
 		$row->t = 'Bar';
 
+		// delete() in deleteRedirect() uses newDeleteQueryBuilder()
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+
+		// findUpdateJobs() uses newSelectQueryBuilder()->fetchResultSet()
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ $row ] );
+
 		$this->connection->expects( $this->once() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				[ 'Foo' => 42 ] )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$this->connection->expects( $this->once() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$propertyTable = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()
@@ -264,9 +332,16 @@ class RedirectStoreTest extends TestCase {
 		$row->ns = NS_MAIN;
 		$row->t = 'Bar';
 
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ $row ] );
+
 		$this->connection->expects( $this->once() )
-			->method( 'select' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$this->connection->expects( $this->once() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$propertyTable = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/RedirectUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/RedirectUpdaterTest.php
@@ -17,6 +17,8 @@ use SMW\SQLStore\RedirectUpdater;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableFieldUpdater;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\RedirectUpdater
@@ -28,6 +30,9 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class RedirectUpdaterTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $store;
 	private $tableFieldUpdater;
@@ -166,9 +171,18 @@ class RedirectUpdaterTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$capturedTables = [];
+		$capturedSets = [];
+		$capturedWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder(
+			$capturedTables,
+			$capturedSets,
+			$capturedWheres
+		);
+
 		$connection->expects( $this->once() )
-			->method( 'query' )
-			->willReturn( true );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$propertyTableInfoFetcher = $this->getMockBuilder( PropertyTableInfoFetcher::class )
 			->disableOriginalConstructor()
@@ -210,6 +224,11 @@ class RedirectUpdaterTest extends TestCase {
 			WikiPage::newFromText( __METHOD__ . '-new', NS_MAIN ),
 			[ 'page_id' => 9999, 'redirect_id' => 0 ]
 		);
+
+		$this->assertSame(
+			[ SQLStore::ID_TABLE ],
+			$capturedTables
+		);
 	}
 
 	public function testChangeTitleForMainNamespaceWithRedirectId() {
@@ -229,9 +248,18 @@ class RedirectUpdaterTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$capturedTables = [];
+		$capturedSets = [];
+		$capturedWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder(
+			$capturedTables,
+			$capturedSets,
+			$capturedWheres
+		);
+
 		$database->expects( $this->once() )
-			->method( 'query' )
-			->willReturn( true );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$propertyTableInfoFetcher = $this->getMockBuilder( PropertyTableInfoFetcher::class )
 			->disableOriginalConstructor()
@@ -272,6 +300,11 @@ class RedirectUpdaterTest extends TestCase {
 			WikiPage::newFromText( __METHOD__ . '-old', NS_MAIN ),
 			WikiPage::newFromText( __METHOD__ . '-new', NS_MAIN ),
 			[ 'page_id' => 9999, 'redirect_id' => 1111 ]
+		);
+
+		$this->assertSame(
+			[ SQLStore::ID_TABLE ],
+			$capturedTables
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/SQLStoreUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreUpdaterTest.php
@@ -23,6 +23,8 @@ use SMW\SQLStore\RedirectUpdater;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\SQLStoreFactory;
 use SMW\SQLStore\SQLStoreUpdater;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\SQLStoreUpdater
@@ -34,6 +36,9 @@ use SMW\SQLStore\SQLStoreUpdater;
  * @author mwjames
  */
 class SQLStoreUpdaterTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $store;
 	private $factory;
@@ -200,6 +205,10 @@ class SQLStoreUpdaterTest extends TestCase {
 		$database->expects( $this->once() )
 			->method( 'endSectionTransaction' )
 			->with( SQLStore::UPDATE_TRANSACTION );
+
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+		$database->method( 'newDeleteQueryBuilder' )->willReturn( $deleteBuilder );
+
 		$propertyTableInfoFetcher = $this->getMockBuilder( PropertyTableInfoFetcher::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -251,6 +260,9 @@ class SQLStoreUpdaterTest extends TestCase {
 		$database = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$deleteBuilder = $this->createMockDeleteQueryBuilder();
+		$database->method( 'newDeleteQueryBuilder' )->willReturn( $deleteBuilder );
 
 		$propertyTableInfoFetcher = $this->getMockBuilder( PropertyTableInfoFetcher::class )
 			->disableOriginalConstructor()
@@ -475,9 +487,13 @@ class SQLStoreUpdaterTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$database->expects( $this->exactly( 2 ) )
-			->method( 'delete' )
-			->willReturn( true );
+		$capturedDeleteTables = [];
+		$capturedDeleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder(
+			$capturedDeleteTables,
+			$capturedDeleteWheres
+		);
+		$database->method( 'newDeleteQueryBuilder' )->willReturn( $deleteBuilder );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
@@ -497,6 +513,15 @@ class SQLStoreUpdaterTest extends TestCase {
 
 		$instance = new SQLStoreUpdater( $this->store, $this->factory );
 		$instance->deleteSubject( $title );
+
+		$this->assertSame(
+			[ SQLStore::CONCEPT_TABLE, SQLStore::CONCEPT_CACHE_TABLE ],
+			$capturedDeleteTables
+		);
+		$this->assertSame(
+			[ [ 's_id' => 0 ], [ 'o_id' => 0 ] ],
+			$capturedDeleteWheres
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/TableFieldUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableFieldUpdaterTest.php
@@ -7,6 +7,8 @@ use SMW\MediaWiki\Collator;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableFieldUpdater;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\TableFieldUpdater
@@ -18,6 +20,9 @@ use SMW\SQLStore\TableFieldUpdater;
  * @author mwjames
  */
 class TableFieldUpdaterTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$store = $this->getMockBuilder( SQLStore::class )
@@ -39,20 +44,21 @@ class TableFieldUpdaterTest extends TestCase {
 			->method( 'getSortKey' )
 			->willReturn( 'Foo' );
 
+		$capturedTables = [];
+		$capturedSets = [];
+		$capturedWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder(
+			$capturedTables,
+			$capturedSets,
+			$capturedWheres
+		);
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->once() )
-			->method( 'timestamp' )
-			->willReturn( '1970' );
-
-		$connection->expects( $this->once() )
-			->method( 'update' )
-				->with(
-					$this->anything(),
-					$this->equalTo( [ 'smw_sortkey' => 'Foo', 'smw_sort' => 'Foo', 'smw_touched' => 1970 ] ),
-					[ 'smw_id' => 42 ] );
+		$connection->method( 'timestamp' )->willReturn( '1970' );
+		$connection->method( 'newUpdateQueryBuilder' )->willReturn( $updateBuilder );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -68,23 +74,36 @@ class TableFieldUpdaterTest extends TestCase {
 		);
 
 		$instance->updateSortField( 42, 'Foo' );
+
+		$this->assertSame( [ SQLStore::ID_TABLE ], $capturedTables );
+
+		$this->assertSame(
+			[ [ 'smw_sortkey' => 'Foo', 'smw_sort' => 'Foo', 'smw_touched' => '1970' ] ],
+			$capturedSets
+		);
+
+		$this->assertSame(
+			[ [ 'smw_id' => 42 ] ],
+			$capturedWheres
+		);
 	}
 
 	public function testUpdateRevField() {
+		$capturedTables = [];
+		$capturedSets = [];
+		$capturedWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder(
+			$capturedTables,
+			$capturedSets,
+			$capturedWheres
+		);
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->once() )
-			->method( 'timestamp' )
-			->willReturn( '1970' );
-
-		$connection->expects( $this->once() )
-			->method( 'update' )
-				->with(
-					$this->anything(),
-					$this->equalTo( [ 'smw_rev' => 1001, 'smw_touched' => 1970 ] ),
-					[ 'smw_id'  => 42 ] );
+		$connection->method( 'timestamp' )->willReturn( '1970' );
+		$connection->method( 'newUpdateQueryBuilder' )->willReturn( $updateBuilder );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -99,23 +118,36 @@ class TableFieldUpdaterTest extends TestCase {
 		);
 
 		$instance->updateRevField( 42, 1001 );
+
+		$this->assertSame( [ SQLStore::ID_TABLE ], $capturedTables );
+
+		$this->assertSame(
+			[ [ 'smw_rev' => 1001, 'smw_touched' => '1970' ] ],
+			$capturedSets
+		);
+
+		$this->assertSame(
+			[ [ 'smw_id' => 42 ] ],
+			$capturedWheres
+		);
 	}
 
 	public function testUpdateTouchedField() {
+		$capturedTables = [];
+		$capturedSets = [];
+		$capturedWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder(
+			$capturedTables,
+			$capturedSets,
+			$capturedWheres
+		);
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->once() )
-			->method( 'timestamp' )
-			->willReturn( '1970' );
-
-		$connection->expects( $this->once() )
-			->method( 'update' )
-				->with(
-					$this->anything(),
-					[ 'smw_touched' => 1970 ],
-					[ 'smw_id'  => 42 ] );
+		$connection->method( 'timestamp' )->willReturn( '1970' );
+		$connection->method( 'newUpdateQueryBuilder' )->willReturn( $updateBuilder );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -130,19 +162,35 @@ class TableFieldUpdaterTest extends TestCase {
 		);
 
 		$instance->updateTouchedField( 42 );
+
+		$this->assertSame( [ SQLStore::ID_TABLE ], $capturedTables );
+
+		$this->assertSame(
+			[ [ 'smw_touched' => '1970' ] ],
+			$capturedSets
+		);
+
+		$this->assertSame(
+			[ [ 'smw_id' => 42 ] ],
+			$capturedWheres
+		);
 	}
 
 	public function testUpdateIwField() {
+		$capturedTables = [];
+		$capturedSets = [];
+		$capturedWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder(
+			$capturedTables,
+			$capturedSets,
+			$capturedWheres
+		);
+
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->once() )
-			->method( 'update' )
-				->with(
-					$this->anything(),
-					$this->equalTo( [ 'smw_iw' => 'foo', 'smw_hash' => 'abc1234' ] ),
-					[ 'smw_id'  => 42 ] );
+		$connection->method( 'newUpdateQueryBuilder' )->willReturn( $updateBuilder );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -157,6 +205,18 @@ class TableFieldUpdaterTest extends TestCase {
 		);
 
 		$instance->updateIwField( 42, 'foo', 'abc1234' );
+
+		$this->assertSame( [ SQLStore::ID_TABLE ], $capturedTables );
+
+		$this->assertSame(
+			[ [ 'smw_iw' => 'foo', 'smw_hash' => 'abc1234' ] ],
+			$capturedSets
+		);
+
+		$this->assertSame(
+			[ [ 'smw_id' => 42 ] ],
+			$capturedWheres
+		);
 	}
 
 }


### PR DESCRIPTION
## Summary

Migrates the QueryBuilder-eligible DML in 9 misc `src/SQLStore/` singletons (~32 callsites) onto the SMW `Database` wrapper's `new*QueryBuilder()` factories. Mechanical, no behaviour change intended.

Files converted (one commit per file):

- `TableFieldUpdater.php` — 4× `update`
- `PropertyTypeFinder.php` — 3× `selectRow` (try/catch around the first `findTypeID` lookup preserved)
- `PropertyStatisticsStore.php` — `update` / `upsert` → `onDuplicateKeyUpdate` / `selectRow` / `select` / `delete` (the `'*'` ALL_ROWS sentinel uses ``IDatabase::ALL_ROWS``). Has Integration coverage; no Unit tests added or in scope.
- `ConceptCache.php` — 5 (delete/update/delete/update/selectRow). The line-126 raw `$db->query()` ``INSERT INTO … SELECT <planner-emitted SQL>`` STAYS — its SELECT body is built from a planner-emitted `QuerySegment` (from / where / alias / joinTable fragments) that's opaque to the QueryBuilder. Out of scope here; deferred to the planner refactor.
- `Rebuilder/Rebuilder.php` — 4× `selectField` + 1× `select`. Legacy options-array ``'ORDER BY' => 'col ASC'`` becomes ``->orderBy('col', 'ASC')``. Raw-string WHERE predicates with embedded ``\$id`` and ``\$connection->addQuotes()`` remain inline as numeric-keyed where() entries.
- `Rebuilder/EntityValidator.php` — 1× multi-predicate `select` (addQuotes()-built predicates retained inline).
- `SQLStoreUpdater.php` — 2× `delete` in `doDelete()` (concept-namespace cleanup of `CONCEPT_TABLE` and `CONCEPT_CACHE_TABLE`). Exact ``fname`` strings (``'SMW::deleteSubject::Conc'`` / ``'SMW::deleteSubject::Conccache'``) preserved on `caller()`.
- `RedirectStore.php` — 5 (selectRow×2, insert, delete, variable-shape select with conditional INNER JOIN + DISTINCT in `findUpdateJobs()`).
- `RedirectUpdater.php` — 1× `update` plus 1× hand-built `query()` UPDATE-with-`!=`-predicate. The latter used ``addQuotes()``-string concatenation to express ``smw_subobject != ''`` (the original comment said "the != is why we cannot use MW array syntax here"); now threads through ``\$connection->expr( 'smw_subobject', '!=', '' )`` inside the `where()` array. The ``Wikimedia\Rdbms\Platform\ISQLPlatform`` import is dropped — was the only consumer.

Each converted chain ends with ``->caller( __METHOD__ )`` (or the explicit fname where preserved). Writes go through the SMW `Database` wrapper's factories so the existing ``Muted*QueryBuilder`` profiler-mute on `execute()` is preserved.

Tests are updated in lockstep using the existing ``MockSelectQueryBuilderTrait`` / ``MockWriteQueryBuilderTrait`` helpers, with captured-argument assertions in place of the legacy ``with(...)`` arg matchers.

A defensive cross-impact fix lands in the RedirectStore commit: ``EntityIdManagerTest::testRedirectInfoRoundtrip`` exercises real ``RedirectStore`` via ``setMethods( null )`` on its ``EntityIdFinder`` mock, so it needed the converted ``new*QueryBuilder`` factories stubbed (12 lines, scoped to that single test).

### Notable behaviour-preserving call-outs

`PropertyStatisticsStore::deleteAll()`'s legacy return was ``bool true``; after the conversion, ``execute()`` returns ``void`` so the method now declares ``: void``. Caller audit confirms this is safe — ``Maintenance/PropertyStatisticsRebuilder.php`` ignores the return; ``Integration/SQLStore/PropertyStatisticsStoreTest.php`` asserts ``!== false`` which still holds against the implicit ``null`` of a void-call expression.

The ``RedirectStore::findUpdateJobs()`` chain branches defensively on the join shape via ``in_array( SQLStore::ID_TABLE, \$query['from'], true )`` and on DISTINCT via ``in_array( 'DISTINCT', \$query['options'], true )``. Today the only caller (``updateRedirect()``) sets DISTINCT unconditionally, so the second branch is technically dead code; kept for forward-compat ergonomics, no SQL-shape change.

### Representative before / after

`PropertyStatisticsStore::insertUsageCount()` upsert:

```php
// Before
\$this->connection->upsert(
    SQLStore::PROPERTY_STATISTICS_TABLE,
    [ 'usage_count' => \$usageCount, 'null_count' => \$nullCount, 'p_id' => \$propertyId ],
    [ [ 'p_id' ] ],
    [ 'usage_count' => \$usageCount, 'null_count' => \$nullCount ],
    __METHOD__
);

// After
\$this->connection->newInsertQueryBuilder()
    ->insertInto( SQLStore::PROPERTY_STATISTICS_TABLE )
    ->row( [
        'usage_count' => \$usageCount,
        'null_count'  => \$nullCount,
        'p_id'        => \$propertyId,
    ] )
    ->onDuplicateKeyUpdate()
    ->uniqueIndexFields( [ 'p_id' ] )
    ->set( [
        'usage_count' => \$usageCount,
        'null_count'  => \$nullCount,
    ] )
    ->caller( __METHOD__ )
    ->execute();
```

`PropertyStatisticsStore::deleteAll()` (the legacy ``'*'`` ALL_ROWS sentinel):

```php
// Before
return \$this->connection->delete(
    SQLStore::PROPERTY_STATISTICS_TABLE,
    '*',
    __METHOD__
);

// After
\$this->connection->newDeleteQueryBuilder()
    ->deleteFrom( SQLStore::PROPERTY_STATISTICS_TABLE )
    ->where( IDatabase::ALL_ROWS )
    ->caller( __METHOD__ )
    ->execute();
```

`RedirectUpdater::moveAsRedirect()` (the hand-built UPDATE-with-`!=` predicate):

```php
// Before — addQuotes()-string concatenation to dodge MW array-syntax
\$table = \$connection->tableName( SQLStore::ID_TABLE );

\$values = [
    'smw_title'     => \$target->getDBkey(),
    'smw_namespace' => \$target->getNamespace(),
    'smw_iw'        => '',
];

\$sql = "UPDATE \$table SET " . \$connection->makeList( \$values, LIST_SET ) .
    ' WHERE smw_title = ' . \$connection->addQuotes( \$source->getDBkey() ) . ' AND ' .
    'smw_namespace = ' . \$connection->addQuotes( \$source->getNamespace() ) . ' AND ' .
    'smw_iw = ' . \$connection->addQuotes( '' ) . ' AND ' .
    'smw_subobject != ' . \$connection->addQuotes( '' );

\$connection->query( \$sql, __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );

// After
\$connection->newUpdateQueryBuilder()
    ->update( SQLStore::ID_TABLE )
    ->set( [
        'smw_title'     => \$target->getDBkey(),
        'smw_namespace' => \$target->getNamespace(),
        'smw_iw'        => '',
    ] )
    ->where( [
        'smw_title'     => \$source->getDBkey(),
        'smw_namespace' => \$source->getNamespace(),
        'smw_iw'        => '',
        \$connection->expr( 'smw_subobject', '!=', '' ),
    ] )
    ->caller( __METHOD__ )
    ->execute();
```

`Rebuilder::matchAsSubject()` (multi-column select with raw-string range predicates retained):

```php
// Before
\$res = \$connection->select(
    SQLStore::ID_TABLE,
    [ 'smw_id', 'smw_title', 'smw_namespace', 'smw_iw',
      'smw_subobject', 'smw_sortkey', 'smw_proptable_hash', 'smw_rev' ],
    [
        "smw_id >= \$id ",
        " smw_id < " . \$connection->addQuotes( \$id + \$this->iterationLimit ),
    ],
    __METHOD__
);

// After
\$res = \$connection->newSelectQueryBuilder()
    ->select( [ 'smw_id', 'smw_title', 'smw_namespace', 'smw_iw',
                'smw_subobject', 'smw_sortkey', 'smw_proptable_hash', 'smw_rev' ] )
    ->from( SQLStore::ID_TABLE )
    ->where( [
        "smw_id >= \$id ",
        " smw_id < " . \$connection->addQuotes( \$id + \$this->iterationLimit ),
    ] )
    ->caller( __METHOD__ )
    ->fetchResultSet();
```

The inline ``addQuotes()``-built numeric-keyed string predicates are intentionally retained — minimising semantic surface area for a mechanical conversion. Tightening to ``\$connection->expr()`` is for follow-up cleanup.

## Test plan

- [x] ``composer analyze`` clean (PHP-Parallel-Lint OK on 2119 files; PHPCS 0 errors / 0 warnings on the 16 changed files)
- [x] Filtered tests pass for every file with existing Unit coverage: ``TableFieldUpdaterTest`` (5/18), ``PropertyTypeFinderTest`` (2/4), ``ConceptCacheTest`` + integration (5/8), ``RebuilderTest`` (4/8), ``EntityValidatorTest`` (7/9), ``SQLStoreUpdaterTest`` (7/13), ``RedirectStoreTest`` (8/26), ``RedirectUpdaterTest`` (5/11), ``EntityIdManagerTest`` (29/61)
- [x] Broader Unit cross-impact suite green: ``Unit/SQLStore`` + ``Unit/MediaWiki`` + ``Unit/Elastic`` + ``Unit/Maintenance`` — 874 tests / 1819 assertions / 1 pre-existing skip (``PostgresTableBuilderTest::testDoCheckOnAfterCreate``, unrelated)
- [x] Local CLI/browser smoke against the dev wiki at ``localhost:8080``:
  - ``Special:Browse``, ``Special:Ask``, ``Special:SearchByProperty`` render with HTTP 200, no ``smw-error`` markers.
  - ``disposeOutdatedEntities.php`` runs end-to-end through the converted ``Rebuilder``, ``EntityValidator``, and ``QueryLinksTableDisposer`` paths against MySQL — no SQL errors.
  - ``rebuildPropertyStatistics.php`` runs ``PropertyStatisticsStore::deleteAll()`` (the converted ``IDatabase::ALL_ROWS`` delete) and 55× ``insertUsageCount()`` upserts (the converted ``onDuplicateKeyUpdate`` chain) against MySQL — clean.
  - ``rebuildData.php --s=1 --e=10`` exercises ``Rebuilder::getMaxId``, ``matchAsSubject``, ``next_position``, ``EntityValidator::findDuplicates``, and the ``RedirectStore``/``RedirectUpdater`` paths through ``Store::updateData`` — clean.
- [ ] CI matrix green on MySQL + Postgres + SQLite (will verify before promoting from draft)