### PR TITLE
Lift RAND() platform dispatch from regex shim to callsite

### DIFF
--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -268,7 +268,12 @@ class Database {
 			$tablePrefix = $this->tablePrefix( '' );
 
 			if ( isset( $options['ORDER BY'] ) ) {
-				$options['ORDER BY'] = str_replace( 'RAND', 'RANDOM', $options['ORDER BY'] );
+				// Idempotent token replacement: leaves an already-emitted
+				// RANDOM() untouched (RAND() is not a substring of RANDOM()).
+				// QueryEngine::getSQLOptions() now emits RANDOM() directly for
+				// SQLite, so this only fires for legacy callers still passing
+				// raw RAND() through select().
+				$options['ORDER BY'] = str_replace( 'RAND()', 'RANDOM()', $options['ORDER BY'] );
 			}
 		}
 
@@ -378,7 +383,10 @@ class Database {
 			$sql = str_replace( 'ENGINE=MEMORY', '', $sql );
 			$sql = str_replace( 'DROP TEMP', 'DROP', $sql );
 			$sql = str_replace( 'TRUNCATE TABLE', 'DELETE FROM', $sql );
-			$sql = str_replace( 'RAND', 'RANDOM', $sql );
+			// Idempotent token replacement: leaves an already-emitted RANDOM()
+			// untouched. Callsites should now emit the platform-correct token
+			// directly; this stays as a fallback for raw query() callers.
+			$sql = str_replace( 'RAND()', 'RANDOM()', $sql );
 		}
 
 		// https://github.com/wikimedia/mediawiki/blob/42d5e6f43a00eb8bedc3532876125f74e3188343/includes/deferred/AutoCommitUpdate.php

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -557,6 +557,14 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		// Build ORDER BY options using discovered sorting fields.
 		$qobj = $this->querySegmentList[$rootId];
 
+		// Postgres masks off SMW_QSORT_RANDOM in getQueryResult() before
+		// reaching this branch (SELECT DISTINCT + ORDER BY RANDOM() is invalid
+		// in Postgres, see #835), so the RANDOM dispatch below only ever runs
+		// for MySQL/MariaDB or SQLite.
+		$randomToken = $this->store->getConnection( 'mw.db.queryengine' )->getType() === 'sqlite'
+			? 'RANDOM()'
+			: 'RAND()';
+
 		foreach ( $this->sortKeys as $propkey => $order ) {
 
 			if ( !is_string( $propkey ) ) {
@@ -574,7 +582,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 
 				$result['ORDER BY'] = ( array_key_exists( 'ORDER BY', $result ) ? $result['ORDER BY'] . ', ' : '' ) . $list . " $order ";
 			} elseif ( ( $order == 'RANDOM' ) && $this->engineOptions->isFlagSet( 'smwgQSortFeatures', SMW_QSORT_RANDOM ) ) {
-				$result['ORDER BY'] = ( array_key_exists( 'ORDER BY', $result ) ? $result['ORDER BY'] . ', ' : '' ) . ' RAND() ';
+				$result['ORDER BY'] = ( array_key_exists( 'ORDER BY', $result ) ? $result['ORDER BY'] . ', ' : '' ) . " $randomToken ";
 			}
 		}
 

