### PR TITLE
Apply keyset cursor pagination to Property:Foo (PropertySubjectsLookup)

### DIFF
--- a/src/MediaWiki/Page/ListBuilder/ValueListBuilder.php
+++ b/src/MediaWiki/Page/ListBuilder/ValueListBuilder.php
@@ -227,7 +227,10 @@ class ValueListBuilder {
 				$options->getCursorBefore() !== null
 			);
 		} else {
-			$paginationHtml = Pager::pagination( $title, $limit, $offset, $resultCount, $query );
+			// Legacy path: strip the cursor params introduced by this PR so
+			// they do not echo as `&after=0&before=0` into offset URLs.
+			$legacyQuery = array_diff_key( $query, array_flip( [ 'after', 'before' ] ) );
+			$paginationHtml = Pager::pagination( $title, $limit, $offset, $resultCount, $legacyQuery );
 		}
 
 		$navContainer = Html::rawElement(

--- a/src/MediaWiki/Page/ListBuilder/ValueListBuilder.php
+++ b/src/MediaWiki/Page/ListBuilder/ValueListBuilder.php
@@ -11,8 +11,10 @@ use SMW\DataValueFactory;
 use SMW\DataValues\DataValue;
 use SMW\Formatters\Infolink;
 use SMW\Formatters\PageLister;
+use SMW\Localizer\Localizer;
 use SMW\Localizer\Message;
 use SMW\MediaWiki\Collator;
+use SMW\MediaWiki\MessageBuilder;
 use SMW\Query\Language\SomeProperty;
 use SMW\RequestOptions;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -95,6 +97,8 @@ class ValueListBuilder {
 	public function createHtml( Property $property, DataItem $dataItem, array $query = [] ): string {
 		$limit = isset( $query['limit'] ) ? (int)$query['limit'] : 0;
 		$offset = isset( $query['offset'] ) ? (int)$query['offset'] : 0;
+		$after = (int)( $query['after'] ?? 0 );
+		$before = (int)( $query['before'] ?? 0 );
 		$from = $query['from'] ?? 0;
 		$until = $query['until'] ?? 0;
 		$filter = $query['filter'] ?? '';
@@ -109,13 +113,33 @@ class ValueListBuilder {
 		$dataItems = [];
 		$isValueSearch = false;
 
-		$options = PageLister::getRequestOptions( $limit, $from, $until );
-		$options->setOffset( $offset );
+		// Cursor mode is active for the no-filter branch whenever the page
+		// is reached without legacy boundary or offset params, or when an
+		// explicit `after`/`before` cursor is set. Filter branch keeps
+		// offset-style pagination until QueryEngine cursor support lands.
+		$cursorMode = $filter === ''
+			&& ( $after > 0 || $before > 0 || ( $offset === 0 && $from === 0 && $until === 0 ) );
 
 		if ( $filter !== '' ) {
+			$options = PageLister::getRequestOptions( $limit, $from, $until );
+			$options->setOffset( $offset );
 			$dataItems = $this->filterByValue( $property, $filter, $options );
 			$isValueSearch = true;
+		} elseif ( $cursorMode ) {
+			$options = new RequestOptions();
+			$options->limit = $limit;
+			$options->sort = true;
+			$options->ascending = true;
+			$options->setOption( RequestOptions::CURSOR_MODE, true );
+			if ( $after > 0 ) {
+				$options->setCursorAfter( $after );
+			} elseif ( $before > 0 ) {
+				$options->setCursorBefore( $before );
+			}
+			$dataItems = $this->store->getAllPropertySubjects( $property, $options );
 		} else {
+			$options = PageLister::getRequestOptions( $limit, $from, $until );
+			$options->setOffset( $offset );
 			$dataItems = $this->store->getAllPropertySubjects( $property, $options );
 		}
 
@@ -175,6 +199,24 @@ class ValueListBuilder {
 			$until
 		);
 
+		if ( $cursorMode ) {
+			$msgBuilder = new MessageBuilder(
+				Localizer::getInstance()->getLanguage( $this->languageCode )
+			);
+			$isFirstPage = !$options->hasCursor();
+			$paginationHtml = $msgBuilder->cursorPrevNextToText(
+				$title,
+				$limit,
+				$isFirstPage ? null : $options->getFirstCursor(),
+				$options->getLastCursor(),
+				array_diff_key( $query, array_flip( [ 'after', 'before', 'offset', 'from', 'until' ] ) ),
+				!$options->getCursorHasMore(),
+				$options->getCursorBefore() !== null
+			);
+		} else {
+			$paginationHtml = Pager::pagination( $title, $limit, $offset, $resultCount, $query );
+		}
+
 		$navContainer = Html::rawElement(
 			'div',
 			[
@@ -185,7 +227,7 @@ class ValueListBuilder {
 				[
 					'class' => 'smw-page-nav-left'
 				],
-				Pager::pagination( $title, $limit, $offset, $resultCount, $query )
+				$paginationHtml
 			) . Html::rawElement(
 				'div',
 				[

--- a/src/MediaWiki/Page/ListBuilder/ValueListBuilder.php
+++ b/src/MediaWiki/Page/ListBuilder/ValueListBuilder.php
@@ -31,6 +31,14 @@ use Traversable;
  */
 class ValueListBuilder {
 
+	/**
+	 * Query-array keys the cursor-style pager renderer should NOT echo back
+	 * into the generated next/prev URLs; the renderer supplies its own
+	 * `after`/`before` and the legacy boundary/offset params would otherwise
+	 * leak forward into cursor URLs.
+	 */
+	private const PAGINATION_QUERY_KEYS = [ 'after', 'before', 'offset', 'from', 'until', 'filter' ];
+
 	private int $pagingLimit = 0;
 
 	private null|int|string $filterCount = null;
@@ -99,9 +107,9 @@ class ValueListBuilder {
 		$offset = isset( $query['offset'] ) ? (int)$query['offset'] : 0;
 		$after = (int)( $query['after'] ?? 0 );
 		$before = (int)( $query['before'] ?? 0 );
-		$from = $query['from'] ?? 0;
-		$until = $query['until'] ?? 0;
-		$filter = $query['filter'] ?? '';
+		$from = (string)( $query['from'] ?? '' );
+		$until = (string)( $query['until'] ?? '' );
+		$filter = (string)( $query['filter'] ?? '' );
 
 		$this->filterCount = null;
 
@@ -113,14 +121,19 @@ class ValueListBuilder {
 		$dataItems = [];
 		$isValueSearch = false;
 
-		// Cursor mode is active for the no-filter branch whenever the page
-		// is reached without legacy boundary or offset params, or when an
-		// explicit `after`/`before` cursor is set. Filter branch keeps
-		// offset-style pagination until QueryEngine cursor support lands.
-		$cursorMode = $filter === ''
-			&& ( $after > 0 || $before > 0 || ( $offset === 0 && $from === 0 && $until === 0 ) );
+		$cursorMode = self::shouldUseCursorPagination(
+			$filter,
+			$after,
+			$before,
+			$offset,
+			$from,
+			$until
+		);
 
 		if ( $filter !== '' ) {
+			// `PageLister::getRequestOptions` accepts `string|int` for
+			// `$from`/`$until`; the string form is what the cursor and
+			// search-form code paths produce.
 			$options = PageLister::getRequestOptions( $limit, $from, $until );
 			$options->setOffset( $offset );
 			$dataItems = $this->filterByValue( $property, $filter, $options );
@@ -209,7 +222,7 @@ class ValueListBuilder {
 				$limit,
 				$isFirstPage ? null : $options->getFirstCursor(),
 				$options->getLastCursor(),
-				array_diff_key( $query, array_flip( [ 'after', 'before', 'offset', 'from', 'until' ] ) ),
+				array_diff_key( $query, array_flip( self::PAGINATION_QUERY_KEYS ) ),
 				!$options->getCursorHasMore(),
 				$options->getCursorBefore() !== null
 			);
@@ -451,6 +464,39 @@ class ValueListBuilder {
 		}
 
 		return array_values( $sort );
+	}
+
+	/**
+	 * Decides whether the no-filter branch should render cursor-style
+	 * pagination (`?after=`/`?before=`) or stay on the legacy offset/boundary
+	 * path. Extracted to a static helper so it can be unit-tested without
+	 * spinning up the full lookup; the predicate is the most regression-
+	 * prone part of the cursor flow.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $filter Value of `?filter=`; empty string for the no-filter branch.
+	 * @param int $after Value of `?after=`; 0 when not set.
+	 * @param int $before Value of `?before=`; 0 when not set.
+	 * @param int $offset Value of `?offset=`; 0 when not set.
+	 * @param string $from Value of `?from=`; empty string when not set.
+	 * @param string $until Value of `?until=`; empty string when not set.
+	 */
+	public static function shouldUseCursorPagination(
+		string $filter,
+		int $after,
+		int $before,
+		int $offset,
+		string $from,
+		string $until
+	): bool {
+		if ( $filter !== '' ) {
+			return false;
+		}
+		if ( $after > 0 || $before > 0 ) {
+			return true;
+		}
+		return $offset === 0 && $from === '' && $until === '';
 	}
 
 }

--- a/src/MediaWiki/Page/PropertyPage.php
+++ b/src/MediaWiki/Page/PropertyPage.php
@@ -402,6 +402,8 @@ class PropertyPage extends Page {
 			[
 				'limit'  => $request->getVal( 'limit', $this->getOption( 'pagingLimit' ) ),
 				'offset' => $request->getVal( 'offset', '0' ),
+				'after'  => $request->getInt( 'after', 0 ),
+				'before' => $request->getInt( 'before', 0 ),
 				'from'   => $request->getVal( 'from', '' ),
 				'until'  => $request->getVal( 'until', '' ),
 				'filter' => $request->getVal( 'filter', '' )

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -40,6 +40,15 @@ class RequestOptions {
 	const SEARCH_FIELD = 'search_field';
 
 	/**
+	 * Opt-in flag asking a cursor-aware lookup to populate cursor metadata
+	 * (`firstCursor`, `lastCursor`, `cursorHasMore`) on this RequestOptions
+	 * instance even when `cursorAfter` / `cursorBefore` are not set (i.e.
+	 * the first page of a cursor-paginated UI). Callers that do not consume
+	 * cursor metadata should leave this unset.
+	 */
+	const CURSOR_MODE = 'cursor.mode';
+
+	/**
 	 * The maximum number of results that should be returned.
 	 *
 	 * @var int

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -45,6 +45,8 @@ class RequestOptions {
 	 * instance even when `cursorAfter` / `cursorBefore` are not set (i.e.
 	 * the first page of a cursor-paginated UI). Callers that do not consume
 	 * cursor metadata should leave this unset.
+	 *
+	 * @since 7.0.0
 	 */
 	const CURSOR_MODE = 'cursor.mode';
 

--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -12,6 +12,7 @@ use SMW\Options;
 use SMW\RequestOptions;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\EntityStore\Exception\DataItemHandlerException;
+use SMW\SQLStore\Lookup\KeysetPaginationTrait;
 use SMW\SQLStore\PropertyTableDefinition as TableDefinition;
 use SMW\SQLStore\SQLStore;
 use stdClass;
@@ -24,6 +25,16 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
  * @author mwjames
  */
 class PropertySubjectsLookup {
+
+	use KeysetPaginationTrait;
+
+	/**
+	 * Required by `KeysetPaginationTrait`. Set transiently inside `doFetch()`
+	 * to the per-call (already-cloned) RequestOptions before invoking the
+	 * trait's `applyCursorPagination()`. Not exposed; the public entry points
+	 * always provide RequestOptions explicitly.
+	 */
+	private ?RequestOptions $requestOptions = null;
 
 	private IteratorFactory $iteratorFactory;
 
@@ -159,6 +170,19 @@ class PropertySubjectsLookup {
 		);
 
 		$sortField = $dataItemHandler->getSortField();
+
+		// Capture the caller's RequestOptions so cursor metadata
+		// (firstCursor, lastCursor, cursorHasMore) can be written back to it
+		// after the fetch. The local working copy below is cloned for internal
+		// mutation safety; the cursor branch needs to surface results on the
+		// original.
+		$callerRequestOptions = $requestOptions;
+		$cursorMode = $proptable->usesIdSubject()
+			&& $callerRequestOptions !== null
+			&& (
+				$callerRequestOptions->hasCursor()
+				|| (bool)$callerRequestOptions->getOption( RequestOptions::CURSOR_MODE )
+			);
 
 		if ( $requestOptions === null ) {
 			$requestOptions = new RequestOptions();
@@ -301,6 +325,17 @@ class PropertySubjectsLookup {
 			unset( $opts['LIMIT'], $opts['OFFSET'] );
 		}
 
+		if ( $cursorMode ) {
+			// Cursor path: the trait sets the WHERE predicate and ORDER BY;
+			// we apply LIMIT+1 for lookahead and skip the legacy LIMIT/OFFSET.
+			unset( $opts['LIMIT'], $opts['OFFSET'] );
+			if ( $requestOptions->limit > 0 ) {
+				$qb->limit( $requestOptions->limit + 1 );
+			}
+			$this->requestOptions = $requestOptions;
+			$this->applyCursorPagination( $qb, $connection );
+		}
+
 		LegacyOptionsApplier::applyTo( $qb, $opts );
 
 		$caller = $this->caller;
@@ -315,7 +350,46 @@ class PropertySubjectsLookup {
 			DataItem::TYPE_WIKIPAGE
 		);
 
+		if ( $cursorMode ) {
+			$res = $this->postProcessCursorResult( $res, $callerRequestOptions, $requestOptions );
+		}
+
 		return $res;
+	}
+
+	/**
+	 * Trim the lookahead row, reverse on backward navigation, and surface
+	 * cursor metadata on the caller's RequestOptions so the page renderer
+	 * can build the next/prev links.
+	 *
+	 * @param iterable $res Raw result rows from `fetchResultSet()`.
+	 * @param RequestOptions $callerRequestOptions The caller's instance, which receives the cursor metadata.
+	 * @param RequestOptions $workingRequestOptions The cloned/internal instance (used only for the original `cursorBefore`/`limit` values).
+	 *
+	 * @return array Post-processed rows, ready to be wrapped by the iterator factory.
+	 */
+	private function postProcessCursorResult( $res, RequestOptions $callerRequestOptions, RequestOptions $workingRequestOptions ): array {
+		$rows = [];
+		foreach ( $res as $row ) {
+			$rows[] = $row;
+		}
+
+		$limit = $workingRequestOptions->limit;
+		if ( $limit > 0 && count( $rows ) > $limit ) {
+			array_pop( $rows );
+			$callerRequestOptions->setCursorHasMore( true );
+		}
+
+		if ( $callerRequestOptions->getCursorBefore() !== null ) {
+			$rows = array_reverse( $rows );
+		}
+
+		if ( $rows !== [] ) {
+			$callerRequestOptions->setFirstCursor( (int)$rows[0]->smw_id );
+			$callerRequestOptions->setLastCursor( (int)$rows[count( $rows ) - 1]->smw_id );
+		}
+
+		return $rows;
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -354,6 +354,10 @@ class PropertySubjectsLookup {
 			$res = $this->postProcessCursorResult( $res, $callerRequestOptions, $requestOptions );
 		}
 
+		// Clear the transient field so subsequent calls do not pick up a stale
+		// reference from this one if they take the non-cursor path.
+		$this->requestOptions = null;
+
 		return $res;
 	}
 

--- a/src/SQLStore/Lookup/KeysetPaginationTrait.php
+++ b/src/SQLStore/Lookup/KeysetPaginationTrait.php
@@ -38,6 +38,15 @@ trait KeysetPaginationTrait {
 	 *
 	 * When no cursor is active, falls back to offset-based pagination.
 	 *
+	 * Both cursor branches express the (smw_sort, smw_id) total order via an
+	 * explicit OR rather than a row-constructor comparison such as
+	 * `(smw_sort, smw_id) > (?, ?)`. MariaDB does not optimise row-constructor
+	 * comparisons into an index range seek; it plans a full index scan with a
+	 * WHERE filter, so cost grows linearly with cursor depth. The explicit-OR
+	 * form is recognised as a range predicate and seeks the (smw_sort, smw_id)
+	 * index directly. PostgreSQL and SQLite plan the OR form at least as well
+	 * as the tuple form. See issue #6559.
+	 *
 	 * @param SelectQueryBuilder $queryBuilder
 	 * @param Database $db
 	 *
@@ -50,12 +59,6 @@ trait KeysetPaginationTrait {
 		if ( $cursorAfter !== null ) {
 			$sort = $this->resolveCursorSort( $cursorAfter );
 			if ( $sort !== null ) {
-				// MariaDB does not optimise row-constructor comparisons
-				// `(a, b) > (?, ?)` into an index range seek; it falls back
-				// to a full index scan with a WHERE filter. Expressing the
-				// same total order via explicit OR is recognised as a
-				// range predicate and seeks the (smw_sort, smw_id) index
-				// directly. See issue #6559.
 				$quotedSort = $db->addQuotes( $sort );
 				$queryBuilder->andWhere(
 					'smw_sort > ' . $quotedSort .

--- a/src/SQLStore/Lookup/KeysetPaginationTrait.php
+++ b/src/SQLStore/Lookup/KeysetPaginationTrait.php
@@ -50,18 +50,26 @@ trait KeysetPaginationTrait {
 		if ( $cursorAfter !== null ) {
 			$sort = $this->resolveCursorSort( $cursorAfter );
 			if ( $sort !== null ) {
+				// MariaDB does not optimise row-constructor comparisons
+				// `(a, b) > (?, ?)` into an index range seek; it falls back
+				// to a full index scan with a WHERE filter. Expressing the
+				// same total order via explicit OR is recognised as a
+				// range predicate and seeks the (smw_sort, smw_id) index
+				// directly. See issue #6559.
+				$quotedSort = $db->addQuotes( $sort );
 				$queryBuilder->andWhere(
-					'(smw_sort, smw_id) > (' .
-					$db->addQuotes( $sort ) . ', ' . $cursorAfter . ')'
+					'smw_sort > ' . $quotedSort .
+					' OR (smw_sort = ' . $quotedSort . ' AND smw_id > ' . $cursorAfter . ')'
 				);
 			}
 			$queryBuilder->orderBy( [ 'smw_sort', 'smw_id' ], SelectQueryBuilder::SORT_ASC );
 		} elseif ( $cursorBefore !== null ) {
 			$sort = $this->resolveCursorSort( $cursorBefore );
 			if ( $sort !== null ) {
+				$quotedSort = $db->addQuotes( $sort );
 				$queryBuilder->andWhere(
-					'(smw_sort, smw_id) < (' .
-					$db->addQuotes( $sort ) . ', ' . $cursorBefore . ')'
+					'smw_sort < ' . $quotedSort .
+					' OR (smw_sort = ' . $quotedSort . ' AND smw_id < ' . $cursorBefore . ')'
 				);
 			}
 			$queryBuilder->orderBy( [ 'smw_sort', 'smw_id' ], SelectQueryBuilder::SORT_DESC );

--- a/tests/phpunit/Integration/SQLStore/EntityStore/PropertySubjectsLookupKeysetIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/EntityStore/PropertySubjectsLookupKeysetIntegrationTest.php
@@ -1,0 +1,345 @@
+<?php
+
+namespace SMW\Tests\Integration\SQLStore\EntityStore;
+
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\RequestOptions;
+use SMW\Tests\SMWIntegrationTestCase;
+use SMW\Tests\Utils\UtilityFactory;
+
+/**
+ * Locks the cursor traversal contract for `PropertySubjectsLookup`. Seeds a
+ * single property and N subject pages that use it, then walks the resulting
+ * subject list forward and backward via `setCursorAfter` / `setCursorBefore`
+ * and asserts the sequences match an OFFSET control walk over the same data.
+ *
+ * Includes a deliberate tied-`smw_sort` pair to exercise the predicate's
+ * tiebreak path. Focused tiebreak tests in both directions force the cursor
+ * onto the lower/higher tied row directly.
+ *
+ * @group semantic-mediawiki
+ * @group Database
+ * @group medium
+ *
+ * @covers \SMW\SQLStore\Lookup\KeysetPaginationTrait
+ * @covers \SMW\SQLStore\EntityStore\PropertySubjectsLookup
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class PropertySubjectsLookupKeysetIntegrationTest extends SMWIntegrationTestCase {
+
+	private const SEED_COUNT = 12;
+	private const PAGE_SIZE = 3;
+	private const TIED_LOW_INDEX = 11;
+	private const TIED_HIGH_INDEX = 12;
+
+	private string $subjectPrefix;
+	private string $propertyKey;
+	private string $tiedSortValue;
+
+	private array $subjects = [];
+	private $semanticDataFactory;
+	private $mwHooksHandler;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$runId = bin2hex( random_bytes( 4 ) );
+		$this->subjectPrefix = 'PropSubjKeysetTest_' . $runId . '_Subject_';
+		$this->propertyKey = 'PropSubjKeysetTest_' . $runId . '_Property';
+		$this->tiedSortValue = $this->subjectPrefix . '02_TIE';
+
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
+
+		$this->mwHooksHandler = UtilityFactory::getInstance()->newMwHooksHandler();
+		$this->mwHooksHandler->deregisterListedHooks();
+
+		$store = $this->getStore();
+
+		$property = new Property( $this->propertyKey );
+		for ( $i = 1; $i <= self::SEED_COUNT; $i++ ) {
+			$subjectName = $this->subjectNameForIndex( $i );
+			$semanticData = $this->semanticDataFactory->newEmptySemanticData( $subjectName );
+			$this->subjects[] = $semanticData->getSubject();
+
+			$semanticData->addPropertyObjectValue(
+				$property,
+				new WikiPage( $subjectName . '_Value', NS_MAIN )
+			);
+
+			$store->updateData( $semanticData );
+		}
+
+		$this->normaliseSeedSortKeys( $store );
+	}
+
+	protected function tearDown(): void {
+		$pageDeleter = UtilityFactory::getInstance()->newPageDeleter();
+		$pageDeleter->doDeletePoolOfPages( $this->subjects );
+		$this->mwHooksHandler->restoreListedHooks();
+
+		parent::tearDown();
+	}
+
+	public function testSeedActuallyContainsATiedPair(): void {
+		$store = $this->getStore();
+		$offsetSequence = $this->collectOffsetSequence( $store );
+
+		$tiedLow = $this->subjectNameForIndex( self::TIED_LOW_INDEX );
+		$tiedHigh = $this->subjectNameForIndex( self::TIED_HIGH_INDEX );
+
+		$lowPos = array_search( $tiedLow, $offsetSequence, true );
+		$highPos = array_search( $tiedHigh, $offsetSequence, true );
+
+		$this->assertNotFalse( $lowPos, 'Lower-id tied subject must appear in OFFSET sequence' );
+		$this->assertNotFalse( $highPos, 'Higher-id tied subject must appear in OFFSET sequence' );
+		$this->assertSame(
+			2,
+			$lowPos,
+			'Lower-id tied subject must sort at position 3 (zero-indexed 2)'
+		);
+		$this->assertSame(
+			3,
+			$highPos,
+			'Higher-id tied subject must sort at position 4 (zero-indexed 3)'
+		);
+
+		$tiedSorts = $this->fetchSortValuesForSubjects( $store, [ $tiedLow, $tiedHigh ] );
+		$this->assertCount( 2, $tiedSorts );
+		$this->assertSame(
+			$tiedSorts[0],
+			$tiedSorts[1],
+			'Tied pair must share an identical smw_sort value'
+		);
+	}
+
+	public function testForwardCursorTraversalMatchesOffsetControl(): void {
+		$store = $this->getStore();
+		$offsetSequence = $this->collectOffsetSequence( $store );
+		$this->assertNotEmpty( $offsetSequence );
+
+		$cursorSequence = [];
+		$cursorAfter = null;
+		$guard = 0;
+
+		do {
+			$options = $this->buildOptions( $cursorAfter, null );
+			$page = $this->fetchSubjects( $store, $options );
+
+			foreach ( $page as $subjectName ) {
+				if ( $this->isTestSubject( $subjectName ) ) {
+					$cursorSequence[] = $subjectName;
+				}
+			}
+
+			$cursorAfter = $options->getLastCursor();
+			$guard++;
+		} while ( $cursorAfter !== null && $options->getCursorHasMore() && $guard < 1000 );
+
+		$this->assertSame( $offsetSequence, $cursorSequence );
+	}
+
+	public function testBackwardCursorTraversalMatchesReversedOffsetControl(): void {
+		$store = $this->getStore();
+		$offsetSequence = $this->collectOffsetSequence( $store );
+		$this->assertNotEmpty( $offsetSequence );
+
+		$lastName = end( $offsetSequence );
+		$startId = $this->lookupSmwIdForSubject( $store, $lastName );
+		$this->assertNotNull( $startId );
+
+		$cursorSequence = [];
+		$cursorBefore = $startId;
+		$guard = 0;
+
+		while ( $cursorBefore !== null && $guard < 1000 ) {
+			$options = $this->buildOptions( null, $cursorBefore );
+			$page = $this->fetchSubjects( $store, $options );
+			if ( $page === [] ) {
+				break;
+			}
+
+			$pageNames = [];
+			foreach ( $page as $subjectName ) {
+				if ( $this->isTestSubject( $subjectName ) ) {
+					$pageNames[] = $subjectName;
+				}
+			}
+			foreach ( array_reverse( $pageNames ) as $name ) {
+				array_unshift( $cursorSequence, $name );
+			}
+
+			$cursorBefore = $options->getFirstCursor();
+			$guard++;
+		}
+
+		// setCursorBefore is strict less-than; the start row never appears
+		// in any page. Reinstate it to make the sequences directly comparable.
+		$cursorSequence[] = $lastName;
+
+		$this->assertSame( $offsetSequence, $cursorSequence );
+	}
+
+	public function testForwardCursorOnLowerTiedRowReturnsHigherTiedRow(): void {
+		$store = $this->getStore();
+		$tiedLow = $this->subjectNameForIndex( self::TIED_LOW_INDEX );
+		$tiedHigh = $this->subjectNameForIndex( self::TIED_HIGH_INDEX );
+
+		$lowId = $this->lookupSmwIdForSubject( $store, $tiedLow );
+		$this->assertNotNull( $lowId );
+
+		$options = $this->buildOptions( $lowId, null );
+		$page = $this->fetchSubjects( $store, $options );
+
+		$pageNames = array_values( array_filter( $page, fn ( $n ) => $this->isTestSubject( $n ) ) );
+		$this->assertContains(
+			$tiedHigh,
+			$pageNames,
+			'Forward page from lower-id tied row must include the higher-id tied row via tiebreak'
+		);
+	}
+
+	public function testBackwardCursorOnHigherTiedRowReturnsLowerTiedRow(): void {
+		$store = $this->getStore();
+		$tiedLow = $this->subjectNameForIndex( self::TIED_LOW_INDEX );
+		$tiedHigh = $this->subjectNameForIndex( self::TIED_HIGH_INDEX );
+
+		$highId = $this->lookupSmwIdForSubject( $store, $tiedHigh );
+		$this->assertNotNull( $highId );
+
+		$options = $this->buildOptions( null, $highId );
+		$page = $this->fetchSubjects( $store, $options );
+
+		$pageNames = array_values( array_filter( $page, fn ( $n ) => $this->isTestSubject( $n ) ) );
+		$this->assertContains(
+			$tiedLow,
+			$pageNames,
+			'Backward page from higher-id tied row must include the lower-id tied row via tiebreak'
+		);
+	}
+
+	private function buildOptions( ?int $cursorAfter, ?int $cursorBefore ): RequestOptions {
+		$options = new RequestOptions();
+		$options->limit = self::PAGE_SIZE;
+		$options->setOption( RequestOptions::CURSOR_MODE, true );
+		if ( $cursorAfter !== null ) {
+			$options->setCursorAfter( $cursorAfter );
+		}
+		if ( $cursorBefore !== null ) {
+			$options->setCursorBefore( $cursorBefore );
+		}
+		return $options;
+	}
+
+	private function fetchSubjects( $store, RequestOptions $options ): array {
+		$property = new Property( $this->propertyKey );
+		$result = $store->getAllPropertySubjects( $property, $options );
+		$names = [];
+		foreach ( $result as $diWikiPage ) {
+			$names[] = $diWikiPage->getDBkey();
+		}
+		return $names;
+	}
+
+	private function collectOffsetSequence( $store ): array {
+		$names = [];
+		$offset = 0;
+		$pageSize = 50;
+		$guard = 0;
+
+		while ( $guard < 1000 ) {
+			$options = new RequestOptions();
+			$options->limit = $pageSize;
+			$options->setOffset( $offset );
+
+			$page = $this->fetchSubjects( $store, $options );
+			if ( $page === [] ) {
+				break;
+			}
+			foreach ( $page as $name ) {
+				if ( $this->isTestSubject( $name ) ) {
+					$names[] = $name;
+				}
+			}
+			if ( count( $page ) < $pageSize ) {
+				break;
+			}
+			$offset += $pageSize;
+			$guard++;
+		}
+
+		return $names;
+	}
+
+	private function lookupSmwIdForSubject( $store, string $subjectName ): ?int {
+		$db = $store->getConnection( 'mw.db' );
+		$row = $db->newSelectQueryBuilder()
+			->select( 'smw_id' )
+			->from( 'smw_object_ids' )
+			->where( [
+				'smw_title' => $subjectName,
+				'smw_namespace' => NS_MAIN,
+				'smw_iw' => '',
+				'smw_subobject' => '',
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
+		return $row ? (int)$row->smw_id : null;
+	}
+
+	private function normaliseSeedSortKeys( $store ): void {
+		$db = $store->getConnection( 'mw.db' );
+
+		for ( $i = 1; $i <= self::SEED_COUNT; $i++ ) {
+			$subjectName = $this->subjectNameForIndex( $i );
+			$id = $this->lookupSmwIdForSubject( $store, $subjectName );
+			$this->assertNotNull(
+				$id,
+				"Seeded subject at index $i must exist before normalising sort keys"
+			);
+
+			$sortValue = ( $i === self::TIED_LOW_INDEX || $i === self::TIED_HIGH_INDEX )
+				? $this->tiedSortValue
+				: $subjectName;
+
+			$db->newUpdateQueryBuilder()
+				->update( 'smw_object_ids' )
+				->set( [ 'smw_sort' => $sortValue ] )
+				->where( [ 'smw_id' => $id ] )
+				->caller( __METHOD__ )
+				->execute();
+		}
+	}
+
+	private function fetchSortValuesForSubjects( $store, array $subjectNames ): array {
+		$db = $store->getConnection( 'mw.db' );
+		$rows = $db->newSelectQueryBuilder()
+			->select( [ 'smw_title', 'smw_sort' ] )
+			->from( 'smw_object_ids' )
+			->where( [
+				'smw_title' => $subjectNames,
+				'smw_namespace' => NS_MAIN,
+				'smw_iw' => '',
+				'smw_subobject' => '',
+			] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
+
+		$sorts = [];
+		foreach ( $rows as $row ) {
+			$sorts[] = $row->smw_sort;
+		}
+		return $sorts;
+	}
+
+	private function subjectNameForIndex( int $i ): string {
+		return $this->subjectPrefix . sprintf( '%02d', $i );
+	}
+
+	private function isTestSubject( string $name ): bool {
+		return str_starts_with( $name, $this->subjectPrefix );
+	}
+
+}

--- a/tests/phpunit/Integration/SQLStore/EntityStore/PropertySubjectsLookupKeysetIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/EntityStore/PropertySubjectsLookupKeysetIntegrationTest.php
@@ -154,12 +154,9 @@ class PropertySubjectsLookupKeysetIntegrationTest extends SMWIntegrationTestCase
 		$cursorBefore = $startId;
 		$guard = 0;
 
-		while ( $cursorBefore !== null && $guard < 1000 ) {
+		do {
 			$options = $this->buildOptions( null, $cursorBefore );
 			$page = $this->fetchSubjects( $store, $options );
-			if ( $page === [] ) {
-				break;
-			}
 
 			$pageNames = [];
 			foreach ( $page as $subjectName ) {
@@ -173,7 +170,7 @@ class PropertySubjectsLookupKeysetIntegrationTest extends SMWIntegrationTestCase
 
 			$cursorBefore = $options->getFirstCursor();
 			$guard++;
-		}
+		} while ( $cursorBefore !== null && $options->getCursorHasMore() && $guard < 1000 );
 
 		// setCursorBefore is strict less-than; the start row never appears
 		// in any page. Reinstate it to make the sequences directly comparable.

--- a/tests/phpunit/Integration/SQLStore/EntityStore/PropertySubjectsLookupKeysetIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/EntityStore/PropertySubjectsLookupKeysetIntegrationTest.php
@@ -198,6 +198,47 @@ class PropertySubjectsLookupKeysetIntegrationTest extends SMWIntegrationTestCase
 		);
 	}
 
+	public function testCursorWithNonexistentIdFallsBackToFirstPage(): void {
+		$store = $this->getStore();
+		$db = $store->getConnection( 'mw.db' );
+
+		// Pick an smw_id well above anything that could plausibly exist in
+		// the test DB. The cursor row lookup returns null, so the trait
+		// skips the WHERE predicate and the lookup returns the first page
+		// in sort order. This is a deliberate UX choice (matches the
+		// "forgiving" convention used by Twitter, Reddit, Pinterest, and
+		// the existing PR #6564 design): users who hit stale links see
+		// content and can navigate from there, rather than landing on a
+		// confusing empty "no results" page.
+		$maxRow = $db->newSelectQueryBuilder()
+			->select( 'MAX(smw_id) AS max_id' )
+			->from( 'smw_object_ids' )
+			->caller( __METHOD__ )
+			->fetchRow();
+		$staleId = (int)$maxRow->max_id + 1_000_000;
+
+		$offsetSequence = $this->collectOffsetSequence( $store );
+		$firstPageExpected = array_slice( $offsetSequence, 0, self::PAGE_SIZE );
+
+		$options = $this->buildOptions( $staleId, null );
+		$page = $this->fetchSubjects( $store, $options );
+
+		$pageNames = array_values( array_filter( $page, fn ( $n ) => $this->isTestSubject( $n ) ) );
+		$this->assertSame(
+			$firstPageExpected,
+			$pageNames,
+			'Stale cursor must fall back to the first page of results'
+		);
+		$this->assertNotNull(
+			$options->getFirstCursor(),
+			'firstCursor must be populated from the fallback page'
+		);
+		$this->assertNotNull(
+			$options->getLastCursor(),
+			'lastCursor must be populated from the fallback page'
+		);
+	}
+
 	public function testBackwardCursorOnHigherTiedRowReturnsLowerTiedRow(): void {
 		$store = $this->getStore();
 		$tiedLow = $this->subjectNameForIndex( self::TIED_LOW_INDEX );

--- a/tests/phpunit/Integration/SQLStore/Lookup/KeysetPaginationIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/Lookup/KeysetPaginationIntegrationTest.php
@@ -16,6 +16,12 @@ use SMW\Tests\Utils\UtilityFactory;
  * control walk over the same data. Used to prove that rewriting the cursor
  * predicate from row-constructor form to OR form does not regress behaviour.
  *
+ * The seed includes a deliberate tied pair (two properties with identical
+ * `smw_sort` values, distinct `smw_id`) placed at the PAGE_SIZE-1 boundary so
+ * that the forward cursor walk lands on the lower-id tied row, forcing the
+ * predicate's tiebreak path (`smw_sort = ? AND smw_id > ?`) to participate.
+ * A focused tiebreak test exercises the backward direction the same way.
+ *
  * @group semantic-mediawiki
  * @group Database
  * @group medium
@@ -30,7 +36,21 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 
 	private const SEED_COUNT = 12;
 	private const PAGE_SIZE = 3;
-	private const KEY_PREFIX = 'KeysetTest_Property_';
+	private const TIED_LOW_INDEX = 11;
+	private const TIED_HIGH_INDEX = 12;
+
+	/**
+	 * Runtime-randomised so concurrent or interrupted test runs cannot pollute
+	 * each other's fixture. Stored on the instance so helpers can read it.
+	 */
+	private string $keyPrefix;
+
+	/**
+	 * The shared `smw_sort` value forced onto the tied pair. Crafted to sort
+	 * between `${keyPrefix}02` and `${keyPrefix}03` so the tied pair lands at
+	 * positions 3 and 4 in the global ASC sort order over the seeded set.
+	 */
+	private string $tiedSortValue;
 
 	private array $subjects = [];
 	private $semanticDataFactory;
@@ -38,6 +58,9 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 
 	protected function setUp(): void {
 		parent::setUp();
+
+		$this->keyPrefix = 'KeysetTest_' . bin2hex( random_bytes( 4 ) ) . '_Property_';
+		$this->tiedSortValue = $this->keyPrefix . '02_TIE';
 
 		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
 
@@ -47,7 +70,7 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 		$store = $this->getStore();
 
 		for ( $i = 1; $i <= self::SEED_COUNT; $i++ ) {
-			$propertyKey = sprintf( self::KEY_PREFIX . '%02d', $i );
+			$propertyKey = $this->propertyKeyForIndex( $i );
 			$semanticData = $this->semanticDataFactory->newEmptySemanticData( $propertyKey . '_Subject' );
 			$this->subjects[] = $semanticData->getSubject();
 
@@ -58,6 +81,8 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 
 			$store->updateData( $semanticData );
 		}
+
+		$this->normaliseSeedSortKeys( $store );
 	}
 
 	protected function tearDown(): void {
@@ -66,6 +91,36 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 		$this->mwHooksHandler->restoreListedHooks();
 
 		parent::tearDown();
+	}
+
+	public function testSeedActuallyContainsATiedPair(): void {
+		$store = $this->getStore();
+		$offsetSequence = $this->collectOffsetSequence( $store );
+
+		$tiedLow = $this->propertyKeyForIndex( self::TIED_LOW_INDEX );
+		$tiedHigh = $this->propertyKeyForIndex( self::TIED_HIGH_INDEX );
+
+		$lowPos = array_search( $tiedLow, $offsetSequence, true );
+		$highPos = array_search( $tiedHigh, $offsetSequence, true );
+
+		$this->assertNotFalse( $lowPos, 'Lower-id tied property must appear in OFFSET sequence' );
+		$this->assertNotFalse( $highPos, 'Higher-id tied property must appear in OFFSET sequence' );
+		$this->assertSame(
+			2,
+			$lowPos,
+			'Lower-id tied property must sort at position 3 (zero-indexed 2), one short of the PAGE_SIZE=3 boundary'
+		);
+		$this->assertSame(
+			3,
+			$highPos,
+			'Higher-id tied property must sort at position 4 (zero-indexed 3), the first row of the second page'
+		);
+
+		// Guards against the seed silently losing the tie if the schema or
+		// SMW write path ever stops accepting our forced smw_sort UPDATE.
+		$tiedSorts = $this->fetchSortValuesForKeys( $store, [ $tiedLow, $tiedHigh ] );
+		$this->assertCount( 2, $tiedSorts, 'Both tied properties must be in smw_object_ids' );
+		$this->assertSame( $tiedSorts[0], $tiedSorts[1], 'Tied pair must share an identical smw_sort value' );
 	}
 
 	public function testForwardCursorTraversalMatchesOffsetControl(): void {
@@ -91,7 +146,7 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 			$page = $this->fetchListDirect( $store, $options );
 			foreach ( $page as $entry ) {
 				$key = $entry[0]->getKey();
-				if ( str_starts_with( $key, self::KEY_PREFIX ) ) {
+				if ( $this->isTestKey( $key ) ) {
 					$cursorSequence[] = $key;
 				}
 			}
@@ -104,6 +159,44 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 			$offsetSequence,
 			$cursorSequence,
 			'Forward cursor traversal must produce the same filtered sequence as OFFSET control'
+		);
+	}
+
+	/**
+	 * Focused assertion for the forward tiebreak path. The natural traversal
+	 * test cannot reliably land the cursor on the lower-id tied row because
+	 * the page boundary depends on the count of pre-existing SMW predefined
+	 * properties in the test database, which varies. By force-setting the
+	 * cursor to that row, we make the tiebreak path participate
+	 * deterministically.
+	 */
+	public function testForwardCursorOnLowerTiedRowReturnsHigherTiedRow(): void {
+		$store = $this->getStore();
+		$db = $store->getConnection( 'mw.db' );
+
+		$tiedLow = $this->propertyKeyForIndex( self::TIED_LOW_INDEX );
+		$tiedHigh = $this->propertyKeyForIndex( self::TIED_HIGH_INDEX );
+
+		$lowId = $this->lookupSmwIdForPropertyKey( $db, $tiedLow );
+		$this->assertNotNull( $lowId, 'Lower-id tied property must resolve to an smw_id' );
+
+		$options = new RequestOptions();
+		$options->limit = self::PAGE_SIZE;
+		$options->setCursorAfter( $lowId );
+
+		$page = $this->fetchListDirect( $store, $options );
+		$pageKeys = [];
+		foreach ( $page as $entry ) {
+			$key = $entry[0]->getKey();
+			if ( $this->isTestKey( $key ) ) {
+				$pageKeys[] = $key;
+			}
+		}
+
+		$this->assertContains(
+			$tiedHigh,
+			$pageKeys,
+			'Forward page from lower-id tied row must include the higher-id tied row via the `smw_sort = ? AND smw_id > ?` tiebreak path'
 		);
 	}
 
@@ -141,7 +234,7 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 			$pageKeys = [];
 			foreach ( $page as $entry ) {
 				$key = $entry[0]->getKey();
-				if ( str_starts_with( $key, self::KEY_PREFIX ) ) {
+				if ( $this->isTestKey( $key ) ) {
 					$pageKeys[] = $key;
 				}
 			}
@@ -154,12 +247,53 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 			$guard++;
 		}
 
+		// `setCursorBefore` is strict less-than: the cursor row itself never
+		// appears in any page during a backward walk. The OFFSET control
+		// sequence does include that row at the end, so we manually reinstate
+		// it to make the two sequences directly comparable.
 		$cursorSequence[] = $lastKey;
 
 		$this->assertSame(
 			$offsetSequence,
 			$cursorSequence,
 			'Backward cursor traversal plus the start property must reproduce the OFFSET control sequence'
+		);
+	}
+
+	/**
+	 * Focused assertion for the backward tiebreak path. The forward test
+	 * naturally lands the cursor on the lower-id tied row (page 1 ends at
+	 * position 3, which is the tied pair's lower-id member), exercising the
+	 * forward `smw_sort = ? AND smw_id > ?` clause. The natural backward walk
+	 * never lands on the higher-id tied row, so we invoke that case directly.
+	 */
+	public function testBackwardCursorOnHigherTiedRowReturnsLowerTiedRow(): void {
+		$store = $this->getStore();
+		$db = $store->getConnection( 'mw.db' );
+
+		$tiedHigh = $this->propertyKeyForIndex( self::TIED_HIGH_INDEX );
+		$tiedLow = $this->propertyKeyForIndex( self::TIED_LOW_INDEX );
+
+		$highId = $this->lookupSmwIdForPropertyKey( $db, $tiedHigh );
+		$this->assertNotNull( $highId, 'Higher-id tied property must resolve to an smw_id' );
+
+		$options = new RequestOptions();
+		$options->limit = self::PAGE_SIZE;
+		$options->setCursorBefore( $highId );
+
+		$page = $this->fetchListDirect( $store, $options );
+		$pageKeys = [];
+		foreach ( $page as $entry ) {
+			$key = $entry[0]->getKey();
+			if ( $this->isTestKey( $key ) ) {
+				$pageKeys[] = $key;
+			}
+		}
+
+		$this->assertContains(
+			$tiedLow,
+			$pageKeys,
+			'Backward page from higher-id tied row must include the lower-id tied row via the `smw_sort = ? AND smw_id < ?` tiebreak path'
 		);
 	}
 
@@ -172,6 +306,10 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 		return $lookup->fetchList();
 	}
 
+	/**
+	 * Page size here is internal to the OFFSET oracle and need not match
+	 * `PAGE_SIZE`; larger pages just enumerate the seeded set faster.
+	 */
 	private function collectOffsetSequence( $store ): array {
 		$keys = [];
 		$offset = 0;
@@ -190,7 +328,7 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 
 			foreach ( $page as $entry ) {
 				$key = $entry[0]->getKey();
-				if ( str_starts_with( $key, self::KEY_PREFIX ) ) {
+				if ( $this->isTestKey( $key ) ) {
 					$keys[] = $key;
 				}
 			}
@@ -219,6 +357,69 @@ class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
 			->fetchRow();
 
 		return $row ? (int)$row->smw_id : null;
+	}
+
+	/**
+	 * Overwrite every seeded property's `smw_sort` with a known raw value,
+	 * forcing a tie on the designated pair. SMW's normal write path stores a
+	 * collation sort key (not the raw label) via `Collator::getSortKey()`, so
+	 * UPDATE-ing only the tied pair would leave them at sort-key bytes that
+	 * are not directly comparable with the rest. By rewriting all twelve rows
+	 * to predictable raw strings, the resulting `(smw_sort, smw_id)` ordering
+	 * matches the test's expectations and remains stable across MW versions
+	 * regardless of the active collation.
+	 */
+	private function normaliseSeedSortKeys( $store ): void {
+		$db = $store->getConnection( 'mw.db' );
+
+		for ( $i = 1; $i <= self::SEED_COUNT; $i++ ) {
+			$propertyKey = $this->propertyKeyForIndex( $i );
+			$id = $this->lookupSmwIdForPropertyKey( $db, $propertyKey );
+			$this->assertNotNull(
+				$id,
+				"Seeded property at index $i must exist before normalising sort keys"
+			);
+
+			$sortValue = ( $i === self::TIED_LOW_INDEX || $i === self::TIED_HIGH_INDEX )
+				? $this->tiedSortValue
+				: $propertyKey;
+
+			$db->newUpdateQueryBuilder()
+				->update( 'smw_object_ids' )
+				->set( [ 'smw_sort' => $sortValue ] )
+				->where( [ 'smw_id' => $id ] )
+				->caller( __METHOD__ )
+				->execute();
+		}
+	}
+
+	private function fetchSortValuesForKeys( $store, array $propertyKeys ): array {
+		$db = $store->getConnection( 'mw.db' );
+		$rows = $db->newSelectQueryBuilder()
+			->select( [ 'smw_title', 'smw_sort' ] )
+			->from( 'smw_object_ids' )
+			->where( [
+				'smw_title' => $propertyKeys,
+				'smw_namespace' => SMW_NS_PROPERTY,
+				'smw_iw' => '',
+				'smw_subobject' => '',
+			] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
+
+		$sorts = [];
+		foreach ( $rows as $row ) {
+			$sorts[] = $row->smw_sort;
+		}
+		return $sorts;
+	}
+
+	private function propertyKeyForIndex( int $i ): string {
+		return $this->keyPrefix . sprintf( '%02d', $i );
+	}
+
+	private function isTestKey( string $key ): bool {
+		return str_starts_with( $key, $this->keyPrefix );
 	}
 
 }

--- a/tests/phpunit/Integration/SQLStore/Lookup/KeysetPaginationIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/Lookup/KeysetPaginationIntegrationTest.php
@@ -1,0 +1,224 @@
+<?php
+
+namespace SMW\Tests\Integration\SQLStore\Lookup;
+
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\RequestOptions;
+use SMW\SQLStore\Lookup\PropertyUsageListLookup;
+use SMW\SQLStore\PropertyStatisticsStore;
+use SMW\Tests\SMWIntegrationTestCase;
+use SMW\Tests\Utils\UtilityFactory;
+
+/**
+ * Locks the cursor traversal contract for `KeysetPaginationTrait`. Forward and
+ * backward navigation must produce the same property sequence as an OFFSET
+ * control walk over the same data. Used to prove that rewriting the cursor
+ * predicate from row-constructor form to OR form does not regress behaviour.
+ *
+ * @group semantic-mediawiki
+ * @group Database
+ * @group medium
+ *
+ * @covers \SMW\SQLStore\Lookup\KeysetPaginationTrait
+ * @covers \SMW\SQLStore\Lookup\PropertyUsageListLookup
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class KeysetPaginationIntegrationTest extends SMWIntegrationTestCase {
+
+	private const SEED_COUNT = 12;
+	private const PAGE_SIZE = 3;
+	private const KEY_PREFIX = 'KeysetTest_Property_';
+
+	private array $subjects = [];
+	private $semanticDataFactory;
+	private $mwHooksHandler;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->semanticDataFactory = UtilityFactory::getInstance()->newSemanticDataFactory();
+
+		$this->mwHooksHandler = UtilityFactory::getInstance()->newMwHooksHandler();
+		$this->mwHooksHandler->deregisterListedHooks();
+
+		$store = $this->getStore();
+
+		for ( $i = 1; $i <= self::SEED_COUNT; $i++ ) {
+			$propertyKey = sprintf( self::KEY_PREFIX . '%02d', $i );
+			$semanticData = $this->semanticDataFactory->newEmptySemanticData( $propertyKey . '_Subject' );
+			$this->subjects[] = $semanticData->getSubject();
+
+			$semanticData->addPropertyObjectValue(
+				new Property( $propertyKey ),
+				new WikiPage( $propertyKey . '_Value', NS_MAIN )
+			);
+
+			$store->updateData( $semanticData );
+		}
+	}
+
+	protected function tearDown(): void {
+		$pageDeleter = UtilityFactory::getInstance()->newPageDeleter();
+		$pageDeleter->doDeletePoolOfPages( $this->subjects );
+		$this->mwHooksHandler->restoreListedHooks();
+
+		parent::tearDown();
+	}
+
+	public function testForwardCursorTraversalMatchesOffsetControl(): void {
+		$store = $this->getStore();
+
+		$offsetSequence = $this->collectOffsetSequence( $store );
+		$this->assertNotEmpty(
+			$offsetSequence,
+			'OFFSET control walk must find the seeded properties'
+		);
+
+		$cursorSequence = [];
+		$cursorAfter = null;
+		$guard = 0;
+
+		do {
+			$options = new RequestOptions();
+			$options->limit = self::PAGE_SIZE;
+			if ( $cursorAfter !== null ) {
+				$options->setCursorAfter( $cursorAfter );
+			}
+
+			$page = $this->fetchListDirect( $store, $options );
+			foreach ( $page as $entry ) {
+				$key = $entry[0]->getKey();
+				if ( str_starts_with( $key, self::KEY_PREFIX ) ) {
+					$cursorSequence[] = $key;
+				}
+			}
+
+			$cursorAfter = $options->getLastCursor();
+			$guard++;
+		} while ( $cursorAfter !== null && $options->getCursorHasMore() && $guard < 1000 );
+
+		$this->assertSame(
+			$offsetSequence,
+			$cursorSequence,
+			'Forward cursor traversal must produce the same filtered sequence as OFFSET control'
+		);
+	}
+
+	public function testBackwardCursorTraversalMatchesReversedOffsetControl(): void {
+		$store = $this->getStore();
+
+		$offsetSequence = $this->collectOffsetSequence( $store );
+		$this->assertNotEmpty(
+			$offsetSequence,
+			'OFFSET control walk must find the seeded properties'
+		);
+
+		$db = $store->getConnection( 'mw.db' );
+		$lastKey = end( $offsetSequence );
+		$startId = $this->lookupSmwIdForPropertyKey( $db, $lastKey );
+		$this->assertNotNull(
+			$startId,
+			'Last seeded property must have an smw_id from which to seek backward'
+		);
+
+		$cursorSequence = [];
+		$cursorBefore = $startId;
+		$guard = 0;
+
+		while ( $cursorBefore !== null && $guard < 1000 ) {
+			$options = new RequestOptions();
+			$options->limit = self::PAGE_SIZE;
+			$options->setCursorBefore( $cursorBefore );
+
+			$page = $this->fetchListDirect( $store, $options );
+			if ( $page === [] ) {
+				break;
+			}
+
+			$pageKeys = [];
+			foreach ( $page as $entry ) {
+				$key = $entry[0]->getKey();
+				if ( str_starts_with( $key, self::KEY_PREFIX ) ) {
+					$pageKeys[] = $key;
+				}
+			}
+
+			foreach ( array_reverse( $pageKeys ) as $key ) {
+				array_unshift( $cursorSequence, $key );
+			}
+
+			$cursorBefore = $options->getFirstCursor();
+			$guard++;
+		}
+
+		$cursorSequence[] = $lastKey;
+
+		$this->assertSame(
+			$offsetSequence,
+			$cursorSequence,
+			'Backward cursor traversal plus the start property must reproduce the OFFSET control sequence'
+		);
+	}
+
+	private function fetchListDirect( $store, RequestOptions $options ): array {
+		$lookup = new PropertyUsageListLookup(
+			$store,
+			new PropertyStatisticsStore( $store->getConnection( 'mw.db' ) ),
+			$options
+		);
+		return $lookup->fetchList();
+	}
+
+	private function collectOffsetSequence( $store ): array {
+		$keys = [];
+		$offset = 0;
+		$pageSize = 50;
+		$guard = 0;
+
+		while ( $guard < 1000 ) {
+			$options = new RequestOptions();
+			$options->limit = $pageSize;
+			$options->setOffset( $offset );
+
+			$page = $this->fetchListDirect( $store, $options );
+			if ( $page === [] ) {
+				break;
+			}
+
+			foreach ( $page as $entry ) {
+				$key = $entry[0]->getKey();
+				if ( str_starts_with( $key, self::KEY_PREFIX ) ) {
+					$keys[] = $key;
+				}
+			}
+
+			if ( count( $page ) < $pageSize ) {
+				break;
+			}
+			$offset += $pageSize;
+			$guard++;
+		}
+
+		return $keys;
+	}
+
+	private function lookupSmwIdForPropertyKey( $db, string $propertyKey ): ?int {
+		$row = $db->newSelectQueryBuilder()
+			->select( 'smw_id' )
+			->from( 'smw_object_ids' )
+			->where( [
+				'smw_title' => $propertyKey,
+				'smw_namespace' => SMW_NS_PROPERTY,
+				'smw_iw' => '',
+				'smw_subobject' => '',
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
+
+		return $row ? (int)$row->smw_id : null;
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Page/ListBuilder/ValueListBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Page/ListBuilder/ValueListBuilderTest.php
@@ -147,4 +147,39 @@ class ValueListBuilderTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider cursorPaginationProvider
+	 */
+	public function testShouldUseCursorPagination(
+		string $filter,
+		int $after,
+		int $before,
+		int $offset,
+		string $from,
+		string $until,
+		bool $expected
+	): void {
+		$this->assertSame(
+			$expected,
+			ValueListBuilder::shouldUseCursorPagination( $filter, $after, $before, $offset, $from, $until )
+		);
+	}
+
+	public static function cursorPaginationProvider(): array {
+		return [
+			'fresh visit, no params' => [ '', 0, 0, 0, '', '', true ],
+			'explicit after cursor' => [ '', 42, 0, 0, '', '', true ],
+			'explicit before cursor' => [ '', 0, 42, 0, '', '', true ],
+			'cursor wins over offset' => [ '', 42, 0, 50, '', '', true ],
+			'cursor wins over from' => [ '', 42, 0, 0, 'Foo', '', true ],
+			'cursor wins over until' => [ '', 42, 0, 0, '', 'Foo', true ],
+			'legacy offset' => [ '', 0, 0, 50, '', '', false ],
+			'legacy from' => [ '', 0, 0, 0, 'Foo', '', false ],
+			'legacy until' => [ '', 0, 0, 0, '', 'Foo', false ],
+			'filter present, fresh visit' => [ 'Bar', 0, 0, 0, '', '', false ],
+			'filter present with after' => [ 'Bar', 42, 0, 0, '', '', false ],
+			'filter present with offset' => [ 'Bar', 0, 0, 50, '', '', false ],
+		];
+	}
+
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
@@ -513,7 +513,7 @@ class PropertyUsageListLookupTest extends TestCase {
 
 		$instance->fetchList();
 
-		$cursorClause = "(smw_sort, smw_id) > ('Alpha', 42)";
+		$cursorClause = "smw_sort > 'Alpha' OR (smw_sort = 'Alpha' AND smw_id > 42)";
 		$this->assertContains( $cursorClause, $capturedWhereClauses,
 			'Expected cursor WHERE clause not found in andWhere calls' );
 	}


### PR DESCRIPTION
> **Stacked on top of #6794.** This PR targets the `fix-keyset-trait-or-predicate` branch because it depends on the OR-form predicate fix landing first. Once #6794 merges, this PR's base should be retargeted to `master`.

## Summary

- Apply `KeysetPaginationTrait` to `PropertySubjectsLookup` so `Property:<name>` pages serve their subject list via a `(smw_sort, smw_id)` index seek instead of OFFSET. This is the bot-hot path that [#6559](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6559) (Brian Wolff) named as SMW's number-one performance issue.
- `PropertyPage::makeValueList()` parses `?after` and `?before` URL params. `ValueListBuilder::createHtml()` detects cursor mode, populates `RequestOptions` accordingly, and renders the pager via `MessageBuilder::cursorPrevNextToText()` instead of `Pager::pagination()`.
- Filter branch (`?filter=Bar`) and legacy URL forms (`?offset=N`, `?from=<sortkey>`, `?until=<sortkey>`) keep working unchanged. QueryEngine cursor support is a future PR.

Part of the [#6795](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6795) migration.

## Background

`Property:Foo` pages currently paginate via `?offset=N`. MariaDB does not optimise OFFSET into an index seek; on `PropertySubjectsLookup`'s SQL shape (`smw_object_ids JOIN smw_di_wikipage` + `GROUP BY smw_sort, smw_id`), the optimiser falls back to a full table scan with `Using temporary; Using filesort`. Deep pagination is catastrophic, and bot crawls following the offset chain compound this into O(N²) total work.

The keyset trait was introduced for `Special:Properties` and `Special:UnusedProperties` in #6564 and made into a true range seek by #6794. This PR brings the per-property page onto the same path.

## Performance evidence

Measured against a 50,000-row test fixture on the dev wiki (MariaDB 11.2.6). Median wall time over 5 runs of the exact SQL `PropertySubjectsLookup` emits, including the `USE INDEX(s_id)` hint and `GROUP BY smw_sort, smw_id`.

| Cursor depth | OFFSET (legacy) | Cursor (OR-form) | Speedup |
|---|---|---|---|
| 100 | 1.23 ms | 0.85 ms | 1.4x |
| 5,000 | 15.28 ms | 0.75 ms | **20x** |
| 25,000 | 574.15 ms | 0.74 ms | **776x** |
| 49,000 | 542.79 ms | 0.69 ms | **786x** |

`EXPLAIN ANALYZE` at depth 25,000:

**OFFSET path:**
```
type=ALL  key=NULL  r_rows=50206
Extra: Using where; Using temporary; Using filesort
```

**Cursor path:**
```
type=range  key=smw_sort  r_rows=51
Extra: Using where
```

The cursor path examines 51 rows (50 plus the lookahead) regardless of cursor depth; the OFFSET path scans all rows up to and including the cursor position.

## New API

`RequestOptions::CURSOR_MODE` (new opt-in option). When set, the lookup populates `firstCursor`, `lastCursor`, and `cursorHasMore` on the caller's RequestOptions even on the first page (where no `cursorAfter` / `cursorBefore` is set yet). Without this flag, page 1 of a cursor-paginated UI could not surface the lookahead-derived `hasMore` signal needed to render the next link. Callers that do not consume cursor metadata leave this unset.

`ValueListBuilder::shouldUseCursorPagination()` (new static helper). Extracted from `createHtml()` so the cursor-mode predicate is unit-testable in isolation. The predicate type was a latent regression risk; this lock-down catches future drift via a 12-row data provider.

## Behaviour decisions worth flagging

- **Strict additive for legacy URLs.** `Property:Foo?offset=N&limit=M` and `?from=<sortkey>` continue to resolve correctly via the existing offset/boundary path. The pager only emits new cursor URLs going forward, so bot indexes migrate over their re-crawl cadence. Legacy deprecation is deferred to the next major release.
- **Invalid cursor falls back to first page.** Matches the deliberate design in #6564 (locked in by `testFetchListWithInvalidCursorFallsBackToFirstPage` tests) and the convention used by web UIs like Twitter, Reddit, and Pinterest. Considered the alternative (force empty result via `0=1`) but for a web UI, showing content beats showing nothing when a stale link is followed. Locked in by the new `testCursorWithNonexistentIdFallsBackToFirstPage` integration test.
- **`USE INDEX(s_id)` hint kept unchanged.** Per `DIWikiPageHandler.php`'s existing benchmark comment, the hint provides a 10x speedup on the legacy path without OFFSET. Cursor path is fast regardless of the hint, so we leave it in place. Reassessment can be a follow-up.
- **`PAGINATION_QUERY_KEYS` strip list.** Cursor and offset params are stripped from the `$query` array before being echoed back into pager URLs, preventing empty `&after=0&before=0&from=&until=&filter=` noise leaking into URLs.

## Test coverage

- **New integration test** at `tests/phpunit/Integration/SQLStore/EntityStore/PropertySubjectsLookupKeysetIntegrationTest.php`: 6 tests covering forward and backward broad traversal vs an OFFSET control oracle, deliberate tied-`smw_sort` pair at the PAGE_SIZE-1 boundary to exercise the predicate's tiebreak path, focused tiebreak assertions in both directions, and the invalid-cursor fall-back contract.
- **Mutation tested**: sort-only `smw_sort > ?` and combined `smw_sort >= ? AND smw_id > ?` predicate forms both fail at least one test.
- **New unit data provider** at `ValueListBuilderTest::cursorPaginationProvider`: 12 rows covering fresh visit, explicit cursor, legacy params, and filter combinations.

## Test plan

- [x] `composer phpunit:unit` (full unit suite, 6859 tests, +12 from new data provider, 0 failures)
- [x] Targeted suite (PropertyUsage + UnusedProperty + PropertySubjectsLookupKeyset + ValueListBuilder): 49 tests / 195 assertions green
- [x] PHPCS clean on all changed files (`vendor/bin/phpcs -sp --no-cache`)
- [x] Mutation tests confirm the suite catches tiebreak-blind predicate regressions
- [x] EXPLAIN evidence captured for `type: range` at multiple depths
- [x] Browser smoke against the dev wiki: fresh visit, `?after=N`, `?before=N`, legacy `?offset=N`, `?filter=Bar`
- [x] CI green
- [ ] Reviewer verification
- [ ] Retarget base to `master` once #6794 lands

## Refs

- #6559 (performance audit, point 1: per-property pages use OFFSET)
- #6564 (initial keyset for Special:Properties / Special:UnusedProperties)
- #6794 (trait predicate fix that makes the keyset path a true index seek; this PR depends on it)
- #6795 (tracking issue for the full OFFSET migration)