### PR TITLE
Declare SMW namespaces in extension.json (1/2)

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -96,6 +96,14 @@
 		"SMW\\SQLStore\\Lookup\\ListLookup": "src/Lookup/ListLookup.php",
 		"SMW\\SQLStore\\Lookup\\CachedListLookup": "src/Lookup/CachedListLookup.php"
 	},
+	"namespaces": [
+		{ "id": 102, "constant": "SMW_NS_PROPERTY",      "name": "Property",        "content": true },
+		{ "id": 103, "constant": "SMW_NS_PROPERTY_TALK", "name": "Property_talk",   "subpages": true },
+		{ "id": 108, "constant": "SMW_NS_CONCEPT",       "name": "Concept",         "content": true },
+		{ "id": 109, "constant": "SMW_NS_CONCEPT_TALK",  "name": "Concept_talk",    "subpages": true },
+		{ "id": 112, "constant": "SMW_NS_SCHEMA",        "name": "smw/schema",      "defaultcontentmodel": "smw/schema" },
+		{ "id": 113, "constant": "SMW_NS_SCHEMA_TALK",   "name": "smw/schema_talk", "subpages": true }
+	],
 	"callback": "SemanticMediaWiki::initExtension",
 	"ExtensionFunctions": [
 		"SemanticMediaWiki::onExtensionFunction"

--- a/src/NamespaceManager.php
+++ b/src/NamespaceManager.php
@@ -260,10 +260,12 @@ class NamespaceManager {
 		 *
 		 * @see https://www.mediawiki.org/wiki/Manual:$wgContentNamespaces
 		 */
-		$vars['wgContentNamespaces'] = array_merge( $vars['wgContentNamespaces'], [
-			SMW_NS_PROPERTY,
-			SMW_NS_CONCEPT
-		] );
+		$vars['wgContentNamespaces'] = array_values( array_unique(
+			array_merge( $vars['wgContentNamespaces'], [
+				SMW_NS_PROPERTY,
+				SMW_NS_CONCEPT,
+			] )
+		) );
 
 		/**
 		 * To indicate which namespaces are enabled for searching by default

--- a/tests/phpunit/Integration/NamespaceRegistrationParityTest.php
+++ b/tests/phpunit/Integration/NamespaceRegistrationParityTest.php
@@ -10,6 +10,10 @@ use PHPUnit\Framework\TestCase;
  * `CanonicalNamespaces` hook have fired, every globals key the design
  * touches is in the expected state.
  *
+ * Reads live `$GLOBALS` after the MediaWiki + SMW bootstrap has run; relies
+ * on the post-bootstrap state being idempotent so test ordering does not
+ * affect outcomes.
+ *
  * @group medium
  *
  * @license GPL-2.0-or-later
@@ -27,6 +31,10 @@ class NamespaceRegistrationParityTest extends TestCase {
 	}
 
 	public function testExtraNamespacesContainsAllSixCanonicalNames(): void {
+		// Once the runtime NamespaceManager bootstrap is removed, MW core writes
+		// canonical names to attributes['ExtensionNamespaces'] (consumed by
+		// NamespaceInfo) instead of $wgExtraNamespaces; this assertion will
+		// need to read NamespaceInfo::getCanonicalName() instead.
 		$extra = $GLOBALS['wgExtraNamespaces'] ?? [];
 		$this->assertSame( 'Property', $extra[SMW_NS_PROPERTY] ?? null );
 		$this->assertSame( 'Property_talk', $extra[SMW_NS_PROPERTY_TALK] ?? null );
@@ -43,9 +51,14 @@ class NamespaceRegistrationParityTest extends TestCase {
 	}
 
 	public function testContentNamespacesContainsPropertyAndConceptExactlyOnce(): void {
-		$counts = array_count_values( $GLOBALS['wgContentNamespaces'] );
-		$this->assertSame( 1, $counts[SMW_NS_PROPERTY] ?? 0 );
-		$this->assertSame( 1, $counts[SMW_NS_CONCEPT] ?? 0 );
+		$contentNamespaces = $GLOBALS['wgContentNamespaces'];
+
+		// Assert presence and count separately so a regression that drops the
+		// namespace fails differently from one that duplicates it.
+		$this->assertContains( SMW_NS_PROPERTY, $contentNamespaces, 'SMW_NS_PROPERTY missing from wgContentNamespaces' );
+		$this->assertContains( SMW_NS_CONCEPT, $contentNamespaces, 'SMW_NS_CONCEPT missing from wgContentNamespaces' );
+		$this->assertCount( 1, array_keys( $contentNamespaces, SMW_NS_PROPERTY, true ), 'SMW_NS_PROPERTY duplicated in wgContentNamespaces' );
+		$this->assertCount( 1, array_keys( $contentNamespaces, SMW_NS_CONCEPT, true ), 'SMW_NS_CONCEPT duplicated in wgContentNamespaces' );
 	}
 
 	public function testSchemaContentModelIsRegistered(): void {

--- a/tests/phpunit/Integration/NamespaceRegistrationParityTest.php
+++ b/tests/phpunit/Integration/NamespaceRegistrationParityTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace SMW\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Parity check between extension.json's `namespaces` block and the runtime
+ * NamespaceManager bootstrap. Asserts that after `wfLoadExtension` plus the
+ * `CanonicalNamespaces` hook have fired, every globals key the design
+ * touches is in the expected state.
+ *
+ * @group medium
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class NamespaceRegistrationParityTest extends TestCase {
+
+	public function testCustomNamespaceConstants(): void {
+		$this->assertSame( 102, SMW_NS_PROPERTY );
+		$this->assertSame( 103, SMW_NS_PROPERTY_TALK );
+		$this->assertSame( 108, SMW_NS_CONCEPT );
+		$this->assertSame( 109, SMW_NS_CONCEPT_TALK );
+		$this->assertSame( 112, SMW_NS_SCHEMA );
+		$this->assertSame( 113, SMW_NS_SCHEMA_TALK );
+	}
+
+	public function testExtraNamespacesContainsAllSixCanonicalNames(): void {
+		$extra = $GLOBALS['wgExtraNamespaces'] ?? [];
+		$this->assertSame( 'Property', $extra[SMW_NS_PROPERTY] ?? null );
+		$this->assertSame( 'Property_talk', $extra[SMW_NS_PROPERTY_TALK] ?? null );
+		$this->assertSame( 'Concept', $extra[SMW_NS_CONCEPT] ?? null );
+		$this->assertSame( 'Concept_talk', $extra[SMW_NS_CONCEPT_TALK] ?? null );
+		$this->assertSame( 'smw/schema', $extra[SMW_NS_SCHEMA] ?? null );
+		$this->assertSame( 'smw/schema_talk', $extra[SMW_NS_SCHEMA_TALK] ?? null );
+	}
+
+	public function testTalkNamespacesHaveSubpages(): void {
+		$this->assertTrue( $GLOBALS['wgNamespacesWithSubpages'][SMW_NS_PROPERTY_TALK] ?? false );
+		$this->assertTrue( $GLOBALS['wgNamespacesWithSubpages'][SMW_NS_CONCEPT_TALK] ?? false );
+		$this->assertTrue( $GLOBALS['wgNamespacesWithSubpages'][SMW_NS_SCHEMA_TALK] ?? false );
+	}
+
+	public function testContentNamespacesContainsPropertyAndConceptExactlyOnce(): void {
+		$counts = array_count_values( $GLOBALS['wgContentNamespaces'] );
+		$this->assertSame( 1, $counts[SMW_NS_PROPERTY] ?? 0 );
+		$this->assertSame( 1, $counts[SMW_NS_CONCEPT] ?? 0 );
+	}
+
+	public function testSchemaContentModelIsRegistered(): void {
+		$this->assertSame(
+			CONTENT_MODEL_SMW_SCHEMA,
+			$GLOBALS['wgNamespaceContentModels'][SMW_NS_SCHEMA] ?? null
+		);
+	}
+
+	public function testNamespacesToBeSearchedByDefault(): void {
+		$this->assertTrue( $GLOBALS['wgNamespacesToBeSearchedDefault'][SMW_NS_PROPERTY] ?? false );
+		$this->assertTrue( $GLOBALS['wgNamespacesToBeSearchedDefault'][SMW_NS_CONCEPT] ?? false );
+	}
+
+	public function testSemanticLinksDefaultsForSmwNamespaces(): void {
+		$this->assertTrue( $GLOBALS['smwgNamespacesWithSemanticLinks'][SMW_NS_PROPERTY] ?? false );
+		$this->assertTrue( $GLOBALS['smwgNamespacesWithSemanticLinks'][SMW_NS_CONCEPT] ?? false );
+		$this->assertTrue( $GLOBALS['smwgNamespacesWithSemanticLinks'][SMW_NS_SCHEMA] ?? false );
+	}
+}

--- a/tests/phpunit/Integration/NamespaceRegistrationParityTest.php
+++ b/tests/phpunit/Integration/NamespaceRegistrationParityTest.php
@@ -31,10 +31,6 @@ class NamespaceRegistrationParityTest extends TestCase {
 	}
 
 	public function testExtraNamespacesContainsAllSixCanonicalNames(): void {
-		// Once the runtime NamespaceManager bootstrap is removed, MW core writes
-		// canonical names to attributes['ExtensionNamespaces'] (consumed by
-		// NamespaceInfo) instead of $wgExtraNamespaces; this assertion will
-		// need to read NamespaceInfo::getCanonicalName() instead.
 		$extra = $GLOBALS['wgExtraNamespaces'] ?? [];
 		$this->assertSame( 'Property', $extra[SMW_NS_PROPERTY] ?? null );
 		$this->assertSame( 'Property_talk', $extra[SMW_NS_PROPERTY_TALK] ?? null );

--- a/tests/phpunit/Unit/NamespaceManagerTest.php
+++ b/tests/phpunit/Unit/NamespaceManagerTest.php
@@ -431,4 +431,18 @@ class NamespaceManagerTest extends TestCase {
 		];
 	}
 
+	public function testInitDoesNotDuplicateContentNamespacesWhenPrePopulated() {
+		// extension.json's "content": true seeds wgContentNamespaces before
+		// init() runs. Verify the runtime merge is idempotent.
+		$vars = $this->default;
+		$vars['wgContentNamespaces'] = [ SMW_NS_PROPERTY, SMW_NS_CONCEPT ];
+
+		$instance = new NamespaceManager( $this->localLanguage );
+		$vars = $instance->init( $vars );
+
+		$counts = array_count_values( $vars['wgContentNamespaces'] );
+		$this->assertSame( 1, $counts[SMW_NS_PROPERTY] );
+		$this->assertSame( 1, $counts[SMW_NS_CONCEPT] );
+	}
+
 }


### PR DESCRIPTION
## Summary

Step 1 of 2 in migrating SMW's six custom namespaces (`SMW_NS_PROPERTY`,
`SMW_NS_PROPERTY_TALK`, `SMW_NS_CONCEPT`, `SMW_NS_CONCEPT_TALK`,
`SMW_NS_SCHEMA`, `SMW_NS_SCHEMA_TALK`) from runtime registration in
`NamespaceManager::initCustomNamespace` to MediaWiki core's declarative
`extension.json` `namespaces` block (supported since MW 1.30).

This PR is additive: it adds the static block and keeps the runtime
path active so the two paths run together. PR-2 will then remove the
runtime path and `$smwgNamespaceIndex`, with a deprecation guard for
upgraders.

- `extension.json` gets a `namespaces` block declaring the six SMW
  namespaces with their canonical IDs (102, 103, 108, 109, 112, 113),
  English names, `subpages`/`content` flags, and (for `SMW_NS_SCHEMA`)
  `defaultcontentmodel: "smw/schema"`. By the time the
  extension callback fires, MediaWiki core has already defined the
  constants, populated `wgNamespacesWithSubpages`, `wgContentNamespaces`,
  and `wgNamespaceContentModels`, and registered the canonical names
  via `attributes['ExtensionNamespaces']` (consumed by `NamespaceInfo`).
- `NamespaceManager::addExtraNamespaceSettings` previously appended
  `SMW_NS_PROPERTY` and `SMW_NS_CONCEPT` to `wgContentNamespaces` via
  `array_merge`. With both paths now contributing, that would produce
  duplicates. The merge is wrapped in `array_values( array_unique( ... ) )`
  to keep PR-1's both-paths-running state regression-free. All other
  namespace-related merges (`+=` on `wgNamespacesWithSubpages`,
  `wgNamespacesToBeSearchedDefault`, `smwgNamespacesWithSemanticLinks`,
  `wgCanonicalNamespaceNames`, `wgExtraNamespaces`) are already
  idempotent.
- `tests/phpunit/Integration/NamespaceRegistrationParityTest.php` is
  new. It captures the post-bootstrap state of every globals key the
  design touches (constants, `wgExtraNamespaces`, `wgNamespacesWithSubpages`,
  `wgContentNamespaces` count semantics, `wgNamespaceContentModels`,
  `wgNamespacesToBeSearchedDefault`, `smwgNamespacesWithSemanticLinks`)
  so the static path is provably faithful to the runtime path. The
  test is scoped to PR-1's review handle and gets retired in PR-2.

User-facing impact: none on this PR. Existing wikis at the default
`$smwgNamespaceIndex` continue to work identically. Wikis with a
non-default `$smwgNamespaceIndex` also continue to work via the
existing runtime path.

Reference: <https://www.mediawiki.org/wiki/Manual:Extension.json/Schema>

## Test plan
- [x] `composer analyze` exits 0
- [x] `composer phpunit -- --filter NamespaceManagerTest` (20 tests / 39 assertions)
- [x] `composer phpunit -- --filter NamespaceRegistrationParityTest` (7 tests / 25 assertions)
- [x] Browser smoke at `localhost:8080`: `Special:Properties`, `Special:Concepts`, real property pages, schema page, `Special:AllPages?namespace={102,108,112}`. All render without errors; constants resolve to 102/108/112; schema page reports `wgPageContentModel=smw/schema`
- [x] CI green