### PR TITLE
Fix Property namespace disabled error

### DIFF
--- a/src/NamespaceManager.php
+++ b/src/NamespaceManager.php
@@ -66,6 +66,9 @@ class NamespaceManager {
 		// claimed them by the time this hook fires.
 		$namespaces = $extraNamespaces + $canonicalNames + $namespaces;
 
+		// $smwgNamespacesWithSemanticLinks defaults are seeded in
+		// ConfigBootstrap::seedComputedDefaults() so Settings::loadFromGlobals()
+		// (called inside wgExtensionFunctions) sees them before this hook fires.
 		Globals::replace( [
 			'wgNamespaceAliases' => $namespaceAliases
 				+ array_flip( $extraNamespaces )
@@ -74,14 +77,6 @@ class NamespaceManager {
 			'wgNamespacesToBeSearchedDefault' => ( $vars['wgNamespacesToBeSearchedDefault'] ?? [] ) + [
 				SMW_NS_PROPERTY => true,
 				SMW_NS_CONCEPT  => true,
-			],
-			'smwgNamespacesWithSemanticLinks' => ( $vars['smwgNamespacesWithSemanticLinks'] ?? [] ) + [
-				SMW_NS_PROPERTY      => true,
-				SMW_NS_PROPERTY_TALK => false,
-				SMW_NS_CONCEPT       => true,
-				SMW_NS_CONCEPT_TALK  => false,
-				SMW_NS_SCHEMA        => true,
-				SMW_NS_SCHEMA_TALK   => false,
 			],
 		] );
 

--- a/src/Setup/ConfigBootstrap.php
+++ b/src/Setup/ConfigBootstrap.php
@@ -161,24 +161,33 @@ class ConfigBootstrap {
 		$GLOBALS['smwgLocalConnectionConf'] = $user;
 
 		// smwgNamespacesWithSemanticLinks — array_plus semantics: user keys win,
-		// standard MW namespaces filled from defaults.
+		// standard MW + SMW custom namespaces filled from defaults. SMW NS
+		// keys must be seeded here (not in the CanonicalNamespaces hook
+		// handler) because Settings::loadFromGlobals() runs inside
+		// wgExtensionFunctions, before any Title resolution fires the hook.
 		$defaults = [
-			NS_MAIN             => true,
-			NS_TALK             => false,
-			NS_USER             => true,
-			NS_USER_TALK        => false,
-			NS_PROJECT          => true,
-			NS_PROJECT_TALK     => false,
-			NS_FILE             => true,
-			NS_FILE_TALK        => false,
-			NS_MEDIAWIKI        => false,
-			NS_MEDIAWIKI_TALK   => false,
-			NS_TEMPLATE         => false,
-			NS_TEMPLATE_TALK    => false,
-			NS_HELP             => true,
-			NS_HELP_TALK        => false,
-			NS_CATEGORY         => true,
-			NS_CATEGORY_TALK    => false,
+			NS_MAIN              => true,
+			NS_TALK              => false,
+			NS_USER              => true,
+			NS_USER_TALK         => false,
+			NS_PROJECT           => true,
+			NS_PROJECT_TALK      => false,
+			NS_FILE              => true,
+			NS_FILE_TALK         => false,
+			NS_MEDIAWIKI         => false,
+			NS_MEDIAWIKI_TALK    => false,
+			NS_TEMPLATE          => false,
+			NS_TEMPLATE_TALK     => false,
+			NS_HELP              => true,
+			NS_HELP_TALK         => false,
+			NS_CATEGORY          => true,
+			NS_CATEGORY_TALK     => false,
+			SMW_NS_PROPERTY      => true,
+			SMW_NS_PROPERTY_TALK => false,
+			SMW_NS_CONCEPT       => true,
+			SMW_NS_CONCEPT_TALK  => false,
+			SMW_NS_SCHEMA        => true,
+			SMW_NS_SCHEMA_TALK   => false,
 		];
 		$GLOBALS['smwgNamespacesWithSemanticLinks'] = ( $GLOBALS['smwgNamespacesWithSemanticLinks'] ?? [] ) + $defaults;
 

--- a/tests/phpunit/Integration/Setup/ConfigBootstrapTest.php
+++ b/tests/phpunit/Integration/Setup/ConfigBootstrapTest.php
@@ -57,12 +57,12 @@ class ConfigBootstrapTest extends TestCase {
 
 		try {
 			ConfigBootstrap::seedComputedDefaults();
-			$this->assertSame( true,  $GLOBALS[$key][SMW_NS_PROPERTY] );
-			$this->assertSame( false, $GLOBALS[$key][SMW_NS_PROPERTY_TALK] );
-			$this->assertSame( true,  $GLOBALS[$key][SMW_NS_CONCEPT] );
-			$this->assertSame( false, $GLOBALS[$key][SMW_NS_CONCEPT_TALK] );
-			$this->assertSame( true,  $GLOBALS[$key][SMW_NS_SCHEMA] );
-			$this->assertSame( false, $GLOBALS[$key][SMW_NS_SCHEMA_TALK] );
+			$this->assertTrue( $GLOBALS[$key][SMW_NS_PROPERTY] );
+			$this->assertFalse( $GLOBALS[$key][SMW_NS_PROPERTY_TALK] );
+			$this->assertTrue( $GLOBALS[$key][SMW_NS_CONCEPT] );
+			$this->assertFalse( $GLOBALS[$key][SMW_NS_CONCEPT_TALK] );
+			$this->assertTrue( $GLOBALS[$key][SMW_NS_SCHEMA] );
+			$this->assertFalse( $GLOBALS[$key][SMW_NS_SCHEMA_TALK] );
 		} finally {
 			$GLOBALS[$key] = $backup;
 		}

--- a/tests/phpunit/Integration/Setup/ConfigBootstrapTest.php
+++ b/tests/phpunit/Integration/Setup/ConfigBootstrapTest.php
@@ -44,6 +44,45 @@ class ConfigBootstrapTest extends TestCase {
 		}
 	}
 
+	public function testSmwNamespacesWithSemanticLinksSeedsSmwNsKeys(): void {
+		// Regression for #6772: the SMW NS defaults must be seeded at
+		// registration time, not in the CanonicalNamespaces hook. The hook
+		// fires on first Title resolution, which happens after
+		// Settings::loadFromGlobals() is called inside wgExtensionFunctions,
+		// so a hook-only seed leaves Settings holding a stale snapshot and
+		// every Property page emits smw-property-namespace-disabled.
+		$key    = 'smwgNamespacesWithSemanticLinks';
+		$backup = $GLOBALS[$key] ?? null;
+		unset( $GLOBALS[$key] );
+
+		try {
+			ConfigBootstrap::seedComputedDefaults();
+			$this->assertSame( true,  $GLOBALS[$key][SMW_NS_PROPERTY] );
+			$this->assertSame( false, $GLOBALS[$key][SMW_NS_PROPERTY_TALK] );
+			$this->assertSame( true,  $GLOBALS[$key][SMW_NS_CONCEPT] );
+			$this->assertSame( false, $GLOBALS[$key][SMW_NS_CONCEPT_TALK] );
+			$this->assertSame( true,  $GLOBALS[$key][SMW_NS_SCHEMA] );
+			$this->assertSame( false, $GLOBALS[$key][SMW_NS_SCHEMA_TALK] );
+		} finally {
+			$GLOBALS[$key] = $backup;
+		}
+	}
+
+	public function testSmwNamespacesWithSemanticLinksUserOverridePreserved(): void {
+		// array_plus semantics: user keys win over defaults.
+		$key    = 'smwgNamespacesWithSemanticLinks';
+		$backup = $GLOBALS[$key] ?? null;
+		$GLOBALS[$key] = [ SMW_NS_PROPERTY => false ];
+
+		try {
+			ConfigBootstrap::seedComputedDefaults();
+			$this->assertFalse( $GLOBALS[$key][SMW_NS_PROPERTY] );
+			$this->assertTrue( $GLOBALS[$key][SMW_NS_CONCEPT] );
+		} finally {
+			$GLOBALS[$key] = $backup;
+		}
+	}
+
 	public function testFalseyButPresentValueIsPreserved(): void {
 		// Sets the user value to literal 0 — falsey, but `isset()` returns
 		// true. A buggy `if ( !$GLOBALS[$key] )` guard would overwrite the

--- a/tests/phpunit/Unit/NamespaceManagerTest.php
+++ b/tests/phpunit/Unit/NamespaceManagerTest.php
@@ -109,31 +109,6 @@ class NamespaceManagerTest extends TestCase {
 		);
 	}
 
-	public function testInitCanonicalNamespacesSeedsSemanticLinkDefaults(): void {
-		unset(
-			$GLOBALS['smwgNamespacesWithSemanticLinks'][SMW_NS_PROPERTY],
-			$GLOBALS['smwgNamespacesWithSemanticLinks'][SMW_NS_CONCEPT],
-			$GLOBALS['smwgNamespacesWithSemanticLinks'][SMW_NS_SCHEMA]
-		);
-
-		$namespaces = [];
-		NamespaceManager::initCanonicalNamespaces( $namespaces );
-
-		$this->assertTrue( $GLOBALS['smwgNamespacesWithSemanticLinks'][SMW_NS_PROPERTY] );
-		$this->assertTrue( $GLOBALS['smwgNamespacesWithSemanticLinks'][SMW_NS_CONCEPT] );
-		$this->assertTrue( $GLOBALS['smwgNamespacesWithSemanticLinks'][SMW_NS_SCHEMA] );
-	}
-
-	public function testInitCanonicalNamespacesPreservesUserSemanticLinkOverride(): void {
-		$GLOBALS['smwgNamespacesWithSemanticLinks'][SMW_NS_PROPERTY] = false;
-
-		$namespaces = [];
-		NamespaceManager::initCanonicalNamespaces( $namespaces );
-
-		$this->assertFalse( $GLOBALS['smwgNamespacesWithSemanticLinks'][SMW_NS_PROPERTY] );
-		$this->assertTrue( $GLOBALS['smwgNamespacesWithSemanticLinks'][SMW_NS_CONCEPT] );
-	}
-
 	public function testInitCanonicalNamespacesSeedsSearchDefaults(): void {
 		unset(
 			$GLOBALS['wgNamespacesToBeSearchedDefault'][SMW_NS_PROPERTY],


### PR DESCRIPTION
## Summary

Every page in the Property namespace currently renders the `smw-property-namespace-disabled` error on master. PR #6772 ("Remove $smwgNamespaceIndex; slim NamespaceManager") moved the seeding of the six SMW namespace keys in `$smwgNamespacesWithSemanticLinks` from eager seeding in `wgExtensionFunctions` into the `CanonicalNamespaces` hook handler. The hook fires lazily on first Title resolution, but `Settings::loadFromGlobals()` runs earlier inside `wgExtensionFunctions` (via `Setup::initConnectionProviders`), so Settings ends up caching a snapshot in which the SMW NS keys are missing, and `CommonExaminer::checkNamespace()` reads the stale cached array.

## Root cause trace

1. `WebStart.php` triggers `wgExtensionFunctions`.
2. `SemanticMediaWiki::onExtensionFunction()` calls `Setup::init()`, which calls `initConnectionProviders()`, which loads SMW Settings via `MwCollaboratorFactory::newConnectionProvider()`.
3. At this point `$GLOBALS['smwgNamespacesWithSemanticLinks']` only contains the standard MW NS keys (0..15) seeded by `ConfigBootstrap::seedComputedDefaults()`. No Title has been resolved, so the `CanonicalNamespaces` hook has not fired.
4. `Settings::loadFromGlobals()` caches the partial array.
5. Title resolution later fires the hook and adds keys 102/103/108/109/112/113 to `$GLOBALS`, but the Settings snapshot is already wrong.
6. `DeclarationExaminerFactory` pulls `smwgNamespacesWithSemanticLinks` from cached Settings; `CommonExaminer::checkNamespace()` finds no `[102]` key and emits `smw-property-namespace-disabled`.

## Fix

Move the SMW namespace defaults to `ConfigBootstrap::seedComputedDefaults()`, alongside the standard MW NS defaults that already use the same `array_plus` semantics. This runs at extension-registration time inside the `extension.json` callback, strictly before `wgExtensionFunctions`, so Settings sees the complete defaults when it loads. Constants are available because `extension.json`'s `namespaces` block defines them before the callback fires (and `setupDefines()` is a backstop).

The same six keys are removed from `NamespaceManager::initCanonicalNamespaces()`. `wgNamespaceAliases` and `wgNamespacesToBeSearchedDefault` stay in the hook because they depend on localised namespace names.

## Test plan

- [x] Reproduced the error against a fresh wiki: `curl -s http://localhost:8080/w/index.php?title=Property:Foo` rendered `smw-property-namespace-disabled`.
- [x] Verified the fix: same curl against the fixed branch renders the normal "no such property" content.
- [x] Verified at runtime that `Settings->get('smwgNamespacesWithSemanticLinks')` now contains keys `0..15, 102, 103, 108, 109, 112, 113` with the expected values.
- [x] `composer analyze` clean.
- [x] `composer test` passes.
- [x] Two new unit cases in `ConfigBootstrapTest` cover: (a) SMW NS keys get seeded when the global is unset, and (b) user override on a SMW NS key wins over the seeded default (`array_plus` semantics).