### PR TITLE
Convert Elastic/* DML to QueryBuilder

### DIFF
--- a/src/Elastic/Indexer/Rebuilder/Rebuilder.php
+++ b/src/Elastic/Indexer/Rebuilder/Rebuilder.php
@@ -70,24 +70,19 @@ class Rebuilder {
 	public function select( Store $store, array $conditions ): array {
 		$connection = $store->getConnection( 'mw.db' );
 
-		$res = $connection->select(
-			SQLStore::ID_TABLE,
-			[
-				'smw_id',
-				'smw_iw',
-				'smw_rev'
-			],
-			$conditions,
-			__METHOD__,
-			[ 'ORDER BY' => 'smw_id' ]
-		);
+		$res = $connection->newSelectQueryBuilder()
+			->select( [ 'smw_id', 'smw_iw', 'smw_rev' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( $conditions )
+			->orderBy( 'smw_id' )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
-		$last = $connection->selectField(
-			SQLStore::ID_TABLE,
-			'MAX(smw_id)',
-			'',
-			__METHOD__
-		);
+		$last = $connection->newSelectQueryBuilder()
+			->select( 'MAX(smw_id)' )
+			->from( SQLStore::ID_TABLE )
+			->caller( __METHOD__ )
+			->fetchField();
 
 		return [ $res, $last ];
 	}

--- a/tests/phpunit/Unit/Elastic/Indexer/Rebuilder/RebuilderTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Rebuilder/RebuilderTest.php
@@ -16,6 +16,7 @@ use SMW\Elastic\Indexer\Rebuilder\Rebuilder;
 use SMW\Elastic\Installer;
 use SMW\MediaWiki\Connection\Database;
 use SMW\Store;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
  * @covers \SMW\Elastic\Indexer\Rebuilder\Rebuilder
@@ -27,6 +28,8 @@ use SMW\Store;
  * @author mwjames
  */
 class RebuilderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $connection;
 	private $fileIndexer;
@@ -76,6 +79,9 @@ class RebuilderTest extends TestCase {
 		$database = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$database->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
 
 		$store = $this->getMockBuilder( Store::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/Elastic/Indexer/Rebuilder/RebuilderTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/Rebuilder/RebuilderTest.php
@@ -80,8 +80,14 @@ class RebuilderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$whereConditions = [];
+		$capturedSelects = [];
 		$database->method( 'newSelectQueryBuilder' )
-			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
+			->willReturnCallback(
+				function () use ( &$whereConditions, &$capturedSelects ) {
+					return $this->createMockSelectQueryBuilder( [], $whereConditions, $capturedSelects );
+				}
+			);
 
 		$store = $this->getMockBuilder( Store::class )
 			->disableOriginalConstructor()
@@ -100,9 +106,11 @@ class RebuilderTest extends TestCase {
 			$this->installer
 		);
 
-		$this->assertIsArray(
+		$this->assertIsArray( $instance->select( $store, [] ) );
 
-			$instance->select( $store, [] )
+		$this->assertSame(
+			[ [ 'smw_id', 'smw_iw', 'smw_rev' ], 'MAX(smw_id)' ],
+			$capturedSelects
 		);
 	}
 


### PR DESCRIPTION
## Summary

PR 11 of the umbrella SMW Rdbms QueryBuilder migration. Converts the only two SMW `Database`-wrapper callsites in `src/Elastic/*` from legacy `IDatabase::select()` / `selectField()` to the QueryBuilder factory.

## Scope

The umbrella plan budgeted `~25 callsites` for `src/Elastic/*`, but that estimate conflated elasticsearch-php client calls (`$this->client->update()`, `$this->bulk->upsert()`, `$indexer->delete()`, etc.) and entity-cache calls (`$entityCache->delete()`) with SMW Rdbms calls. The actual SMW Database-wrapper callsites in scope are **2**, both in `Rebuilder::select()`.

A grep across `src/Elastic/` for `(->select|->selectField|->selectRow|->insert|->update|->delete|->upsert)` against the SMW Database wrapper confirms no other callsites exist.

## Changes

### `src/Elastic/Indexer/Rebuilder/Rebuilder.php`

The `select( Store $store, array $conditions ): array` helper acquires the MW DB connection and emits two queries:

**Before:**
```php
$res = $connection->select(
    SQLStore::ID_TABLE,
    [ 'smw_id', 'smw_iw', 'smw_rev' ],
    $conditions,
    __METHOD__,
    [ 'ORDER BY' => 'smw_id' ]
);

$last = $connection->selectField(
    SQLStore::ID_TABLE,
    'MAX(smw_id)',
    '',
    __METHOD__
);
```

**After:**
```php
$res = $connection->newSelectQueryBuilder()
    ->select( [ 'smw_id', 'smw_iw', 'smw_rev' ] )
    ->from( SQLStore::ID_TABLE )
    ->where( $conditions )
    ->orderBy( 'smw_id' )
    ->caller( __METHOD__ )
    ->fetchResultSet();

$last = $connection->newSelectQueryBuilder()
    ->select( 'MAX(smw_id)' )
    ->from( SQLStore::ID_TABLE )
    ->caller( __METHOD__ )
    ->fetchField();
```

Behaviour preserved exactly: same fields, same conditions, same `ORDER BY`, same caller, same aggregate. No `->limit( 1 )` added: `fetchRow()`/`fetchField()` delegate to legacy `selectRow()`/`selectField()` which inject `LIMIT 1` upstream, and aggregates return one row regardless.

### `tests/phpunit/Unit/Elastic/Indexer/Rebuilder/RebuilderTest.php`

`testSelect` now stubs `newSelectQueryBuilder` via `MockSelectQueryBuilderTrait` so the converted code path resolves through a chained-builder mock. The pre-conversion test was a smoke test (no expectations on the two legacy methods); this PR also tightens it by capturing both `select()` invocations and asserting:

```php
$this->assertSame(
    [ [ 'smw_id', 'smw_iw', 'smw_rev' ], 'MAX(smw_id)' ],
    $capturedSelects
);
```

so a regression that silently loses either query is now caught.

## Verification

- `composer analyze` clean (2122 files, 0 syntax errors, 0 PHPCS issues)
- Full unit suite green: 6873 tests, 14105 assertions, 6 pre-existing skips (elasticsearch-php / postgres test environment, unrelated)
- `RebuilderTest`: 54 tests, 112 assertions

## Test plan
- [x] Local unit suite green on mariadb container
- [ ] CI matrix green (MySQL, Postgres, SQLite)