### PR TITLE
Convert MediaWiki/Specials DML to QueryBuilder

### DIFF
--- a/src/MediaWiki/Specials/Admin/Alerts/ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Alerts/ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler.php
@@ -51,14 +51,14 @@ class ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler extends TaskHandler 
 	private function fetchCount(): int {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$row = $connection->selectRow(
-			SQLStore::ID_TABLE,
-			'COUNT(smw_id) AS count',
-			[
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'count' => 'COUNT(smw_id)' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				'smw_namespace NOT IN (' . $connection->makeList( array_keys( $this->namespacesWithSemanticLinks ) ) . ')'
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return $row !== false ? (int)$row->count : 0;
 	}

--- a/src/MediaWiki/Specials/Admin/Alerts/OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Alerts/OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandler.php
@@ -46,14 +46,12 @@ class OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandler extends TaskH
 	private function fetchCount(): int {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$row = $connection->selectRow(
-			SQLStore::ID_TABLE,
-			'COUNT(smw_id) AS count',
-			[
-				'smw_iw' => SMW_SQL3_SMWDELETEIW
-			],
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( [ 'count' => 'COUNT(smw_id)' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_iw' => SMW_SQL3_SMWDELETEIW ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		return $row !== false ? (int)$row->count : 0;
 	}

--- a/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
@@ -213,22 +213,22 @@ class EntityLookupTaskHandler extends TaskHandler implements ActionableTask {
 			$condition = "smw_sortkey $op " . $connection->addQuotes( str_replace( [ '_', '*' ], [ ' ', '%' ], $id ) );
 		}
 
-		$rows = $connection->select(
-				SQLStore::ID_TABLE,
-				[
-					'smw_id',
-					'smw_title',
-					'smw_namespace',
-					'smw_iw',
-					'smw_subobject',
-					'smw_sortkey',
-					'smw_proptable_hash',
-					'smw_rev',
-					'smw_touched'
-				],
-				$condition,
-				__METHOD__
-		);
+		$rows = $connection->newSelectQueryBuilder()
+			->select( [
+				'smw_id',
+				'smw_title',
+				'smw_namespace',
+				'smw_iw',
+				'smw_subobject',
+				'smw_sortkey',
+				'smw_proptable_hash',
+				'smw_rev',
+				'smw_touched'
+			] )
+			->from( SQLStore::ID_TABLE )
+			->where( [ $condition ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		return $this->createMessageFromRows( $id, $rows );
 	}
@@ -292,18 +292,16 @@ class EntityLookupTaskHandler extends TaskHandler implements ActionableTask {
 			return;
 		}
 
-		$row = $connection->selectRow(
-				SQLStore::FT_SEARCH_TABLE,
-				[
-					's_id',
-					'p_id',
-					'o_text'
-				],
-				[
-					's_id' => $id
-				],
-				__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( [
+				's_id',
+				'p_id',
+				'o_text'
+			] )
+			->from( SQLStore::FT_SEARCH_TABLE )
+			->where( [ 's_id' => $id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row !== false ) {
 			$references[$id][SQLStore::FT_SEARCH_TABLE] = (array)$row;

--- a/src/MediaWiki/Specials/SpecialConcepts.php
+++ b/src/MediaWiki/Specials/SpecialConcepts.php
@@ -87,19 +87,19 @@ class SpecialConcepts extends SpecialPage {
 			'OFFSET' => $offset,
 		];
 
-		$res = $connection->select(
-			[
+		$res = $connection->newSelectQueryBuilder()
+			->select( $fields )
+			->tables( [
 				SQLStore::ID_TABLE,
 				SQLStore::CONCEPT_TABLE
-			],
-			$fields,
-			$conditions,
-			__METHOD__,
-			$options,
-			[
+			] )
+			->joinConds( [
 				SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=s_id' ] ]
-			]
-		);
+			] )
+			->where( $conditions )
+			->options( $options )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		foreach ( $res as $row ) {
 			$results[] = new WikiPage( $row->smw_title, SMW_NS_CONCEPT );

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Alerts/ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Alerts/ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandlerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\Specials\Admin\Alerts\ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\MediaWiki\Specials\Admin\Alerts\ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler
@@ -17,6 +18,8 @@ use SMW\SQLStore\SQLStore;
  * @author mwjames
  */
 class ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandlerTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 
@@ -41,8 +44,10 @@ class ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandlerTest extends TestCase
 			->getMock();
 
 		$connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)[ 'count' => 50000 ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn(
+				$this->createMockSelectQueryBuilder( [ (object)[ 'count' => 50000 ] ] )
+			);
 
 		$this->store->expects( $this->once() )
 			->method( 'getConnection' )

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Alerts/OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Alerts/OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandlerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\Specials\Admin\Alerts\OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandler;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\MediaWiki\Specials\Admin\Alerts\OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandler
@@ -17,6 +18,8 @@ use SMW\SQLStore\SQLStore;
  * @author mwjames
  */
 class OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandlerTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 
@@ -41,8 +44,10 @@ class OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandlerTest extends T
 			->getMock();
 
 		$connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( (object)[ 'count' => 50000 ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn(
+				$this->createMockSelectQueryBuilder( [ (object)[ 'count' => 50000 ] ] )
+			);
 
 		$this->store->expects( $this->once() )
 			->method( 'getConnection' )

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandlerTest.php
@@ -14,6 +14,7 @@ use SMW\MediaWiki\Specials\Admin\OutputFormatter;
 use SMW\MediaWiki\Specials\Admin\Supplement\EntityLookupTaskHandler;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\MediaWiki\Specials\Admin\Supplement\EntityLookupTaskHandler
@@ -25,6 +26,8 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class EntityLookupTaskHandlerTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $store;
@@ -139,8 +142,8 @@ class EntityLookupTaskHandlerTest extends TestCase {
 
 	public function testPerformActionWithId() {
 		$this->connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( [] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
 
 		$manualEntryLogger = $this->getMockBuilder( ManualEntryLogger::class )
 			->disableOriginalConstructor()


### PR DESCRIPTION
## Summary

Migrates 5 callsites in `src/MediaWiki/Specials/` (4 files) onto MediaWiki Rdbms QueryBuilder factories. Mechanical, no behaviour change intended.

Files converted (one commit per file):

- `SpecialConcepts.php` — multi-table ``select()`` with ``INNER JOIN`` + ``LIMIT/OFFSET``. Uses ``->tables()`` + ``->joinConds()`` + ``->options()`` to consume the legacy table-list / joinConds / options shapes verbatim.
- `Admin/Alerts/ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler.php` — ``selectRow`` with ``COUNT(smw_id)`` and a raw ``makeList()`` ``NOT IN`` predicate.
- `Admin/Alerts/OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandler.php` — ``selectRow`` with ``COUNT(smw_id)`` and a key=>val predicate.
- `Admin/Supplement/EntityLookupTaskHandler.php` — 9-column ``select()`` with a raw ``$condition`` string (built via either ``intval()`` for digit IDs or ``addQuotes()``/``LIKE`` for sortkey patterns) plus a ``selectRow`` for fulltext info. The ``tableExists()`` guard before the fulltext lookup is preserved.

Each converted chain ends with ``->caller( __METHOD__ )``. Reads on `$this->store->getConnection( 'mw.db' )` go through the SMW ``Database`` wrapper's ``newSelectQueryBuilder()`` factory.

### Notable behaviour-preserving call-outs

The ``COUNT(smw_id) AS count`` projections in the two alert handlers convert to alias-keyed projections ``[ 'count' => 'COUNT(smw_id)' ]`` — MW's ``SelectQueryBuilder::select()`` emits ``SELECT COUNT(smw_id) AS count`` for the alias-keyed array form, so downstream ``$row->count`` access is unchanged.

``EntityLookupTaskHandler::createInfoMessageById`` builds ``$condition`` as a single raw SQL string before the select call (either ``"smw_id=42"`` or ``"smw_sortkey LIKE 'foo'"``). The conversion wraps it as ``->where( [ $condition ] )`` (numeric-keyed string predicate), which MW's QueryBuilder emits verbatim into the ``WHERE`` clause. Identical to the legacy form.

Raw ``makeList()``-built and ``addQuotes()``-built predicates are retained inline. Predicate-style cleanup via ``$db->expr()`` is deferred to follow-up work.

### Representative before / after

``SpecialConcepts::buildSearchListByOffset()``:

```php
// Before
$res = $connection->select(
    [ SQLStore::ID_TABLE, SQLStore::CONCEPT_TABLE ],
    $fields,
    $conditions,
    __METHOD__,
    $options,
    [ SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=s_id' ] ] ]
);

// After
$res = $connection->newSelectQueryBuilder()
    ->select( $fields )
    ->tables( [ SQLStore::ID_TABLE, SQLStore::CONCEPT_TABLE ] )
    ->joinConds( [ SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=s_id' ] ] ] )
    ->where( $conditions )
    ->options( $options )
    ->caller( __METHOD__ )
    ->fetchResultSet();
```

``ByNamespaceInvalidEntities::fetchCount()``:

```php
// Before
$row = $connection->selectRow(
    SQLStore::ID_TABLE,
    'COUNT(smw_id) AS count',
    [
        'smw_namespace NOT IN (' . $connection->makeList( array_keys( $this->namespacesWithSemanticLinks ) ) . ')'
    ],
    __METHOD__
);

// After
$row = $connection->newSelectQueryBuilder()
    ->select( [ 'count' => 'COUNT(smw_id)' ] )
    ->from( SQLStore::ID_TABLE )
    ->where( [
        'smw_namespace NOT IN (' . $connection->makeList( array_keys( $this->namespacesWithSemanticLinks ) ) . ')'
    ] )
    ->caller( __METHOD__ )
    ->fetchRow();
```

## Test plan

- [x] ``composer analyze`` clean (PHP-Parallel-Lint OK on 2122 files; PHPCS 0/0 on changed files).
- [x] Filtered tests pass for every file with existing Unit coverage: ``SpecialConceptsTest`` (4/6), ``ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandlerTest`` (2/4), ``OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandlerTest`` (2/4), ``EntityLookupTaskHandlerTest`` (4/9).
- [x] Broader Unit cross-impact suite green: ``Unit/SQLStore`` + ``Unit/MediaWiki`` + ``Unit/Elastic`` + ``Unit/Maintenance`` (874 tests / 1819 assertions / 1 pre-existing skip in ``PostgresTableBuilderTest``, unrelated).
- [x] Local browser smoke against the dev wiki at ``localhost:8080`` with 79 seeded dog-breed pages:
  - ``Special:Concepts`` renders with HTTP 200 and no ``smw-error``.
  - ``Special:SemanticMediaWiki?tab=alerts`` renders with HTTP 200 and no ``smw-error`` (exercises both alert task handlers).
  - ``Special:SemanticMediaWiki?action=lookup&id=1`` (digit-id branch) and ``?id=Boxer*`` (sortkey LIKE branch) both render with HTTP 200 and no ``smw-error``.
- [ ] CI matrix green on MySQL + Postgres + SQLite (will verify before promoting from draft).