--- a/tests/phpunit/Unit/MediaWiki/Connection/DatabaseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/DatabaseTest.php
@@ -267,7 +267,8 @@ class DatabaseTest extends TestCase {
 	public function querySqliteProvider() {
 		$provider = [
 			[ 'TEMPORARY', 'TEMP' ],
-			[ 'RAND', 'RANDOM' ],
+			[ 'RAND()', 'RANDOM()' ],
+			[ 'RANDOM()', 'RANDOM()' ],
 			[ 'ENGINE=MEMORY', '' ],
 			[ 'DROP TEMP', 'DROP' ]
 		];


### PR DESCRIPTION
## Summary

PR 13 of the umbrella SMW Rdbms QueryBuilder migration. Replaces the post-hoc regex rewriting of `RAND()` -> `RANDOM()` in `Database::executeQuery()` and `Database::select()` with explicit `getType()`-dispatched emission at the only callsite that produces the token, `QueryEngine::getSQLOptions()`.

The umbrella spec originally listed PR 13 as "replace `RAND()` and `@INT`"; PR 8 already eliminated `@INT` from emission code (the shim still has it for legacy raw-SQL callers, and PR 14 deletes the shim block), so this PR is `RAND()` only.

## Why

After Wave 2 (PRs 2 to 12), all SMW DML callsites delegate dialect-aware emission to MW core's QueryBuilder + platform classes wherever possible. `RAND()` / `RANDOM()` is one of the few tokens with no platform-class abstraction in MW core, so SMW must own the dispatch. Lifting it from a regex shim to the callsite makes the dialect choice explicit, removes a fragile string rewrite, and is a precondition for PR 14's full shim removal.

## Cross-DB analysis

| Platform | Pre-PR | Post-PR |
|---|---|---|
| MySQL / MariaDB | callsite emits `RAND()`; no shim runs (the executeQuery shim only translates RAND for Postgres / SQLite) | callsite emits `RAND()` directly via dispatch; no shim runs. End-to-end SQL byte-identical to pre-PR. |
| SQLite | callsite emits `RAND()`; shim does `str_replace( 'RAND', 'RANDOM', ... )` post-hoc on the SQL string | callsite emits `RANDOM()` directly via dispatch; shim is now idempotent and a no-op for the QueryEngine path. End-to-end SQL same as pre-PR. |
| Postgres | unreachable: `QueryEngine::getQueryResult()` masks off `SMW_QSORT_RANDOM` for Postgres at lines 181-186 (issue #835: SELECT DISTINCT + ORDER BY RANDOM() is invalid in Postgres) | unreachable, untouched. The shim's "DISTINCT-skip" workaround at `Database.php:372` remains but is dead code in practice. PR 14 deletes the entire shim block. |

The legacy DISTINCT-skip behaviour the umbrella spec asked PR 13 to "preserve or correct" turned out to be dead code: the Postgres path is short-circuited before emission ever runs, so the workaround at `Database.php:372` never fires for any current caller. PR 13 leaves it untouched and PR 14 will remove it with the rest of the shim.

## Changes

### `src/SQLStore/QueryEngine/QueryEngine.php`

In `getSQLOptions()`, hoist a one-shot `getType()` lookup outside the `foreach ( $this->sortKeys ...)` loop, and select the platform-correct token from it:

```php
$randomToken = $this->store->getConnection( 'mw.db.queryengine' )->getType() === 'sqlite'
    ? 'RANDOM()'
    : 'RAND()';
```

The `' RAND() '` literal in the random-sort branch is replaced with `" $randomToken "`. The hoisted lookup is a true cache hit (the connection is acquired before `getSQLOptions()` runs at all three call sites; `getType()` is instance-cached on first hit), so the lift adds no work.

### `src/MediaWiki/Connection/Database.php`

Both surviving SQLite RAND-rewriting shims (in `Database::select()` line 271 on the `ORDER BY` option, and in `Database::executeQuery()` line 386 on the SQL string) change from token-substring matching to full-token matching:

```php
- $sql = str_replace( 'RAND', 'RANDOM', $sql );
+ $sql = str_replace( 'RAND()', 'RANDOM()', $sql );
```

This is necessary because the callsite now emits `RANDOM()` directly for SQLite; the old substring shim would mangle that to `RANDOMOM()` because `RAND` is a prefix of `RANDOM`. The new form is provably idempotent (byte 4 of `RANDOM()` is `O`, not `(`, so `RAND()` is not a substring of `RANDOM()`) and still translates raw `RAND()` for any legacy callers passing it through `query()`.

### `tests/phpunit/Unit/MediaWiki/Connection/DatabaseTest.php`

`querySqliteProvider` data-row updates:

- `[ 'RAND', 'RANDOM' ]` (which exercised the old substring-matching shim) becomes `[ 'RAND()', 'RANDOM()' ]` (full-token match).
- New row `[ 'RANDOM()', 'RANDOM()' ]` asserts idempotency on already-emitted `RANDOM()`.
- Other SQLite shim entries (`TEMPORARY` -> `TEMP`, `ENGINE=MEMORY` -> empty, `DROP TEMP` -> `DROP`) unchanged.

## Verification

- `composer analyze`: clean (2122 files, 0 syntax errors, 0 PHPCS issues).
- Full unit suite: 6874 tests, 14144 assertions, 6 pre-existing skips.
- `DatabaseTest` and `QueryEngineTest`: 43 and 17 tests respectively, all green.
- Two rounds of code review against this diff; both ship-it after applying suggested loop-invariant lift.

## Test plan
- [x] Local unit suite green on MariaDB container
- [x] CI green
- [x] Pre-promote browser smoke against the seeded dev wiki: an `[[Has property::Foo]]` Ask query with `sort=RANDOM` to confirm the new emission produces a working query end-to-end on MariaDB.

## Out of scope

- The full `Database::executeQuery()` shim block deletion is PR 14.
- A regression test for the `Database::select()`-path shim's idempotency: deferred to PR 14 alongside the shim removal. The pre-PR coverage was the same (no test for the select() path either), so the PR doesn't regress coverage.