### PR TITLE
Add Database::getReplicaDatabase() / getPrimaryDatabase() bridge accessors

### DIFF
--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -93,6 +93,35 @@ class Database {
 	}
 
 	/**
+	 * Read-side connection acquisition matching MW core's
+	 * `IConnectionProvider::getReplicaDatabase()`.
+	 *
+	 * Migration vector for callsites moving off this wrapper. New code
+	 * should acquire `IDatabase` via this accessor (or the primary-side
+	 * counterpart) and stop typing local `$connection` variables as
+	 * SMW's `Database`. The wrapper itself is slated for removal once
+	 * the SMW-specific responsibilities (section transactions, AUTO_COMMIT
+	 * flag handling for temp-table DDL, Postgres-only sequence/bytea
+	 * helpers) are extracted into focused helpers.
+	 *
+	 * @since 7.0.0
+	 */
+	public function getReplicaDatabase(): IDatabase {
+		return $this->connRef->getConnection( 'read' );
+	}
+
+	/**
+	 * Write-side connection acquisition matching MW core's
+	 * `IConnectionProvider::getPrimaryDatabase()`. See
+	 * `getReplicaDatabase()` for migration context.
+	 *
+	 * @since 7.0.0
+	 */
+	public function getPrimaryDatabase(): IDatabase {
+		return $this->connRef->getConnection( 'write' );
+	}
+
+	/**
 	 * @since 3.0
 	 *
 	 * @return bool

--- a/tests/phpunit/Unit/MediaWiki/Connection/DatabaseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/DatabaseTest.php
@@ -544,4 +544,30 @@ class DatabaseTest extends TestCase {
 
 		$this->assertSame( $builder, $instance->newReplaceQueryBuilder() );
 	}
+
+	public function testGetReplicaDatabaseReturnsReadConnection(): void {
+		$readDb = $this->createMock( IDatabase::class );
+
+		$this->connRef->expects( $this->once() )
+			->method( 'getConnection' )
+			->with( 'read' )
+			->willReturn( $readDb );
+
+		$instance = new Database( $this->connRef, $this->transactionHandler );
+
+		$this->assertSame( $readDb, $instance->getReplicaDatabase() );
+	}
+
+	public function testGetPrimaryDatabaseReturnsWriteConnection(): void {
+		$writeDb = $this->createMock( IDatabase::class );
+
+		$this->connRef->expects( $this->once() )
+			->method( 'getConnection' )
+			->with( 'write' )
+			->willReturn( $writeDb );
+
+		$instance = new Database( $this->connRef, $this->transactionHandler );
+
+		$this->assertSame( $writeDb, $instance->getPrimaryDatabase() );
+	}
 }


### PR DESCRIPTION
## Summary

Tiny scaffolding PR. Adds two pass-through accessors on `SMW\MediaWiki\Connection\Database` matching MW core's `IConnectionProvider` naming:

- `getReplicaDatabase(): IDatabase`
- `getPrimaryDatabase(): IDatabase`

Each returns the underlying `IDatabase` directly via `connRef->getConnection( 'read' | 'write' )` — no wrapping, no SMW-specific behaviour.

## Why now

These are the migration vector for the eventual wrapper retirement. SMW's `Database` was added in 2014 to backfill capabilities MW core didn't have natively (`IConnectionProvider`, QueryBuilder factories, `silenceForScope`, `expr`, etc.). Those capabilities now exist in MW core, so the wrapper is largely a historical artifact — it survives mainly because some callsites still need SMW-specific concerns (section transactions, `AUTO_COMMIT` flag handling for temp-table DDL, Postgres-only sequence/bytea helpers).

The plan is to migrate callsites in waves:
- This PR (3b.1): just the bridge entry points
- Subsequent per-package PRs: migrate callsites that use only IDatabase-compatible methods to acquire `IDatabase` via the bridge and retype local `\$connection` holders from SMW's `Database` to `IDatabase`
- Eventual 3e: extract the SMW-specific responsibilities into focused helpers (`SectionTransactionGuard`, `TempTableDDLExecutor`, `PostgresHelpers`), then drop the wrapper entirely

Splitting this way lets each per-package migration ship as a focused review unit and avoids one mega-PR touching ~80 callsites.

## What changes

- `src/MediaWiki/Connection/Database.php`: two new public methods, ~30 lines including docblocks documenting the migration intent.
- `tests/phpunit/Unit/MediaWiki/Connection/DatabaseTest.php`: two new tests using `assertSame` to pin pure pass-through identity (no wrapping).

No callsite migrations in this PR. No behaviour change for existing code.

## Test plan

- [x] `composer analyze` clean (parallel-lint + PHPCS)
- [x] Full unit suite (`semantic-mediawiki-unit`) — 6856 tests, 14118 assertions, 0 failures
- [x] New `DatabaseTest::testGetReplicaDatabaseReturnsReadConnection` and `testGetPrimaryDatabaseReturnsWriteConnection` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)