### PR TITLE
Restore implicit LIMIT 1 in QueryBuilder fetchRow() conversions

### DIFF
--- a/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
@@ -300,6 +300,7 @@ class EntityLookupTaskHandler extends TaskHandler implements ActionableTask {
 			] )
 			->from( SQLStore::FT_SEARCH_TABLE )
 			->where( [ 's_id' => $id ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/ConceptCache.php
+++ b/src/SQLStore/ConceptCache.php
@@ -229,6 +229,7 @@ class ConceptCache {
 			->select( [ 'concept_txt', 'concept_features', 'concept_size', 'concept_depth', 'cache_date', 'cache_count' ] )
 			->from( 'smw_fpt_conc' )
 			->where( [ 's_id' => $cid ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/EntityStore/DuplicateFinder.php
+++ b/src/SQLStore/EntityStore/DuplicateFinder.php
@@ -112,6 +112,7 @@ class DuplicateFinder {
 					->select( [ 'smw_id', 'smw_title', 'smw_namespace', 'smw_iw', 'smw_subobject' ] )
 					->from( SQLStore::ID_TABLE )
 					->where( [ 'smw_id' => $row->s_id ] )
+					->limit( 1 )
 					->caller( $fname )
 					->fetchRow();
 

--- a/src/SQLStore/EntityStore/EntityIdFinder.php
+++ b/src/SQLStore/EntityStore/EntityIdFinder.php
@@ -66,6 +66,7 @@ class EntityIdFinder {
 				'smw_iw' => $dataItem->getInterWiki(),
 				'smw_subobject' => $dataItem->getSubobjectName()
 			] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 
@@ -121,6 +122,7 @@ class EntityIdFinder {
 			->select( $fields )
 			->from( SQLStore::ID_TABLE )
 			->where( [ 'smw_id' => $id ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 
@@ -200,6 +202,7 @@ class EntityIdFinder {
 				'smw_iw' => $iw,
 				'smw_subobject' => $subobjectName
 			] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -752,6 +752,7 @@ class EntityIdManager {
 			->select( 'smw_rev' )
 			->from( SQLStore::ID_TABLE )
 			->where( $cond )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/EntityStore/IdChanger.php
+++ b/src/SQLStore/EntityStore/IdChanger.php
@@ -51,6 +51,7 @@ class IdChanger {
 			->select( '*' )
 			->from( SQLStore::ID_TABLE )
 			->where( [ 'smw_id' => $curid ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 
@@ -160,6 +161,7 @@ class IdChanger {
 					->select( [ 's_id' ] )
 					->from( $proptable->getName() )
 					->where( [ 's_id' => $old_id ] )
+					->limit( 1 )
 					->caller( __METHOD__ )
 					->fetchRow();
 
@@ -203,6 +205,7 @@ class IdChanger {
 						->select( [ $fieldName ] )
 						->from( $proptable->getName() )
 						->where( [ $fieldName => $old_id ] )
+						->limit( 1 )
 						->caller( __METHOD__ )
 						->fetchRow();
 

--- a/src/SQLStore/EntityStore/IdEntityFinder.php
+++ b/src/SQLStore/EntityStore/IdEntityFinder.php
@@ -165,7 +165,7 @@ class IdEntityFinder {
 			->caller( __METHOD__ );
 
 		if ( $selectRow ) {
-			return $queryBuilder->fetchRow();
+			return $queryBuilder->limit( 1 )->fetchRow();
 		}
 
 		return $queryBuilder->fetchResultSet();

--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -420,6 +420,7 @@ class PropertySubjectsLookup {
 			->select( [ 'usage_count' ] )
 			->from( SQLStore::PROPERTY_STATISTICS_TABLE )
 			->where( [ 'p_id' => $pid ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/EntityStore/SequenceMapFinder.php
+++ b/src/SQLStore/EntityStore/SequenceMapFinder.php
@@ -84,6 +84,7 @@ class SequenceMapFinder {
 			->select( [ 'smw_seqmap' ] )
 			->from( SQLStore::ID_AUXILIARY_TABLE )
 			->where( [ 'smw_id' => $sid ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/Lookup/KeysetPaginationTrait.php
+++ b/src/SQLStore/Lookup/KeysetPaginationTrait.php
@@ -27,6 +27,7 @@ trait KeysetPaginationTrait {
 			->from( SQLStore::ID_TABLE )
 			->field( 'smw_sort' )
 			->where( [ 'smw_id' => $cursorId ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/PropertyStatisticsStore.php
+++ b/src/SQLStore/PropertyStatisticsStore.php
@@ -232,6 +232,7 @@ class PropertyStatisticsStore {
 			->select( [ 'usage_count' ] )
 			->from( SQLStore::PROPERTY_STATISTICS_TABLE )
 			->where( [ 'p_id' => $propertyId ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/PropertyTable/PropertyTableHashes.php
+++ b/src/SQLStore/PropertyTable/PropertyTableHashes.php
@@ -103,6 +103,7 @@ class PropertyTableHashes {
 			->select( [ 'smw_proptable_hash' ] )
 			->from( SQLStore::ID_TABLE )
 			->where( [ 'smw_id' => $id ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/PropertyTableIdReferenceFinder.php
+++ b/src/SQLStore/PropertyTableIdReferenceFinder.php
@@ -194,6 +194,7 @@ class PropertyTableIdReferenceFinder {
 				->select( [ 's_id' ] )
 				->from( $proptable->getName() )
 				->where( [ 's_id' => $id ] )
+				->limit( 1 )
 				->caller( __METHOD__ )
 				->fetchRow();
 		}
@@ -214,6 +215,7 @@ class PropertyTableIdReferenceFinder {
 				->select( $field )
 				->from( $proptable->getName() )
 				->where( [ 'o_id' => $id ] )
+				->limit( 1 )
 				->caller( __METHOD__ )
 				->fetchRow();
 
@@ -230,6 +232,7 @@ class PropertyTableIdReferenceFinder {
 				->select( [ 's_id' ] )
 				->from( $proptable->getName() )
 				->where( [ 'p_id' => $id ] )
+				->limit( 1 )
 				->caller( __METHOD__ )
 				->fetchRow();
 		}
@@ -245,6 +248,7 @@ class PropertyTableIdReferenceFinder {
 			->select( [ 's_id' ] )
 			->from( SQLStore::QUERY_LINKS_TABLE )
 			->where( [ 'o_id' => $id ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/PropertyTableRowDiffer.php
+++ b/src/SQLStore/PropertyTableRowDiffer.php
@@ -197,6 +197,7 @@ class PropertyTableRowDiffer {
 					->select( 's_id' )
 					->from( $propertyTable->getName() )
 					->where( [ 's_id' => $sid ] )
+					->limit( 1 )
 					->caller( __METHOD__ )
 					->fetchRow();
 

--- a/src/SQLStore/PropertyTableRowMapper.php
+++ b/src/SQLStore/PropertyTableRowMapper.php
@@ -285,6 +285,7 @@ class PropertyTableRowMapper {
 			->select( [ 'cache_date', 'cache_count' ] )
 			->from( 'smw_fpt_conc' )
 			->where( [ 's_id' => $sid ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/PropertyTypeFinder.php
+++ b/src/SQLStore/PropertyTypeFinder.php
@@ -78,6 +78,7 @@ class PropertyTypeFinder {
 					'smw_iw'        => '',
 					'smw_subobject' => '',
 				] )
+				->limit( 1 )
 				->caller( __METHOD__ )
 				->fetchRow();
 		} catch ( Exception ) {
@@ -103,6 +104,7 @@ class PropertyTypeFinder {
 			->select( [ 'o_serialized' ] )
 			->from( $this->typeTableName )
 			->where( [ 's_id' => $row->smw_id ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/QueryDependency/DependencyLinksValidator.php
+++ b/src/SQLStore/QueryDependency/DependencyLinksValidator.php
@@ -154,6 +154,7 @@ class DependencyLinksValidator {
 				'p.s_id' => $list,
 				'smw_touched > ' . $connection->addQuotes( $touched ),
 			] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -474,6 +474,7 @@ class QueryDependencyLinksStore {
 			->select( [ 's_id' ] )
 			->from( SQLStore::QUERY_LINKS_TABLE )
 			->where( [ 's_id' => $sid ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/RedirectStore.php
+++ b/src/SQLStore/RedirectStore.php
@@ -236,6 +236,7 @@ class RedirectStore {
 			->select( [ 'o_id' ] )
 			->from( self::TABLE_NAME )
 			->where( [ 's_title' => $title, 's_namespace' => $namespace ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 
@@ -249,6 +250,7 @@ class RedirectStore {
 			->select( [ 'o_id' ] )
 			->from( self::TABLE_NAME )
 			->where( [ 's_title' => $title, 's_namespace' => $namespace, 'o_id' => $id ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/TableBuilder/Examiner/FixedProperties.php
+++ b/src/SQLStore/TableBuilder/Examiner/FixedProperties.php
@@ -91,6 +91,7 @@ class FixedProperties {
 				'smw_namespace' => SMW_NS_PROPERTY,
 				'smw_subobject' => ''
 			] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 

--- a/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
+++ b/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
@@ -86,6 +86,7 @@ class PredefinedProperties {
 					'smw_namespace' => SMW_NS_PROPERTY,
 					'smw_subobject' => ''
 				] )
+				->limit( 1 )
 				->caller( __METHOD__ )
 				->fetchRow();
 
@@ -113,6 +114,7 @@ class PredefinedProperties {
 			] )
 			->from( SQLStore::ID_TABLE )
 			->where( [ 'smw_id' => $id ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 
@@ -152,6 +154,7 @@ class PredefinedProperties {
 			->select( [ 'p_id' ] )
 			->from( SQLStore::PROPERTY_STATISTICS_TABLE )
 			->where( [ 'p_id' => $id ] )
+			->limit( 1 )
 			->caller( __METHOD__ )
 			->fetchRow();
 


### PR DESCRIPTION
## Summary

Audits all `fetchRow()` callsites converted from legacy `IDatabase::selectRow()` during the umbrella QueryBuilder migration (PR-2 through PR-9) and restores the implicit `LIMIT 1` that was silently dropped.

## Background

Legacy `IDatabase::selectRow()` injects `LIMIT 1` into the options before delegating to `select()`:

```php
public function selectRow( $tables, $vars, $conds, ..., $options = [], ... ) {
    $options = (array)$options;
    $options['LIMIT'] = 1;
    $res = $this->select( $tables, $vars, $conds, $fname, $options, $join_conds );
    ...
}
```

The QueryBuilder factory method `fetchRow()` does **not** add this bound. So conversions written as

```php
$db->newSelectQueryBuilder()
    ->select( [...] )
    ->from( $table )
    ->where( $conds )
    ->caller( __METHOD__ )
    ->fetchRow();
```

return the first row of an unbounded scan rather than the first row of a `LIMIT 1` query. For non-selective WHERE clauses (e.g. `s_id = ?` against tables without a unique index, or `smw_iw = ?`) this can scan many more rows than intended.

For aggregate-only projections (`COUNT(...)`, `SUM(...)`, `MAX(...)`, etc.) the behaviour is identical with or without `LIMIT 1` since the query always returns exactly one row, so those callsites were left untouched.

## Scope

32 callsites across 21 files audited and patched. All fixes are mechanical: insert `->limit( 1 )` as the last call before `->caller( __METHOD__ )`. No behavioural changes beyond bound restoration.

Files modified:

- `src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php`
- `src/SQLStore/ConceptCache.php`
- `src/SQLStore/EntityStore/DuplicateFinder.php`
- `src/SQLStore/EntityStore/EntityIdFinder.php` (3 callsites)
- `src/SQLStore/EntityStore/EntityIdManager.php`
- `src/SQLStore/EntityStore/IdChanger.php` (3 callsites)
- `src/SQLStore/EntityStore/IdEntityFinder.php`
- `src/SQLStore/EntityStore/PropertySubjectsLookup.php`
- `src/SQLStore/EntityStore/SequenceMapFinder.php`
- `src/SQLStore/Lookup/KeysetPaginationTrait.php`
- `src/SQLStore/PropertyStatisticsStore.php`
- `src/SQLStore/PropertyTable/PropertyTableHashes.php`
- `src/SQLStore/PropertyTableIdReferenceFinder.php` (4 callsites)
- `src/SQLStore/PropertyTableRowDiffer.php`
- `src/SQLStore/PropertyTableRowMapper.php`
- `src/SQLStore/PropertyTypeFinder.php` (2 callsites)
- `src/SQLStore/QueryDependency/DependencyLinksValidator.php`
- `src/SQLStore/QueryDependency/QueryDependencyLinksStore.php`
- `src/SQLStore/RedirectStore.php` (2 callsites)
- `src/SQLStore/TableBuilder/Examiner/FixedProperties.php`
- `src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php` (3 callsites)

`IdEntityFinder.php:168` is a special case: the same `$queryBuilder` is consumed via `fetchRow()` in one branch and `fetchResultSet()` in another. The limit is applied inline only on the fetchRow branch (`return $queryBuilder->limit( 1 )->fetchRow();`) so the result-set path keeps its existing semantics.

## Aggregate-only callsites left untouched

For reference, these `fetchRow()` callsites were classified as aggregate-only and require no change:

- `src/SQLStore/Lookup/UsageStatisticsListLookup.php` (4 callsites: SUM/COUNT)
- `src/SQLStore/Lookup/TableStatisticsLookup.php` (3 callsites: COUNT)
- `src/SQLStore/QueryDependency/QueryDependencyLinksStore.php:217` (COUNT)
- `src/SQLStore/PropertyTypeFinder.php:57` (COUNT)
- `src/SQLStore/TableBuilder/Examiner/TouchedField.php:41` (COUNT)
- `src/MediaWiki/Specials/Admin/Alerts/OutdatedEntitiesMaxCountThresholdMaintenanceAlertTaskHandler.php:54` (COUNT)
- `src/MediaWiki/Specials/Admin/Alerts/ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler.php:61` (COUNT)

A similar fix-up was already merged in #6757 (`Rebuilder::next_position()` for `fetchField`); this PR is the corresponding sweep for `fetchRow`.

## Test plan
- [x] `composer phpunit -- --testsuite=semantic-mediawiki-unit` passes locally (mariadb container)
- [ ] CI green across all DB matrices