### PR TITLE
Fix JsonCodec round-trip in SemanticData::newFromJsonArray

### DIFF
--- a/src/DataModel/SemanticData.php
+++ b/src/DataModel/SemanticData.php
@@ -905,24 +905,51 @@ class SemanticData implements JsonDeserializable {
 	 */
 	public static function newFromJsonArray( JsonDeserializer $deserializer, array $json ): self {
 		$obj = new self(
-			$deserializer->deserialize( $json['mSubject'] ),
+			self::maybeDeserialize( $deserializer, $json['mSubject'] ),
 			$json['mNoDuplicates']
 		);
 		$obj->stubObject = $json['stubObject'];
 		$obj->mPropVals = array_map( static function ( array $x ) use( $deserializer ): array {
-			return $deserializer->deserializeArray( $x );
+			return self::maybeDeserializeArray( $deserializer, $x );
 		}, $json['mPropVals'] );
-		$obj->mProperties = $deserializer->deserializeArray( $json['mProperties'] );
+		$obj->mProperties = self::maybeDeserializeArray( $deserializer, $json['mProperties'] );
 		$obj->mHasVisibleProps = $json['mHasVisibleProps'];
 		$obj->mHasVisibleSpecs = $json['mHasVisibleSpecs'];
-		$obj->subSemanticData = $json['subSemanticData'] ? $deserializer->deserialize( $json['subSemanticData'] ) : null;
+		$obj->subSemanticData = $json['subSemanticData'] ? self::maybeDeserialize( $deserializer, $json['subSemanticData'] ) : null;
 		$obj->errors = $json['errors'];
 		$obj->hash = $json['hash'];
-		$obj->options = $json['options'] ? $deserializer->deserialize( $json['options'] ) : null;
+		$obj->options = $json['options'] ? self::maybeDeserialize( $deserializer, $json['options'] ) : null;
 		$obj->extensionData = $json['extensionData'];
 		$obj->sequenceMap = $json['sequenceMap'];
 		$obj->countMap = $json['countMap'];
 		return $obj;
+	}
+
+	/**
+	 * MediaWiki's JsonCodec recursively deserializes nested `_type_`-marked
+	 * values while walking a structure, so a field reaching `newFromJsonArray`
+	 * may already be a fully reified object rather than a marked array.
+	 * Passing such a value back through `deserialize()` trips its
+	 * `stdClass|array|string` parameter assert; the resulting JsonException is
+	 * swallowed by `ParserCache::restoreFromJson` and reported as a cache
+	 * miss, defeating the parser cache for every page touched by SMW. Skip
+	 * the redundant call when the value has already been deserialized.
+	 *
+	 * @since 7.0.0
+	 */
+	public static function maybeDeserialize( JsonDeserializer $deserializer, mixed $value ): mixed {
+		return is_object( $value ) ? $value : $deserializer->deserialize( $value );
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public static function maybeDeserializeArray( JsonDeserializer $deserializer, array $value ): array {
+		$result = [];
+		foreach ( $value as $k => $v ) {
+			$result[$k] = self::maybeDeserialize( $deserializer, $v );
+		}
+		return $result;
 	}
 
 }

--- a/src/DataModel/SubSemanticData.php
+++ b/src/DataModel/SubSemanticData.php
@@ -242,8 +242,11 @@ class SubSemanticData implements JsonDeserializable {
 	 * @since 4.0.0
 	 */
 	public static function newFromJsonArray( JsonDeserializer $deserializer, array $json ): self {
-		$obj = new self( $deserializer->deserialize( $json['subject'] ), $json['noDuplicates'] );
-		$obj->subSemanticData = $deserializer->deserializeArray( $json['subSemanticData'] );
+		$obj = new self(
+			SemanticData::maybeDeserialize( $deserializer, $json['subject'] ),
+			$json['noDuplicates']
+		);
+		$obj->subSemanticData = SemanticData::maybeDeserializeArray( $deserializer, $json['subSemanticData'] );
 		$obj->subContainerMaxDepth = $json['subContainerMaxDepth'];
 		return $obj;
 	}

--- a/tests/phpunit/Integration/SemanticDataJsonCodecRoundtripTest.php
+++ b/tests/phpunit/Integration/SemanticDataJsonCodecRoundtripTest.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace SMW\Tests\Integration;
+
+use MediaWiki\MediaWikiServices;
+use PHPUnit\Framework\TestCase;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
+use SMW\DataModel\Subobject;
+use SMW\DataValueFactory;
+use SMW\Services\ServicesFactory as ApplicationFactory;
+
+/**
+ * Round-trips SemanticData through MediaWiki's JsonCodec, the same path
+ * ParserCache uses to persist objects. Exercises the JsonDeserializable
+ * implementation in SemanticData and SubSemanticData and ensures the
+ * deserialization step does not throw when nested values have already been
+ * recursively deserialized by the codec.
+ *
+ * @covers \SMW\DataModel\SemanticData
+ * @covers \SMW\DataModel\SubSemanticData
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ */
+class SemanticDataJsonCodecRoundtripTest extends TestCase {
+
+	/**
+	 * @dataProvider semanticDataProvider
+	 */
+	public function testJsonCodecRoundtrip( SemanticData $data ): void {
+		$codec = MediaWikiServices::getInstance()->getJsonCodec();
+
+		$json = $codec->serialize( $data );
+		$restored = $codec->deserialize( $json );
+
+		$this->assertInstanceOf( SemanticData::class, $restored );
+		$this->assertSame( $data->getHash(), $restored->getHash() );
+	}
+
+	public function semanticDataProvider(): array {
+		ApplicationFactory::clear();
+
+		$provider = [];
+		$title = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __METHOD__ );
+
+		// Empty container.
+		$empty = new SemanticData( WikiPage::newFromTitle( $title ) );
+		$provider['empty'] = [ $empty ];
+
+		// Single property value.
+		$single = new SemanticData( WikiPage::newFromTitle( $title ) );
+		$single->addDataValue(
+			DataValueFactory::getInstance()->newDataValueByText( 'Has fooQuex', 'Bar' )
+		);
+		$provider['single property'] = [ $single ];
+
+		// With a populated SubSemanticData (subobject) — the path that
+		// triggered the regression in #6538.
+		$withSub = new SemanticData( WikiPage::newFromTitle( $title ) );
+		$withSub->addDataValue(
+			DataValueFactory::getInstance()->newDataValueByText( 'Has fooQuex', 'Bar' )
+		);
+
+		$subobject = new Subobject( $title );
+		$subobject->setEmptyContainerForId( 'Foo' );
+		$subobject->addDataValue(
+			DataValueFactory::getInstance()->newDataValueByText( 'Has subobjects', 'Bam' )
+		);
+
+		$withSub->addPropertyObjectValue( $subobject->getProperty(), $subobject->getContainer() );
+
+		$provider['with subobject'] = [ $withSub ];
+
+		return $provider;
+	}
+
+}


### PR DESCRIPTION
## Summary

`MediaWiki\Json\JsonCodec` recursively deserializes nested `_type_`-marked values while walking a structure, so by the time `SemanticData::newFromJsonArray` is invoked, fields like `mSubject`, `subSemanticData` and `options` may already be fully reified objects rather than the marked arrays the original code expected. Passing such a value back through `$deserializer->deserialize(...)` trips its `stdClass|array|string` parameter assert; the resulting `JsonException` is swallowed by `ParserCache::restoreFromJson`, and the entry is reported as a `miss/unserialize`. The page is then re-parsed on every view, defeating the parser cache for any page in a namespace covered by `$smwgNamespacesWithSemanticLinks`.

This regression was introduced in #6538 (`e36ae539`), which removed the `maybeUnserialize` compatibility helpers under the (incorrect) assumption that `$deserializer->deserialize(...)` would always be needed. The closed PR #5274 was attempting to handle exactly this situation; it had described its approach as making the code agnostic about whether unserialization occurs before or after `::newFromJsonArray()` runs.

## Fix

Restore the agnostic helper pattern as `maybeDeserialize` / `maybeDeserializeArray` on `SemanticData`. They no-op on already-reified objects and fall through to `deserialize()` only for arrays/strings, which keeps the code working under both pre- and post-recursion codec behaviour. `SubSemanticData::newFromJsonArray` reuses the same helpers via the public static methods on `SemanticData`.

The trace from the live diagnostic was:

```
JsonException: Bad value for parameter $json: must be a stdClass|array|string
  #0 MediaWiki\Json\JsonCodec->deserialize         SemanticData.php:918
  #1 SMW\DataModel\SemanticData::newFromJsonArray  JsonDeserializableCodec.php:52
  #2 Wikimedia\JsonCodec\JsonCodec->newFromJsonArray  JsonCodec.php:408
```

Note: the trace points at the `subSemanticData` call site in `SemanticData::newFromJsonArray`, but the `TypeError` actually fires one level deeper. At that line the value is still a marked array (the outer walk's escape-hoist of `_type_: ["SubSemanticData","array"]` keeps it as an array). The deeper `deserialize()` call processes the SubSemanticData JSON properly without the escape-hoist, recursively reifies `subject` into a `WikiPage` object, and then `SubSemanticData::newFromJsonArray` calls `$deserializer->deserialize($json['subject'])` on that object. So the helper is required in **both** files; fixing only `SemanticData` is not enough.

## Test plan

- [x] New unit test `SemanticDataJsonCodecRoundtripTest` round-trips empty / single-property / with-subobject `SemanticData` instances through `MediaWikiServices::getJsonCodec()` (the same path `ParserCache` uses). Confirmed RED on master with the exact stack trace above; GREEN after the fix.
- [x] All 169 existing SemanticData / SubSemanticData PHPUnit tests pass (`composer phpunit -- --filter "SemanticData|SubSemanticData"`).
- [x] `composer analyze` clean.
- [x] Browser smoke against a seeded dev wiki: three consecutive views of an SMW-bearing page (`/wiki/Beagle`) return identical `Saved in parser cache ... timestamp ...` stamps, confirming cache hits.

## Notes

- The compatibility helpers are exposed as `public static` so that `SubSemanticData` can route through them. This mirrors how the previous `maybeUnserialize` / `maybeUnserializeArray` lived as static helpers and is the smallest possible change.
- Tested against `wikimedia/json-codec v3.0.3` (the version pinned by MW 1.43); the same recursive-walk behaviour exists in v4.x, so the fix is correct for both.

Refs: closes the gap left by #5274, fixes the regression introduced in #6538.