### PR TITLE
Rebuilder::next_position(): restore implicit LIMIT 1 lost during QueryBuilder migration

### DIFF
--- a/src/SQLStore/Rebuilder/Rebuilder.php
+++ b/src/SQLStore/Rebuilder/Rebuilder.php
@@ -403,6 +403,7 @@ class Rebuilder {
 				->from( 'page' )
 				->where( [ "page_id >= $nextPosition" ] )
 				->orderBy( 'page_id', 'ASC' )
+				->limit( 1 )
 				->caller( __METHOD__ )
 				->fetchField();
 
@@ -411,6 +412,7 @@ class Rebuilder {
 				->from( SQLStore::ID_TABLE )
 				->where( [ "smw_id >= $nextPosition" ] )
 				->orderBy( 'smw_id', 'ASC' )
+				->limit( 1 )
 				->caller( __METHOD__ )
 				->fetchField();
 


### PR DESCRIPTION
## Summary

The QueryBuilder migration of `Rebuilder::next_position()` in #6749 lost an implicit `LIMIT 1` that the legacy `IDatabase::selectField()` injects before delegating to `select()`. Without the explicit `->limit(1)`, the two forward-scan queries:

```php
$nextByPageId = (int)$db->newSelectQueryBuilder()
    ->select( [ 'page_id' ] )
    ->from( 'page' )
    ->where( [ "page_id >= $nextPosition" ] )
    ->orderBy( 'page_id', 'ASC' )
    ->caller( __METHOD__ )
    ->fetchField();
```

now scan **every** row matching `page_id >= $nextPosition` (and the equivalent for `smw_id`) instead of stopping after the first one. `fetchField()` still extracts only the first scalar so the returned value is correctness-equivalent, but the database does a full index scan, which on large wikis is a noticeable performance regression in `rebuildData.php`.

The fix is the obvious one: add `->limit( 1 )` to both chains.

The two `MAX(...)` `selectField()` calls in `getMaxId()` do not need the fix since aggregate queries always return a single row.

Caught by CodeRabbit on #6749 after merge.

## Before / after

```diff
 $nextByPageId = (int)$db->newSelectQueryBuilder()
     ->select( [ 'page_id' ] )
     ->from( 'page' )
     ->where( [ "page_id >= $nextPosition" ] )
     ->orderBy( 'page_id', 'ASC' )
+    ->limit( 1 )
     ->caller( __METHOD__ )
     ->fetchField();

 $nextBySmwId = (int)$db->newSelectQueryBuilder()
     ->select( [ 'smw_id' ] )
     ->from( SQLStore::ID_TABLE )
     ->where( [ "smw_id >= $nextPosition" ] )
     ->orderBy( 'smw_id', 'ASC' )
+    ->limit( 1 )
     ->caller( __METHOD__ )
     ->fetchField();
```

## Test plan

- [x] PHPCS clean on the changed file.
- [x] `Unit/SQLStore/Rebuilder` tests green (11 / 17).
- [x] CI matrix green on MySQL + Postgres + SQLite (will verify before promoting from draft).