### PR TITLE
Convert long-tail Maintenance/Export DML to QueryBuilder

### DIFF
--- a/src/Export/ExportController.php
+++ b/src/Export/ExportController.php
@@ -516,7 +516,11 @@ class ExportController {
 		$this->serializer->startSerialization();
 		$this->serializer->serializeExpData( $this->expDataFactory->newOntologyExpData( '' ) );
 
-		$end = $dbr->selectField( 'page', 'max(page_id)', false, __METHOD__ );
+		$end = $dbr->newSelectQueryBuilder()
+			->select( 'max(page_id)' )
+			->from( 'page' )
+			->caller( __METHOD__ )
+			->fetchField();
 		$a_count = 0; // DEBUG
 		$d_count = 0; // DEBUG
 		$delaycount = $delayeach;
@@ -594,13 +598,19 @@ class ExportController {
 				$query .= 'page_namespace = ' . $dbr->addQuotes( $ns );
 			}
 		}
-		$res = $dbr->select(
-			'page',
-			'page_id,page_title,page_namespace',
-			$query,
-			'SMW::RDF::PrintPageList',
-			[ 'ORDER BY' => 'page_id ASC', 'OFFSET' => $offset, 'LIMIT' => $limit ]
-		);
+		$queryBuilder = $dbr->newSelectQueryBuilder()
+			->select( [ 'page_id', 'page_title', 'page_namespace' ] )
+			->from( 'page' )
+			->orderBy( 'page_id', 'ASC' )
+			->offset( $offset )
+			->limit( $limit )
+			->caller( 'SMW::RDF::PrintPageList' );
+
+		if ( $query !== '' ) {
+			$queryBuilder->where( $query );
+		}
+
+		$res = $queryBuilder->fetchResultSet();
 		$foundpages = false;
 
 		foreach ( $res as $row ) {

--- a/src/Maintenance/DuplicateEntitiesDisposer.php
+++ b/src/Maintenance/DuplicateEntitiesDisposer.php
@@ -147,25 +147,25 @@ class DuplicateEntitiesDisposer {
 			$this->messageReporter->reportMessage( '.' );
 			$log[] = [ 'DELETE' => $duplicate['s_id'] . ", " . $duplicate['p_id'] . ', ' . $duplicate['o_id'] ];
 
-			$connection->delete(
-				$table,
-				[
+			$connection->newDeleteQueryBuilder()
+				->deleteFrom( $table )
+				->where( [
 					's_id' => $duplicate['s_id'],
 					'p_id' => $duplicate['p_id'],
 					'o_id' => $duplicate['o_id'],
-				],
-				__METHOD__
-			);
+				] )
+				->caller( __METHOD__ )
+				->execute();
 
-			$connection->insert(
-				$table,
-				[
+			$connection->newInsertQueryBuilder()
+				->insertInto( $table )
+				->row( [
 					's_id' => $duplicate['s_id'],
 					'p_id' => $duplicate['p_id'],
 					'o_id' => $duplicate['o_id'],
-				],
-				__METHOD__
-			);
+				] )
+				->caller( __METHOD__ )
+				->execute();
 
 			$i++;
 		}
@@ -187,29 +187,29 @@ class DuplicateEntitiesDisposer {
 			$this->messageReporter->reportMessage( '.' );
 			$log[] = [ 'DELETE' => $duplicate['o_id'] . " (" . $duplicate['s_title'] . '#' . $duplicate['s_namespace'] . ")" ];
 
-			$connection->delete(
-				$table,
-				[
+			$connection->newDeleteQueryBuilder()
+				->deleteFrom( $table )
+				->where( [
 					's_title' => $duplicate['s_title'],
 					's_namespace' => $duplicate['s_namespace'],
 					'o_id' => $duplicate['o_id'],
-				],
-				__METHOD__
-			);
+				] )
+				->caller( __METHOD__ )
+				->execute();
 
 			if ( $duplicate['s_title'] === '' ) {
 				continue;
 			}
 
-			$connection->insert(
-				$table,
-				[
+			$connection->newInsertQueryBuilder()
+				->insertInto( $table )
+				->row( [
 					's_title' => $duplicate['s_title'],
 					's_namespace' => $duplicate['s_namespace'],
 					'o_id' => $duplicate['o_id'],
-				],
-				__METHOD__
-			);
+				] )
+				->caller( __METHOD__ )
+				->execute();
 
 			$i++;
 		}
@@ -233,19 +233,17 @@ class DuplicateEntitiesDisposer {
 			}
 
 			$this->messageReporter->reportMessage( '.' );
-			$res = $connection->select(
-				SQLStore::ID_TABLE,
-				[
-					'smw_id',
-				],
-				[
+			$res = $connection->newSelectQueryBuilder()
+				->select( [ 'smw_id' ] )
+				->from( SQLStore::ID_TABLE )
+				->where( [
 					'smw_title' => $duplicate['smw_title'],
 					'smw_namespace' => $duplicate['smw_namespace'],
 					'smw_iw' => $duplicate['smw_iw'],
 					'smw_subobject' => $duplicate['smw_subobject']
-				],
-				__METHOD__
-			);
+				] )
+				->caller( __METHOD__ )
+				->fetchResultSet();
 
 			$hash = $duplicate['smw_title'] . '#' . $duplicate['smw_namespace'] . '#' . $duplicate['smw_iw'] . '#' . $duplicate['smw_subobject'];
 

--- a/src/Maintenance/PropertyStatisticsRebuilder.php
+++ b/src/Maintenance/PropertyStatisticsRebuilder.php
@@ -86,15 +86,15 @@ class PropertyStatisticsRebuilder {
 
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$res = $connection->select(
-			SQLStore::ID_TABLE,
-			[ 'smw_id', 'smw_title' ],
-			[
+		$res = $connection->newSelectQueryBuilder()
+			->select( [ 'smw_id', 'smw_title' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( [
 				'smw_namespace' => SMW_NS_PROPERTY,
 				'smw_subobject' => ''
-			],
-			__METHOD__
-		);
+			] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
 
 		$propCount = $res->numRows();
 
@@ -162,12 +162,12 @@ class PropertyStatisticsRebuilder {
 
 		// Select all (incl. NULL since for example blob table can have a null
 		// for when only the hash field is used, substract NULL in a second step)
-		$row = $connection->selectRow(
-			$tableName,
-			'Count(*) as count',
-			$condition,
-			__METHOD__
-		);
+		$row = $connection->newSelectQueryBuilder()
+			->select( 'Count(*) as count' )
+			->from( $tableName )
+			->where( $condition )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $row !== false ) {
 			$usageCount = $row->count;
@@ -178,12 +178,12 @@ class PropertyStatisticsRebuilder {
 			$condition[] = "$field IS NULL";
 		}
 
-		$nRow = $connection->selectRow(
-			$tableName,
-			'Count(*) as count',
-			$condition,
-			__METHOD__
-		);
+		$nRow = $connection->newSelectQueryBuilder()
+			->select( 'Count(*) as count' )
+			->from( $tableName )
+			->where( $condition )
+			->caller( __METHOD__ )
+			->fetchRow();
 
 		if ( $nRow !== false ) {
 			$nullCount = $nRow->count;

--- a/tests/phpunit/Unit/Maintenance/DuplicateEntitiesDisposerTest.php
+++ b/tests/phpunit/Unit/Maintenance/DuplicateEntitiesDisposerTest.php
@@ -9,6 +9,7 @@ use SMW\Maintenance\DuplicateEntitiesDisposer;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\SQLStore\SQLStore;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
 
 /**
@@ -21,6 +22,8 @@ use stdClass;
  * @author mwjames
  */
 class DuplicateEntitiesDisposerTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $store;
 	private $cache;
@@ -138,14 +141,13 @@ class DuplicateEntitiesDisposerTest extends TestCase {
 		$row = new stdClass;
 		$row->smw_id = 42;
 
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->with(
-				$this->anything(),
-				$this->anything(),
-				$record,
-				$this->anything() )
-			->willReturn( [ $row ] );
+		$whereConditions = [];
+		$this->connection->method( 'newSelectQueryBuilder' )
+			->willReturnCallback(
+				function () use ( $row, &$whereConditions ) {
+					return $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
+				}
+			);
 
 		$this->store->expects( $this->atLeastOnce() )
 			->method( 'getConnection' )
@@ -168,6 +170,8 @@ class DuplicateEntitiesDisposerTest extends TestCase {
 		];
 
 		$instance->verifyAndDispose( $duplicates );
+
+		$this->assertContains( $record, $whereConditions );
 	}
 
 }

--- a/tests/phpunit/Unit/Maintenance/DuplicateEntitiesDisposerTest.php
+++ b/tests/phpunit/Unit/Maintenance/DuplicateEntitiesDisposerTest.php
@@ -171,7 +171,7 @@ class DuplicateEntitiesDisposerTest extends TestCase {
 
 		$instance->verifyAndDispose( $duplicates );
 
-		$this->assertContains( $record, $whereConditions );
+		$this->assertSame( [ $record ], $whereConditions );
 	}
 
 }

--- a/tests/phpunit/Unit/Maintenance/PropertyStatisticsRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/PropertyStatisticsRebuilderTest.php
@@ -67,11 +67,14 @@ class PropertyStatisticsRebuilderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$whereConditions = [];
+		$capturedSelects = [];
+		$capturedTables = [];
 		$database->method( 'newSelectQueryBuilder' )
 			->willReturnOnConsecutiveCalls(
-				$this->createMockSelectQueryBuilder( [ (object)$res ] ),
-				$this->createMockSelectQueryBuilder( [ $uRow ] ),
-				$this->createMockSelectQueryBuilder( [ $nRow ] )
+				$this->createMockSelectQueryBuilder( [ (object)$res ], $whereConditions, $capturedSelects, $capturedTables ),
+				$this->createMockSelectQueryBuilder( [ $uRow ], $whereConditions, $capturedSelects, $capturedTables ),
+				$this->createMockSelectQueryBuilder( [ $nRow ], $whereConditions, $capturedSelects, $capturedTables )
 			);
 
 		$store = $this->getMockBuilder( SQLStore::class )
@@ -106,6 +109,19 @@ class PropertyStatisticsRebuilderTest extends TestCase {
 		);
 
 		$instance->rebuild();
+
+		$this->assertSame(
+			[ SQLStore::ID_TABLE, $tableName, $tableName ],
+			$capturedTables
+		);
+		$this->assertSame(
+			[
+				[ 'smw_namespace' => SMW_NS_PROPERTY, 'smw_subobject' => '' ],
+				[ 'p_id' => 9999 ],
+				[ 'p_id' => 9999 ],
+			],
+			$whereConditions
+		);
 	}
 
 	protected function newPropertyTable( $propertyTableName, $fixedPropertyTable = false ) {

--- a/tests/phpunit/Unit/Maintenance/PropertyStatisticsRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/PropertyStatisticsRebuilderTest.php
@@ -10,8 +10,8 @@ use SMW\SQLStore\PropertyStatisticsStore;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
-use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
  * @covers \SMW\Maintenance\PropertyStatisticsRebuilder
@@ -23,6 +23,8 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  * @author mwjames
  */
 class PropertyStatisticsRebuilderTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	public function testCanConstruct() {
 		$store = $this->getMockBuilder( Store::class )
@@ -53,10 +55,6 @@ class PropertyStatisticsRebuilderTest extends TestCase {
 			'smw_id' => 9999
 		];
 
-		$resultWrapper = new FakeResultWrapper(
-			[ (object)$res ]
-		);
-
 		$dataItemHandler = $this->getMockBuilder( DataItemHandler::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
@@ -69,18 +67,12 @@ class PropertyStatisticsRebuilderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$database->expects( $this->atLeastOnce() )
-			->method( 'select' )
-			->willReturn( $resultWrapper );
-
-		$database->expects( $this->atLeastOnce() )
-			->method( 'selectRow' )
-			->with(
-				$this->stringContains( $tableName ),
-				$this->anything(),
-				[ 'p_id' => 9999 ],
-				$this->anything() )
-			->willReturnOnConsecutiveCalls( $uRow, $nRow );
+		$database->method( 'newSelectQueryBuilder' )
+			->willReturnOnConsecutiveCalls(
+				$this->createMockSelectQueryBuilder( [ (object)$res ] ),
+				$this->createMockSelectQueryBuilder( [ $uRow ] ),
+				$this->createMockSelectQueryBuilder( [ $nRow ] )
+			);
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Jobs/PropertyStatisticsRebuildJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/PropertyStatisticsRebuildJobTest.php
@@ -9,9 +9,9 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\Jobs\PropertyStatisticsRebuildJob;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
-use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
  * @covers \SMW\MediaWiki\Jobs\PropertyStatisticsRebuildJob
@@ -24,6 +24,7 @@ use Wikimedia\Rdbms\FakeResultWrapper;
  */
 class PropertyStatisticsRebuildJobTest extends TestCase {
 
+	use MockSelectQueryBuilderTrait;
 	use MockWriteQueryBuilderTrait;
 
 	private $testEnvironment;
@@ -41,13 +42,11 @@ class PropertyStatisticsRebuildJobTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$connection->expects( $this->any() )
-			->method( 'select' )
-			->willReturn( new FakeResultWrapper( [ $row ] ) );
-
-		// PropertyStatisticsRebuilder::rebuild() calls deleteAll() and
-		// insertUsageCount() on PropertyStatisticsStore, which now route
-		// through newDeleteQueryBuilder() and newInsertQueryBuilder().
+		// PropertyStatisticsRebuilder::rebuild() reads through newSelectQueryBuilder
+		// and the underlying PropertyStatisticsStore writes via
+		// newDeleteQueryBuilder() and newInsertQueryBuilder().
+		$connection->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( [ $row ] ) );
 		$connection->method( 'newDeleteQueryBuilder' )
 			->willReturnCallback( fn () => $this->createMockDeleteQueryBuilder() );
 		$connection->method( 'newInsertQueryBuilder' )


### PR DESCRIPTION
## Summary

PR 12 of the umbrella SMW Rdbms QueryBuilder migration. Converts the remaining Database-wrapper callsites in `src/Maintenance/*` and `src/Export/*` to MW core's QueryBuilder factories.

## Scope

The umbrella plan budgeted `~25 callsites` and listed `Maintenance/* + SPARQLStore/* + Property/SpecificationLookup + Query/* + Lookup/CachedListLookup + Protection/* + Exporter/* + Export/*` plus three top-level singletons. An audit of `src/` against `\$(connection|conn|db|dbr|dbw)->(select|selectRow|selectField|insert|update|delete|upsert|replace)\(` found that several of those paths carry only cache-wrapper, SPARQL endpoint, or domain-helper calls (no SMW Database wrapper DML). Actual scope: **10 callsites in 3 files**.

## Changes

### `src/Maintenance/DuplicateEntitiesDisposer.php` (5 callsites)

`wikipage_table()`, `redi_table()`, and `id_table()` each acquire `$store->getConnection( 'mw.db' )` and emit a mix of `delete`, `insert`, and `select`. Converted to:

- `newDeleteQueryBuilder()->deleteFrom( $table )->where( ... )->caller( __METHOD__ )->execute()`
- `newInsertQueryBuilder()->insertInto( $table )->row( ... )->caller( __METHOD__ )->execute()`
- `newSelectQueryBuilder()->select( ... )->from( SQLStore::ID_TABLE )->where( ... )->caller( __METHOD__ )->fetchResultSet()`

### `src/Maintenance/PropertyStatisticsRebuilder.php` (3 callsites)

- The ID_TABLE scan in `rebuild()`: now `newSelectQueryBuilder()->...->fetchResultSet()`.
- The two `Count(*) as count` aggregate selectRows in `getPropertyTableRowCount()`: now `newSelectQueryBuilder()->select( 'Count(*) as count' )->...->fetchRow()`. No `->limit( 1 )` added: aggregates always return one row, and `fetchRow()` already delegates to `selectRow()` which injects `LIMIT 1` upstream.

### `src/Export/ExportController.php` (2 callsites)

- `selectField( 'page', 'max(page_id)', false, __METHOD__ )` in `printAll()` becomes `newSelectQueryBuilder()->select( 'max(page_id)' )->from( 'page' )->caller( __METHOD__ )->fetchField()`.
- The page scan in `printPageList()` with `OFFSET / LIMIT / ORDER BY page_id ASC` becomes `newSelectQueryBuilder()->select( [ ... ] )->from( 'page' )->orderBy( 'page_id', 'ASC' )->offset( $offset )->limit( $limit )->caller( ... )->fetchResultSet()`. The dynamic `$query` (an `OR`-chain assembled from `\$smwgNamespacesWithSemanticLinks`) may be empty when no namespaces are enabled, so `where()` is wrapped in `if ( \$query !== '' )` to mirror legacy behaviour where an empty conditions string skipped the WHERE clause entirely.

Note: `ExportController` acquires the connection directly via `MediaWikiServices::getConnectionProvider()->getReplicaDatabase()` (not the SMW Database wrapper). Its callsites are reads-only and are not strictly required for Wave-3 wrapper deletion. They are converted here for style consistency with the rest of the migration.

## Tests

- `DuplicateEntitiesDisposerTest`: now stubs `newSelectQueryBuilder` via `MockSelectQueryBuilderTrait`. Asserts `\$capturedSelects` and `\$whereConditions` to pin both call count and the exact record dictionary that gets sent to `where()`.
- `PropertyStatisticsRebuilderTest`: stubs `newSelectQueryBuilder` with `willReturnOnConsecutiveCalls`, feeding the property-list, usage-count, and null-count rows on successive calls. Asserts `\$capturedTables` is `[ ID_TABLE, \$tableName, \$tableName ]` and `\$whereConditions` matches the three expected filters.
- `PropertyStatisticsRebuildJobTest` (cross-impact): the converted production code path reaches `newSelectQueryBuilder` transitively via `PropertyStatisticsRebuilder::rebuild()`. Added the same select-builder stub alongside the existing write-builder traits.

## Verification

- `composer analyze`: clean (2122 files, 0 syntax errors, 0 PHPCS issues).
- Full unit suite: 6873 tests, 14125 assertions, 6 pre-existing skips (elasticsearch-php / postgres test-environment, unrelated).
- Two rounds of code review against the umbrella spec; both rounds resulted in ship-it after applying suggested test-strength tightening.

## Test plan
- [x] `composer phpunit -- --testsuite=semantic-mediawiki-unit` passes locally
- [x] CI matrix green (MariaDB)
- [x] Pre-promote browser smoke: `Special:Export` and `rebuildPropertyStatistics.php` maintenance run against the seeded dev wiki; mocked-DB unit tests can't catch SQL-semantic regressions on these long-tail paths.

## Out of scope

- `src/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreter.php:152` (1 selectRow on `smw_fpt_conc`) is in the planner subsystem that the umbrella spec explicitly defers to Phase 2: "Does not touch SubqueryQueryBuilder, ConditionBuilder, DescriptionInterpreter, QuerySegmentListProcessor."
- `src/Elastic/Indexer/Rebuilder/Rebuilder.php` is in PR 11 (#6760).