### PR TITLE
Preserve non-SMW handlers when MwHooksHandler clears shared hooks

### DIFF
--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -2,7 +2,9 @@
 
 namespace SMW\Tests\Utils;
 
+use MediaWiki\HookContainer\HookContainer;
 use MediaWiki\MediaWikiServices;
+use ReflectionProperty;
 use RuntimeException;
 use SMW\MediaWiki\Hooks;
 
@@ -19,6 +21,7 @@ class MwHooksHandler {
 	 */
 	private $hookRegistry = null;
 	private $hookContainer = null;
+	private ?ReflectionProperty $handlersProperty = null;
 
 	private $wgHooks = [];
 	private $inTestRegisteredHooks = [];
@@ -89,18 +92,98 @@ class MwHooksHandler {
 	 * @return MwHooksHandler
 	 */
 	public function deregisterListedHooks() {
-		$listOfHooks = array_merge(
-			$this->listOfSmwHooks,
-			$this->getHookRegistry()->getHandlerList()
-		);
-
-		foreach ( $listOfHooks as $hook ) {
+		// SMW-internal hooks (listOfSmwHooks): clear without preservation so tests
+		// see a fresh slate. SMW-shipped wgHooks closures registered through
+		// `data/config/*.php` files are expected to be reset here, and existing
+		// tests (e.g. HookDispatcherTest) rely on that.
+		foreach ( $this->listOfSmwHooks as $hook ) {
 			if ( $this->hookContainer->isRegistered( $hook ) ) {
 				$this->hookContainer->clear( $hook );
 			}
 		}
 
+		// Shared MediaWiki hooks (getHandlerList): preserve non-SMW handlers
+		// across the clear. HookContainer::clear() wipes every handler, not just
+		// SMW's, so without this snapshot third-party handlers on shared hooks
+		// (e.g. Scribunto's ParserFirstCallInit) silently disappear during tests.
+		// Preserved handlers are appended back before invokeHooksFromRegistry()
+		// runs, so SMW's handler ends up last on the chain - a behaviour change
+		// versus pre-fix order, but acceptable for the hooks involved (parser
+		// function registration, etc., none of which depend on order). See
+		// issue #6797.
+		foreach ( $this->getHookRegistry()->getHandlerList() as $hook ) {
+			if ( !$this->hookContainer->isRegistered( $hook ) ) {
+				continue;
+			}
+
+			$preserved = $this->collectNonSmwHandlerEntries( $hook );
+
+			$this->hookContainer->clear( $hook );
+
+			if ( $preserved ) {
+				$this->writeHandlerEntries( $hook, $preserved );
+			}
+		}
+
 		return $this;
+	}
+
+	/**
+	 * Returns the normalized handler entries currently registered for $hook,
+	 * excluding those that target an SMW class. The full entry is kept (not
+	 * just the callback) so metadata such as the `args` field for the deprecated
+	 * `[$callable, $data...]` registration form survives the round-trip.
+	 *
+	 * Reflection is used because HookContainer exposes no non-deprecated way
+	 * to enumerate handlers (getHandlerCallbacks emits a deprecation warning).
+	 *
+	 * @return array[] List of normalized handler entries
+	 */
+	private function collectNonSmwHandlerEntries( string $hook ): array {
+		$handlers = $this->getHandlersProperty()->getValue( $this->hookContainer )[$hook] ?? [];
+
+		$preserved = [];
+		foreach ( $handlers as $entry ) {
+			$callback = $entry['callback'] ?? null;
+			if ( $callback === null || $this->isSmwHandler( $callback ) ) {
+				continue;
+			}
+			$preserved[] = $entry;
+		}
+
+		return $preserved;
+	}
+
+	/**
+	 * Writes the given normalized handler entries directly into HookContainer's
+	 * cache for $hook. Used to restore preserved entries verbatim after a clear,
+	 * since HookContainer::register() would re-normalize them and drop fields
+	 * like `args`.
+	 */
+	private function writeHandlerEntries( string $hook, array $entries ): void {
+		$property = $this->getHandlersProperty();
+		$handlers = $property->getValue( $this->hookContainer );
+		$handlers[$hook] = $entries;
+		$property->setValue( $this->hookContainer, $handlers );
+	}
+
+	private function getHandlersProperty(): ReflectionProperty {
+		if ( $this->handlersProperty === null ) {
+			$this->handlersProperty = new ReflectionProperty( HookContainer::class, 'handlers' );
+		}
+		return $this->handlersProperty;
+	}
+
+	private function isSmwHandler( $callback ): bool {
+		if ( is_string( $callback ) ) {
+			return str_starts_with( $callback, 'SMW\\' );
+		}
+
+		if ( is_array( $callback ) && isset( $callback[0] ) && is_object( $callback[0] ) ) {
+			return str_starts_with( $callback[0]::class, 'SMW\\' );
+		}
+
+		return false;
 	}
 
 	/**

--- a/tests/phpunit/Utils/MwHooksHandlerTest.php
+++ b/tests/phpunit/Utils/MwHooksHandlerTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace SMW\Tests\Utils;
+
+use MediaWiki\HookContainer\HookContainer;
+use MediaWiki\MediaWikiServices;
+use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+
+/**
+ * @covers \SMW\Tests\Utils\MwHooksHandler
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ */
+class MwHooksHandlerTest extends TestCase {
+
+	private HookContainer $hookContainer;
+	private ReflectionProperty $handlersProperty;
+
+	/** @var array<string, array> */
+	private array $handlerSnapshot = [];
+
+	private const PROBED_HOOKS = [
+		'ParserFirstCallInit',
+	];
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+		$this->handlersProperty = new ReflectionProperty( HookContainer::class, 'handlers' );
+
+		foreach ( self::PROBED_HOOKS as $hook ) {
+			$this->hookContainer->isRegistered( $hook );
+		}
+		$handlers = $this->handlersProperty->getValue( $this->hookContainer );
+		foreach ( self::PROBED_HOOKS as $hook ) {
+			$this->handlerSnapshot[$hook] = $handlers[$hook] ?? [];
+		}
+	}
+
+	protected function tearDown(): void {
+		$handlers = $this->handlersProperty->getValue( $this->hookContainer );
+		foreach ( $this->handlerSnapshot as $hook => $entries ) {
+			$handlers[$hook] = $entries;
+		}
+		$this->handlersProperty->setValue( $this->hookContainer, $handlers );
+		parent::tearDown();
+	}
+
+	public function testDeregisterListedHooksPreservesNonSmwClosureOnSharedHooks(): void {
+		$callback = static function (): bool {
+			return true;
+		};
+		$expectedDescription = '*closure#' . spl_object_hash( $callback ) . '*';
+
+		$this->hookContainer->register( 'ParserFirstCallInit', $callback );
+		$this->assertContains(
+			$expectedDescription,
+			$this->hookContainer->getHandlerDescriptions( 'ParserFirstCallInit' ),
+			'precondition: closure should be registered before deregisterListedHooks runs'
+		);
+
+		( new MwHooksHandler() )
+			->deregisterListedHooks()
+			->invokeHooksFromRegistry();
+
+		$this->assertContains(
+			$expectedDescription,
+			$this->hookContainer->getHandlerDescriptions( 'ParserFirstCallInit' ),
+			'non-SMW ParserFirstCallInit handler must survive deregisterListedHooks/invokeHooksFromRegistry (see issue #6797)'
+		);
+	}
+
+	public function testDeregisterListedHooksPreservesNonSmwObjectMethodOnSharedHooks(): void {
+		// Anonymous class has no SMW\ namespace prefix, so MwHooksHandler::isSmwHandler()
+		// classifies it as third-party.
+		$handler = new class() {
+			public function onParserFirstCallInit(): bool {
+				return true;
+			}
+		};
+		$expectedDescription = $handler::class . '::onParserFirstCallInit';
+
+		$this->hookContainer->register( 'ParserFirstCallInit', [ $handler, 'onParserFirstCallInit' ] );
+		$this->assertContains(
+			$expectedDescription,
+			$this->hookContainer->getHandlerDescriptions( 'ParserFirstCallInit' ),
+			'precondition: [obj, method] handler should be registered before deregisterListedHooks runs'
+		);
+
+		( new MwHooksHandler() )
+			->deregisterListedHooks()
+			->invokeHooksFromRegistry();
+
+		$this->assertContains(
+			$expectedDescription,
+			$this->hookContainer->getHandlerDescriptions( 'ParserFirstCallInit' ),
+			'non-SMW [obj, method] ParserFirstCallInit handler must survive deregisterListedHooks/invokeHooksFromRegistry'
+		);
+	}
+
+	public function testInvokeHooksFromRegistryRestoresSmwHandler(): void {
+		( new MwHooksHandler() )
+			->deregisterListedHooks()
+			->invokeHooksFromRegistry();
+
+		$smwHandlers = array_filter(
+			$this->hookContainer->getHandlerDescriptions( 'ParserFirstCallInit' ),
+			static fn ( string $d ): bool => str_starts_with( $d, 'SMW\\' )
+		);
+
+		$this->assertNotEmpty(
+			$smwHandlers,
+			'SMW ParserFirstCallInit handler must be re-registered after deregisterListedHooks/invokeHooksFromRegistry'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #6797. `MwHooksHandler::deregisterListedHooks()` called `HookContainer::clear()` for every hook in `Hooks::getHandlerList()`, which wipes *every* handler on the hook, not just SMW's. The subsequent `invokeHooksFromRegistry()` re-registers only SMW's handler, so third-party handlers on shared MediaWiki hooks (e.g. Scribunto's `ParserFirstCallInit`) silently disappear during tests that use `JSONScriptTestCaseRunner` or any descendant of it.

The PR snapshots non-SMW handler entries via reflection on `HookContainer::$handlers` before each clear and writes them back verbatim afterwards. Keeping the full normalized entry (not just the callback) means the `args` field for the deprecated `[$callable, $data...]` registration form survives the round-trip. SMW's own handlers are re-added by the existing `invokeHooksFromRegistry()` flow, ending up after the preserved entries on the call chain - a minor ordering change, but acceptable for the parser-callback-style hooks involved.

`listOfSmwHooks` (purely SMW extension points) keep the original clear-without-preservation behaviour: SMW-shipped `\$wgHooks` closures in `data/config/*.php` are expected to be reset there, and `HookDispatcherTest` relies on it.

## Why reflection?

`HookContainer` exposes no non-deprecated way to enumerate handlers. `getHandlerCallbacks()` has been deprecated since MW 1.41 and emits `wfDeprecated`, which would pollute test output. Reflection on the private `$handlers` property is the pragmatic choice in test-only code.

## Test plan

- [x] `composer analyze` clean on the changed files
- [x] New `MwHooksHandlerTest` covering closure handlers, `[\$obj, \$method]` handlers, and SMW handler re-registration (with setUp/tearDown snapshotting so no hook state leaks)
- [x] `HookDispatcherTest::testOnInstallerBeforeCreateTablesComplete` (which relies on `data/config/db-primary-keys.php` being cleared) still passes
- [x] Full unit suite: 6850 tests, 0 failures, 6 pre-existing skips (5 elasticsearch-php, 1 Postgres mock)
- [x] `JSONScriptTestCaseRunnerTest` (the runner where the bug manifests): 400+ JSON fixtures pass