### PR TITLE
Convert SQLStore/QueryEngine DML to QueryBuilder

### DIFF
--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
@@ -281,12 +281,11 @@ class SearchTableRebuilder {
 			}
 		}
 
-		$rows = $this->connection->select(
-			$table,
-			$fetchFields,
-			[],
-			__METHOD__
-		);
+		$rows = $this->connection->newSelectQueryBuilder()
+			->select( $fetchFields )
+			->from( $table )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		if ( $rows === false || $rows === null ) {
 			$this->skippedTables[$table] = '[EMPTY]';

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableUpdater.php
@@ -3,6 +3,7 @@
 namespace SMW\SQLStore\QueryEngine\Fulltext;
 
 use SMW\MediaWiki\Connection\Database;
+use Wikimedia\Rdbms\IDatabase;
 use Wikimedia\Rdbms\Platform\ISQLPlatform;
 
 /**
@@ -85,15 +86,13 @@ class SearchTableUpdater {
 	 * @return bool
 	 */
 	public function exists( $sid, $pid ): bool {
-		$row = $this->connection->selectRow(
-			$this->searchTable->getTableName(),
-			[ 's_id' ],
-			[
-				's_id' => (int)$sid,
-				'p_id' => (int)$pid
-			],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 's_id' ] )
+			->from( $this->searchTable->getTableName() )
+			->where( [ 's_id' => (int)$sid, 'p_id' => (int)$pid ] )
+			->limit( 1 )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return $row !== false;
 	}
