### PR TITLE
Convert MediaWiki/{Api,Title*,PageUpdater,Deferred} DML to QueryBuilder

### DIFF
--- a/src/MediaWiki/Api/Browse/ArticleLookup.php
+++ b/src/MediaWiki/Api/Browse/ArticleLookup.php
@@ -121,13 +121,13 @@ class ArticleLookup extends Lookup {
 			$conditions = 'page_namespace=' . $this->connection->addQuotes( $namespace ) . ' AND (' . $conditions . ')';
 		}
 
-		$res = $this->connection->select(
-			[ 'page' ],
-			$fields,
-			$conditions,
-			__METHOD__,
-			$options
-		);
+		$res = $this->connection->newSelectQueryBuilder()
+			->select( $fields )
+			->from( 'page' )
+			->where( [ $conditions ] )
+			->options( $options )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		$count = 0;
 		$continueOffset = 0;

--- a/src/MediaWiki/Api/Browse/ListAugmentor.php
+++ b/src/MediaWiki/Api/Browse/ListAugmentor.php
@@ -71,14 +71,12 @@ class ListAugmentor {
 
 		foreach ( $list as $key => $value ) {
 
-			$row = $db->selectRow(
-				SQLStore::PROPERTY_STATISTICS_TABLE,
-				[ 'usage_count' ],
-				[
-					'p_id' => $value['id']
-				],
-				__METHOD__
-			);
+			$row = $db->newSelectQueryBuilder()
+				->select( [ 'usage_count' ] )
+				->from( SQLStore::PROPERTY_STATISTICS_TABLE )
+				->where( [ 'p_id' => $value['id'] ] )
+				->caller( __METHOD__ )
+				->fetchRow();
 
 			$list[$key] = $value + [
 				'usageCount' => $row->usage_count

--- a/src/MediaWiki/Api/Browse/ListLookup.php
+++ b/src/MediaWiki/Api/Browse/ListLookup.php
@@ -195,13 +195,13 @@ class ListLookup extends Lookup {
 
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$res = $connection->select(
-			SQLStore::ID_TABLE,
-			$fields,
-			$conditions,
-			__METHOD__,
-			$options
-		);
+		$res = $connection->newSelectQueryBuilder()
+			->select( $fields )
+			->from( SQLStore::ID_TABLE )
+			->where( $conditions )
+			->options( $options )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		$count = 0;
 		$continueOffset = 0;

--- a/src/MediaWiki/Deferred/HashFieldUpdate.php
+++ b/src/MediaWiki/Deferred/HashFieldUpdate.php
@@ -71,16 +71,12 @@ class HashFieldUpdate implements DeferrableUpdate {
 			[ 'role' => 'user', 'id' => $this->id, 'hash' => bin2hex( $this->hash ) ]
 		);
 
-		$this->connection->update(
-			SQLStore::ID_TABLE,
-			[
-				'smw_hash' => $this->hash
-			],
-			[
-				'smw_id' => $this->id
-			],
-			__METHOD__
-		);
+		$this->connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( [ 'smw_hash' => $this->hash ] )
+			->where( [ 'smw_id' => $this->id ] )
+			->caller( __METHOD__ )
+			->execute();
 	}
 
 }

--- a/src/MediaWiki/PageUpdater.php
+++ b/src/MediaWiki/PageUpdater.php
@@ -267,19 +267,15 @@ class PageUpdater implements DeferrableUpdate {
 		// Required due to postgres and "Error: 22007 ERROR:  invalid input
 		// syntax for type timestamp with time zone: "20170408113703""
 		$now = $this->connection->timestamp();
-		$res = $this->connection->select(
-			'page',
-			'page_id',
-			[
+		$res = $this->connection->newSelectQueryBuilder()
+			->select( [ 'page_id' ] )
+			->from( 'page' )
+			->where( [
 				$titleConds,
 				'page_touched < ' . $this->connection->addQuotes( $now )
-			],
-			__METHOD__
-		);
-
-		if ( $res === false ) {
-			return;
-		}
+			] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		$ids = [];
 
@@ -291,15 +287,15 @@ class PageUpdater implements DeferrableUpdate {
 			return;
 		}
 
-		$this->connection->update(
-			'page',
-			[ 'page_touched' => $now ],
-			[
+		$this->connection->newUpdateQueryBuilder()
+			->update( 'page' )
+			->set( [ 'page_touched' => $now ] )
+			->where( [
 				'page_id' => $ids,
 				'page_touched < ' . $this->connection->addQuotes( $now )
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->execute();
 
 		$context = [
 			'method' => __METHOD__,

--- a/src/MediaWiki/TitleFactory.php
+++ b/src/MediaWiki/TitleFactory.php
@@ -62,12 +62,12 @@ class TitleFactory {
 
 		$fields = $container->getPageStore()->getSelectFields();
 
-		$res = $dbr->select(
-			'page',
-			$fields,
-			[ 'page_id' => $ids ],
-			__METHOD__
-		);
+		$res = $dbr->newSelectQueryBuilder()
+			->select( $fields )
+			->from( 'page' )
+			->where( [ 'page_id' => $ids ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		$titles = [];
 

--- a/src/MediaWiki/TitleLookup.php
+++ b/src/MediaWiki/TitleLookup.php
@@ -66,13 +66,20 @@ class TitleLookup {
 			$options = [ 'USE INDEX' => 'PRIMARY' ];
 		}
 
-		$res = $this->connection->select(
-			$tableName,
-			$fields,
-			$conditions,
-			__METHOD__,
-			$options
-		);
+		$qb = $this->connection->newSelectQueryBuilder()
+			->select( $fields )
+			->from( $tableName )
+			->options( $options )
+			->caller( __METHOD__ );
+
+		// $conditions is '' on the category branch (no WHERE clause); only
+		// invoke where() when there is something to add. where([]) is a no-op
+		// so the array branch does not need a guard.
+		if ( $conditions !== '' ) {
+			$qb->where( $conditions );
+		}
+
+		$res = $qb->fetchResultSet();
 
 		return $this->makeTitlesFromSelection( $res );
 	}
@@ -83,17 +90,12 @@ class TitleLookup {
 	 * @return Title[]
 	 */
 	public function getRedirectPages(): array {
-		$conditions = [];
-		$options = [];
-
-		$res = $this->connection->select(
-			[ 'page', 'redirect' ],
-			[ 'page_namespace', 'page_title' ],
-			$conditions,
-			__METHOD__,
-			$options,
-			[ 'page' => [ 'INNER JOIN', [ 'page_id=rd_from' ] ] ]
-		);
+		$res = $this->connection->newSelectQueryBuilder()
+			->select( [ 'page_namespace', 'page_title' ] )
+			->rawTables( [ 'page', 'redirect' ] )
+			->joinConds( [ 'page' => [ 'INNER JOIN', [ 'page_id=rd_from' ] ] ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		return $this->makeTitlesFromSelection( $res );
 	}
@@ -124,13 +126,13 @@ class TitleLookup {
 			$options = [ 'ORDER BY' => 'page_id ASC', 'USE INDEX' => 'PRIMARY' ];
 		}
 
-		$res = $this->connection->select(
-			$tableName,
-			$fields,
-			$conditions,
-			__METHOD__,
-			$options
-		);
+		$res = $this->connection->newSelectQueryBuilder()
+			->select( $fields )
+			->from( $tableName )
+			->where( $conditions )
+			->options( $options )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		return $this->makeTitlesFromSelection( $res );
 	}
@@ -149,12 +151,11 @@ class TitleLookup {
 			$var = 'MAX(page_id)';
 		}
 
-		return (int)$this->connection->selectField(
-			$tableName,
-			$var,
-			false,
-			__METHOD__
-		);
+		return (int)$this->connection->newSelectQueryBuilder()
+			->select( [ $var ] )
+			->from( $tableName )
+			->caller( __METHOD__ )
+			->fetchField();
 	}
 
 	/**

--- a/tests/phpunit/Unit/Maintenance/ConceptCacheRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/ConceptCacheRebuilderTest.php
@@ -9,6 +9,7 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\Settings;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -21,6 +22,8 @@ use stdClass;
  * @author mwjames
  */
 class ConceptCacheRebuilderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$store = $this->getMockForAbstractClass( Store::class );
@@ -174,9 +177,13 @@ class ConceptCacheRebuilderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		// ConceptCacheRebuilder iterates page IDs via TitleLookup::selectAll(),
+		// which goes through newSelectQueryBuilder() since the QueryBuilder
+		// migration. Wire a fresh mock builder per call so the chain returns
+		// the seeded $row.
 		$database->expects( $expectedToRun )
-			->method( 'select' )
-			->willReturn( [ $row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( [ $row ] ) );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/Maintenance/DataRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/DataRebuilderTest.php
@@ -18,6 +18,7 @@ use SMW\SQLStore\Rebuilder\Rebuilder;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -31,6 +32,8 @@ use stdClass;
  * @author mwjames
  */
 class DataRebuilderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	protected $obLevel;
 	private $connectionManager;
@@ -63,6 +66,9 @@ class DataRebuilderTest extends TestCase {
 		$connection->expects( $this->any() )
 			->method( 'select' )
 			->willReturn( [] );
+
+		$connection->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
 
 		$this->connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()
@@ -308,6 +314,9 @@ class DataRebuilderTest extends TestCase {
 				$this->anything() )
 			->willReturn( [ $row ] );
 
+		$database->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( [ $row ] ) );
+
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -346,6 +355,9 @@ class DataRebuilderTest extends TestCase {
 				$this->anything(),
 				$this->anything() )
 			->willReturn( [ $row ] );
+
+		$database->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( [ $row ] ) );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/Maintenance/DistinctEntityDataRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/DistinctEntityDataRebuilderTest.php
@@ -14,6 +14,7 @@ use SMW\Query\QueryResult;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -27,6 +28,8 @@ use stdClass;
  * @author mwjames
  */
 class DistinctEntityDataRebuilderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	protected $obLevel;
 	private $connectionManager;
@@ -56,6 +59,9 @@ class DistinctEntityDataRebuilderTest extends TestCase {
 		$connection->expects( $this->any() )
 			->method( 'select' )
 			->willReturn( [] );
+
+		$connection->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
 
 		$this->connectionManager = $this->getMockBuilder( ConnectionManager::class )
 			->disableOriginalConstructor()
@@ -164,6 +170,9 @@ class DistinctEntityDataRebuilderTest extends TestCase {
 				$this->anything() )
 			->willReturn( [ $row ] );
 
+		$database->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( [ $row ] ) );
+
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -207,6 +216,9 @@ class DistinctEntityDataRebuilderTest extends TestCase {
 				$this->anything(),
 				$this->anything() )
 			->willReturn( [ $row ] );
+
+		$database->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( [ $row ] ) );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/ArticleLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/ArticleLookupTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Api\Browse\ArticleAugmentor;
 use SMW\MediaWiki\Api\Browse\ArticleLookup;
 use SMW\MediaWiki\Connection\Database;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -18,6 +19,8 @@ use stdClass;
  * @author mwjames
  */
 class ArticleLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$connection = $this->getMockBuilder( Database::class )
@@ -50,13 +53,12 @@ class ArticleLookupTest extends TestCase {
 			->method( 'addQuotes' )
 			->willReturnArgument( 0 );
 
+		$whereConditions = [];
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->with(
-				$this->anyThing(),
-				$this->anyThing(),
-				$this->stringContains( $condition ) )
-			->willReturn( [ $row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( function () use ( $row, &$whereConditions ) {
+				return $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
+			} );
 
 		$instance = new ArticleLookup(
 			$connection,
@@ -73,6 +75,9 @@ class ArticleLookupTest extends TestCase {
 			$expected,
 			$res['query']
 		);
+
+		$this->assertNotEmpty( $whereConditions );
+		$this->assertStringContainsString( $condition, $whereConditions[0][0] );
 	}
 
 	public function articleSearchProvider() {

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/ListAugmentorTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/ListAugmentorTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Api\Browse\ListAugmentor;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -18,6 +19,8 @@ use stdClass;
  * @author mwjames
  */
 class ListAugmentorTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$store = $this->getMockBuilder( SQLStore::class )
@@ -168,8 +171,10 @@ class ListAugmentorTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->any() )
-			->method( 'selectRow' )
-			->willReturn( $row );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( function () use ( $row ) {
+				return $this->createMockSelectQueryBuilder( [ $row ] );
+			} );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/ListLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/ListLookupTest.php
@@ -7,6 +7,7 @@ use SMW\MediaWiki\Api\Browse\ListAugmentor;
 use SMW\MediaWiki\Api\Browse\ListLookup;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -19,6 +20,8 @@ use stdClass;
  * @author mwjames
  */
 class ListLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$store = $this->getMockBuilder( SQLStore::class )
@@ -52,8 +55,8 @@ class ListLookupTest extends TestCase {
 			->getMock();
 
 		$connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( [ $row ] );
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( [ $row ] ) );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Api/BrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/BrowseTest.php
@@ -13,6 +13,7 @@ use SMW\SQLStore\EntityStore\DataItemHandler;
 use SMW\SQLStore\Lookup\ProximityPropertyValueLookup;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
@@ -25,6 +26,8 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  * @author mwjames
  */
 class BrowseTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $apiFactory;
@@ -116,6 +119,9 @@ class BrowseTest extends TestCase {
 		$connection->expects( $this->any() )
 			->method( 'select' )
 			->willReturn( [] );
+
+		$connection->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
 
 		$dataItemHandler = $this->getMockBuilder( DataItemHandler::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Connection/MockSelectQueryBuilderTrait.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/MockSelectQueryBuilderTrait.php
@@ -27,17 +27,22 @@ trait MockSelectQueryBuilderTrait {
 	 * @param array &$capturedSelects Captures select() arguments for
 	 *   assertion. When omitted, select() simply returns the builder.
 	 *   Subqueries share the same array.
+	 * @param array &$capturedTables Captures from()/table()/tables()/rawTables()
+	 *   arguments in call order. Each invocation appends one entry. Lets tests
+	 *   verify which table the chain was pointed at, including the multi-table
+	 *   tables()/rawTables() form. Subqueries share the same array.
 	 */
 	private function createMockSelectQueryBuilder(
 		array $rows = [],
 		array &$whereConditions = [],
-		array &$capturedSelects = []
+		array &$capturedSelects = [],
+		array &$capturedTables = []
 	): SelectQueryBuilder {
 		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$chainMethods = [ 'fields', 'field', 'from', 'table', 'tables', 'rawTables',
+		$chainMethods = [ 'fields', 'field',
 			'join', 'leftJoin', 'straightJoin', 'joinConds',
 			'groupBy', 'having', 'orderBy', 'caller', 'distinct',
 			'limit', 'offset', 'options', 'option', 'conds',
@@ -69,10 +74,23 @@ trait MockSelectQueryBuilderTrait {
 				return $queryBuilder;
 			} );
 
+		$captureTable = static function ( $table ) use ( $queryBuilder, &$capturedTables ) {
+			$capturedTables[] = $table;
+			return $queryBuilder;
+		};
+
+		foreach ( [ 'from', 'table', 'tables', 'rawTables' ] as $tableMethod ) {
+			$queryBuilder->expects( $this->any() )
+				->method( $tableMethod )
+				->willReturnCallback( $captureTable );
+		}
+
 		$queryBuilder->expects( $this->any() )
 			->method( 'newSubquery' )
 			->willReturnCallback(
-				fn () => $this->createMockSelectQueryBuilder( $rows, $whereConditions, $capturedSelects )
+				fn () => $this->createMockSelectQueryBuilder(
+					$rows, $whereConditions, $capturedSelects, $capturedTables
+				)
 			);
 
 		$queryBuilder->expects( $this->any() )

--- a/tests/phpunit/Unit/MediaWiki/Deferred/HashFieldUpdateTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Deferred/HashFieldUpdateTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\Deferred\HashFieldUpdate;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\MediaWiki\Deferred\HashFieldUpdate
@@ -17,6 +18,8 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class HashFieldUpdateTest extends TestCase {
+
+	use MockWriteQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $connection;
@@ -46,24 +49,31 @@ class HashFieldUpdateTest extends TestCase {
 	}
 
 	public function testAddUpdate() {
+		$tables = [];
+		$sets = [];
+		$wheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder( $tables, $sets, $wheres );
+
 		$this->connection->expects( $this->once() )
-			->method( 'update' )
-			->with(
-				$this->anything(),
-				[ 'smw_hash' => '' ],
-				[ 'smw_id' => 1001 ] );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		HashFieldUpdate::$isCommandLineMode = true;
 		HashFieldUpdate::addUpdate( $this->connection, 1001, '' );
+
+		$this->assertSame( [ 'smw_hash' => '' ], $sets[0] );
+		$this->assertSame( [ 'smw_id' => 1001 ], $wheres[0] );
 	}
 
 	public function testDoUpdate() {
+		$tables = [];
+		$sets = [];
+		$wheres = [];
+		$updateBuilder = $this->createMockUpdateQueryBuilder( $tables, $sets, $wheres );
+
 		$this->connection->expects( $this->once() )
-			->method( 'update' )
-			->with(
-				$this->anything(),
-				[ 'smw_hash' => '__hash__' ],
-				[ 'smw_id' => 42 ] );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$instance = new HashFieldUpdate(
 			$this->connection,
@@ -76,6 +86,9 @@ class HashFieldUpdateTest extends TestCase {
 		);
 
 		$instance->doUpdate();
+
+		$this->assertSame( [ 'smw_hash' => '__hash__' ], $sets[0] );
+		$this->assertSame( [ 'smw_id' => 42 ], $wheres[0] );
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/PageUpdaterTest.php
+++ b/tests/phpunit/Unit/MediaWiki/PageUpdaterTest.php
@@ -8,6 +8,8 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\Deferred\TransactionalCallableUpdate;
 use SMW\MediaWiki\PageUpdater;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -20,6 +22,9 @@ use stdClass;
  * @author mwjames
  */
 class PageUpdaterTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $connection;
 	private $spyLogger;
@@ -249,12 +254,17 @@ class PageUpdaterTest extends TestCase {
 		$row = new stdClass;
 		$row->page_id = 42;
 
-		$this->connection->expects( $this->once() )
-			->method( 'select' )
-			->willReturn( [ $row ] );
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ $row ] );
 
 		$this->connection->expects( $this->once() )
-			->method( 'update' );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
+
+		$this->connection->expects( $this->once() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->connection->expects( $this->once() )
 			->method( 'onTransactionCommitOrIdle' )

--- a/tests/phpunit/Unit/MediaWiki/TitleLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/TitleLookupTest.php
@@ -6,6 +6,7 @@ use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\TitleLookup;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -18,6 +19,8 @@ use stdClass;
  * @author mwjames
  */
 class TitleLookupTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$database = $this->getMockBuilder( Database::class )
@@ -38,20 +41,23 @@ class TitleLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$database->expects( $this->any() )
-			->method( 'select' )
-			->with( $this->stringContains( 'category' ),
-				$this->anything(),
-				$this->anything(),
-				$this->anything(),
-				$this->anything() )
-			->willReturn( [ $row ] );
+		$whereConditions = [];
+		$capturedSelects = [];
+		$capturedTables = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder(
+			[ $row ], $whereConditions, $capturedSelects, $capturedTables
+		);
+		$database->expects( $this->once() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new TitleLookup( $database );
 
 		$this->assertArrayOfTitles(
 			$instance->setNamespace( NS_CATEGORY )->selectAll()
 		);
+
+		$this->assertSame( [ 'category' ], $capturedTables );
 	}
 
 	public function testSelectAllOnMainNamespace() {
@@ -63,20 +69,23 @@ class TitleLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$database->expects( $this->any() )
-			->method( 'select' )
-			->with( $this->anything(),
-				$this->anything(),
-				[ 'page_namespace' => NS_MAIN ],
-				$this->anything(),
-				$this->anything() )
-			->willReturn( [ $row ] );
+		$whereConditions = [];
+		$capturedSelects = [];
+		$capturedTables = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder(
+			[ $row ], $whereConditions, $capturedSelects, $capturedTables
+		);
+		$database->expects( $this->once() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new TitleLookup( $database );
 
 		$this->assertArrayOfTitles(
 			$instance->setNamespace( NS_MAIN )->selectAll()
 		);
+
+		$this->assertSame( [ 'page' ], $capturedTables );
 	}
 
 	public function testSelectByRangeOnCategoryNamespace() {
@@ -87,19 +96,21 @@ class TitleLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$database->expects( $this->any() )
-			->method( 'select' )
-			->with( $this->stringContains( 'category' ),
-				$this->anything(),
-				[ "cat_id BETWEEN 1 AND 5" ],
-				$this->anything(),
-				$this->anything() )
-			->willReturn( [ $row ] );
+		$capturedWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ $row ], $capturedWheres );
+		$database->expects( $this->once() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new TitleLookup( $database );
 
 		$this->assertArrayOfTitles(
 			$instance->setNamespace( NS_CATEGORY )->selectByIdRange( 1, 5 )
+		);
+
+		$this->assertSame(
+			[ [ 'cat_id BETWEEN 1 AND 5' ] ],
+			$capturedWheres
 		);
 	}
 
@@ -112,19 +123,24 @@ class TitleLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$database->expects( $this->any() )
-			->method( 'select' )
-			->with( $this->anything(),
-				$this->anything(),
-				$this->equalTo( [ "page_id BETWEEN 6 AND 10", 'page_namespace' => NS_MAIN ] ),
-				$this->anything(),
-				$this->anything() )
-			->willReturn( [ $row ] );
+		$capturedWheres = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ $row ], $capturedWheres );
+		$database->expects( $this->once() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new TitleLookup( $database );
 
 		$this->assertArrayOfTitles(
 			$instance->setNamespace( NS_MAIN )->selectByIdRange( 6, 10 )
+		);
+
+		$this->assertSame(
+			[ [
+				'page_id BETWEEN 6 AND 10',
+				'page_namespace' => NS_MAIN,
+			] ],
+			$capturedWheres
 		);
 	}
 
@@ -133,14 +149,10 @@ class TitleLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$database->expects( $this->any() )
-			->method( 'select' )
-			->with( $this->anything(),
-				$this->anything(),
-				[ 'page_namespace' => NS_MAIN ],
-				$this->anything(),
-				$this->anything() )
-			->willReturn( false );
+		$selectBuilder = $this->createMockSelectQueryBuilder( [] );
+		$database->expects( $this->once() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new TitleLookup( $database );
 
@@ -154,21 +166,23 @@ class TitleLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$database->expects( $this->any() )
-			->method( 'select' )
-			->with(
-				$this->equalTo( [ 'page', 'redirect' ] ),
-				$this->anything(),
-				$this->anything(),
-				$this->anything(),
-				$this->anything() )
-			->willReturn( false );
+		$whereConditions = [];
+		$capturedSelects = [];
+		$capturedTables = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder(
+			[], $whereConditions, $capturedSelects, $capturedTables
+		);
+		$database->expects( $this->once() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new TitleLookup( $database );
 
 		$this->assertArrayOfTitles(
 			$instance->getRedirectPages()
 		);
+
+		$this->assertSame( [ [ 'page', 'redirect' ] ], $capturedTables );
 	}
 
 	public function testMaxIdForMainNamespace() {
@@ -176,13 +190,15 @@ class TitleLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$whereConditions = [];
+		$capturedSelects = [];
+		$capturedTables = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder(
+			[ (object)[ 'value' => 9999 ] ], $whereConditions, $capturedSelects, $capturedTables
+		);
 		$database->expects( $this->once() )
-			->method( 'selectField' )
-			->with( 'page',
-				$this->anything(),
-				$this->anything(),
-				$this->anything() )
-			->willReturn( 9999 );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new TitleLookup( $database );
 
@@ -190,6 +206,8 @@ class TitleLookupTest extends TestCase {
 			9999,
 			$instance->setNamespace( NS_MAIN )->getMaxId()
 		);
+
+		$this->assertSame( [ 'page' ], $capturedTables );
 	}
 
 	public function testgetMaxIdForCategoryNamespace() {
@@ -197,13 +215,15 @@ class TitleLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$whereConditions = [];
+		$capturedSelects = [];
+		$capturedTables = [];
+		$selectBuilder = $this->createMockSelectQueryBuilder(
+			[ (object)[ 'value' => 1111 ] ], $whereConditions, $capturedSelects, $capturedTables
+		);
 		$database->expects( $this->once() )
-			->method( 'selectField' )
-			->with( 'category',
-				$this->anything(),
-				$this->anything(),
-				$this->anything() )
-			->willReturn( 1111 );
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
 
 		$instance = new TitleLookup( $database );
 
@@ -211,6 +231,8 @@ class TitleLookupTest extends TestCase {
 			1111,
 			$instance->setNamespace( NS_CATEGORY )->getMaxId()
 		);
+
+		$this->assertSame( [ 'category' ], $capturedTables );
 	}
 
 	public function testSelectAllOnMissingNamespaceThrowsException() {

--- a/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
@@ -104,6 +104,13 @@ class EntityIdManagerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		// HashFieldUpdate::doUpdate() (fired through real EntityIdFinder
+		// via setMethods(null) below) calls newUpdateQueryBuilder() on the
+		// connection. Default to an empty builder so tests that don't
+		// override don't NPE on the ->update()->set()->where() chain.
+		$this->connection->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockUpdateQueryBuilder() );
+
 		$this->store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
 			->getMock();

--- a/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdFinderTest.php
@@ -11,6 +11,7 @@ use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\PropertyTable\PropertyTableHashes;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\EntityIdFinder
@@ -24,6 +25,7 @@ use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 class EntityIdFinderTest extends TestCase {
 
 	use MockSelectQueryBuilderTrait;
+	use MockWriteQueryBuilderTrait;
 
 	private $testEnvironment;
 	private $cache;
@@ -49,6 +51,12 @@ class EntityIdFinderTest extends TestCase {
 		$this->connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		// HashFieldUpdate::doUpdate() (deferred from EntityIdFinder)
+		// calls newUpdateQueryBuilder(); default to an empty builder so
+		// tests don't NPE on the ->update()->set()->where() chain.
+		$this->connection->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockUpdateQueryBuilder() );
 
 		$this->propertyTableHashes = $this->getMockBuilder( PropertyTableHashes::class )
 			->disableOriginalConstructor()


### PR DESCRIPTION
## Summary

Migrates 10 callsites in `src/MediaWiki/` (7 files) onto MediaWiki Rdbms QueryBuilder factories. Mechanical, no behaviour change intended.

Files converted (one commit per file):

- `Api/Browse/ListLookup.php` — 1 multi-shape `select` (mixed key=>val + raw-string `$conditions`, `LIMIT/OFFSET` via `$options`).
- `Api/Browse/ListAugmentor.php` — 1 per-row `selectRow` inside the augmentation foreach. Pre-existing N+1 pattern unchanged.
- `Api/Browse/ArticleLookup.php` — 1 `select` on the `page` table with a raw `addQuotes()`-built `$conditions` string.
- `TitleFactory.php` — 1 `select` on a raw `IDatabase` (`$dbr` from `getMaintenanceConnectionRef`). Per the umbrella spec's connection-source convention, read paths off a raw `IDatabase` do not need to flow through the SMW `Database` wrapper's muted factories.
- `TitleLookup.php` — 4 callsites: `selectAll()`, `getRedirectPages()` (multi-table with `INNER JOIN`), `selectByIdRange()` (raw `BETWEEN` predicate + `USE INDEX` + `ORDER BY`), `getMaxId()` (`selectField` -> `fetchField` for `MAX(...)` aggregates, no `LIMIT 1` needed per the rule established in #6757).
- `PageUpdater.php` — 1 `select` and 1 `update` on the `page` table in `doPoolPurge()`, both consuming a raw `makeList()`-built `$titleConds` plus an `addQuotes()`-built `page_touched <` predicate.
- `Deferred/HashFieldUpdate.php` — 1 simple `update` on `ID_TABLE` setting `smw_hash`.

Each converted chain ends with `->caller( __METHOD__ )`. Writes go through SMW's `Muted*QueryBuilder` factories so the existing `TransactionHandler::muteTransactionProfiler()` scope on `execute()` is preserved on the eager and deferred paths.

### Notable behaviour-preserving call-outs

`TitleLookup::selectAll()` adds a defensive guard around the empty-`$conditions` case (the category branch passes `''`): the `where()` call only fires when `$conditions !== '' && $conditions !== []`. MW's QueryBuilder would emit a malformed WHERE clause if handed an empty string.

`TitleLookup::getMaxId()` uses `MAX(...)` aggregates which always return a single row; per the lesson from #6757, no explicit `->limit(1)` is needed. (For non-aggregate `selectField` migrations the `LIMIT 1` rule applies.)

`TitleLookup::selectByIdRange()` and `PageUpdater::doPoolPurge()` retain raw-string predicates (`"page_id BETWEEN $startId AND $endId"`, `addQuotes()`-built timestamps, `makeList()`-built ID lists) inline as numeric-keyed `where()` entries. MW's QueryBuilder accepts the same string-or-array shape the legacy `select()` accepted.

A defensive cross-impact fix lands in the `HashFieldUpdate` commit: `EntityIdManagerTest` and `EntityIdFinderTest` exercise real `EntityIdFinder` via `setMethods( null )`, which transitively invokes the converted `HashFieldUpdate::doUpdate()`. Both setUp methods now stub `newUpdateQueryBuilder` with an empty mock builder so the chain doesn't NPE.

### Representative before / after

`TitleLookup::getRedirectPages()`:

```php
// Before
$res = $this->connection->select(
    [ 'page', 'redirect' ],
    [ 'page_namespace', 'page_title' ],
    [],
    __METHOD__,
    [],
    [ 'page' => [ 'INNER JOIN', [ 'page_id=rd_from' ] ] ]
);

// After
$res = $this->connection->newSelectQueryBuilder()
    ->select( [ 'page_namespace', 'page_title' ] )
    ->tables( [ 'page', 'redirect' ] )
    ->joinConds( [ 'page' => [ 'INNER JOIN', [ 'page_id=rd_from' ] ] ] )
    ->caller( __METHOD__ )
    ->fetchResultSet();
```

`PageUpdater::doPoolPurge()` update:

```php
// Before
$this->connection->update(
    'page',
    [ 'page_touched' => $now ],
    [
        'page_id' => $ids,
        'page_touched < ' . $this->connection->addQuotes( $now )
    ],
    __METHOD__
);

// After
$this->connection->newUpdateQueryBuilder()
    ->update( 'page' )
    ->set( [ 'page_touched' => $now ] )
    ->where( [
        'page_id' => $ids,
        'page_touched < ' . $this->connection->addQuotes( $now )
    ] )
    ->caller( __METHOD__ )
    ->execute();
```

## Test plan

- [x] `composer analyze` clean (PHP-Parallel-Lint OK on 2122 files; PHPCS 0 errors / 0 warnings on changed files).
- [x] Filtered tests pass for every file: `ListLookupTest`, `ListAugmentorTest`, `ArticleLookupTest`, `TitleFactoryTest`, `TitleLookupTest`, `PageUpdaterTest`, `HashFieldUpdateTest`.
- [x] Broader Unit cross-impact suite green: `Unit/SQLStore` + `Unit/MediaWiki` + `Unit/Elastic` + `Unit/Maintenance` (874 tests / 1819 assertions / 1 pre-existing skip in `PostgresTableBuilderTest`, unrelated). Includes the cross-impact fixes for `EntityIdManagerTest` and `EntityIdFinderTest` exercising the converted `HashFieldUpdate::doUpdate()`.
- [x] Local browser smoke against the dev wiki at `localhost:8080` with 79 seeded dog-breed pages:
  - `Special:Browse/Property:Has_breed_group` renders with HTTP 200, no `smw-error` (exercises `TitleLookup` paths).
  - Api `smwbrowse` for `browse=property&params={search:"Breed"}` returns the seeded properties (exercises `ListLookup` + `ListAugmentor`).
  - Api `smwbrowse` for `browse=page&params={search:"Akita"}` returns the seeded "Akita" breed page (exercises `ArticleLookup`).
- [ ] CI matrix green on MySQL + Postgres + SQLite (will verify before promoting from draft).