### PR TITLE
Clarify $smwgConfigFileDir override semantics

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -209,9 +209,9 @@ them.
 ## $smwgConfigFileDir
 
 Directory used to persistently store SMW configuration files (`.smw.json`,
-`.smw.maintenance.json`). The directory must be writable. You may assign
-the same directory as `$wgUploadDirectory` or select an entirely different
-location.
+`.smw.maintenance.json`). The directory must be writable. To override the
+default, set this in `LocalSettings.php` to an absolute path, for example
+`$wgUploadDirectory` or any other writable location.
 
 **Since:** 3.0
 **Default:** the extension's root directory

--- a/docs/config.md
+++ b/docs/config.md
@@ -209,9 +209,8 @@ them.
 ## $smwgConfigFileDir
 
 Directory used to persistently store SMW configuration files (`.smw.json`,
-`.smw.maintenance.json`). The directory must be writable. To override the
-default, set this in `LocalSettings.php` to an absolute path, for example
-`$wgUploadDirectory` or any other writable location.
+`.smw.maintenance.json`). The directory must be writable. Override in
+`LocalSettings.php` with any writable path, for example `$wgUploadDirectory`.
 
 **Since:** 3.0
 **Default:** the extension's root directory


### PR DESCRIPTION
## Summary

Follow-up to #6747. [Nikerabbit pointed out](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6747#issuecomment-4370751617) that the new `$smwgConfigFileDir` section in `docs/config.md` reads as a contradiction:

> On one hand this says values are prefixed with SMW's extension directory, on other hand it says e.g. config directory can be overwritten to upload directory.

Both statements are individually correct (the manifest's `path: true` flag prefixes the *default* with the extension directory, while a `LocalSettings.php` override is taken verbatim), but the prior wording never spelled out that distinction, so a reader naturally infers a conflict.

## Change

Reword only the body of `$smwgConfigFileDir`, making it explicit that the override is set in `LocalSettings.php` to an absolute path, with `$wgUploadDirectory` cited as one example. The default value, the `**Default:**` line, and the manifest entry are unchanged.

```diff
-`.smw.maintenance.json`). The directory must be writable. You may assign
-the same directory as `$wgUploadDirectory` or select an entirely different
-location.
+`.smw.maintenance.json`). The directory must be writable. To override the
+default, set this in `LocalSettings.php` to an absolute path, for example
+`$wgUploadDirectory` or any other writable location.
```

## Test plan

- [x] CI green (docs-only, no code paths touched)
- [x] Visual review of the rendered section on GitHub