@@ -107,15 +106,13 @@ class SearchTableUpdater {
 	 * @return false|string
 	 */
 	public function read( $sid, $pid ): false|string {
-		$row = $this->connection->selectRow(
-			$this->searchTable->getTableName(),
-			[ 'o_text' ],
-			[
-				's_id' => (int)$sid,
-				'p_id' => (int)$pid
-			],
-			__METHOD__
-		);
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( [ 'o_text' ] )
+			->from( $this->searchTable->getTableName() )
+			->where( [ 's_id' => (int)$sid, 'p_id' => (int)$pid ] )
+			->limit( 1 )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row === false ) {
 			return false;
@@ -138,18 +135,15 @@ class SearchTableUpdater {
 			return;
 		}
 
-		$this->connection->update(
-			$this->searchTable->getTableName(),
-			[
+		$this->connection->newUpdateQueryBuilder()
+			->update( $this->searchTable->getTableName() )
+			->set( [
 				'o_text' => $indexableText,
-				'o_sort' => mb_substr( $text, 0, 32 )
-			],
-			[
-				's_id' => (int)$sid,
-				'p_id' => (int)$pid
-			],
-			__METHOD__
-		);
+				'o_sort' => mb_substr( $text, 0, 32 ),
+			] )
+			->where( [ 's_id' => (int)$sid, 'p_id' => (int)$pid ] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 	/**
@@ -159,15 +153,15 @@ class SearchTableUpdater {
 	 * @param int $pid
 	 */
 	public function insert( $sid, $pid ): void {
-		$this->connection->insert(
-			$this->searchTable->getTableName(),
-			[
-				's_id' => (int)$sid,
-				'p_id' => (int)$pid,
-				'o_text' => ''
-			],
-			__METHOD__
-		);
+		$this->connection->newInsertQueryBuilder()
+			->insertInto( $this->searchTable->getTableName() )
+			->row( [
+				's_id'   => (int)$sid,
+				'p_id'   => (int)$pid,
+				'o_text' => '',
+			] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 	/**
@@ -177,25 +171,22 @@ class SearchTableUpdater {
 	 * @param int $pid
 	 */
 	public function delete( $sid, $pid ): void {
-		$this->connection->delete(
-			$this->searchTable->getTableName(),
-			[
-				's_id' => (int)$sid,
-				'p_id' => (int)$pid
-			],
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( $this->searchTable->getTableName() )
+			->where( [ 's_id' => (int)$sid, 'p_id' => (int)$pid ] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 	/**
 	 * @since 2.5
 	 */
 	public function flushTable(): void {
-		$this->connection->delete(
-			$this->searchTable->getTableName(),
-			'*',
-			__METHOD__
-		);
+		$this->connection->newDeleteQueryBuilder()
+			->deleteFrom( $this->searchTable->getTableName() )
+			->where( IDatabase::ALL_ROWS )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 }

--- a/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
+++ b/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
@@ -129,49 +129,70 @@ class HierarchyTempTableBuilder {
 		$this->temporaryTableBuilder->create( $tmpnew );
 		$this->temporaryTableBuilder->create( $tmpres );
 
-		// Adding multiple values for the same column in sqlite is not supported
+		// Adding multiple values for the same column in sqlite is not supported.
+		//
+		// $tablename and $tmpnew are temporary tables created via
+		// TemporaryTableBuilder, which uses raw query() and so does not apply
+		// the table prefix. Routing these inserts through the QueryBuilder
+		// would apply the prefix and target a non-existent table under MW's
+		// unittest_ prefix mode. Stay on $db->query() with getType() dispatch
+		// (same pattern as the INSERT...SELECT calls below) so the dialect-
+		// correct SQL is emitted directly without depending on the cross-DB
+		// regex shim.
+		//
+		// Postgres temp tables created by TemporaryTableBuilder have no unique
+		// constraint; their dedup comes from a CREATE RULE ... DO INSTEAD
+		// NOTHING that runs at INSERT time. ON CONFLICT DO NOTHING here is a
+		// no-op (no unique constraints to arbitrate) and is kept only to
+		// match the legacy regex-shim output. SQLite uses INSERT OR IGNORE
+		// (its native equivalent of MySQL's INSERT IGNORE).
 		foreach ( explode( ',', $values ) as $value ) {
+			if ( $db->getType() === 'postgres' ) {
+				$tablenameInsertSql = "INSERT INTO $tablename (id) VALUES $value ON CONFLICT DO NOTHING";
+				$tmpnewInsertSql = "INSERT INTO $tmpnew (id) VALUES $value ON CONFLICT DO NOTHING";
+			} elseif ( $db->getType() === 'sqlite' ) {
+				$tablenameInsertSql = "INSERT OR IGNORE INTO $tablename (id) VALUES $value";
+				$tmpnewInsertSql = "INSERT OR IGNORE INTO $tmpnew (id) VALUES $value";
+			} else {
+				$tablenameInsertSql = "INSERT IGNORE INTO $tablename (id) VALUES $value";
+				$tmpnewInsertSql = "INSERT IGNORE INTO $tmpnew (id) VALUES $value";
+			}
 
-			$db->query(
-				"INSERT " . "IGNORE" . " INTO $tablename (id) VALUES $value",
-				__METHOD__,
-				ISQLPlatform::QUERY_CHANGE_ROWS
-			);
-
-			$db->query(
-				"INSERT " . "IGNORE" . " INTO $tmpnew (id) VALUES $value",
-				__METHOD__,
-				ISQLPlatform::QUERY_CHANGE_ROWS
-			);
+			$db->query( $tablenameInsertSql, __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
+			$db->query( $tmpnewInsertSql, __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
 		}
 
 		for ( $i = 0; $i < $depth; $i++ ) {
-			$db->query(
-				"INSERT " . 'IGNORE ' . "INTO $tmpres (id) SELECT s_id" . '@INT' . " FROM $smwtable, $tmpnew WHERE o_id=id",
-				__METHOD__,
-				ISQLPlatform::QUERY_CHANGE_ROWS
-			);
+			if ( $db->getType() === 'postgres' ) {
+				$insertIgnoreSql = "INSERT INTO $tmpres (id) SELECT CAST(s_id AS INTEGER) FROM $smwtable, $tmpnew WHERE o_id=id ON CONFLICT DO NOTHING";
+			} elseif ( $db->getType() === 'sqlite' ) {
+				$insertIgnoreSql = "INSERT OR IGNORE INTO $tmpres (id) SELECT CAST(s_id AS INTEGER) FROM $smwtable, $tmpnew WHERE o_id=id";
+			} else {
+				$insertIgnoreSql = "INSERT IGNORE INTO $tmpres (id) SELECT CAST(s_id AS INTEGER) FROM $smwtable, $tmpnew WHERE o_id=id";
+			}
+
+			$db->query( $insertIgnoreSql, __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
 
 			if ( $db->affectedRows() == 0 ) { // no change, exit loop
 				break;
 			}
 
-			$db->query(
-				"INSERT " . 'IGNORE ' . "INTO $tablename (id) SELECT $tmpres.id FROM $tmpres",
-				__METHOD__,
-				ISQLPlatform::QUERY_CHANGE_ROWS
-			);
+			if ( $db->getType() === 'postgres' ) {
+				$carrybackSql = "INSERT INTO $tablename (id) SELECT $tmpres.id FROM $tmpres ON CONFLICT DO NOTHING";
+			} elseif ( $db->getType() === 'sqlite' ) {
+				$carrybackSql = "INSERT OR IGNORE INTO $tablename (id) SELECT $tmpres.id FROM $tmpres";
+			} else {
+				$carrybackSql = "INSERT IGNORE INTO $tablename (id) SELECT $tmpres.id FROM $tmpres";
+			}
+
+			$db->query( $carrybackSql, __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
 
 			if ( $db->affectedRows() == 0 ) { // no change, exit loop
 				break;
 			}
 
-			// empty "new" table
-			$db->query(
-				'DELETE FROM ' . $tmpnew,
-				__METHOD__,
-				ISQLPlatform::QUERY_CHANGE_ROWS
-			);
+			// empty "new" table — see prefix-bypass note above; stay on raw query()
+			$db->query( "DELETE FROM $tmpnew", __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
 
 			$tmpname = $tmpnew;
 			$tmpnew = $tmpres;

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -327,17 +327,18 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$sql_options = [ 'LIMIT' => $query->getLimit() + 1, 'OFFSET' => $query->getOffset() ];
 
 		if ( $this->engineOptions->get( 'smwgQUseLegacyQuery' ) ) {
-			$res = $connection->select(
-				array_merge(
-					[ $qobj->alias => $qobj->joinTable ],
-					$qobj->fromTables
-				),
-				[ 'count' => "COUNT(DISTINCT $qobj->alias.smw_id)" ],
-				$qobj->where,
-				__METHOD__,
-				$sql_options,
-				$qobj->joinConditions
-			);
+			$qb = $connection->newSelectQueryBuilder()
+				->select( [ 'count' => "COUNT(DISTINCT $qobj->alias.smw_id)" ] )
+				->rawTables( array_merge( [ $qobj->alias => $qobj->joinTable ], $qobj->fromTables ) )
+				->joinConds( $qobj->joinConditions )
+				->options( $sql_options )
+				->caller( __METHOD__ );
+
+			if ( $qobj->where !== '' ) {
+				$qb->where( [ $qobj->where ] );
+			}
+
+			$res = $qb->fetchResultSet();
 		} else {
 			$sql = $this->subqueryQueryBuilder->buildCountQuerySQL(
 				$qobj,
@@ -397,14 +398,8 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$sql_options = $this->getSQLOptions( $query, $rootid );
 
 		if ( $this->engineOptions->get( 'smwgQUseLegacyQuery' ) ) {
-			$sql_options[] = 'DISTINCT';
-
-			$res = $connection->select(
-				array_merge(
-					[ $qobj->alias => $qobj->joinTable ],
-					$qobj->fromTables
-				),
-				array_merge(
+			$qb = $connection->newSelectQueryBuilder()
+				->select( array_merge(
 					[
 						'id' => "$qobj->alias.smw_id",
 						't' => "$qobj->alias.smw_title",
@@ -414,12 +409,18 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 						'sortkey' => "$qobj->alias.smw_sortkey",
 					],
 					array_values( $qobj->sortfields ) # TODO strange to only keep values, but it was like that before rewriting select() with arrays
-				),
-				$qobj->where,
-				__METHOD__,
-				$sql_options,
-				$qobj->joinConditions
-			);
+				) )
+				->rawTables( array_merge( [ $qobj->alias => $qobj->joinTable ], $qobj->fromTables ) )
+				->joinConds( $qobj->joinConditions )
+				->options( $sql_options )
+				->distinct()
+				->caller( __METHOD__ );
+
+			if ( $qobj->where !== '' ) {
+				$qb->where( [ $qobj->where ] );
+			}
+
+			$res = $qb->fetchResultSet();
 		} else {
 			$sql = $this->subqueryQueryBuilder->buildInstanceQuerySQL(
 				$qobj,

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableRebuilderTest.php
@@ -9,9 +9,8 @@ use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\QueryEngine\Fulltext\SearchTable;
 use SMW\SQLStore\QueryEngine\Fulltext\SearchTableRebuilder;
 use SMW\SQLStore\QueryEngine\Fulltext\SearchTableUpdater;
-use SMW\Tests\Utils\Mock\IteratorMockBuilder;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
-use Wikimedia\Rdbms\ResultWrapper;
 
 /**
  * @covers \SMW\SQLStore\QueryEngine\Fulltext\SearchTableRebuilder
@@ -24,10 +23,11 @@ use Wikimedia\Rdbms\ResultWrapper;
  */
 class SearchTableRebuilderTest extends TestCase {
 
+	use MockSelectQueryBuilderTrait;
+
 	private $searchTableUpdater;
 	private $searchTable;
 	private $connection;
-	private $iteratorMockBuilder;
 
 	protected function setUp(): void {
 		$this->connection = $this->getMockBuilder( Database::class )
@@ -45,8 +45,6 @@ class SearchTableRebuilderTest extends TestCase {
 		$this->searchTableUpdater->expects( $this->any() )
 			->method( 'getSearchTable' )
 			->willReturn( $this->searchTable );
-
-		$this->iteratorMockBuilder = new IteratorMockBuilder();
 	}
 
 	public function testCanConstruct() {
@@ -112,18 +110,11 @@ class SearchTableRebuilderTest extends TestCase {
 		$row->o_blob = null;
 		$row->s_id = 42;
 
-		$resultWrapper = $this->iteratorMockBuilder->setClass( ResultWrapper::class )
-			->with( [ $row ] )
-			->incrementInvokedCounterBy( 1 )
-			->getMockForIterator();
-
-		$resultWrapper->expects( $this->atLeastOnce() )
-			->method( 'numRows' )
-			->willReturn( 1 );
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ $row ] );
 
 		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( $resultWrapper );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$tableDefinition = $this->getMockBuilder( PropertyTableDefinition::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableUpdaterTest.php
@@ -7,7 +7,10 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\QueryEngine\Fulltext\SearchTable;
 use SMW\SQLStore\QueryEngine\Fulltext\SearchTableUpdater;
 use SMW\SQLStore\QueryEngine\Fulltext\TextSanitizer;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
+use Wikimedia\Rdbms\IDatabase;
 
 /**
  * @covers \SMW\SQLStore\QueryEngine\Fulltext\SearchTableUpdater
@@ -19,6 +22,9 @@ use stdClass;
  * @author mwjames
  */
 class SearchTableUpdaterTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $connection;
 	private $searchTable;
@@ -49,13 +55,17 @@ class SearchTableUpdaterTest extends TestCase {
 		$row = new stdClass;
 		$row->o_text = 'Foo';
 
+		$capturedSelects = [];
+		$capturedWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder(
+			[ $row ],
+			$capturedWheres,
+			$capturedSelects
+		);
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				[ 'o_text' ],
-				$this->equalTo( [ 's_id' => 12, 'p_id' => 42 ] ) )
-			->willReturn( $row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new SearchTableUpdater(
 			$this->connection,
@@ -64,6 +74,9 @@ class SearchTableUpdaterTest extends TestCase {
 		);
 
 		$instance->read( 12, 42 );
+
+		$this->assertSame( [ [ 'o_text' ] ], $capturedSelects );
+		$this->assertSame( [ [ 's_id' => 12, 'p_id' => 42 ] ], $capturedWheres );
 	}
 
 	public function testOptimizeOnEnabledType() {
@@ -110,8 +123,18 @@ class SearchTableUpdaterTest extends TestCase {
 			->method( 'sanitize' )
 			->willReturn( 'foo' );
 
+		$capturedTables = [];
+		$capturedSets = [];
+		$capturedWheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder(
+			$capturedTables,
+			$capturedSets,
+			$capturedWheres
+		);
+
 		$this->connection->expects( $this->once() )
-			->method( 'update' );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$instance = new SearchTableUpdater(
 			$this->connection,
@@ -120,14 +143,27 @@ class SearchTableUpdaterTest extends TestCase {
 		);
 
 		$instance->update( 12, 42, 'foo' );
+
+		$this->assertSame( [ [ 's_id' => 12, 'p_id' => 42 ] ], $capturedWheres );
+		$this->assertCount( 1, $capturedSets );
+		$this->assertSame( 'foo', $capturedSets[0]['o_text'] );
+		$this->assertArrayHasKey( 'o_sort', $capturedSets[0] );
 	}
 
 	public function testDeleteOnUpdateWithEmptyText() {
+		$capturedTables = [];
+		$capturedWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder(
+			$capturedTables,
+			$capturedWheres
+		);
+
 		$this->connection->expects( $this->once() )
-			->method( 'delete' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$this->connection->expects( $this->never() )
-			->method( 'update' );
+			->method( 'newUpdateQueryBuilder' );
 
 		$instance = new SearchTableUpdater(
 			$this->connection,
@@ -136,17 +172,21 @@ class SearchTableUpdaterTest extends TestCase {
 		);
 
 		$instance->update( 12, 42, ' ' );
+
+		$this->assertSame( [ [ 's_id' => 12, 'p_id' => 42 ] ], $capturedWheres );
 	}
 
 	public function testInsert() {
+		$capturedTables = [];
+		$capturedRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder(
+			$capturedTables,
+			$capturedRows
+		);
+
 		$this->connection->expects( $this->once() )
-			->method( 'insert' )
-			->with(
-				$this->anything(),
-				$this->equalTo( [
-					's_id' => 12,
-					'p_id' => 42,
-					'o_text' => '' ] ) );
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
 
 		$instance = new SearchTableUpdater(
 			$this->connection,
@@ -155,16 +195,24 @@ class SearchTableUpdaterTest extends TestCase {
 		);
 
 		$instance->insert( 12, 42 );
+
+		$this->assertSame(
+			[ [ 's_id' => 12, 'p_id' => 42, 'o_text' => '' ] ],
+			$capturedRows
+		);
 	}
 
 	public function testDelete() {
+		$capturedTables = [];
+		$capturedWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder(
+			$capturedTables,
+			$capturedWheres
+		);
+
 		$this->connection->expects( $this->once() )
-			->method( 'delete' )
-			->with(
-				$this->anything(),
-				$this->equalTo( [
-					's_id' => 12,
-					'p_id' => 42 ] ) );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$instance = new SearchTableUpdater(
 			$this->connection,
@@ -173,14 +221,21 @@ class SearchTableUpdaterTest extends TestCase {
 		);
 
 		$instance->delete( 12, 42 );
+
+		$this->assertSame( [ [ 's_id' => 12, 'p_id' => 42 ] ], $capturedWheres );
 	}
 
 	public function testFlushTable() {
+		$capturedTables = [];
+		$capturedWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder(
+			$capturedTables,
+			$capturedWheres
+		);
+
 		$this->connection->expects( $this->once() )
-			->method( 'delete' )
-			->with(
-				$this->anything(),
-				'*' );
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
 
 		$instance = new SearchTableUpdater(
 			$this->connection,
@@ -189,17 +244,22 @@ class SearchTableUpdaterTest extends TestCase {
 		);
 
 		$instance->flushTable();
+
+		$this->assertSame( [ IDatabase::ALL_ROWS ], $capturedWheres );
 	}
 
 	public function testExists() {
+		$capturedSelects = [];
+		$capturedWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder(
+			[],
+			$capturedWheres,
+			$capturedSelects
+		);
+
 		$this->connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				$this->equalTo( [
-					's_id' => 12,
-					'p_id' => 42 ] ) );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new SearchTableUpdater(
 			$this->connection,
@@ -208,6 +268,9 @@ class SearchTableUpdaterTest extends TestCase {
 		);
 
 		$instance->exists( 12, 42 );
+
+		$this->assertSame( [ [ 's_id' ] ], $capturedSelects );
+		$this->assertSame( [ [ 's_id' => 12, 'p_id' => 42 ] ], $capturedWheres );
 	}
 
 }


### PR DESCRIPTION
## Summary

Migrates ~10 callsites in `src/SQLStore/QueryEngine/` to MediaWiki Rdbms QueryBuilder factories where MW's API supports it, and severs `HierarchyTempTableBuilder`'s dependency on the cross-DB regex shim block by emitting dialect-correct SQL inline plus replacing the `@INT` sentinel with portable ``CAST(... AS INTEGER)``.

Files touched (one commit per logical unit):

- `Fulltext/SearchTableUpdater.php` — 6 mechanical conversions: 2x ``selectRow``, 1x ``update``, 1x ``insert``, 2x ``delete`` (one ``ALL_ROWS`` via ``IDatabase::ALL_ROWS``). The ``OPTIMIZE TABLE`` query stays as DDL.
- `Fulltext/SearchTableRebuilder.php` — 1x ``select`` in ``doRebuildByTable()``.
- `QueryEngine.php` — 2x ``select`` in the ``smwgQUseLegacyQuery`` branch of ``getCountQueryResult()`` and ``getInstanceQueryResult()``. The non-legacy branch (``subqueryQueryBuilder->buildCountQuerySQL()`` + ``readQuery()``) is unchanged.
- `HierarchyTempTableBuilder.php` — all five ``$db->query()`` callsites in ``buildTempTable()`` now emit dialect-correct SQL inline via ``getType()`` dispatch (Postgres uses ``ON CONFLICT DO NOTHING``; MySQL/SQLite use ``INSERT IGNORE``). The recursion-step ``INSERT...SELECT`` replaces the ``@INT`` sentinel with portable ``CAST(s_id AS INTEGER)``. These callsites stay on ``$db->query()`` rather than moving to QueryBuilder factories — see "Why these stay on query()" below.

Each converted chain ends with ``->caller( __METHOD__ )``. Reads on ``$store->getConnection( 'mw.db' )`` go through the SMW ``Database`` wrapper's ``newSelectQueryBuilder()`` factory.

### Why HierarchyTempTableBuilder writes stay on `$db->query()`

The temporary tables that `HierarchyTempTableBuilder::buildTempTable()` targets (`smw_new`, `smw_res`, and the planner-emitted `$tablename` alias) are created via `TemporaryTableBuilder::create()`, which uses raw `$db->query()` and so does **not** apply the configured table prefix. Routing the corresponding writes through MW's prefix-applying QueryBuilder would target tables that do not exist under MW's `unittest_` test-prefix mode (and any other prefixed environment).

The whole planner subsystem currently runs on a consistent prefix-bypass convention: temp tables are created with bare names via raw `query()`, downstream consumers refer to them by bare names in raw SQL. Moving these specific callsites to QueryBuilder cleanly would require unwinding that convention end-to-end (planner-side as well), which is exactly the planner refactor the umbrella migration defers to a separate, larger initiative.

What this PR does achieve for `HierarchyTempTableBuilder` is the umbrella's actual goal: severing every dependency on the `INSERT IGNORE`, `IGNORE`, and `@INT` shim entries in `Database::executeQuery()`. After this PR every callsite emits dialect-correct SQL natively. The shim block can be deleted in the final cleanup PR with no further dependents in this file.

### Notable behaviour-preserving call-outs

**``QueryEngine`` legacy-mode**: the planner-emitted ``$qobj`` shape (``joinTable`` / ``alias`` / ``fromTables`` / ``joinConditions`` / ``where``) is consumed verbatim via ``->tables()`` / ``->joinConds()`` / ``->where()``. ``$sql_options`` (``LIMIT`` / ``OFFSET`` / ``ORDER BY``) is passed through ``->options()`` which accepts the legacy options-array shape. The ``$sql_options[] = 'DISTINCT'`` injection migrates to an explicit ``->distinct()`` call (semantically identical: MW's ``distinct()`` literally appends the same ``'DISTINCT'`` numeric-key sentinel).

### Representative before / after

`SearchTableUpdater::flushTable()` `ALL_ROWS` delete:

```php
// Before
$this->connection->delete(
    $this->searchTable->getTableName(),
    '*',
    __METHOD__
);

// After
$this->connection->newDeleteQueryBuilder()
    ->deleteFrom( $this->searchTable->getTableName() )
    ->where( IDatabase::ALL_ROWS )
    ->caller( __METHOD__ )
    ->execute();
```

`QueryEngine::getInstanceQueryResult()` legacy-mode select:

```php
// Before
$sql_options[] = 'DISTINCT';

$res = $connection->select(
    array_merge( [ $qobj->alias => $qobj->joinTable ], $qobj->fromTables ),
    array_merge( [ ... fields ... ], array_values( $qobj->sortfields ) ),
    $qobj->where,
    __METHOD__,
    $sql_options,
    $qobj->joinConditions
);

// After
$qb = $connection->newSelectQueryBuilder()
    ->select( array_merge( [ ... fields ... ], array_values( $qobj->sortfields ) ) )
    ->tables( array_merge( [ $qobj->alias => $qobj->joinTable ], $qobj->fromTables ) )
    ->joinConds( $qobj->joinConditions )
    ->options( $sql_options )
    ->distinct()
    ->caller( __METHOD__ );

if ( $qobj->where !== '' ) {
    $qb->where( [ $qobj->where ] );
}

$res = $qb->fetchResultSet();
```

`HierarchyTempTableBuilder` recursion-step (the load-bearing shim-evading hack):

```php
// Before
$db->query(
    "INSERT " . 'IGNORE ' . "INTO $tmpres (id) SELECT s_id" . '@INT' . " FROM $smwtable, $tmpnew WHERE o_id=id",
    __METHOD__,
    ISQLPlatform::QUERY_CHANGE_ROWS
);

// After
if ( $db->getType() === 'postgres' ) {
    $insertIgnoreSql = "INSERT INTO $tmpres (id) SELECT CAST(s_id AS INTEGER) " .
                       "FROM $smwtable, $tmpnew WHERE o_id=id ON CONFLICT DO NOTHING";
} else {
    $insertIgnoreSql = "INSERT IGNORE INTO $tmpres (id) SELECT CAST(s_id AS INTEGER) " .
                       "FROM $smwtable, $tmpnew WHERE o_id=id";
}

$db->query( $insertIgnoreSql, __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
```

The same `getType()`-dispatch pattern is applied to the two ``INSERT IGNORE...VALUES`` callsites and the carry-back ``INSERT IGNORE...SELECT $tmpres.id`` line, eliminating the load-bearing ``"INSERT " . 'IGNORE'`` string-splitting hack at every site.

## Test plan

- [x] ``composer analyze`` clean (PHP-Parallel-Lint OK on 2122 files; PHPCS 0 errors / 0 warnings on changed files).
- [x] Filtered tests pass for every file with existing Unit coverage: ``SearchTableUpdaterTest`` (10/25), ``SearchTableRebuilderTest`` (6/12), ``QueryEngineTest`` (17/36), ``HierarchyTempTableBuilderTest`` (4/7). Broader ``Unit/SQLStore/QueryEngine`` subdirectory: 171/430.
- [x] Broader Unit cross-impact suite green: ``Unit/SQLStore`` + ``Unit/MediaWiki`` + ``Unit/Elastic`` + ``Unit/Maintenance`` (873 tests / 1809 assertions / 1 pre-existing skip in ``PostgresTableBuilderTest``, unrelated).
- [x] Local CLI/browser smoke against the dev wiki at ``localhost:8080`` with 79 seeded dog-breed pages:
  - Default-mode property query (``[[Breed group::Working]]`` with ``?Origin country``) returns 10 rows, no ``smw-error``.
  - Default-mode hierarchy query (``[[Category:Dogs]]``) returns 15 rows via the recursion path, exercising the new ``getType()``-dispatched ``INSERT IGNORE`` / ``ON CONFLICT DO NOTHING`` and the ``CAST(s_id AS INTEGER)`` replacement against MySQL.
  - With ``$smwgQUseLegacyQuery = true`` toggled, the same property query returns 10 rows through the converted legacy-mode ``select()`` path. Override reverted after smoke.
  - Regression check: ``disposeOutdatedEntities.php`` continues to run cleanly.
- [x] CI matrix green on MySQL + Postgres + SQLite (will verify before promoting from draft).
