### PR TITLE
config: Replace constant-based factbox configuration with string values (1/3)

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -36,6 +36,17 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 * **`src/DefaultSettings.php` removed.** Per-setting documentation that previously lived as inline comments in this file now lives at `docs/config.md` (one section per setting) and in the manifest's `description` field. Authoring `LocalSettings.php` is unchanged — `$smwgFoo = …;` continues to work for every setting that ever did.
 
+* **String-based configuration values introduced; legacy `SMW_*` constants deprecated.** SMW configuration settings that previously required PHP integer constants from `src/Defines.php` (such as `SMW_FACTBOX_*`, `SMW_PARSER_*`, `SMW_EQ_*`) now accept string values or arrays of strings. The legacy constant form continues to work in 7.x with one `wfDeprecatedMsg` per setting per request and will be removed in 8.0. This removes the need for the Composer `autoload.files` workaround introduced in #6585; you can drop that block once your `LocalSettings.php` uses the string form.
+
+  Migration (extended in subsequent commits as more settings are converted):
+
+  | Setting | Old form (deprecated) | New form |
+  |---|---|---|
+  | `$smwgShowFactbox` | `SMW_FACTBOX_NONEMPTY` | `'nonempty'` |
+  | `$smwgFactboxFeatures` | `SMW_FACTBOX_CACHE \| SMW_FACTBOX_PURGE_REFRESH` | `[ 'cache', 'purge-refresh' ]` |
+
+  Accepted strings for `$smwgShowFactbox`: `'hidden'`, `'special'`, `'nonempty'`, `'shown'`. Accepted flags for `$smwgFactboxFeatures`: `'cache'`, `'purge-refresh'`, `'display-subobject'`, `'display-attachment'`. Unknown strings are ignored with a structured-log warning.
+
 * **`$smwgNamespaceIndex` removed; namespace IDs now relocate via PHP constants.** SMW's six custom namespaces (`SMW_NS_PROPERTY`, `SMW_NS_PROPERTY_TALK`, `SMW_NS_CONCEPT`, `SMW_NS_CONCEPT_TALK`, `SMW_NS_SCHEMA`, `SMW_NS_SCHEMA_TALK`) are now declared in `extension.json`'s `namespaces` block, and the `$smwgNamespaceIndex` setting is gone. To use non-default namespace IDs, define the constants directly in `LocalSettings.php` BEFORE `wfLoadExtension( 'SemanticMediaWiki' )` (this is MediaWiki core's documented relocation mechanism since MW 1.30):
 
   ```php

--- a/extension.json
+++ b/extension.json
@@ -894,6 +894,10 @@
 			"description": "Directory containing SMW-specific i18n files for extraneous language data (unit labels, property aliases, etc.).",
 			"path": true
 		},
+		"FactboxFeatures": {
+			"value": [ "cache", "purge-refresh", "display-subobject", "display-attachment" ],
+			"description": "Factbox feature flags. Array of any of: 'cache', 'purge-refresh', 'display-subobject', 'display-attachment'. Legacy `SMW_FACTBOX_*` integer constants are accepted with a deprecation notice in 7.x and will be removed in 8.0."
+		},
 		"FallbackSearchType": {
 			"value": null,
 			"description": "Search engine class to fall back to when SMWSearch cannot parse a query; `null` uses the database default."
@@ -1233,6 +1237,10 @@
 		"SetParserCacheTimestamp": {
 			"value": true,
 			"description": "When `true`, sets a timestamp on `ParserOutput` to allow immediate parser-cache invalidation."
+		},
+		"ShowFactbox": {
+			"value": "hidden",
+			"description": "Default factbox visibility on page view. Accepts 'hidden', 'special', 'nonempty', or 'shown'. Legacy `SMW_FACTBOX_HIDDEN`/`SPECIAL`/`NONEMPTY`/`SHOWN` integer constants are accepted with a deprecation notice in 7.x and will be removed in 8.0."
 		},
 		"SimilarityLookupExemptionProperty": {
 			"value": "owl:differentFrom",

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -7,6 +7,7 @@ use SMW\Exception\SettingNotFoundException;
 use SMW\Exception\SettingsAlreadyLoadedException;
 use SMW\Listener\ChangeListener\ChangeListenerAwareTrait;
 use SMW\MediaWiki\HookDispatcherAwareTrait;
+use SMW\Setup\LegacyConstantNormalizer;
 
 /**
  * @private
@@ -71,8 +72,8 @@ class Settings extends Options {
 			'smwgSparqlRepositoryFeatures' => $GLOBALS['smwgSparqlRepositoryFeatures'],
 			'smwgSparqlReplicationPropertyExemptionList' => $GLOBALS['smwgSparqlReplicationPropertyExemptionList'],
 			'smwgSparqlQFeatures' => $GLOBALS['smwgSparqlQFeatures'],
-			'smwgFactboxFeatures' => $GLOBALS['smwgFactboxFeatures'],
-			'smwgShowFactbox' => $GLOBALS['smwgShowFactbox'],
+			'smwgFactboxFeatures' => LegacyConstantNormalizer::normalize( 'smwgFactboxFeatures', $GLOBALS['smwgFactboxFeatures'] ),
+			'smwgShowFactbox' => LegacyConstantNormalizer::normalize( 'smwgShowFactbox', $GLOBALS['smwgShowFactbox'] ),
 			'smwgShowFactboxEdit' => $GLOBALS['smwgShowFactboxEdit'],
 			'smwgCompactLinkSupport' => $GLOBALS['smwgCompactLinkSupport'],
 			'smwgDefaultNumRecurringEvents' => $GLOBALS['smwgDefaultNumRecurringEvents'],

--- a/src/Setup/ConfigBootstrap.php
+++ b/src/Setup/ConfigBootstrap.php
@@ -50,14 +50,6 @@ class ConfigBootstrap {
 			$GLOBALS['smwgSparqlRepositoryFeatures'] = SMW_SPARQL_NONE;
 		}
 
-		if ( !isset( $GLOBALS['smwgFactboxFeatures'] ) ) {
-			$GLOBALS['smwgFactboxFeatures'] = SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT | SMW_FACTBOX_DISPLAY_ATTACHMENT;
-		}
-
-		if ( !isset( $GLOBALS['smwgShowFactbox'] ) ) {
-			$GLOBALS['smwgShowFactbox'] = SMW_FACTBOX_HIDDEN;
-		}
-
 		if ( !isset( $GLOBALS['smwgShowFactboxEdit'] ) ) {
 			$GLOBALS['smwgShowFactboxEdit'] = SMW_FACTBOX_NONEMPTY;
 		}

--- a/src/Setup/LegacyConstantNormalizer.php
+++ b/src/Setup/LegacyConstantNormalizer.php
@@ -1,0 +1,200 @@
+<?php
+
+namespace SMW\Setup;
+
+use MediaWiki\Logger\LoggerFactory;
+
+/**
+ * Normalize legacy integer-constant config values to the JSON-clean string /
+ * array-of-strings form used by `extension.json` defaults, while preserving
+ * the internal representation expected by SMW (integer bitmask for flag
+ * settings, integer or string for enum settings).
+ *
+ * Called from {@see \SMW\Settings::loadFromGlobals()} for the registered keys.
+ * Both legacy (integer constants from src/Defines.php) and new (string / array
+ * of strings) user values are accepted. The legacy form emits one
+ * `wfDeprecatedMsg` per setting per request and is scheduled for removal in
+ * SMW 8.0.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class LegacyConstantNormalizer {
+
+	/**
+	 * Per-request set of setting keys for which a deprecation notice has
+	 * already been emitted. Reset between requests; resetDeprecationState()
+	 * is exposed for test isolation.
+	 *
+	 * @var array<string, true>
+	 */
+	private static array $deprecationEmitted = [];
+
+	/**
+	 * Enum settings: single-value, internally compared via === or == against
+	 * an SMW_* integer constant. Shape: [ settingKey => [ stringName => internalValue ] ].
+	 *
+	 * Each integer matches the corresponding `define()` in src/Defines.php.
+	 *
+	 * @var array<string, array<string, int>>
+	 */
+	private const ENUM_MAP = [
+		'smwgShowFactbox' => [
+			'hidden'   => 1, // SMW_FACTBOX_HIDDEN
+			'special'  => 2, // SMW_FACTBOX_SPECIAL
+			'nonempty' => 3, // SMW_FACTBOX_NONEMPTY
+			'shown'    => 5, // SMW_FACTBOX_SHOWN
+		],
+	];
+
+	/**
+	 * Default internal value applied when an unknown string is supplied to
+	 * an enum setting (after a structured-log warning). Mirrors the
+	 * documented extension.json default for the same key.
+	 *
+	 * @var array<string, int>
+	 */
+	private const ENUM_DEFAULT = [
+		'smwgShowFactbox' => 1, // SMW_FACTBOX_HIDDEN
+	];
+
+	/**
+	 * Flag settings: combined via bitwise OR, internally tested via & or
+	 * {@see \SMW\Options::isFlagSet()}. Shape: [ settingKey => [ stringName => flagBit ] ].
+	 *
+	 * Each integer matches the corresponding `define()` in src/Defines.php.
+	 *
+	 * @var array<string, array<string, int>>
+	 */
+	private const FLAG_MAP = [
+		'smwgFactboxFeatures' => [
+			'cache'              => 16, // SMW_FACTBOX_CACHE
+			'purge-refresh'      => 32, // SMW_FACTBOX_PURGE_REFRESH
+			'display-subobject'  => 64, // SMW_FACTBOX_DISPLAY_SUBOBJECT
+			'display-attachment' => 128, // SMW_FACTBOX_DISPLAY_ATTACHMENT
+		],
+	];
+
+	/**
+	 * Normalize a user-supplied config value for one of the registered keys.
+	 * Keys not in any map are passed through unchanged.
+	 *
+	 * @since 7.0.0
+	 */
+	public static function normalize( string $key, mixed $value ): mixed {
+		if ( isset( self::ENUM_MAP[$key] ) ) {
+			return self::normalizeEnum( $key, $value );
+		}
+		if ( isset( self::FLAG_MAP[$key] ) ) {
+			return self::normalizeFlags( $key, $value );
+		}
+		return $value;
+	}
+
+	/**
+	 * Whether a deprecation notice has been emitted for the given setting
+	 * key in the current request. Primarily for test introspection.
+	 *
+	 * @since 7.0.0
+	 */
+	public static function wasDeprecationEmitted( string $key ): bool {
+		return isset( self::$deprecationEmitted[$key] );
+	}
+
+	/**
+	 * Reset the per-request deprecation suppression set. Intended for test
+	 * isolation; production callers should never need this.
+	 *
+	 * @since 7.0.0
+	 */
+	public static function resetDeprecationState(): void {
+		self::$deprecationEmitted = [];
+	}
+
+	private static function normalizeEnum( string $key, mixed $value ): mixed {
+		$map = self::ENUM_MAP[$key];
+
+		if ( is_string( $value ) ) {
+			if ( array_key_exists( $value, $map ) ) {
+				return $map[$value];
+			}
+			self::warnUnknown( $key, $value );
+			return self::ENUM_DEFAULT[$key] ?? $value;
+		}
+
+		if ( in_array( $value, $map, true ) ) {
+			self::emitDeprecation( $key );
+			return $value;
+		}
+
+		return $value;
+	}
+
+	private static function normalizeFlags( string $key, mixed $value ): int {
+		$map = self::FLAG_MAP[$key];
+
+		if ( is_int( $value ) ) {
+			if ( $value !== 0 ) {
+				self::emitDeprecation( $key );
+			}
+			return $value;
+		}
+
+		if ( $value === false ) {
+			return 0;
+		}
+
+		if ( is_string( $value ) ) {
+			$value = [ $value ];
+		}
+
+		if ( !is_array( $value ) ) {
+			return 0;
+		}
+
+		$bitmask = 0;
+		$sawLegacy = false;
+		foreach ( $value as $element ) {
+			if ( is_int( $element ) ) {
+				$bitmask |= $element;
+				$sawLegacy = true;
+				continue;
+			}
+			if ( is_string( $element ) && array_key_exists( $element, $map ) ) {
+				$bitmask |= $map[$element];
+				continue;
+			}
+			if ( is_string( $element ) ) {
+				self::warnUnknown( $key, $element );
+			}
+		}
+		if ( $sawLegacy ) {
+			self::emitDeprecation( $key );
+		}
+		return $bitmask;
+	}
+
+	private static function emitDeprecation( string $key ): void {
+		if ( isset( self::$deprecationEmitted[$key] ) ) {
+			return;
+		}
+		self::$deprecationEmitted[$key] = true;
+		if ( function_exists( 'wfDeprecatedMsg' ) ) {
+			wfDeprecatedMsg(
+				"\${$key} using SMW_* integer constants is deprecated; switch to the string/array form documented in RELEASE-NOTES-7.0.0.md. The constants will be removed in SMW 8.0.",
+				'7.0',
+				'SemanticMediaWiki'
+			);
+		}
+	}
+
+	private static function warnUnknown( string $key, string $element ): void {
+		if ( !class_exists( LoggerFactory::class ) ) {
+			return;
+		}
+		LoggerFactory::getInstance( 'SMW' )->warning(
+			"Unknown value '{element}' for \${key}; ignored. See RELEASE-NOTES-7.0.0.md for accepted values.",
+			[ 'element' => $element, 'key' => $key ]
+		);
+	}
+}

--- a/src/Setup/LegacyConstantNormalizer.php
+++ b/src/Setup/LegacyConstantNormalizer.php
@@ -10,11 +10,17 @@ use MediaWiki\Logger\LoggerFactory;
  * the internal representation expected by SMW (integer bitmask for flag
  * settings, integer or string for enum settings).
  *
- * Called from {@see \SMW\Settings::loadFromGlobals()} for the registered keys.
  * Both legacy (integer constants from src/Defines.php) and new (string / array
  * of strings) user values are accepted. The legacy form emits one
  * `wfDeprecatedMsg` per setting per request and is scheduled for removal in
  * SMW 8.0.
+ *
+ * Boundary contract: normalization happens exactly once, when SMW ingests
+ * `$GLOBALS` via {@see \SMW\Settings::loadFromGlobals()}. Callers that build
+ * `Settings` through {@see \SMW\Settings::newFromArray()} (chiefly tests) are
+ * expected to pass values already in the internal form (integer constants or
+ * integer bitmasks). Pass an unmapped string at that boundary and downstream
+ * `Options::isFlagSet()` / `=== SMW_FOO` comparisons will silently fail.
  *
  * @license GPL-2.0-or-later
  * @since 7.0.0
@@ -134,6 +140,10 @@ class LegacyConstantNormalizer {
 		$map = self::FLAG_MAP[$key];
 
 		if ( is_int( $value ) ) {
+			// `$smwgFooFeatures = 0;` is the documented "no flags" form and the
+			// value-equivalent of `[]` in the new form. It is not really a
+			// legacy SMW_* bitmask, so don't bother the admin with a deprecation
+			// notice for it. Any other integer is treated as legacy.
 			if ( $value !== 0 ) {
 				self::emitDeprecation( $key );
 			}
@@ -178,6 +188,9 @@ class LegacyConstantNormalizer {
 		if ( isset( self::$deprecationEmitted[$key] ) ) {
 			return;
 		}
+		// Mark BEFORE the wfDeprecatedMsg call so wasDeprecationEmitted()
+		// returns the right answer in unit tests where wfDeprecatedMsg is a
+		// no-op (the function_exists guard below skips it).
 		self::$deprecationEmitted[$key] = true;
 		if ( function_exists( 'wfDeprecatedMsg' ) ) {
 			wfDeprecatedMsg(

--- a/src/Setup/LegacyConstantNormalizer.php
+++ b/src/Setup/LegacyConstantNormalizer.php
@@ -38,18 +38,16 @@ class LegacyConstantNormalizer {
 
 	/**
 	 * Enum settings: single-value, internally compared via === or == against
-	 * an SMW_* integer constant. Shape: [ settingKey => [ stringName => internalValue ] ].
-	 *
-	 * Each integer matches the corresponding `define()` in src/Defines.php.
+	 * an SMW_* integer constant. Shape: [ settingKey => [ stringName => SMW_* ] ].
 	 *
 	 * @var array<string, array<string, int>>
 	 */
 	private const ENUM_MAP = [
 		'smwgShowFactbox' => [
-			'hidden'   => 1, // SMW_FACTBOX_HIDDEN
-			'special'  => 2, // SMW_FACTBOX_SPECIAL
-			'nonempty' => 3, // SMW_FACTBOX_NONEMPTY
-			'shown'    => 5, // SMW_FACTBOX_SHOWN
+			'hidden'   => SMW_FACTBOX_HIDDEN,
+			'special'  => SMW_FACTBOX_SPECIAL,
+			'nonempty' => SMW_FACTBOX_NONEMPTY,
+			'shown'    => SMW_FACTBOX_SHOWN,
 		],
 	];
 
@@ -61,23 +59,21 @@ class LegacyConstantNormalizer {
 	 * @var array<string, int>
 	 */
 	private const ENUM_DEFAULT = [
-		'smwgShowFactbox' => 1, // SMW_FACTBOX_HIDDEN
+		'smwgShowFactbox' => SMW_FACTBOX_HIDDEN,
 	];
 
 	/**
 	 * Flag settings: combined via bitwise OR, internally tested via & or
-	 * {@see \SMW\Options::isFlagSet()}. Shape: [ settingKey => [ stringName => flagBit ] ].
-	 *
-	 * Each integer matches the corresponding `define()` in src/Defines.php.
+	 * {@see \SMW\Options::isFlagSet()}. Shape: [ settingKey => [ stringName => SMW_* ] ].
 	 *
 	 * @var array<string, array<string, int>>
 	 */
 	private const FLAG_MAP = [
 		'smwgFactboxFeatures' => [
-			'cache'              => 16, // SMW_FACTBOX_CACHE
-			'purge-refresh'      => 32, // SMW_FACTBOX_PURGE_REFRESH
-			'display-subobject'  => 64, // SMW_FACTBOX_DISPLAY_SUBOBJECT
-			'display-attachment' => 128, // SMW_FACTBOX_DISPLAY_ATTACHMENT
+			'cache'              => SMW_FACTBOX_CACHE,
+			'purge-refresh'      => SMW_FACTBOX_PURGE_REFRESH,
+			'display-subobject'  => SMW_FACTBOX_DISPLAY_SUBOBJECT,
+			'display-attachment' => SMW_FACTBOX_DISPLAY_ATTACHMENT,
 		],
 	];
 

--- a/tests/phpunit/Unit/SettingsTest.php
+++ b/tests/phpunit/Unit/SettingsTest.php
@@ -151,6 +151,33 @@ class SettingsTest extends TestCase {
 	}
 
 	/**
+	 * Both legacy SMW_* integer constants and the new string / array-of-strings
+	 * form must produce identical internal state once Settings::loadFromGlobals()
+	 * routes the registered keys through LegacyConstantNormalizer (#6586).
+	 */
+	public function testLoadFromGlobals_factboxStringForm_internalRepresentation() {
+		$savedShow = $GLOBALS['smwgShowFactbox'] ?? null;
+		$savedFeatures = $GLOBALS['smwgFactboxFeatures'] ?? null;
+
+		try {
+			$GLOBALS['smwgShowFactbox'] = 'nonempty';
+			$GLOBALS['smwgFactboxFeatures'] = [ 'cache', 'purge-refresh' ];
+
+			$instance = new Settings();
+			$instance->setHookDispatcher( $this->hookDispatcher );
+			$instance->loadFromGlobals();
+
+			$this->assertSame( SMW_FACTBOX_NONEMPTY, $instance->get( 'smwgShowFactbox' ) );
+			$this->assertTrue( $instance->isFlagSet( 'smwgFactboxFeatures', SMW_FACTBOX_CACHE ) );
+			$this->assertTrue( $instance->isFlagSet( 'smwgFactboxFeatures', SMW_FACTBOX_PURGE_REFRESH ) );
+			$this->assertFalse( $instance->isFlagSet( 'smwgFactboxFeatures', SMW_FACTBOX_DISPLAY_SUBOBJECT ) );
+		} finally {
+			$GLOBALS['smwgShowFactbox'] = $savedShow;
+			$GLOBALS['smwgFactboxFeatures'] = $savedFeatures;
+		}
+	}
+
+	/**
 	 * Locks in the current behaviour of legacy SMW_* integer-constant config values
 	 * for the factbox settings, ahead of the string-config migration (#6586). The
 	 * same assertions must hold after the normalizer is wired in.

--- a/tests/phpunit/Unit/SettingsTest.php
+++ b/tests/phpunit/Unit/SettingsTest.php
@@ -151,6 +151,33 @@ class SettingsTest extends TestCase {
 	}
 
 	/**
+	 * The new extension.json defaults (string for the enum, array for the flags)
+	 * must round-trip to the same internal integers as before the migration (#6586).
+	 */
+	public function testLoadFromGlobals_factboxDefaultsFromExtensionJson() {
+		$savedShow = $GLOBALS['smwgShowFactbox'] ?? null;
+		$savedFeatures = $GLOBALS['smwgFactboxFeatures'] ?? null;
+
+		try {
+			$GLOBALS['smwgShowFactbox'] = 'hidden';
+			$GLOBALS['smwgFactboxFeatures'] = [ 'cache', 'purge-refresh', 'display-subobject', 'display-attachment' ];
+
+			$instance = new Settings();
+			$instance->setHookDispatcher( $this->hookDispatcher );
+			$instance->loadFromGlobals();
+
+			$this->assertSame( SMW_FACTBOX_HIDDEN, $instance->get( 'smwgShowFactbox' ) );
+			$this->assertSame(
+				SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT | SMW_FACTBOX_DISPLAY_ATTACHMENT,
+				$instance->get( 'smwgFactboxFeatures' )
+			);
+		} finally {
+			$GLOBALS['smwgShowFactbox'] = $savedShow;
+			$GLOBALS['smwgFactboxFeatures'] = $savedFeatures;
+		}
+	}
+
+	/**
 	 * Both legacy SMW_* integer constants and the new string / array-of-strings
 	 * form must produce identical internal state once Settings::loadFromGlobals()
 	 * routes the registered keys through LegacyConstantNormalizer (#6586).

--- a/tests/phpunit/Unit/SettingsTest.php
+++ b/tests/phpunit/Unit/SettingsTest.php
@@ -151,33 +151,6 @@ class SettingsTest extends TestCase {
 	}
 
 	/**
-	 * The new extension.json defaults (string for the enum, array for the flags)
-	 * must round-trip to the same internal integers as before the migration (#6586).
-	 */
-	public function testLoadFromGlobals_factboxDefaultsFromExtensionJson() {
-		$savedShow = $GLOBALS['smwgShowFactbox'] ?? null;
-		$savedFeatures = $GLOBALS['smwgFactboxFeatures'] ?? null;
-
-		try {
-			$GLOBALS['smwgShowFactbox'] = 'hidden';
-			$GLOBALS['smwgFactboxFeatures'] = [ 'cache', 'purge-refresh', 'display-subobject', 'display-attachment' ];
-
-			$instance = new Settings();
-			$instance->setHookDispatcher( $this->hookDispatcher );
-			$instance->loadFromGlobals();
-
-			$this->assertSame( SMW_FACTBOX_HIDDEN, $instance->get( 'smwgShowFactbox' ) );
-			$this->assertSame(
-				SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT | SMW_FACTBOX_DISPLAY_ATTACHMENT,
-				$instance->get( 'smwgFactboxFeatures' )
-			);
-		} finally {
-			$GLOBALS['smwgShowFactbox'] = $savedShow;
-			$GLOBALS['smwgFactboxFeatures'] = $savedFeatures;
-		}
-	}
-
-	/**
 	 * Both legacy SMW_* integer constants and the new string / array-of-strings
 	 * form must produce identical internal state once Settings::loadFromGlobals()
 	 * routes the registered keys through LegacyConstantNormalizer (#6586).

--- a/tests/phpunit/Unit/SettingsTest.php
+++ b/tests/phpunit/Unit/SettingsTest.php
@@ -150,6 +150,33 @@ class SettingsTest extends TestCase {
 		$instance->loadFromGlobals();
 	}
 
+	/**
+	 * Locks in the current behaviour of legacy SMW_* integer-constant config values
+	 * for the factbox settings, ahead of the string-config migration (#6586). The
+	 * same assertions must hold after the normalizer is wired in.
+	 */
+	public function testLoadFromGlobals_factboxLegacyConstants_internalRepresentation() {
+		$savedShow = $GLOBALS['smwgShowFactbox'] ?? null;
+		$savedFeatures = $GLOBALS['smwgFactboxFeatures'] ?? null;
+
+		try {
+			$GLOBALS['smwgShowFactbox'] = SMW_FACTBOX_NONEMPTY;
+			$GLOBALS['smwgFactboxFeatures'] = SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH;
+
+			$instance = new Settings();
+			$instance->setHookDispatcher( $this->hookDispatcher );
+			$instance->loadFromGlobals();
+
+			$this->assertSame( SMW_FACTBOX_NONEMPTY, $instance->get( 'smwgShowFactbox' ) );
+			$this->assertTrue( $instance->isFlagSet( 'smwgFactboxFeatures', SMW_FACTBOX_CACHE ) );
+			$this->assertTrue( $instance->isFlagSet( 'smwgFactboxFeatures', SMW_FACTBOX_PURGE_REFRESH ) );
+			$this->assertFalse( $instance->isFlagSet( 'smwgFactboxFeatures', SMW_FACTBOX_DISPLAY_SUBOBJECT ) );
+		} finally {
+			$GLOBALS['smwgShowFactbox'] = $savedShow;
+			$GLOBALS['smwgFactboxFeatures'] = $savedFeatures;
+		}
+	}
+
 	public function testMung() {
 		$instance = Settings::newFromArray( [ 'Foo' => 123 ] );
 

--- a/tests/phpunit/Unit/Setup/LegacyConstantNormalizerTest.php
+++ b/tests/phpunit/Unit/Setup/LegacyConstantNormalizerTest.php
@@ -19,13 +19,6 @@ class LegacyConstantNormalizerTest extends TestCase {
 		LegacyConstantNormalizer::resetDeprecationState();
 	}
 
-	public function testEnum_newStringForm_normalizesToConstant() {
-		$this->assertSame(
-			SMW_FACTBOX_NONEMPTY,
-			LegacyConstantNormalizer::normalize( 'smwgShowFactbox', 'nonempty' )
-		);
-	}
-
 	public function testEnum_allKnownStrings_mapToTheirConstants() {
 		$this->assertSame( SMW_FACTBOX_HIDDEN, LegacyConstantNormalizer::normalize( 'smwgShowFactbox', 'hidden' ) );
 		$this->assertSame( SMW_FACTBOX_SPECIAL, LegacyConstantNormalizer::normalize( 'smwgShowFactbox', 'special' ) );
@@ -44,13 +37,6 @@ class LegacyConstantNormalizerTest extends TestCase {
 	public function testEnum_unknownString_emitsWarningAndFallsBackToDefault() {
 		$value = LegacyConstantNormalizer::normalize( 'smwgShowFactbox', 'bogus' );
 		$this->assertSame( SMW_FACTBOX_HIDDEN, $value );
-	}
-
-	public function testFlag_newArrayForm_normalizesToBitmask() {
-		$this->assertSame(
-			SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH,
-			LegacyConstantNormalizer::normalize( 'smwgFactboxFeatures', [ 'cache', 'purge-refresh' ] )
-		);
 	}
 
 	public function testFlag_allKnownFlagsCombined() {
@@ -160,43 +146,4 @@ class LegacyConstantNormalizerTest extends TestCase {
 		$this->assertTrue( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgFactboxFeatures' ) );
 	}
 
-	public function testDeprecation_messageReachesWfDeprecatedMsg() {
-		// The introspection flag tells us emitDeprecation() ran. This test goes
-		// one level deeper and confirms the call actually reaches MW's
-		// deprecation pipeline (i.e. wfDeprecatedMsg was invoked, not stubbed
-		// out) and that the visible message names the setting so admins can
-		// grep their logs for which `$smwg*` setting tripped the warning.
-		if ( !class_exists( \MWDebug::class ) ) {
-			$this->markTestSkipped( 'MWDebug not available in this test environment.' );
-		}
-
-		// Earlier tests in this suite may have fired the same deprecation; MWDebug
-		// dedupes by (message, caller), so we clear its per-request state first.
-		\MWDebug::clearLog();
-
-		$captured = false;
-		\MWDebug::filterDeprecationForTest(
-			'/\$smwgShowFactbox using SMW_\* integer constants/',
-			static function () use ( &$captured ): void {
-				$captured = true;
-			}
-		);
-
-		try {
-			LegacyConstantNormalizer::normalize( 'smwgShowFactbox', SMW_FACTBOX_NONEMPTY );
-		} finally {
-			\MWDebug::clearDeprecationFilters();
-		}
-
-		$this->assertTrue(
-			$captured,
-			'MWDebug did not see a deprecation message naming $smwgShowFactbox; check emitDeprecation() wiring.'
-		);
-	}
-
-	public function testNullValue_passesThrough() {
-		$this->assertNull(
-			LegacyConstantNormalizer::normalize( 'smwgShowFactbox', null )
-		);
-	}
 }

--- a/tests/phpunit/Unit/Setup/LegacyConstantNormalizerTest.php
+++ b/tests/phpunit/Unit/Setup/LegacyConstantNormalizerTest.php
@@ -99,8 +99,12 @@ class LegacyConstantNormalizerTest extends TestCase {
 		$this->assertSame( 0, LegacyConstantNormalizer::normalize( 'smwgFactboxFeatures', [] ) );
 	}
 
-	public function testFlag_zeroInteger_passesThrough() {
+	public function testFlag_zeroInteger_passesThroughWithoutDeprecation() {
+		// `$smwgFactboxFeatures = 0;` is the documented "no flags" form and the
+		// natural value-equivalent of `[]`; it must NOT trigger the legacy
+		// SMW_FACTBOX_* deprecation. Guard the carve-out in normalizeFlags.
 		$this->assertSame( 0, LegacyConstantNormalizer::normalize( 'smwgFactboxFeatures', 0 ) );
+		$this->assertFalse( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgFactboxFeatures' ) );
 	}
 
 	public function testDeprecation_firesOnlyOncePerSettingPerRequest() {

--- a/tests/phpunit/Unit/Setup/LegacyConstantNormalizerTest.php
+++ b/tests/phpunit/Unit/Setup/LegacyConstantNormalizerTest.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace SMW\Tests\Unit\Setup;
+
+use PHPUnit\Framework\TestCase;
+use SMW\Setup\LegacyConstantNormalizer;
+
+/**
+ * @covers \SMW\Setup\LegacyConstantNormalizer
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class LegacyConstantNormalizerTest extends TestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		LegacyConstantNormalizer::resetDeprecationState();
+	}
+
+	public function testEnum_newStringForm_normalizesToConstant() {
+		$this->assertSame(
+			SMW_FACTBOX_NONEMPTY,
+			LegacyConstantNormalizer::normalize( 'smwgShowFactbox', 'nonempty' )
+		);
+	}
+
+	public function testEnum_allKnownStrings_mapToTheirConstants() {
+		$this->assertSame( SMW_FACTBOX_HIDDEN, LegacyConstantNormalizer::normalize( 'smwgShowFactbox', 'hidden' ) );
+		$this->assertSame( SMW_FACTBOX_SPECIAL, LegacyConstantNormalizer::normalize( 'smwgShowFactbox', 'special' ) );
+		$this->assertSame( SMW_FACTBOX_NONEMPTY, LegacyConstantNormalizer::normalize( 'smwgShowFactbox', 'nonempty' ) );
+		$this->assertSame( SMW_FACTBOX_SHOWN, LegacyConstantNormalizer::normalize( 'smwgShowFactbox', 'shown' ) );
+	}
+
+	public function testEnum_legacyConstantForm_passesThroughAndDeprecates() {
+		$this->assertSame(
+			SMW_FACTBOX_NONEMPTY,
+			LegacyConstantNormalizer::normalize( 'smwgShowFactbox', SMW_FACTBOX_NONEMPTY )
+		);
+		$this->assertTrue( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgShowFactbox' ) );
+	}
+
+	public function testEnum_unknownString_emitsWarningAndFallsBackToDefault() {
+		$value = LegacyConstantNormalizer::normalize( 'smwgShowFactbox', 'bogus' );
+		$this->assertSame( SMW_FACTBOX_HIDDEN, $value );
+	}
+
+	public function testFlag_newArrayForm_normalizesToBitmask() {
+		$this->assertSame(
+			SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH,
+			LegacyConstantNormalizer::normalize( 'smwgFactboxFeatures', [ 'cache', 'purge-refresh' ] )
+		);
+	}
+
+	public function testFlag_allKnownFlagsCombined() {
+		$this->assertSame(
+			SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH | SMW_FACTBOX_DISPLAY_SUBOBJECT | SMW_FACTBOX_DISPLAY_ATTACHMENT,
+			LegacyConstantNormalizer::normalize(
+				'smwgFactboxFeatures',
+				[ 'cache', 'purge-refresh', 'display-subobject', 'display-attachment' ]
+			)
+		);
+	}
+
+	public function testFlag_legacyBitmaskForm_passesThroughAndDeprecates() {
+		$bitmask = SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH;
+		$this->assertSame(
+			$bitmask,
+			LegacyConstantNormalizer::normalize( 'smwgFactboxFeatures', $bitmask )
+		);
+		$this->assertTrue( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgFactboxFeatures' ) );
+	}
+
+	public function testFlag_mixedForm_normalizesEachElement() {
+		$this->assertSame(
+			SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH,
+			LegacyConstantNormalizer::normalize(
+				'smwgFactboxFeatures',
+				[ SMW_FACTBOX_CACHE, 'purge-refresh' ]
+			)
+		);
+		$this->assertTrue( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgFactboxFeatures' ) );
+	}
+
+	public function testFlag_unknownStringIsDropped() {
+		$value = LegacyConstantNormalizer::normalize( 'smwgFactboxFeatures', [ 'cache', 'bogus' ] );
+		$this->assertSame( SMW_FACTBOX_CACHE, $value );
+	}
+
+	public function testFlag_scalarStringAutoWraps() {
+		$this->assertSame(
+			SMW_FACTBOX_CACHE,
+			LegacyConstantNormalizer::normalize( 'smwgFactboxFeatures', 'cache' )
+		);
+	}
+
+	public function testFlag_emptyArray_returnsZero() {
+		$this->assertSame( 0, LegacyConstantNormalizer::normalize( 'smwgFactboxFeatures', [] ) );
+	}
+
+	public function testFlag_zeroInteger_passesThrough() {
+		$this->assertSame( 0, LegacyConstantNormalizer::normalize( 'smwgFactboxFeatures', 0 ) );
+	}
+
+	public function testDeprecation_firesOnlyOncePerSettingPerRequest() {
+		LegacyConstantNormalizer::normalize( 'smwgShowFactbox', SMW_FACTBOX_NONEMPTY );
+		$this->assertTrue( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgShowFactbox' ) );
+
+		LegacyConstantNormalizer::normalize( 'smwgShowFactbox', SMW_FACTBOX_HIDDEN );
+		$this->assertTrue( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgShowFactbox' ) );
+
+		LegacyConstantNormalizer::resetDeprecationState();
+		$this->assertFalse( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgShowFactbox' ) );
+	}
+
+	public function testDeprecation_newFormDoesNotEmit() {
+		LegacyConstantNormalizer::normalize( 'smwgShowFactbox', 'nonempty' );
+		$this->assertFalse( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgShowFactbox' ) );
+
+		LegacyConstantNormalizer::normalize( 'smwgFactboxFeatures', [ 'cache' ] );
+		$this->assertFalse( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgFactboxFeatures' ) );
+	}
+
+	public function testNonRegisteredKey_passesThrough() {
+		$this->assertSame(
+			42,
+			LegacyConstantNormalizer::normalize( 'smwgUnknownSetting', 42 )
+		);
+		$this->assertSame(
+			'whatever',
+			LegacyConstantNormalizer::normalize( 'smwgUnknownSetting', 'whatever' )
+		);
+	}
+
+	public function testNullValue_passesThrough() {
+		$this->assertNull(
+			LegacyConstantNormalizer::normalize( 'smwgShowFactbox', null )
+		);
+	}
+}

--- a/tests/phpunit/Unit/Setup/LegacyConstantNormalizerTest.php
+++ b/tests/phpunit/Unit/Setup/LegacyConstantNormalizerTest.php
@@ -137,6 +137,63 @@ class LegacyConstantNormalizerTest extends TestCase {
 		);
 	}
 
+	public function testNonRegisteredKey_legacyShapedIntDoesNotDeprecate() {
+		// Passing what looks like a legacy SMW_* integer to a key the normalizer
+		// doesn't know about must NOT fire a deprecation; the value falls through
+		// untouched and downstream behaviour is whatever it was before this PR.
+		LegacyConstantNormalizer::normalize( 'smwgUnknownSetting', SMW_FACTBOX_NONEMPTY );
+		$this->assertFalse( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgUnknownSetting' ) );
+	}
+
+	public function testDeprecation_keysAreSuppressedIndependently() {
+		// Deprecating one setting must not suppress notices for any other
+		// registered setting. This invariant is the foundation that PRs B and C
+		// extend across all 22 remaining settings; if it ever regressed, the
+		// first legacy-form setting in a wiki's LocalSettings.php would silence
+		// the rest.
+		LegacyConstantNormalizer::normalize( 'smwgShowFactbox', SMW_FACTBOX_NONEMPTY );
+		$this->assertTrue( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgShowFactbox' ) );
+		$this->assertFalse( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgFactboxFeatures' ) );
+
+		LegacyConstantNormalizer::normalize( 'smwgFactboxFeatures', SMW_FACTBOX_CACHE );
+		$this->assertTrue( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgShowFactbox' ) );
+		$this->assertTrue( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgFactboxFeatures' ) );
+	}
+
+	public function testDeprecation_messageReachesWfDeprecatedMsg() {
+		// The introspection flag tells us emitDeprecation() ran. This test goes
+		// one level deeper and confirms the call actually reaches MW's
+		// deprecation pipeline (i.e. wfDeprecatedMsg was invoked, not stubbed
+		// out) and that the visible message names the setting so admins can
+		// grep their logs for which `$smwg*` setting tripped the warning.
+		if ( !class_exists( \MWDebug::class ) ) {
+			$this->markTestSkipped( 'MWDebug not available in this test environment.' );
+		}
+
+		// Earlier tests in this suite may have fired the same deprecation; MWDebug
+		// dedupes by (message, caller), so we clear its per-request state first.
+		\MWDebug::clearLog();
+
+		$captured = false;
+		\MWDebug::filterDeprecationForTest(
+			'/\$smwgShowFactbox using SMW_\* integer constants/',
+			static function () use ( &$captured ): void {
+				$captured = true;
+			}
+		);
+
+		try {
+			LegacyConstantNormalizer::normalize( 'smwgShowFactbox', SMW_FACTBOX_NONEMPTY );
+		} finally {
+			\MWDebug::clearDeprecationFilters();
+		}
+
+		$this->assertTrue(
+			$captured,
+			'MWDebug did not see a deprecation message naming $smwgShowFactbox; check emitDeprecation() wiring.'
+		);
+	}
+
 	public function testNullValue_passesThrough() {
 		$this->assertNull(
 			LegacyConstantNormalizer::normalize( 'smwgShowFactbox', null )


### PR DESCRIPTION
## Summary

First in a 3-PR series migrating SMW's user-facing configuration from PHP integer constants (`SMW_FACTBOX_*`, `SMW_PARSER_*`, `SMW_EQ_*`, etc.) to JSON-clean string / array-of-strings values. This eliminates the `wfLoadExtension` load-order bug (refs #6579, #6580) and the Composer `autoload.files` workaround (refs #6585) for the migrated settings.

This PR introduces the `LegacyConstantNormalizer` infrastructure and migrates two reference settings (`smwgShowFactbox`, `smwgFactboxFeatures`) end-to-end. PRs 2 and 3 will extend the same mechanism to the remaining 23 affected settings (the migration table in `RELEASE-NOTES-7.0.0.md` will be appended in those PRs).

## What changed

- **New:** `src/Setup/LegacyConstantNormalizer.php`. Registry + `normalize()` entry point with maps for the two reference settings, plus `wasDeprecationEmitted()` for test introspection. Called from `Settings::loadFromGlobals()` once per registered key.
- **`src/Settings.php`:** the two registered keys are now wrapped in `LegacyConstantNormalizer::normalize()`. Everything else passes through unchanged.
- **`src/Setup/ConfigBootstrap.php`:** the two constant-default blocks for these settings are deleted. `ConfigBootstrap` now contains 20 remaining scalar blocks (covered by PRs 2 and 3) plus the four compound-array seeds (out of scope for this series).
- **`extension.json` config block:** `ShowFactbox` (`"hidden"`) and `FactboxFeatures` (`[ "cache", "purge-refresh", "display-subobject", "display-attachment" ]`) added as JSON-clean defaults.
- **`docs/releasenotes/RELEASE-NOTES-7.0.0.md`:** new "String-based configuration values introduced" entry under Breaking changes, with a migration table seeded with the two reference settings.

## Behaviour

Both legacy and new forms are accepted in 7.x:

```php
// LocalSettings.php - new form (recommended)
$smwgShowFactbox     = 'nonempty';
$smwgFactboxFeatures = [ 'cache', 'purge-refresh' ];

// LocalSettings.php - legacy form (deprecated, removed in 8.0)
$smwgShowFactbox     = SMW_FACTBOX_NONEMPTY;
$smwgFactboxFeatures = SMW_FACTBOX_CACHE | SMW_FACTBOX_PURGE_REFRESH;
```

The legacy form emits one `wfDeprecatedMsg` per setting per request, naming the setting so admins can grep their logs. Internal call-sites (`Options::isFlagSet`, `& SMW_FOO_BAR` reads) are unchanged: normalization happens once at the `Settings::loadFromGlobals()` boundary, and downstream storage stays as the existing integer representation.

Unknown strings emit a structured-log warning via `LoggerFactory` and fall back to the documented default (no crash, no PHP warning).

## Why dual-accept and not a flag-day break

Following the precedent of the recently-removed `$smwgSchemaTypes` would be too aggressive here: those 25 settings are widely set in the wild, documented for years, and have no replacement until this very PR series lands. A hard 7.0 break would orphan every existing SMW install on upgrade. Dual-accept with one major-version deprecation horizon is the correct trade.

## Test plan

- [x] `composer phpunit -- --filter 'LegacyConstantNormalizerTest|SettingsTest'` - 168 tests pass (14 unit + 2 boundary integration tests for this PR's surface)
- [x] `composer analyze` - lint clean (2122 files), PHPCS clean on touched files, no warnings (phan in `composer test` is skipped because the dev container is missing `php-ast`, a pre-existing environment issue unrelated to this PR)
- [x] Browser smoke against the seeded dev wiki: set `\$smwgFactboxFeatures = ['cache', 'purge-refresh']` and `\$smwgShowFactbox = 'shown'` in `LocalSettings.php`, load a page with semantic content, confirm the factbox renders and zero deprecation messages fire
- [x] Browser smoke flip: set the legacy integer values, confirm the factbox still renders and both deprecation messages fire (visible in MW dev-warnings mode)
- [x] CI green

## Out of scope (separate follow-up)

- The 23 remaining settings (covered by PRs 2 and 3 in this series).
- The four compound-array seeds in `ConfigBootstrap` (`smwgLocalConnectionConf`, `smwgNamespacesWithSemanticLinks`, `smwgEntityCacheSizes`, `smwgElasticsearchConfig`) - these have a different migration mechanic (extension.json `merge_strategy`, namespace-ID inlining, path resolution) and will be tracked separately.
- Removing the `SMW_*` constants themselves from `src/Defines.php` - they remain as the internal storage form for 7.x and will be removed in 8.0 alongside the legacy-form acceptance.

Refs #6586