### PR TITLE
Convert planner-coupled raw SQL to QueryBuilder/insertSelect

### DIFF
--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -419,26 +419,26 @@ class Database {
 	 * @see removed method IDatabase::nextSequenceValue
 	 *
 	 * @since 1.9
-	 *
-	 * @param string $seqName
-	 *
-	 * @return int|null
 	 */
-	public function nextSequenceValue( $seqName ): ?int {
+	public function nextSequenceValue( string $seqName ): ?int {
 		$this->insertId = null;
 
 		if ( !$this->isType( 'postgres' ) ) {
 			return null;
 		}
 
-		// #3101, #2903
-		// MW 1.31+
-		// https://github.com/wikimedia/mediawiki/commit/0a9c55bfd39e22828f2d152ab71789cef3b0897c#diff-278465351b7c14bbcadac82036080e9f
+		// #3101, #2903 — Postgres-only sequence advance.
+		// `nextval()` has no portable Rdbms abstraction, so route a raw
+		// expression through newSelectQueryBuilder()->fetchField(). The
+		// FROMless SELECT is emitted natively by SQLPlatform::selectSQLText
+		// when `tables` is empty.
 		$safeseq = str_replace( "'", "''", $seqName );
-		$res = $this->connRef->getConnection( 'write' )->query( "SELECT nextval('$safeseq')", ISQLPlatform::QUERY_CHANGE_NONE );
-		$row = $res->fetchRow();
+		$value = $this->connRef->getConnection( 'write' )->newSelectQueryBuilder()
+			->select( "nextval('$safeseq')" )
+			->caller( __METHOD__ )
+			->fetchField();
 
-		$this->insertId = $row[0] === null ? null : (int)$row[0];
+		$this->insertId = $value === false || $value === null ? null : (int)$value;
 		return $this->insertId;
 	}
 

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -267,28 +267,17 @@ class Database {
 	 * @see IDatabase::insertSelect
 	 *
 	 * @since 7.0.0
-	 *
-	 * @param string $destTable
-	 * @param string|array $srcTable
-	 * @param array $varMap
-	 * @param string|array $conds
-	 * @param string $fname
-	 * @param array $insertOptions
-	 * @param array $selectOptions
-	 * @param array $selectJoinConds
-	 *
-	 * @return bool
 	 */
 	public function insertSelect(
-		$destTable,
-		$srcTable,
-		$varMap,
-		$conds,
-		$fname = __METHOD__,
-		$insertOptions = [],
-		$selectOptions = [],
-		$selectJoinConds = []
-	) {
+		string $destTable,
+		string|array $srcTable,
+		array $varMap,
+		string|array $conds,
+		string $fname = __METHOD__,
+		array $insertOptions = [],
+		array $selectOptions = [],
+		array $selectJoinConds = []
+	): bool {
 		$scope = $this->transactionHandler->muteTransactionProfiler();
 
 		$result = $this->connRef->getConnection( 'write' )->insertSelect(

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -24,7 +24,9 @@ use Wikimedia\ScopedCallback;
  * **Façade guardrail.** As of 7.0.0 this class is a deliberately slim façade
  * over MW core's IDatabase. It may only expose:
  *
- * 1. QueryBuilder factories (`new*QueryBuilder()`).
+ * 1. QueryBuilder factories (`new*QueryBuilder()`) and the structured
+ *    `insertSelect()` wrapper (no raw SQL — takes column maps and conds, MW
+ *    core emits platform-correct INSERT...SELECT with the IGNORE option).
  * 2. Connection-routing helpers (`getType()`, `tableName()`, `tablePrefix()`,
  *    `tableExists()`, `listTables()`, `addQuotes()`, `expr()`, `conditional()`,
  *    `makeList()`, `timestamp()`, etc.).
@@ -259,6 +261,50 @@ class Database {
 	 */
 	public function addQuotes( $value ) {
 		return $this->connRef->getConnection( 'read' )->addQuotes( $value );
+	}
+
+	/**
+	 * @see IDatabase::insertSelect
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $destTable
+	 * @param string|array $srcTable
+	 * @param array $varMap
+	 * @param string|array $conds
+	 * @param string $fname
+	 * @param array $insertOptions
+	 * @param array $selectOptions
+	 * @param array $selectJoinConds
+	 *
+	 * @return bool
+	 */
+	public function insertSelect(
+		$destTable,
+		$srcTable,
+		$varMap,
+		$conds,
+		$fname = __METHOD__,
+		$insertOptions = [],
+		$selectOptions = [],
+		$selectJoinConds = []
+	) {
+		$scope = $this->transactionHandler->muteTransactionProfiler();
+
+		$result = $this->connRef->getConnection( 'write' )->insertSelect(
+			$destTable,
+			$srcTable,
+			$varMap,
+			$conds,
+			$fname,
+			$insertOptions,
+			$selectOptions,
+			$selectJoinConds
+		);
+
+		ScopedCallback::consume( $scope );
+
+		return $result;
 	}
 
 	/**

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -8,6 +8,7 @@ use SMW\Connection\ConnRef;
 use Wikimedia\Rdbms\DBConnRef;
 use Wikimedia\Rdbms\DeleteQueryBuilder;
 use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\IExpression;
 use Wikimedia\Rdbms\InsertQueryBuilder;
 use Wikimedia\Rdbms\IResultWrapper;
 use Wikimedia\Rdbms\Platform\ISQLPlatform;
@@ -272,7 +273,7 @@ class Database {
 		string $destTable,
 		string|array $srcTable,
 		array $varMap,
-		string|array $conds,
+		string|IExpression|array $conds,
 		string $fname = __METHOD__,
 		array $insertOptions = [],
 		array $selectOptions = [],

--- a/src/SQLStore/ConceptCache.php
+++ b/src/SQLStore/ConceptCache.php
@@ -107,7 +107,7 @@ class ConceptCache {
 			->caller( __METHOD__ )
 			->execute();
 
-		$concCacheTableName = $db->tablename( SQLStore::CONCEPT_CACHE_TABLE );
+		$concCacheTableName = $db->tableName( SQLStore::CONCEPT_CACHE_TABLE );
 
 		// MySQL just uses INSERT IGNORE, no extra conditions
 		$where = $querySegment->where;

--- a/src/SQLStore/ConceptCache.php
+++ b/src/SQLStore/ConceptCache.php
@@ -126,6 +126,16 @@ class ConceptCache {
 		// Platform-specific INSERT verb. Postgres dedups via the LEFT JOIN
 		// substitution above, so the INSERT verb has no IGNORE clause. SQLite
 		// uses INSERT OR IGNORE; MySQL uses INSERT IGNORE.
+		//
+		// This is residual planner-side raw SQL: the cache-population query
+		// stitches in `$querySegment->from`, an arbitrary INNER/LEFT JOIN
+		// chain composed by the QuerySegment planner as a stringly-typed SQL
+		// fragment (see SomePropertyInterpreter / DescriptionInterpreter).
+		// `IDatabase::insertSelect()` only accepts structured `$selectJoinConds`
+		// (`[ alias => [ JOIN_TYPE, condition ] ]`), so converting requires
+		// restructuring the planner IR — out of scope for the QueryBuilder
+		// migration. The INSERT verb dispatch stays manual until that
+		// restructuring or an upstream MW core API extension lands.
 		if ( $db->getType() === 'postgres' ) {
 			$insertVerb = 'INSERT INTO';
 		} elseif ( $db->getType() === 'sqlite' ) {

--- a/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
+++ b/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
@@ -5,7 +5,7 @@ namespace SMW\SQLStore\QueryEngine;
 use RuntimeException;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\TableBuilder\TemporaryTableBuilder;
-use Wikimedia\Rdbms\Platform\ISQLPlatform;
+use Wikimedia\Rdbms\IDatabase;
 
 /**
  * @license GPL-2.0-or-later
@@ -25,6 +25,16 @@ class HierarchyTempTableBuilder {
 	private $hierarchyCache = [];
 
 	private array $tableDefinitions = [];
+
+	/**
+	 * Bare logical table names (pre-prefix) keyed by definition type. Used
+	 * internally by buildTempTable() to feed insertSelect(), which applies
+	 * the prefix itself. `tableDefinitions` continues to expose the prefix-
+	 * applied/quoted form for callers that compose raw SQL.
+	 *
+	 * @var string[]
+	 */
+	private array $bareTableNames = [];
 
 	/**
 	 * @since 2.3
@@ -62,6 +72,7 @@ class HierarchyTempTableBuilder {
 				$this->connection->tableName( $tableDefinition['table'] ),
 				$tableDefinition['depth']
 			];
+			$this->bareTableNames[$key] = $tableDefinition['table'];
 		}
 	}
 
@@ -94,7 +105,12 @@ class HierarchyTempTableBuilder {
 	public function fillTempTable( $type, $tablename, $valueComposite, $depth = null ): void {
 		$this->temporaryTableBuilder->create( $tablename );
 
-		[ $smwtable, $d ] = $this->getTableDefinitionByType( $type );
+		[ , $d ] = $this->getTableDefinitionByType( $type );
+		// `getTableDefinitionByType()` returns the prefix-applied/quoted name
+		// for callers that compose raw SQL. Inside this class we feed
+		// insertSelect(), which applies the prefix itself, so use the bare
+		// logical name captured in setTableDefinitions().
+		$smwtable = $this->bareTableNames[$type];
 
 		if ( $depth === null ) {
 			$depth = $d;
@@ -102,10 +118,17 @@ class HierarchyTempTableBuilder {
 
 		if ( array_key_exists( $valueComposite, $this->hierarchyCache ) ) { // Just copy known result.
 
-			$this->connection->query(
-				"INSERT INTO $tablename (id) SELECT id" . ' FROM ' . $this->hierarchyCache[$valueComposite],
+			// No IGNORE: the cache source is already deduped, matching legacy
+			// SQL semantics (a plain INSERT...SELECT with no conflict clause).
+			$this->connection->insertSelect(
+				$tablename,
+				$this->hierarchyCache[$valueComposite],
+				[ 'id' => 'id' ],
+				'*',
 				__METHOD__,
-				ISQLPlatform::QUERY_CHANGE_ROWS
+				[],
+				[],
+				[]
 			);
 
 			return;
@@ -129,70 +152,70 @@ class HierarchyTempTableBuilder {
 		$this->temporaryTableBuilder->create( $tmpnew );
 		$this->temporaryTableBuilder->create( $tmpres );
 
-		// Adding multiple values for the same column in sqlite is not supported.
-		//
-		// $tablename and $tmpnew are temporary tables created via
-		// TemporaryTableBuilder, which uses raw query() and so does not apply
-		// the table prefix. Routing these inserts through the QueryBuilder
-		// would apply the prefix and target a non-existent table under MW's
-		// unittest_ prefix mode. Stay on $db->query() with getType() dispatch
-		// (same pattern as the INSERT...SELECT calls below) so the dialect-
-		// correct SQL is emitted directly without depending on the cross-DB
-		// regex shim.
-		//
-		// Postgres temp tables created by TemporaryTableBuilder have no unique
-		// constraint; their dedup comes from a CREATE RULE ... DO INSTEAD
-		// NOTHING that runs at INSERT time. ON CONFLICT DO NOTHING here is a
-		// no-op (no unique constraints to arbitrate) and is kept only to
-		// match the legacy regex-shim output. SQLite uses INSERT OR IGNORE
-		// (its native equivalent of MySQL's INSERT IGNORE).
-		foreach ( explode( ',', $values ) as $value ) {
-			if ( $db->getType() === 'postgres' ) {
-				$tablenameInsertSql = "INSERT INTO $tablename (id) VALUES $value ON CONFLICT DO NOTHING";
-				$tmpnewInsertSql = "INSERT INTO $tmpnew (id) VALUES $value ON CONFLICT DO NOTHING";
-			} elseif ( $db->getType() === 'sqlite' ) {
-				$tablenameInsertSql = "INSERT OR IGNORE INTO $tablename (id) VALUES $value";
-				$tmpnewInsertSql = "INSERT OR IGNORE INTO $tmpnew (id) VALUES $value";
-			} else {
-				$tablenameInsertSql = "INSERT IGNORE INTO $tablename (id) VALUES $value";
-				$tmpnewInsertSql = "INSERT IGNORE INTO $tmpnew (id) VALUES $value";
-			}
+		// Seed both temp tables with the supplied id values. `$values` is a
+		// comma-joined string of parenthesised single literals like
+		// '(123),(456)'. Use one builder per destination, accumulate rows
+		// via row(), then a single execute() per builder. The IGNORE option
+		// produces platform-correct INSERT IGNORE / OR IGNORE / ON CONFLICT
+		// DO NOTHING automatically.
+		$tablenameQb = $db->newInsertQueryBuilder()
+			->insertInto( $tablename )
+			->ignore()
+			->caller( __METHOD__ );
+		$tmpnewQb = $db->newInsertQueryBuilder()
+			->insertInto( $tmpnew )
+			->ignore()
+			->caller( __METHOD__ );
 
-			$db->query( $tablenameInsertSql, __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
-			$db->query( $tmpnewInsertSql, __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
+		foreach ( explode( ',', $values ) as $value ) {
+			// $value looks like '(123)'. Strip parens/spaces to get the int id.
+			$id = (int)trim( $value, '() ' );
+			$tablenameQb->row( [ 'id' => $id ] );
+			$tmpnewQb->row( [ 'id' => $id ] );
 		}
 
+		$tablenameQb->execute();
+		$tmpnewQb->execute();
+
 		for ( $i = 0; $i < $depth; $i++ ) {
-			if ( $db->getType() === 'postgres' ) {
-				$insertIgnoreSql = "INSERT INTO $tmpres (id) SELECT CAST(s_id AS INTEGER) FROM $smwtable, $tmpnew WHERE o_id=id ON CONFLICT DO NOTHING";
-			} elseif ( $db->getType() === 'sqlite' ) {
-				$insertIgnoreSql = "INSERT OR IGNORE INTO $tmpres (id) SELECT CAST(s_id AS INTEGER) FROM $smwtable, $tmpnew WHERE o_id=id";
-			} else {
-				$insertIgnoreSql = "INSERT IGNORE INTO $tmpres (id) SELECT CAST(s_id AS INTEGER) FROM $smwtable, $tmpnew WHERE o_id=id";
-			}
-
-			$db->query( $insertIgnoreSql, __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
-
-			if ( $db->affectedRows() == 0 ) { // no change, exit loop
-				break;
-			}
-
-			if ( $db->getType() === 'postgres' ) {
-				$carrybackSql = "INSERT INTO $tablename (id) SELECT $tmpres.id FROM $tmpres ON CONFLICT DO NOTHING";
-			} elseif ( $db->getType() === 'sqlite' ) {
-				$carrybackSql = "INSERT OR IGNORE INTO $tablename (id) SELECT $tmpres.id FROM $tmpres";
-			} else {
-				$carrybackSql = "INSERT IGNORE INTO $tablename (id) SELECT $tmpres.id FROM $tmpres";
-			}
-
-			$db->query( $carrybackSql, __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
+			// INSERT IGNORE INTO $tmpres (id)
+			//   SELECT CAST(s_id AS INTEGER) FROM $smwtable, $tmpnew WHERE o_id=id
+			$db->insertSelect(
+				$tmpres,
+				[ $smwtable, $tmpnew ],
+				[ 'id' => 'CAST(s_id AS INTEGER)' ],
+				[ 'o_id=id' ],
+				__METHOD__,
+				[ 'IGNORE' ],
+				[],
+				[]
+			);
 
 			if ( $db->affectedRows() == 0 ) { // no change, exit loop
 				break;
 			}
 
-			// empty "new" table — see prefix-bypass note above; stay on raw query()
-			$db->query( "DELETE FROM $tmpnew", __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
+			// INSERT IGNORE INTO $tablename (id) SELECT $tmpres.id FROM $tmpres
+			$db->insertSelect(
+				$tablename,
+				$tmpres,
+				[ 'id' => 'id' ],
+				'*',
+				__METHOD__,
+				[ 'IGNORE' ],
+				[],
+				[]
+			);
+
+			if ( $db->affectedRows() == 0 ) { // no change, exit loop
+				break;
+			}
+
+			$db->newDeleteQueryBuilder()
+				->deleteFrom( $tmpnew )
+				->where( IDatabase::ALL_ROWS )
+				->caller( __METHOD__ )
+				->execute();
 
 			$tmpname = $tmpnew;
 			$tmpnew = $tmpres;

--- a/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
+++ b/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
@@ -24,22 +24,13 @@ class HierarchyTempTableBuilder {
 	 */
 	private $hierarchyCache = [];
 
-	private array $tableDefinitions = [];
-
 	/**
-	 * Bare logical table names (pre-prefix) keyed by definition type. Used
-	 * internally by buildTempTable() to feed insertSelect(), which applies
-	 * the prefix itself. `tableDefinitions` continues to expose the prefix-
-	 * applied/quoted form for callers that compose raw SQL.
-	 *
-	 * Transitional: drop this dual-store once QuerySegmentListProcessor's
-	 * remaining raw `query()` callsites are converted to QueryBuilder. At
-	 * that point `getTableDefinitionByType()` can return bare names and
-	 * the prefix is owned exclusively by Rdbms / TemporaryTableBuilder.
-	 *
-	 * @var string[]
+	 * Hierarchy-table definitions keyed by type (`'class'` / `'property'`),
+	 * each entry shaped as `[ bareTableName, depth ]`. Names are stored
+	 * bare; QueryBuilder consumers (insertSelect, newSelectQueryBuilder)
+	 * apply the prefix internally.
 	 */
-	private array $bareTableNames = [];
+	private array $tableDefinitions = [];
 
 	/**
 	 * @since 2.3
@@ -74,10 +65,9 @@ class HierarchyTempTableBuilder {
 	public function setTableDefinitions( array $tableDefinitions ): void {
 		foreach ( $tableDefinitions as $key => $tableDefinition ) {
 			$this->tableDefinitions[$key] = [
-				$this->connection->tableName( $tableDefinition['table'] ),
+				$tableDefinition['table'],
 				$tableDefinition['depth']
 			];
-			$this->bareTableNames[$key] = $tableDefinition['table'];
 		}
 	}
 
@@ -105,12 +95,7 @@ class HierarchyTempTableBuilder {
 	public function fillTempTable( string $type, string $tablename, string $valueComposite, ?int $depth = null ): void {
 		$this->temporaryTableBuilder->create( $tablename );
 
-		[ , $d ] = $this->getTableDefinitionByType( $type );
-		// `getTableDefinitionByType()` returns the prefix-applied/quoted name
-		// for callers that compose raw SQL. Inside this class we feed
-		// insertSelect(), which applies the prefix itself, so use the bare
-		// logical name captured in setTableDefinitions().
-		$smwtable = $this->bareTableNames[$type];
+		[ $smwtable, $d ] = $this->getTableDefinitionByType( $type );
 
 		if ( $depth === null ) {
 			$depth = $d;

--- a/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
+++ b/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
@@ -32,6 +32,11 @@ class HierarchyTempTableBuilder {
 	 * the prefix itself. `tableDefinitions` continues to expose the prefix-
 	 * applied/quoted form for callers that compose raw SQL.
 	 *
+	 * Transitional: drop this dual-store once QuerySegmentListProcessor's
+	 * remaining raw `query()` callsites are converted to QueryBuilder. At
+	 * that point `getTableDefinitionByType()` can return bare names and
+	 * the prefix is owned exclusively by Rdbms / TemporaryTableBuilder.
+	 *
 	 * @var string[]
 	 */
 	private array $bareTableNames = [];
@@ -95,14 +100,9 @@ class HierarchyTempTableBuilder {
 	/**
 	 * @since 2.3
 	 *
-	 * @param string $type
-	 * @param string $tablename
-	 * @param string $valueComposite
-	 * @param int|null $depth
-	 *
 	 * @throws RuntimeException
 	 */
-	public function fillTempTable( $type, $tablename, $valueComposite, $depth = null ): void {
+	public function fillTempTable( string $type, string $tablename, string $valueComposite, ?int $depth = null ): void {
 		$this->temporaryTableBuilder->create( $tablename );
 
 		[ , $d ] = $this->getTableDefinitionByType( $type );
@@ -143,7 +143,7 @@ class HierarchyTempTableBuilder {
 	 * but then every iteration would use all elements of this table, while only the new ones
 	 * obtained in the previous step are relevant. So this is a performance measure.
 	 */
-	private function buildTempTable( $tablename, $values, $smwtable, $depth ): void {
+	private function buildTempTable( string $tablename, string $values, string $smwtable, int $depth ): void {
 		$db = $this->connection;
 
 		$tmpnew = 'smw_new';

--- a/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
+++ b/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
@@ -220,7 +220,10 @@ class QuerySegmentListProcessor {
 
 	private function disjunction( QuerySegment &$query ): void {
 		if ( $this->queryMode !== Query::MODE_NONE ) {
-			$this->temporaryTableBuilder->create( $this->connection->tableName( $query->alias ) );
+			// TemporaryTableBuilder applies tableName() internally, so pass
+			// the bare alias here. The raw INSERT...SELECT below keeps its
+			// own tableName() call for the same physical name.
+			$this->temporaryTableBuilder->create( $query->alias );
 		}
 
 		$this->executedQueries[$query->alias] = [];
@@ -326,7 +329,6 @@ class QuerySegmentListProcessor {
 		}
 
 		$res->free();
-		$tablename = $this->connection->tableName( $query->alias );
 		$this->executedQueries[$query->alias] = [
 			"Recursively computed hierarchy for element(s) $values.",
 			"SELECT s_id FROM $smwtable WHERE $valuecond LIMIT 1"
@@ -335,9 +337,12 @@ class QuerySegmentListProcessor {
 		$query->joinTable = $query->alias;
 		$query->joinfield = "$query->alias.id";
 
+		// Pass the bare alias: HierarchyTempTableBuilder routes it through
+		// TemporaryTableBuilder (which applies the prefix internally) and
+		// MW core's insertSelect() (which also applies the prefix).
 		$this->hierarchyTempTableBuilder->fillTempTable(
 			$type,
-			$tablename,
+			$query->alias,
 			$values,
 			$depth
 		);
@@ -351,7 +356,9 @@ class QuerySegmentListProcessor {
 	 */
 	public function cleanUp(): void {
 		foreach ( $this->executedQueries as $table => $log ) {
-			$this->temporaryTableBuilder->drop( $this->connection->tableName( $table ) );
+			// TemporaryTableBuilder applies tableName() internally; pass the
+			// bare alias key.
+			$this->temporaryTableBuilder->drop( $table );
 		}
 	}
 

--- a/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
+++ b/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
@@ -231,30 +231,18 @@ class QuerySegmentListProcessor {
 		foreach ( $query->components as $qid => $joinField ) {
 			$subQuery = $this->querySegmentList[$qid];
 			$this->segment( $subQuery );
-			$sql = '';
 
 			if ( $subQuery->joinTable !== '' ) {
+				// Residual planner-side raw SQL: INSERT IGNORE...SELECT pieced
+				// together from the planner's stringly-typed fragments
+				// (`$subQuery->where`, `$subQuery->from`, `$subQuery->joinfield`).
+				// Cannot be translated to insertSelect() without restructuring
+				// the QuerySegment IR; this is the documented escape hatch.
 				$sql = 'INSERT ' . 'IGNORE ' . 'INTO ' .
 					   $this->connection->tableName( $query->alias ) .
 					   " SELECT $subQuery->joinfield FROM " . $this->connection->tableName( $subQuery->joinTable ) .
 					   " AS $subQuery->alias $subQuery->from" . ( $subQuery->where ? " WHERE $subQuery->where" : '' );
-			} elseif ( $subQuery->joinfield !== '' ) {
-				// NOTE: this works only for single "unconditional" values without further
-				// WHERE or FROM. The execution must take care of not creating any others.
-				$values = '';
 
-				// This produces an error on postgres with
-				// pg_query(): Query failed: ERROR:  duplicate key value violates
-				// unique constraint "sunittest_t3_pkey" DETAIL:  Key (id)=(274) already exists.
-
-				foreach ( $subQuery->joinfield as $value ) {
-					$values .= ( $values ? ',' : '' ) . '(' . $this->connection->addQuotes( $value ) . ')';
-				}
-
-				$sql = 'INSERT ' . 'IGNORE ' . 'INTO ' . $this->connection->tableName( $query->alias ) . " (id) VALUES $values";
-			} // else: // interpret empty joinfields as impossible condition (empty result), ignore
-
-			if ( $sql ) {
 				$this->executedQueries[$query->alias][] = $sql;
 
 				// @phan-suppress-next-line PhanImpossibleValueComparisonInLoop
@@ -265,7 +253,32 @@ class QuerySegmentListProcessor {
 						ISQLPlatform::QUERY_CHANGE_ROWS
 					);
 				}
-			}
+			} elseif ( $subQuery->joinfield !== '' ) {
+				// NOTE: this works only for single "unconditional" values without further
+				// WHERE or FROM. The execution must take care of not creating any others.
+
+				// Diagnostic log entry: canonical form (MW core emits the
+				// platform-correct verb — INSERT IGNORE / OR IGNORE /
+				// ON CONFLICT DO NOTHING — when ->ignore() is set).
+				$values = '';
+				foreach ( $subQuery->joinfield as $value ) {
+					$values .= ( $values ? ',' : '' ) . '(' . $this->connection->addQuotes( $value ) . ')';
+				}
+				$this->executedQueries[$query->alias][] =
+					'INSERT IGNORE INTO ' . $this->connection->tableName( $query->alias ) . " (id) VALUES $values";
+
+				// @phan-suppress-next-line PhanImpossibleValueComparisonInLoop
+				if ( $this->queryMode !== Query::MODE_NONE ) {
+					$insertBuilder = $this->connection->newInsertQueryBuilder()
+						->insertInto( $query->alias )
+						->ignore()
+						->caller( __METHOD__ );
+					foreach ( $subQuery->joinfield as $value ) {
+						$insertBuilder->row( [ 'id' => $value ] );
+					}
+					$insertBuilder->execute();
+				}
+			} // else: interpret empty joinfields as impossible condition (empty result), ignore
 		}
 
 		$query->type = QuerySegment::Q_TABLE;
@@ -319,19 +332,22 @@ class QuerySegmentListProcessor {
 			$valuecond .= ( $valuecond ? ' OR ' : '' ) . 'o_id=' . $this->connection->addQuotes( $value );
 		}
 
-		// Try to safe time (SELECT is cheaper than creating/dropping 3 temp tables):
-		$res = $this->connection->query( "SELECT s_id FROM $smwtable WHERE $valuecond LIMIT 1" );
+		// Try to save time (SELECT is cheaper than creating/dropping 3 temp tables):
+		$row = $this->connection->newSelectQueryBuilder()
+			->select( 's_id' )
+			->from( $smwtable )
+			->where( [ 'o_id' => $query->joinfield ] )
+			->caller( __METHOD__ )
+			->fetchRow();
 
-		if ( !$res->fetchObject() ) { // no subobjects, we are done!
-			$res->free();
+		if ( !$row ) { // no subobjects, we are done!
 			$query->type = QuerySegment::Q_VALUE;
 			return;
 		}
 
-		$res->free();
 		$this->executedQueries[$query->alias] = [
 			"Recursively computed hierarchy for element(s) $values.",
-			"SELECT s_id FROM $smwtable WHERE $valuecond LIMIT 1"
+			'SELECT s_id FROM ' . $this->connection->tableName( $smwtable ) . " WHERE $valuecond LIMIT 1"
 		];
 
 		$query->joinTable = $query->alias;

--- a/src/SQLStore/TableBuilder/Examiner/HashField.php
+++ b/src/SQLStore/TableBuilder/Examiner/HashField.php
@@ -7,6 +7,7 @@ use SMW\Maintenance\populateHashField;
 use SMW\SQLStore\SQLStore;
 use SMW\Utils\CliMsgFormatter;
 use Wikimedia\Rdbms\DBError;
+use Wikimedia\Rdbms\RawSQLValue;
 
 /**
  * @license GPL-2.0-or-later
@@ -76,23 +77,26 @@ class HashField {
 			$cliMsgFormatter->twoCols( "... converting hex hashes to binary ...", "(rows) $count", 3 )
 		);
 
-		$table = $connection->tableName( SQLStore::ID_TABLE );
 		$type = $connection->getType();
 
 		try {
 			if ( $type === 'postgres' ) {
-				$connection->query(
-					"UPDATE $table SET smw_hash = decode(smw_hash, 'hex') WHERE LENGTH(smw_hash) = 40",
-					__METHOD__
-				);
+				$connection->newUpdateQueryBuilder()
+					->update( SQLStore::ID_TABLE )
+					->set( [ 'smw_hash' => new RawSQLValue( "decode(smw_hash, 'hex')" ) ] )
+					->where( [ 'LENGTH(smw_hash) = 40' ] )
+					->caller( __METHOD__ )
+					->execute();
 			} elseif ( $type === 'sqlite' ) {
 				// unhex() requires SQLite 3.38+; fall back to PHP-side conversion
 				$this->migrateHexHashesViaPHP( $connection );
 			} else {
-				$connection->query(
-					"UPDATE $table SET smw_hash = UNHEX(smw_hash) WHERE LENGTH(smw_hash) = 40",
-					__METHOD__
-				);
+				$connection->newUpdateQueryBuilder()
+					->update( SQLStore::ID_TABLE )
+					->set( [ 'smw_hash' => new RawSQLValue( 'UNHEX(smw_hash)' ) ] )
+					->where( [ 'LENGTH(smw_hash) = 40' ] )
+					->caller( __METHOD__ )
+					->execute();
 			}
 		} catch ( DBError $e ) {
 			$this->reportMigrationFailure( $cliMsgFormatter );

--- a/src/SQLStore/TableBuilder/TableBuildExaminer.php
+++ b/src/SQLStore/TableBuilder/TableBuildExaminer.php
@@ -8,7 +8,8 @@ use SMW\PropertyRegistry;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableBuilder as ITableBuilder;
-use Wikimedia\Rdbms\Platform\ISQLPlatform;
+use Wikimedia\Rdbms\IDatabase;
+use Wikimedia\Rdbms\RawSQLValue;
 
 /**
  * @private
@@ -201,7 +202,12 @@ class TableBuildExaminer {
 
 			$this->messageReporter->reportMessage( "   Table " . SQLStore::ID_TABLE . " ...\n" );
 			$this->messageReporter->reportMessage( "   ... copying $copyField to $emptyField ... " );
-			$connection->query( "UPDATE $tableName SET $emptyField = $copyField", __METHOD__, ISQLPlatform::QUERY_CHANGE_ROWS );
+			$connection->newUpdateQueryBuilder()
+				->update( SQLStore::ID_TABLE )
+				->set( [ $emptyField => new RawSQLValue( $copyField ) ] )
+				->where( IDatabase::ALL_ROWS )
+				->caller( __METHOD__ )
+				->execute();
 			$this->messageReporter->reportMessage( "done.\n" );
 		}
 

--- a/src/SQLStore/TableBuilder/TemporaryTableBuilder.php
+++ b/src/SQLStore/TableBuilder/TemporaryTableBuilder.php
@@ -42,8 +42,13 @@ class TemporaryTableBuilder {
 			$this->connection->setFlag( Database::AUTO_COMMIT );
 		}
 
+		// Resolve the bare logical name through tableName() so the temp table
+		// lives at the prefix-applied physical name, matching what MW core's
+		// QueryBuilder produces when consumers reference it later.
+		$resolvedName = $this->connection->tableName( $tableName );
+
 		$this->connection->query(
-			$this->getSQLCodeFor( $tableName ),
+			$this->getSQLCodeFor( $resolvedName ),
 			__METHOD__,
 			ISQLPlatform::QUERY_CHANGE_SCHEMA
 		);
@@ -59,15 +64,19 @@ class TemporaryTableBuilder {
 			$this->connection->setFlag( Database::AUTO_COMMIT );
 		}
 
+		// Resolve the bare logical name through tableName() so we drop the
+		// prefix-applied physical name. See create() for the rationale.
+		$resolvedName = $this->connection->tableName( $tableName );
+
 		// Platform-specific DDL: MySQL has DROP TEMPORARY TABLE; Postgres
 		// uses plain DROP TABLE IF EXISTS (the temp-table scope handles
 		// teardown); SQLite uses plain DROP TABLE.
 		if ( $this->connection->isType( 'postgres' ) ) {
-			$sql = 'DROP TABLE IF EXISTS ' . $tableName;
+			$sql = 'DROP TABLE IF EXISTS ' . $resolvedName;
 		} elseif ( $this->connection->isType( 'sqlite' ) ) {
-			$sql = 'DROP TABLE ' . $tableName;
+			$sql = 'DROP TABLE ' . $resolvedName;
 		} else {
-			$sql = 'DROP TEMPORARY TABLE ' . $tableName;
+			$sql = 'DROP TEMPORARY TABLE ' . $resolvedName;
 		}
 
 		$this->connection->query(

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/HierarchyTempTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/HierarchyTempTableBuilderTest.php
@@ -90,9 +90,16 @@ class HierarchyTempTableBuilderTest extends TestCase {
 		// before the loop breaks.
 		$this->connection->method( 'affectedRows' )->willReturn( 0 );
 
-		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'insertSelect' )
-			->willReturn( true );
+		$insertSelectCalls = [];
+		$this->connection->method( 'insertSelect' )
+			->willReturnCallback( static function ( $dest, $src, $varMap, $conds, $fname, $insertOptions ) use ( &$insertSelectCalls ) {
+				$insertSelectCalls[] = [
+					'dest' => $dest,
+					'src' => $src,
+					'insertOptions' => $insertOptions,
+				];
+				return true;
+			} );
 
 		$instance = new HierarchyTempTableBuilder(
 			$this->connection,
@@ -107,6 +114,13 @@ class HierarchyTempTableBuilderTest extends TestCase {
 		// one targeting $tmpnew ('smw_new'). Each receives a single row.
 		$this->assertSame( [ 'foobar', 'smw_new' ], $insertTables );
 		$this->assertSame( [ [ 'id' => 42 ], [ 'id' => 42 ] ], $insertRows );
+
+		// Pin the depth-loop's insertSelect count: one carryback INSERT into
+		// $tmpres, then affectedRows()=0 breaks the loop before the next call.
+		$this->assertCount( 1, $insertSelectCalls );
+		$this->assertSame( 'smw_res', $insertSelectCalls[0]['dest'] );
+		$this->assertSame( [ 'bar', 'smw_new' ], $insertSelectCalls[0]['src'] );
+		$this->assertSame( [ 'IGNORE' ], $insertSelectCalls[0]['insertOptions'] );
 
 		$expected = [
 			'(42)' => 'foobar'

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/HierarchyTempTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/HierarchyTempTableBuilderTest.php
@@ -42,11 +42,8 @@ class HierarchyTempTableBuilderTest extends TestCase {
 	}
 
 	public function testGetHierarchyTableDefinitionForType() {
-		$this->connection->expects( $this->once() )
-			->method( 'tableName' )
-			->with(
-				$this->stringContains( 'bar' ) )
-			->willReturn( '_bar' );
+		$this->connection->expects( $this->never() )
+			->method( 'tableName' );
 
 		$instance = new HierarchyTempTableBuilder(
 			$this->connection,
@@ -56,7 +53,7 @@ class HierarchyTempTableBuilderTest extends TestCase {
 		$instance->setTableDefinitions( [ 'property' => [ 'table' => 'bar', 'depth' => 3 ] ] );
 
 		$this->assertEquals(
-			[ '_bar', 3 ],
+			[ 'bar', 3 ],
 			$instance->getTableDefinitionByType( 'property' )
 		);
 	}
@@ -72,11 +69,8 @@ class HierarchyTempTableBuilderTest extends TestCase {
 	}
 
 	public function testFillTempTable() {
-		$this->connection->expects( $this->once() )
-			->method( 'tableName' )
-			->with(
-				$this->stringContains( 'bar' ) )
-			->willReturn( '_bar' );
+		$this->connection->expects( $this->never() )
+			->method( 'tableName' );
 
 		$insertTables = [];
 		$insertRows = [];
@@ -131,10 +125,8 @@ class HierarchyTempTableBuilderTest extends TestCase {
 	}
 
 	public function testFillTempTableUsesCacheOnRepeatComposite() {
-		$this->connection->expects( $this->once() )
-			->method( 'tableName' )
-			->with( 'bar' )
-			->willReturn( '_bar' );
+		$this->connection->expects( $this->never() )
+			->method( 'tableName' );
 
 		// First fill seeds the cache with insertInto + insertSelect calls;
 		// second fill must hit the cache branch and use insertSelect() to

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/HierarchyTempTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/HierarchyTempTableBuilderTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\QueryEngine\HierarchyTempTableBuilder;
 use SMW\SQLStore\TableBuilder\TemporaryTableBuilder;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\QueryEngine\HierarchyTempTableBuilder
@@ -17,6 +18,8 @@ use SMW\SQLStore\TableBuilder\TemporaryTableBuilder;
  * @author mwjames
  */
 class HierarchyTempTableBuilderTest extends TestCase {
+
+	use MockWriteQueryBuilderTrait;
 
 	private $connection;
 	private $temporaryTableBuilder;
@@ -75,8 +78,27 @@ class HierarchyTempTableBuilderTest extends TestCase {
 				$this->stringContains( 'bar' ) )
 			->willReturn( '_bar' );
 
+		$insertTables = [];
+		$insertRows = [];
+		$this->connection->method( 'newInsertQueryBuilder' )
+			->willReturnCallback( function () use ( &$insertTables, &$insertRows ) {
+				return $this->createMockInsertQueryBuilder( $insertTables, $insertRows );
+			} );
+
+		$deleteTables = [];
+		$this->connection->method( 'newDeleteQueryBuilder' )
+			->willReturnCallback( function () use ( &$deleteTables ) {
+				return $this->createMockDeleteQueryBuilder( $deleteTables );
+			} );
+
+		// affectedRows() returns 0 by default — the depth loop exits at the
+		// first iteration, so insertSelect() is invoked once (for $tmpres)
+		// before the loop breaks.
+		$this->connection->method( 'affectedRows' )->willReturn( 0 );
+
 		$this->connection->expects( $this->atLeastOnce() )
-			->method( 'query' );
+			->method( 'insertSelect' )
+			->willReturn( true );
 
 		$instance = new HierarchyTempTableBuilder(
 			$this->connection,
@@ -86,6 +108,11 @@ class HierarchyTempTableBuilderTest extends TestCase {
 		$instance->setTableDefinitions( [ 'class' => [ 'table' => 'bar', 'depth' => 3 ] ] );
 
 		$instance->fillTempTable( 'class', 'foobar', '(42)' );
+
+		// Two INSERT IGNORE seed builders: one targeting $tablename ('foobar'),
+		// one targeting $tmpnew ('smw_new'). Each receives a single row.
+		$this->assertSame( [ 'foobar', 'smw_new' ], $insertTables );
+		$this->assertSame( [ [ 'id' => 42 ], [ 'id' => 42 ] ], $insertRows );
 
 		$expected = [
 			'(42)' => 'foobar'
@@ -101,6 +128,71 @@ class HierarchyTempTableBuilderTest extends TestCase {
 		$this->assertEmpty(
 			$instance->getHierarchyCache()
 		);
+	}
+
+	public function testFillTempTableUsesCacheOnRepeatComposite() {
+		$this->connection->expects( $this->once() )
+			->method( 'tableName' )
+			->with( 'bar' )
+			->willReturn( '_bar' );
+
+		// First fill seeds the cache with insertInto + insertSelect calls;
+		// second fill must hit the cache branch and use insertSelect() to
+		// copy rows from the cached table.
+		$insertTables = [];
+		$insertRows = [];
+		$this->connection->method( 'newInsertQueryBuilder' )
+			->willReturnCallback( function () use ( &$insertTables, &$insertRows ) {
+				return $this->createMockInsertQueryBuilder( $insertTables, $insertRows );
+			} );
+
+		$this->connection->method( 'newDeleteQueryBuilder' )
+			->willReturnCallback( function () {
+				return $this->createMockDeleteQueryBuilder();
+			} );
+
+		$this->connection->method( 'affectedRows' )->willReturn( 0 );
+
+		$insertSelectCalls = [];
+		$this->connection->method( 'insertSelect' )
+			->willReturnCallback( static function ( $dest, $src, $varMap, $conds, $fname, $insertOptions ) use ( &$insertSelectCalls ) {
+				$insertSelectCalls[] = [
+					'dest' => $dest,
+					'src' => $src,
+					'varMap' => $varMap,
+					'conds' => $conds,
+					'insertOptions' => $insertOptions,
+				];
+				return true;
+			} );
+
+		$instance = new HierarchyTempTableBuilder(
+			$this->connection,
+			$this->temporaryTableBuilder
+		);
+
+		$instance->setTableDefinitions( [ 'class' => [ 'table' => 'bar', 'depth' => 3 ] ] );
+
+		// First call: builds the temp table (no cache hit).
+		$instance->fillTempTable( 'class', 'firstTable', '(42)' );
+
+		// Second call with same composite: must use cache branch.
+		$instance->fillTempTable( 'class', 'secondTable', '(42)' );
+
+		// Find the cache-copy invocation (no IGNORE option, dest=secondTable).
+		$cacheCopy = null;
+		foreach ( $insertSelectCalls as $call ) {
+			if ( $call['dest'] === 'secondTable' ) {
+				$cacheCopy = $call;
+				break;
+			}
+		}
+
+		$this->assertNotNull( $cacheCopy, 'Cache-copy insertSelect must be issued on second fill' );
+		$this->assertSame( 'firstTable', $cacheCopy['src'] );
+		$this->assertSame( [ 'id' => 'id' ], $cacheCopy['varMap'] );
+		$this->assertSame( '*', $cacheCopy['conds'] );
+		$this->assertSame( [], $cacheCopy['insertOptions'] );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/HierarchyTempTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/HierarchyTempTableBuilderTest.php
@@ -193,6 +193,11 @@ class HierarchyTempTableBuilderTest extends TestCase {
 		$this->assertSame( [ 'id' => 'id' ], $cacheCopy['varMap'] );
 		$this->assertSame( '*', $cacheCopy['conds'] );
 		$this->assertSame( [], $cacheCopy['insertOptions'] );
+
+		// First fill issues 1 insertSelect (depth-loop carryback, then breaks
+		// because affectedRows()=0); second fill issues 1 insertSelect (cache
+		// copy). Pin the total so silent regressions in either branch fail.
+		$this->assertCount( 2, $insertSelectCalls );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
@@ -105,15 +105,19 @@ class HashFieldTest extends TestCase {
 		$this->connection->method( 'newSelectQueryBuilder' )
 			->willReturn( $selectBuilder );
 
-		$this->connection->method( 'tableName' )
-			->willReturn( 'smw_object_ids' );
-
 		$this->connection->method( 'getType' )
 			->willReturn( 'mysql' );
 
+		$updateTables = [];
+		$updateSets = [];
+		$updateWheres = [];
 		$this->connection->expects( $this->once() )
-			->method( 'query' )
-			->with( $this->stringContains( 'UNHEX(smw_hash)' ) );
+			->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback(
+				function () use ( &$updateTables, &$updateSets, &$updateWheres ) {
+					return $this->createMockUpdateQueryBuilder( $updateTables, $updateSets, $updateWheres );
+				}
+			);
 
 		$this->store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -125,6 +129,11 @@ class HashFieldTest extends TestCase {
 		$instance = new HashField( $this->store );
 		$instance->setMessageReporter( $this->spyMessageReporter );
 		$instance->migrateHexHashes();
+
+		$this->assertSame( [ SQLStore::ID_TABLE ], $updateTables );
+		$this->assertCount( 1, $updateSets );
+		$this->assertSame( 'UNHEX(smw_hash)', $updateSets[0]['smw_hash']->toSql() );
+		$this->assertSame( [ [ 'LENGTH(smw_hash) = 40' ] ], $updateWheres );
 
 		$this->assertStringContainsString(
 			'converting hex hashes to binary',
@@ -144,9 +153,6 @@ class HashFieldTest extends TestCase {
 		$this->connection->method( 'newSelectQueryBuilder' )
 			->willReturn( $selectBuilder );
 
-		$this->connection->method( 'tableName' )
-			->willReturn( 'smw_object_ids' );
-
 		$this->connection->method( 'getType' )
 			->willReturn( 'mysql' );
 
@@ -154,8 +160,12 @@ class HashFieldTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->connection->method( 'query' )
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
+		$updateBuilder->method( 'execute' )
 			->willThrowException( $dbError );
+
+		$this->connection->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
 
 		$this->store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
@@ -188,7 +198,7 @@ class HashFieldTest extends TestCase {
 			->willReturn( $selectBuilder );
 
 		$this->connection->expects( $this->never() )
-			->method( 'query' );
+			->method( 'newUpdateQueryBuilder' );
 
 		$instance = new HashField( $this->store );
 		$instance->setMessageReporter( $this->spyMessageReporter );

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/TableBuildExaminerTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/TableBuildExaminerTest.php
@@ -14,6 +14,7 @@ use SMW\SQLStore\TableBuilder\Examiner\TouchedField;
 use SMW\SQLStore\TableBuilder\TableBuildExaminer;
 use SMW\SQLStore\TableBuilder\TableBuildExaminerFactory;
 use SMW\Tests\TestEnvironment;
+use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 
 /**
  * @covers \SMW\SQLStore\TableBuilder\TableBuildExaminer
@@ -25,6 +26,8 @@ use SMW\Tests\TestEnvironment;
  * @author mwjames
  */
 class TableBuildExaminerTest extends TestCase {
+
+	use MockWriteQueryBuilderTrait;
 
 	private $spyMessageReporter;
 	private $hashField;
@@ -103,6 +106,17 @@ class TableBuildExaminerTest extends TestCase {
 		$connection->expects( $this->atLeastOnce() )
 			->method( 'tableName' )
 			->willReturn( 'smw_object_ids' );
+
+		$updateTables = [];
+		$updateSets = [];
+		$updateWheres = [];
+		$connection->expects( $this->once() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback(
+				function () use ( &$updateTables, &$updateSets, &$updateWheres ) {
+					return $this->createMockUpdateQueryBuilder( $updateTables, $updateSets, $updateWheres );
+				}
+			);
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->setMethods( [ 'moveSMWPageID' ] )

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/TemporaryTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/TemporaryTableBuilderTest.php
@@ -25,6 +25,12 @@ class TemporaryTableBuilderTest extends TestCase {
 		$this->connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		// `create()` and `drop()` resolve the logical name via tableName()
+		// internally so the temp table lives at the prefix-applied physical
+		// name. Stub the resolver as identity so existing assertions on the
+		// emitted SQL keep matching the bare input name.
+		$this->connection->method( 'tableName' )->willReturnArgument( 0 );
 	}
 
 	public function testCanConstruct() {
@@ -171,6 +177,54 @@ class TemporaryTableBuilderTest extends TestCase {
 			);
 
 		$instance = new TemporaryTableBuilder( $this->connection );
+		$instance->drop( 'Foo' );
+	}
+
+	public function testCreatePassesNameThroughTableName(): void {
+		// Fresh mock so we can assert tableName() invocation explicitly
+		// (the shared setUp() stub uses the loose any-args matcher).
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->once() )
+			->method( 'tableName' )
+			->with( 'Foo' )
+			->willReturn( 'unittest_Foo' );
+
+		$connection->expects( $this->once() )
+			->method( 'query' )
+			->with(
+				$this->stringContains( 'unittest_Foo' ),
+				$this->anything(),
+				$this->anything()
+			);
+
+		$instance = new TemporaryTableBuilder( $connection );
+		$instance->create( 'Foo' );
+	}
+
+	public function testDropPassesNameThroughTableName(): void {
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->method( 'isType' )->willReturn( false );
+
+		$connection->expects( $this->once() )
+			->method( 'tableName' )
+			->with( 'Foo' )
+			->willReturn( 'unittest_Foo' );
+
+		$connection->expects( $this->once() )
+			->method( 'query' )
+			->with(
+				'DROP TEMPORARY TABLE unittest_Foo',
+				$this->anything(),
+				$this->anything()
+			);
+
+		$instance = new TemporaryTableBuilder( $connection );
 		$instance->drop( 'Foo' );
 	}
 


### PR DESCRIPTION
## Summary

Phase 2 of the SMW Rdbms QueryBuilder migration: converts the planner-coupled raw `query()` callsites in HierarchyTempTableBuilder, QuerySegmentListProcessor, TableBuildExaminer, HashField, and `Database::nextSequenceValue` to QueryBuilder / `insertSelect()` / `RawSQLValue`, and adds an `insertSelect()` delegation method to the SMW `Database` facade for INSERT IGNORE…SELECT against hierarchy temp tables.

## What changed

- `TemporaryTableBuilder::create()` and `drop()` now apply `tableName()` resolution internally; callers pass bare logical names. The 3-way platform dispatch for the DDL itself (Postgres `CREATE RULE` / SQLite `CREATE TEMP TABLE` / MySQL `CREATE TEMPORARY TABLE`, plus the matching DROP variants) is retained because Rdbms has no DDL abstraction.
- `HierarchyTempTableBuilder`'s 7 raw queries now use `newInsertQueryBuilder()->ignore()` (5 INSERT IGNORE seeds), `newDeleteQueryBuilder()` (1 truncate), and `IDatabase::insertSelect()` (3 INSERT…SELECT). MW core emits the platform-correct verb (`INSERT IGNORE` / `OR IGNORE` / `ON CONFLICT DO NOTHING`) per dialect.
- `QuerySegmentListProcessor::disjunction()`'s `INSERT IGNORE INTO ... VALUES (...)` batch is now a single shared `newInsertQueryBuilder()->ignore()` builder with one `->row()` per joinfield value. `hierarchy()`'s `SELECT s_id ... LIMIT 1` pre-emptive existence check uses `newSelectQueryBuilder()->fetchRow()`.
- `Database::insertSelect()` is added as a slim delegation that wraps MW core's `IDatabase::insertSelect()` with the `transactionHandler->muteTransactionProfiler()` scope. Uses native PHP 8.1+ types: `string $destTable, string|array $srcTable, array $varMap, string|IExpression|array $conds, ...: bool`.
- `Database::nextSequenceValue()`'s Postgres-only `nextval()` SELECT routes through `newSelectQueryBuilder()->fetchField()` (FROMless SELECT — emitted natively by `SQLPlatform::selectSQLText` when no `from()` is supplied). Tightened to native `string` parameter and `?int` return.
- `TableBuildExaminer::checkSortField()`'s column-to-column UPDATE uses `newUpdateQueryBuilder()` with `RawSQLValue`. `HashField::migrateHexHashes()` MySQL/Postgres branches use the same shape (function-call SET via `RawSQLValue`, raw-fragment WHERE for `LENGTH(smw_hash) = 40`). The SQLite branch is unchanged (already uses the PHP-side fallback).

## Residual raw SQL (intentional)

Two raw `query()` callsites remain — both stitch in the planner's stringly-typed `\$querySegment->from` fragment (an arbitrary INNER/LEFT JOIN chain), which `IDatabase::insertSelect()` cannot accept (it only takes structured `\$selectJoinConds`):

- `QuerySegmentListProcessor::disjunction()`'s `joinTable !== ''` branch
- `ConceptCache::refreshConceptCache()`

Both are documented inline as the "residual planner-side raw SQL" escape hatch matching the `Database` facade's existing guardrail. Converting either requires restructuring the QuerySegment IR — out of scope here.

## Test plan

- [x] `composer analyze` — clean (parallel-lint 2122 files, PHPCS 16/16)
- [x] Full unit suite (`semantic-mediawiki-unit`) — 6874 tests, 14138 assertions, 0 failures
- [x] JSONScript characterization: q-0614 (hierarchy) + q-0201 (concept cache) — both pass
- [x] Browser smoke against seeded dev wiki:
  - `[[Category:Dogs]]` — hierarchy expansion verified (subcategory pages like Australian Cattle Dog, Bernese Mountain Dog returned)
  - `[[Category:Dogs]] OR [[Category:Dog_Care]]` — disjunction → INSERT VALUES batch builder path
  - `[[Category:Dogs]] order=rand` — RAND() sort + hierarchy
  - `Special:Browse/Bulldog` — renders cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)