### PR TITLE
Convert orphaned legacy DB callsites missed by Wave 2

### DIFF
--- a/src/MediaWiki/Connection/Sequence.php
+++ b/src/MediaWiki/Connection/Sequence.php
@@ -59,7 +59,11 @@ class Sequence {
 			$this->connection->tablePrefix( $this->tablePrefix );
 		}
 
-		$seq_num = $this->connection->selectField( $table, "max({$field})", [], __METHOD__ );
+		$seq_num = $this->connection->newSelectQueryBuilder()
+			->select( "max({$field})" )
+			->from( $table )
+			->caller( __METHOD__ )
+			->fetchField();
 		$seq_num += 1;
 
 		$sequence = self::makeSequence( $table, $field );

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreter.php
@@ -149,12 +149,12 @@ class ConceptDescriptionInterpreter implements DescriptionInterpreter {
 	 * do on getWikiValue
 	 */
 	private function findConceptById( $connection, $id ) {
-		return $connection->selectRow(
-			'smw_fpt_conc',
-			[ 'concept_txt', 'concept_features', 'concept_size', 'concept_depth', 'cache_date' ],
-			[ 's_id' => $id ],
-			__METHOD__
-		);
+		return $connection->newSelectQueryBuilder()
+			->select( [ 'concept_txt', 'concept_features', 'concept_size', 'concept_depth', 'cache_date' ] )
+			->from( 'smw_fpt_conc' )
+			->where( [ 's_id' => $id ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 	}
 
 	/**

--- a/tests/phpunit/Unit/MediaWiki/Connection/SequenceTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/SequenceTest.php
@@ -17,6 +17,8 @@ use SMW\MediaWiki\Connection\Sequence;
  */
 class SequenceTest extends TestCase {
 
+	use MockSelectQueryBuilderTrait;
+
 	private $connection;
 
 	protected function setUp(): void {
@@ -72,9 +74,8 @@ class SequenceTest extends TestCase {
 			->method( 'query' )
 			->with( 'ALTER SEQUENCE Foo_bar_seq RESTART WITH 43' );
 
-		$this->connection->expects( $this->once() )
-			->method( 'selectField' )
-			->willReturn( 42 );
+		$this->connection->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( [ [ 42 ] ] ) );
 
 		$instance = new Sequence(
 			$this->connection

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreterTest.php
@@ -11,6 +11,7 @@ use SMW\SQLStore\QueryEngine\DescriptionInterpreters\ConceptDescriptionInterpret
 use SMW\SQLStore\QueryEngineFactory;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use SMW\Utils\CircularReferenceGuard;
 use stdClass;
 
@@ -24,6 +25,8 @@ use stdClass;
  * @author mwjames
  */
 class ConceptDescriptionInterpreterTest extends TestCase {
+
+	use MockSelectQueryBuilderTrait;
 
 	private $querySegmentValidator;
 	private $descriptionInterpreterFactory;
@@ -125,9 +128,9 @@ class ConceptDescriptionInterpreterTest extends TestCase {
 			->method( 'addQuotes' )
 			->willReturnArgument( 0 );
 
-		$connection->expects( $this->once() )
-			->method( 'selectRow' )
-			->willReturn( $concept );
+		$concept_rows = $concept === false ? [] : [ $concept ];
+		$connection->method( 'newSelectQueryBuilder' )
+			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( $concept_rows ) );
 
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )


### PR DESCRIPTION
## Summary

Pre-Wave-3 fixup. Converts two orphaned legacy `IDatabase` callsites missed by earlier slices of the umbrella SMW Rdbms QueryBuilder migration. Mechanical, behaviour-preserving conversions; no production-logic changes.

## Audit

A grep against `origin/master` after PR 12 for `\$(connection|conn|db|dbr|dbw)->(select|selectRow|selectField|insert|update|delete|upsert|replace)\(` found three candidates, two of which are real and one of which turned out to be commented-out dead code:

| File | Line | Method | In scope? |
|---|---|---|---|
| `src/MediaWiki/Connection/Sequence.php` | 62 | `selectField` | Yes, missed in PR 10 (`MediaWiki/*` cluster). |
| `src/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreter.php` | 152 | `selectRow` | Yes. PR 8 explicitly excluded `DescriptionInterpreters/`, but this is a plain entity lookup, not planner-emission code; the exclusion was overly broad. |
| `src/SQLStore/PropertyTable/PropertyTableHashes.php` | 58 | `upsert` | No — inside a `/* ... */` comment block (lines 55-70). Not a real callsite. |

These conversions clear the way for PR 14 to delete SMW's `Database::select()/selectRow()/selectField()/insert()/update()/delete()/upsert()/replace()` overrides without leaving stranded callers.

## Changes

### `src/MediaWiki/Connection/Sequence.php`

`Sequence::restart()` is Postgres-only (early-returns null on non-Postgres). The body computes the next sequence number by reading `max(\$field)` from the table:

**Before:**
```php
$seq_num = $this->connection->selectField( $table, "max({$field})", [], __METHOD__ );
```

**After:**
```php
$seq_num = $this->connection->newSelectQueryBuilder()
    ->select( "max({$field})" )
    ->from( $table )
    ->caller( __METHOD__ )
    ->fetchField();
```

Empty conds → `where()` correctly omitted. `fetchField()` delegates to `selectField()` upstream, which still injects `LIMIT 1` (and aggregates always return one row anyway).

### `src/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreter.php`

`findConceptById()` reads concept-cache metadata for a given `s_id`:

**Before:**
```php
return $connection->selectRow(
    'smw_fpt_conc',
    [ 'concept_txt', 'concept_features', 'concept_size', 'concept_depth', 'cache_date' ],
    [ 's_id' => $id ],
    __METHOD__
);
```

**After:**
```php
return $connection->newSelectQueryBuilder()
    ->select( [ 'concept_txt', 'concept_features', 'concept_size', 'concept_depth', 'cache_date' ] )
    ->from( 'smw_fpt_conc' )
    ->where( [ 's_id' => $id ] )
    ->caller( __METHOD__ )
    ->fetchRow();
```

## Tests

- `tests/phpunit/Unit/MediaWiki/Connection/SequenceTest.php`: `testPostgres` now stubs `newSelectQueryBuilder` via `MockSelectQueryBuilderTrait`. Returns `[ [ 42 ] ]`; the trait's `fetchField()` resolves to `42`. The downstream `'ALTER SEQUENCE Foo_bar_seq RESTART WITH 43'` assertion transitively verifies the lookup ran exactly once with the right return value (any zero-call or wrong-value path would change the integer in the SQL).
- `tests/phpunit/Unit/SQLStore/QueryEngine/DescriptionInterpreters/ConceptDescriptionInterpreterTest.php`: `testInterpretDescription` now stubs `newSelectQueryBuilder`. The data provider passes either `false` (no row) or a stdClass; converted to `\$concept_rows = \$concept === false ? [] : [\$concept]` so the trait's `fetchRow()` returns the stdClass for the populated case and `false` for the empty case (matching legacy `selectRow` semantics). The downstream `\$expected->joinfield` / `where` / `components` assertions encode the row's contents.

## Verification

- `composer analyze`: clean (2122 files, 0 syntax errors, 0 PHPCS issues).
- Full unit suite: 6873 tests, 14136 assertions, 6 pre-existing skips.
- Targeted: `SequenceTest` and `ConceptDescriptionInterpreterTest` 17 tests, 32 assertions, all green.
- Code review pass: ship verdict, no Critical/Important issues.

## Test plan
- [x] Local unit suite green on MariaDB container
- [ ] CI green