### PR TITLE
Use OR-form keyset cursor predicate to enable MariaDB range seek

### DIFF
--- a/src/SQLStore/Lookup/KeysetPaginationTrait.php
+++ b/src/SQLStore/Lookup/KeysetPaginationTrait.php
@@ -38,6 +38,15 @@ trait KeysetPaginationTrait {
 	 *
 	 * When no cursor is active, falls back to offset-based pagination.
 	 *
+	 * Both cursor branches express the (smw_sort, smw_id) total order via an
+	 * explicit OR rather than a row-constructor comparison such as
+	 * `(smw_sort, smw_id) > (?, ?)`. MariaDB does not optimise row-constructor
+	 * comparisons into an index range seek; it plans a full index scan with a
+	 * WHERE filter, so cost grows linearly with cursor depth. The explicit-OR
+	 * form is recognised as a range predicate and seeks the (smw_sort, smw_id)
+	 * index directly. PostgreSQL and SQLite plan the OR form at least as well
+	 * as the tuple form. See issue #6559.
+	 *
 	 * @param SelectQueryBuilder $queryBuilder
 	 * @param Database $db
 	 *
@@ -50,12 +59,6 @@ trait KeysetPaginationTrait {
 		if ( $cursorAfter !== null ) {
 			$sort = $this->resolveCursorSort( $cursorAfter );
 			if ( $sort !== null ) {
-				// MariaDB does not optimise row-constructor comparisons
-				// `(a, b) > (?, ?)` into an index range seek; it falls back
-				// to a full index scan with a WHERE filter. Expressing the
-				// same total order via explicit OR is recognised as a
-				// range predicate and seeks the (smw_sort, smw_id) index
-				// directly. See issue #6559.
 				$quotedSort = $db->addQuotes( $sort );
 				$queryBuilder->andWhere(
 					'smw_sort > ' . $quotedSort .

--- a/src/SQLStore/Lookup/KeysetPaginationTrait.php
+++ b/src/SQLStore/Lookup/KeysetPaginationTrait.php
@@ -50,18 +50,26 @@ trait KeysetPaginationTrait {
 		if ( $cursorAfter !== null ) {
 			$sort = $this->resolveCursorSort( $cursorAfter );
 			if ( $sort !== null ) {
+				// MariaDB does not optimise row-constructor comparisons
+				// `(a, b) > (?, ?)` into an index range seek; it falls back
+				// to a full index scan with a WHERE filter. Expressing the
+				// same total order via explicit OR is recognised as a
+				// range predicate and seeks the (smw_sort, smw_id) index
+				// directly. See issue #6559.
+				$quotedSort = $db->addQuotes( $sort );
 				$queryBuilder->andWhere(
-					'(smw_sort, smw_id) > (' .
-					$db->addQuotes( $sort ) . ', ' . $cursorAfter . ')'
+					'smw_sort > ' . $quotedSort .
+					' OR (smw_sort = ' . $quotedSort . ' AND smw_id > ' . $cursorAfter . ')'
 				);
 			}
 			$queryBuilder->orderBy( [ 'smw_sort', 'smw_id' ], SelectQueryBuilder::SORT_ASC );
 		} elseif ( $cursorBefore !== null ) {
 			$sort = $this->resolveCursorSort( $cursorBefore );
 			if ( $sort !== null ) {
+				$quotedSort = $db->addQuotes( $sort );
 				$queryBuilder->andWhere(
-					'(smw_sort, smw_id) < (' .
-					$db->addQuotes( $sort ) . ', ' . $cursorBefore . ')'
+					'smw_sort < ' . $quotedSort .
+					' OR (smw_sort = ' . $quotedSort . ' AND smw_id < ' . $cursorBefore . ')'
 				);
 			}
 			$queryBuilder->orderBy( [ 'smw_sort', 'smw_id' ], SelectQueryBuilder::SORT_DESC );

--- a/tests/phpunit/Integration/SQLStore/Lookup/KeysetPaginationIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/Lookup/KeysetPaginationIntegrationTest.php
@@ -16,6 +16,12 @@ use SMW\Tests\Utils\UtilityFactory;
  * control walk over the same data. Used to prove that rewriting the cursor
  * predicate from row-constructor form to OR form does not regress behaviour.
  *
+ * The seed includes a deliberate tied pair (two properties with identical
+ * `smw_sort` values, distinct `smw_id`) placed at the PAGE_SIZE-1 boundary so
+ * that the forward cursor walk lands on the lower-id tied row, forcing the
+ * predicate's tiebreak path (`smw_sort = ? AND smw_id > ?`) to participate.
+ * A focused tiebreak test exercises the backward direction the same way.
+ *
  * @group semantic-mediawiki
  * @group Database
  * @group medium
@@ -30,7 +36,21 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 
 	private const SEED_COUNT = 12;
 	private const PAGE_SIZE = 3;
-	private const KEY_PREFIX = 'KeysetTest_Property_';
+	private const TIED_LOW_INDEX = 11;
+	private const TIED_HIGH_INDEX = 12;
+
+	/**
+	 * Runtime-randomised so concurrent or interrupted test runs cannot pollute
+	 * each other's fixture. Stored on the instance so helpers can read it.
+	 */
+	private string $keyPrefix;
+
+	/**
+	 * The shared `smw_sort` value forced onto the tied pair. Crafted to sort
+	 * between `${keyPrefix}02` and `${keyPrefix}03` so the tied pair lands at
+	 * positions 3 and 4 in the global ASC sort order over the seeded set.
+	 */
+	private string $tiedSortValue;
 
 	private array $subjects = [];
 	private $semanticDataFactory;
@@ -38,6 +58,9 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
+
+		$this->keyPrefix = 'KeysetTest_' . bin2hex( random_bytes( 4 ) ) . '_Property_';
+		$this->tiedSortValue = $this->keyPrefix . '02_TIE';
 
 		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
 
@@ -47,7 +70,7 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 		$store = $this->getStore();
 
 		for ( $i = 1; $i <= self::SEED_COUNT; $i++ ) {
-			$propertyKey = sprintf( self::KEY_PREFIX . '%02d', $i );
+			$propertyKey = $this->propertyKeyForIndex( $i );
 			$semanticData = $this->semanticDataFactory->newEmptySemanticData( $propertyKey . '_Subject' );
 			$this->subjects[] = $semanticData->getSubject();
 
@@ -58,6 +81,8 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 
 			$store->updateData( $semanticData );
 		}
+
+		$this->normaliseSeedSortKeys( $store );
 	}
 
 	protected function tearDown(): void {
@@ -66,6 +91,36 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 		$this->mwHooksHandler->restoreListedHooks();
 
 		parent::tearDown();
+	}
+
+	public function testSeedActuallyContainsATiedPair(): void {
+		$store = $this->getStore();
+		$offsetSequence = $this->collectOffsetSequence( $store );
+
+		$tiedLow = $this->propertyKeyForIndex( self::TIED_LOW_INDEX );
+		$tiedHigh = $this->propertyKeyForIndex( self::TIED_HIGH_INDEX );
+
+		$lowPos = array_search( $tiedLow, $offsetSequence, true );
+		$highPos = array_search( $tiedHigh, $offsetSequence, true );
+
+		$this->assertNotFalse( $lowPos, 'Lower-id tied property must appear in OFFSET sequence' );
+		$this->assertNotFalse( $highPos, 'Higher-id tied property must appear in OFFSET sequence' );
+		$this->assertSame(
+			2,
+			$lowPos,
+			'Lower-id tied property must sort at position 3 (zero-indexed 2), one short of the PAGE_SIZE=3 boundary'
+		);
+		$this->assertSame(
+			3,
+			$highPos,
+			'Higher-id tied property must sort at position 4 (zero-indexed 3), the first row of the second page'
+		);
+
+		// Guards against the seed silently losing the tie if the schema or
+		// SMW write path ever stops accepting our forced smw_sort UPDATE.
+		$tiedSorts = $this->fetchSortValuesForKeys( $store, [ $tiedLow, $tiedHigh ] );
+		$this->assertCount( 2, $tiedSorts, 'Both tied properties must be in smw_object_ids' );
+		$this->assertSame( $tiedSorts[0], $tiedSorts[1], 'Tied pair must share an identical smw_sort value' );
 	}
 
 	public function testForwardCursorTraversalMatchesOffsetControl(): void {
@@ -91,7 +146,7 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 			$page = $this->fetchListDirect( $store, $options );
 			foreach ( $page as $entry ) {
 				$key = $entry[0]->getKey();
-				if ( str_starts_with( $key, self::KEY_PREFIX ) ) {
+				if ( $this->isTestKey( $key ) ) {
 					$cursorSequence[] = $key;
 				}
 			}
@@ -104,6 +159,44 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 			$offsetSequence,
 			$cursorSequence,
 			'Forward cursor traversal must produce the same filtered sequence as OFFSET control'
+		);
+	}
+
+	/**
+	 * Focused assertion for the forward tiebreak path. The natural traversal
+	 * test cannot reliably land the cursor on the lower-id tied row because
+	 * the page boundary depends on the count of pre-existing SMW predefined
+	 * properties in the test database, which varies. By force-setting the
+	 * cursor to that row, we make the tiebreak path participate
+	 * deterministically.
+	 */
+	public function testForwardCursorOnLowerTiedRowReturnsHigherTiedRow(): void {
+		$store = $this->getStore();
+		$db = $store->getConnection( 'mw.db' );
+
+		$tiedLow = $this->propertyKeyForIndex( self::TIED_LOW_INDEX );
+		$tiedHigh = $this->propertyKeyForIndex( self::TIED_HIGH_INDEX );
+
+		$lowId = $this->lookupSmwIdForPropertyKey( $db, $tiedLow );
+		$this->assertNotNull( $lowId, 'Lower-id tied property must resolve to an smw_id' );
+
+		$options = new RequestOptions();
+		$options->limit = self::PAGE_SIZE;
+		$options->setCursorAfter( $lowId );
+
+		$page = $this->fetchListDirect( $store, $options );
+		$pageKeys = [];
+		foreach ( $page as $entry ) {
+			$key = $entry[0]->getKey();
+			if ( $this->isTestKey( $key ) ) {
+				$pageKeys[] = $key;
+			}
+		}
+
+		$this->assertContains(
+			$tiedHigh,
+			$pageKeys,
+			'Forward page from lower-id tied row must include the higher-id tied row via the `smw_sort = ? AND smw_id > ?` tiebreak path'
 		);
 	}
 
@@ -141,7 +234,7 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 			$pageKeys = [];
 			foreach ( $page as $entry ) {
 				$key = $entry[0]->getKey();
-				if ( str_starts_with( $key, self::KEY_PREFIX ) ) {
+				if ( $this->isTestKey( $key ) ) {
 					$pageKeys[] = $key;
 				}
 			}
@@ -154,12 +247,53 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 			$guard++;
 		}
 
+		// `setCursorBefore` is strict less-than: the cursor row itself never
+		// appears in any page during a backward walk. The OFFSET control
+		// sequence does include that row at the end, so we manually reinstate
+		// it to make the two sequences directly comparable.
 		$cursorSequence[] = $lastKey;
 
 		$this->assertSame(
 			$offsetSequence,
 			$cursorSequence,
 			'Backward cursor traversal plus the start property must reproduce the OFFSET control sequence'
+		);
+	}
+
+	/**
+	 * Focused assertion for the backward tiebreak path. The forward test
+	 * naturally lands the cursor on the lower-id tied row (page 1 ends at
+	 * position 3, which is the tied pair's lower-id member), exercising the
+	 * forward `smw_sort = ? AND smw_id > ?` clause. The natural backward walk
+	 * never lands on the higher-id tied row, so we invoke that case directly.
+	 */
+	public function testBackwardCursorOnHigherTiedRowReturnsLowerTiedRow(): void {
+		$store = $this->getStore();
+		$db = $store->getConnection( 'mw.db' );
+
+		$tiedHigh = $this->propertyKeyForIndex( self::TIED_HIGH_INDEX );
+		$tiedLow = $this->propertyKeyForIndex( self::TIED_LOW_INDEX );
+
+		$highId = $this->lookupSmwIdForPropertyKey( $db, $tiedHigh );
+		$this->assertNotNull( $highId, 'Higher-id tied property must resolve to an smw_id' );
+
+		$options = new RequestOptions();
+		$options->limit = self::PAGE_SIZE;
+		$options->setCursorBefore( $highId );
+
+		$page = $this->fetchListDirect( $store, $options );
+		$pageKeys = [];
+		foreach ( $page as $entry ) {
+			$key = $entry[0]->getKey();
+			if ( $this->isTestKey( $key ) ) {
+				$pageKeys[] = $key;
+			}
+		}
+
+		$this->assertContains(
+			$tiedLow,
+			$pageKeys,
+			'Backward page from higher-id tied row must include the lower-id tied row via the `smw_sort = ? AND smw_id < ?` tiebreak path'
 		);
 	}
 
@@ -172,6 +306,10 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 		return $lookup->fetchList();
 	}
 
+	/**
+	 * Page size here is internal to the OFFSET oracle and need not match
+	 * `PAGE_SIZE`; larger pages just enumerate the seeded set faster.
+	 */
 	private function collectOffsetSequence( $store ): array {
 		$keys = [];
 		$offset = 0;
@@ -190,7 +328,7 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 
 			foreach ( $page as $entry ) {
 				$key = $entry[0]->getKey();
-				if ( str_starts_with( $key, self::KEY_PREFIX ) ) {
+				if ( $this->isTestKey( $key ) ) {
 					$keys[] = $key;
 				}
 			}
@@ -219,6 +357,69 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 			->fetchRow();
 
 		return $row ? (int)$row->smw_id : null;
+	}
+
+	/**
+	 * Overwrite every seeded property's `smw_sort` with a known raw value,
+	 * forcing a tie on the designated pair. SMW's normal write path stores a
+	 * collation sort key (not the raw label) via `Collator::getSortKey()`, so
+	 * UPDATE-ing only the tied pair would leave them at sort-key bytes that
+	 * are not directly comparable with the rest. By rewriting all twelve rows
+	 * to predictable raw strings, the resulting `(smw_sort, smw_id)` ordering
+	 * matches the test's expectations and remains stable across MW versions
+	 * regardless of the active collation.
+	 */
+	private function normaliseSeedSortKeys( $store ): void {
+		$db = $store->getConnection( 'mw.db' );
+
+		for ( $i = 1; $i <= self::SEED_COUNT; $i++ ) {
+			$propertyKey = $this->propertyKeyForIndex( $i );
+			$id = $this->lookupSmwIdForPropertyKey( $db, $propertyKey );
+			$this->assertNotNull(
+				$id,
+				"Seeded property at index $i must exist before normalising sort keys"
+			);
+
+			$sortValue = ( $i === self::TIED_LOW_INDEX || $i === self::TIED_HIGH_INDEX )
+				? $this->tiedSortValue
+				: $propertyKey;
+
+			$db->newUpdateQueryBuilder()
+				->update( 'smw_object_ids' )
+				->set( [ 'smw_sort' => $sortValue ] )
+				->where( [ 'smw_id' => $id ] )
+				->caller( __METHOD__ )
+				->execute();
+		}
+	}
+
+	private function fetchSortValuesForKeys( $store, array $propertyKeys ): array {
+		$db = $store->getConnection( 'mw.db' );
+		$rows = $db->newSelectQueryBuilder()
+			->select( [ 'smw_title', 'smw_sort' ] )
+			->from( 'smw_object_ids' )
+			->where( [
+				'smw_title' => $propertyKeys,
+				'smw_namespace' => SMW_NS_PROPERTY,
+				'smw_iw' => '',
+				'smw_subobject' => '',
+			] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
+
+		$sorts = [];
+		foreach ( $rows as $row ) {
+			$sorts[] = $row->smw_sort;
+		}
+		return $sorts;
+	}
+
+	private function propertyKeyForIndex( int $i ): string {
+		return $this->keyPrefix . sprintf( '%02d', $i );
+	}
+
+	private function isTestKey( string $key ): bool {
+		return str_starts_with( $key, $this->keyPrefix );
 	}
 
 }

--- a/tests/phpunit/Integration/SQLStore/Lookup/KeysetPaginationIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/Lookup/KeysetPaginationIntegrationTest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace SMW\Tests\Integration\SQLStore\Lookup;
+
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\RequestOptions;
+use SMW\SQLStore\Lookup\PropertyUsageListLookup;
+use SMW\SQLStore\PropertyStatisticsStore;
+use SMW\Tests\SMWIntegrationTestCase;
+use SMW\Tests\Utils\UtilityFactory;
+
+/**
+ * Locks the cursor traversal contract for `KeysetPaginationTrait`. Forward and
+ * backward navigation must produce the same property sequence as an OFFSET
+ * control walk over the same data. Used to prove that rewriting the cursor
+ * predicate from row-constructor form to OR form does not regress behaviour.
+ *
+ * @group semantic-mediawiki
+ * @group Database
+ * @group medium
+ *
+ * @covers \SMW\SQLStore\Lookup\KeysetPaginationTrait
+ * @covers \SMW\SQLStore\Lookup\PropertyUsageListLookup
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
+
+	private const SEED_COUNT = 12;
+	private const PAGE_SIZE = 3;
+	private const KEY_PREFIX = 'KeysetTest_Property_';
+
+	private array $subjects = [];
+	private $semanticDataFactory;
+	private $mwHooksHandler;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
+
+		$this->mwHooksHandler = UtilityFactory::getInstance()->newMwHooksHandler();
+		$this->mwHooksHandler->deregisterListedHooks();
+
+		$store = $this->getStore();
+
+		for ( $i = 1; $i <= self::SEED_COUNT; $i++ ) {
+			$propertyKey = sprintf( self::KEY_PREFIX . '%02d', $i );
+			$semanticData = $this->semanticDataFactory->newEmptySemanticData( $propertyKey . '_Subject' );
+			$this->subjects[] = $semanticData->getSubject();
+
+			$semanticData->addPropertyObjectValue(
+				new Property( $propertyKey ),
+				new WikiPage( $propertyKey . '_Value', NS_MAIN )
+			);
+
+			$store->updateData( $semanticData );
+		}
+	}
+
+	protected function tearDown(): void {
+		$pageDeleter = UtilityFactory::getInstance()->newPageDeleter();
+		$pageDeleter->doDeletePoolOfPages( $this->subjects );
+		$this->mwHooksHandler->restoreListedHooks();
+
+		parent::tearDown();
+	}
+
+	public function testForwardCursorTraversalMatchesOffsetControl(): void {
+		$store = $this->getStore();
+
+		$offsetSequence = $this->collectOffsetSequence( $store );
+		$this->assertNotEmpty(
+			$offsetSequence,
+			'OFFSET control walk must find the seeded properties'
+		);
+
+		$cursorSequence = [];
+		$cursorAfter = null;
+		$guard = 0;
+
+		do {
+			$options = new RequestOptions();
+			$options->limit = self::PAGE_SIZE;
+			if ( $cursorAfter !== null ) {
+				$options->setCursorAfter( $cursorAfter );
+			}
+
+			$page = $this->fetchListDirect( $store, $options );
+			foreach ( $page as $entry ) {
+				$key = $entry[0]->getKey();
+				if ( str_starts_with( $key, self::KEY_PREFIX ) ) {
+					$cursorSequence[] = $key;
+				}
+			}
+
+			$cursorAfter = $options->getLastCursor();
+			$guard++;
+		} while ( $cursorAfter !== null && $options->getCursorHasMore() && $guard < 1000 );
+
+		$this->assertSame(
+			$offsetSequence,
+			$cursorSequence,
+			'Forward cursor traversal must produce the same filtered sequence as OFFSET control'
+		);
+	}
+
+	public function testBackwardCursorTraversalMatchesReversedOffsetControl(): void {
+		$store = $this->getStore();
+
+		$offsetSequence = $this->collectOffsetSequence( $store );
+		$this->assertNotEmpty(
+			$offsetSequence,
+			'OFFSET control walk must find the seeded properties'
+		);
+
+		$db = $store->getConnection( 'mw.db' );
+		$lastKey = end( $offsetSequence );
+		$startId = $this->lookupSmwIdForPropertyKey( $db, $lastKey );
+		$this->assertNotNull(
+			$startId,
+			'Last seeded property must have an smw_id from which to seek backward'
+		);
+
+		$cursorSequence = [];
+		$cursorBefore = $startId;
+		$guard = 0;
+
+		while ( $cursorBefore !== null && $guard < 1000 ) {
+			$options = new RequestOptions();
+			$options->limit = self::PAGE_SIZE;
+			$options->setCursorBefore( $cursorBefore );
+
+			$page = $this->fetchListDirect( $store, $options );
+			if ( $page === [] ) {
+				break;
+			}
+
+			$pageKeys = [];
+			foreach ( $page as $entry ) {
+				$key = $entry[0]->getKey();
+				if ( str_starts_with( $key, self::KEY_PREFIX ) ) {
+					$pageKeys[] = $key;
+				}
+			}
+
+			foreach ( array_reverse( $pageKeys ) as $key ) {
+				array_unshift( $cursorSequence, $key );
+			}
+
+			$cursorBefore = $options->getFirstCursor();
+			$guard++;
+		}
+
+		$cursorSequence[] = $lastKey;
+
+		$this->assertSame(
+			$offsetSequence,
+			$cursorSequence,
+			'Backward cursor traversal plus the start property must reproduce the OFFSET control sequence'
+		);
+	}
+
+	private function fetchListDirect( $store, RequestOptions $options ): array {
+		$lookup = new PropertyUsageListLookup(
+			$store,
+			new PropertyStatisticsStore( $store->getConnection( 'mw.db' ) ),
+			$options
+		);
+		return $lookup->fetchList();
+	}
+
+	private function collectOffsetSequence( $store ): array {
+		$keys = [];
+		$offset = 0;
+		$pageSize = 50;
+		$guard = 0;
+
+		while ( $guard < 1000 ) {
+			$options = new RequestOptions();
+			$options->limit = $pageSize;
+			$options->setOffset( $offset );
+
+			$page = $this->fetchListDirect( $store, $options );
+			if ( $page === [] ) {
+				break;
+			}
+
+			foreach ( $page as $entry ) {
+				$key = $entry[0]->getKey();
+				if ( str_starts_with( $key, self::KEY_PREFIX ) ) {
+					$keys[] = $key;
+				}
+			}
+
+			if ( count( $page ) < $pageSize ) {
+				break;
+			}
+			$offset += $pageSize;
+			$guard++;
+		}
+
+		return $keys;
+	}
+
+	private function lookupSmwIdForPropertyKey( $db, string $propertyKey ): ?int {
+		$row = $db->newSelectQueryBuilder()
+			->select( 'smw_id' )
+			->from( 'smw_object_ids' )
+			->where( [
+				'smw_title' => $propertyKey,
+				'smw_namespace' => SMW_NS_PROPERTY,
+				'smw_iw' => '',
+				'smw_subobject' => '',
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
+
+		return $row ? (int)$row->smw_id : null;
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
@@ -513,7 +513,7 @@ class PropertyUsageListLookupTest extends TestCase {
 
 		$instance->fetchList();
 
-		$cursorClause = "(smw_sort, smw_id) > ('Alpha', 42)";
+		$cursorClause = "smw_sort > 'Alpha' OR (smw_sort = 'Alpha' AND smw_id > 42)";
 		$this->assertContains( $cursorClause, $capturedWhereClauses,
 			'Expected cursor WHERE clause not found in andWhere calls' );
 	}


### PR DESCRIPTION
## Summary

- Rewrite the cursor predicate in `KeysetPaginationTrait` from row-constructor form `(smw_sort, smw_id) > (?, ?)` to boolean-equivalent OR form `smw_sort > ? OR (smw_sort = ? AND smw_id > ?)`. MariaDB recognises the OR form as a range predicate and seeks the `(smw_sort, smw_id)` index directly; it does not optimise the row-constructor form into a seek.
- Add a real-DB integration test covering forward and backward cursor traversal plus focused tiebreak assertions in both directions.
- `PropertyUsageListLookup` (Special:Properties) and `UnusedPropertyListLookup` (Special:UnusedProperties) inherit the speedup with zero source changes; no API, URL, or schema change.

## Background

[#6564](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6564) introduced keyset pagination to address [#6559](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6559) point 1. That PR's stated goal was O(log n) per-page cost via index seek, but the trait it shipped used the row-constructor comparison, which MariaDB does not plan as an index range seek. `ANALYZE` reports `type: index` and reads rows linearly with cursor depth. The two existing Special pages were therefore getting roughly a 3x speedup over OFFSET rather than the order-of-magnitude that the `(smw_sort, smw_id)` index allows.

## The fix

```php
// Before
$queryBuilder->andWhere(
    '(smw_sort, smw_id) > (' . $db->addQuotes( $sort ) . ', ' . $cursorAfter . ')'
);

// After
$quotedSort = $db->addQuotes( $sort );
$queryBuilder->andWhere(
    'smw_sort > ' . $quotedSort .
    ' OR (smw_sort = ' . $quotedSort . ' AND smw_id > ' . $cursorAfter . ')'
);
```

Symmetric rewrite on the `cursorBefore` branch (`<` for both comparisons). Same boolean semantics, same NULL handling, same public trait API. Cursor params are typed `?int` on `RequestOptions::setCursorAfter(int)`/`setCursorBefore(int)`, so the unquoted interpolation is injection-safe (and consistent with the pre-existing code).

## Performance evidence

Measured on the dev wiki MariaDB 11.2.6 against a 50,000-row test fixture (since cleaned up). `ANALYZE` rows-examined and median wall time over 5 runs.

| Cursor depth | OFFSET (rows examined / wall) | Old tuple form (rows / wall) | New OR form (rows / wall) | OR form speedup vs OFFSET |
|---|---|---|---|---|
| 5,000 | 5,050 rows / ~20 ms | 5,197 rows / ~20 ms | **51 rows** / **0.8 ms** | **~25x** |
| 25,000 | 25,050 rows / ~110 ms | 25,198 rows / ~33 ms | **51 rows** / **0.8 ms** | **~130x** |
| 49,000 | 49,050 rows / ~211 ms | 49,123 rows / ~68 ms | **51 rows** / **0.8 ms** | **~260x** |

Wall time of the OR form stays roughly constant with cursor depth (true range seek), while OFFSET and the old tuple form grow linearly. EXPLAIN access type changes from `index` (full scan) to `range` (seek) on the `smw_sort` index.

## Compatibility

- **MariaDB / MySQL**: range seek as measured above.
- **PostgreSQL**: planner handles row-constructor comparisons natively and would already seek for the old form; the OR form produces an equivalent plan. No regression expected. **Not exercised in CI** (the project's CI matrix is MariaDB-only), so this is a reasoned claim, not a measured one.
- **SQLite**: weaker optimiser; the OR-form rewrite over an indexed column is the textbook keyset pattern and is at least as good as the tuple form. **Also not exercised in CI**; reasoned, not measured.

The rewrite is universally safe in terms of semantics, so even if a backend's planner happens to plan the OR form less well than the tuple form, results remain correct. No DB-specific branching.

## Tests

New integration test at `tests/phpunit/Integration/SQLStore/Lookup/KeysetPaginationIntegrationTest.php` exercises `PropertyUsageListLookup` through the real DB:

- **Forward and backward broad traversal**: walk all twelve seeded properties via successive `setCursorAfter` / `setCursorBefore` and assert the produced sequence is identical to an OFFSET-based control walk over the same data.
- **Tied pair fixture**: the seed forces two properties to share an identical `smw_sort` (placed between `..._02` and `..._03` in the global sort order). A `testSeedActuallyContainsATiedPair` assertion fails if the fixture ever silently loses its tie.
- **Focused forward and backward tiebreak tests**: force the cursor onto the lower/higher tied row directly and assert the next/previous page contains the other tied row via the `smw_sort = ? AND smw_id ≷ ?` clause. These catch tiebreak-blind predicate mutations (e.g. `smw_sort > ?` alone) that the broad walks alone would miss because page boundaries depend on the count of pre-existing SMW predefined properties, which varies.

Mutation-tested before commit: both `smw_sort > X` (drops tiebreak) and `smw_sort >= X AND smw_id > Y` (drops the OR) cause at least one test to fail.

The one unit test that asserted on the literal cursor SQL string (`PropertyUsageListLookupTest::testFetchListWithCursorAfterAppliesCorrectWhereClause`) is updated to the new shape. `UnusedPropertyListLookupTest` tests behaviour (counts, order, cursor IDs), not literal SQL, so no source change there.

## Test plan

- [x] `composer phpunit:unit` — 6847 tests, 14110 assertions, 6 pre-existing skips, 0 failures
- [x] Targeted suite (PropertyUsage + UnusedProperty + KeysetPaginationIntegration) — 32 tests, 158 assertions, green
- [x] PHPCS clean on all changed files (`vendor/bin/phpcs -sp --no-cache`)
- [x] Mutation tests confirm the test suite catches tiebreak-blind predicates
- [x] EXPLAIN evidence captured for `type: range`, `r_rows = 51` at cursor depth 5,000 / 25,000 / 49,000
- [x] CI green
- [ ] Reviewer verification (recommend independent EXPLAIN check on a populated instance for full confidence)

Refs #6559 (point 1, originally addressed by #6564).