### PR TITLE
Pass RequestOptions to KeysetPaginationTrait as parameter

### DIFF
--- a/src/SQLStore/EntityStore/PropertySubjectsLookup.php
+++ b/src/SQLStore/EntityStore/PropertySubjectsLookup.php
@@ -28,14 +28,6 @@ class PropertySubjectsLookup {
 
 	use KeysetPaginationTrait;
 
-	/**
-	 * Required by `KeysetPaginationTrait`. Set transiently inside `doFetch()`
-	 * to the per-call (already-cloned) RequestOptions before invoking the
-	 * trait's `applyCursorPagination()`. Not exposed; the public entry points
-	 * always provide RequestOptions explicitly.
-	 */
-	private ?RequestOptions $requestOptions = null;
-
 	private IteratorFactory $iteratorFactory;
 
 	/**
@@ -332,8 +324,7 @@ class PropertySubjectsLookup {
 			if ( $requestOptions->limit > 0 ) {
 				$qb->limit( $requestOptions->limit + 1 );
 			}
-			$this->requestOptions = $requestOptions;
-			$this->applyCursorPagination( $qb, $connection );
+			$this->applyCursorPagination( $qb, $connection, $requestOptions );
 		}
 
 		LegacyOptionsApplier::applyTo( $qb, $opts );
@@ -353,10 +344,6 @@ class PropertySubjectsLookup {
 		if ( $cursorMode ) {
 			$res = $this->postProcessCursorResult( $res, $callerRequestOptions, $requestOptions );
 		}
-
-		// Clear the transient field so subsequent calls do not pick up a stale
-		// reference from this one if they take the non-cursor path.
-		$this->requestOptions = null;
 
 		return $res;
 	}

--- a/src/SQLStore/Lookup/KeysetPaginationTrait.php
+++ b/src/SQLStore/Lookup/KeysetPaginationTrait.php
@@ -8,12 +8,24 @@ use SMW\SQLStore\SQLStore;
 use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
- * Shared keyset (cursor-based) pagination logic for property list lookups.
+ * Shared keyset (cursor-based) pagination logic for paginated lookups.
+ *
+ * Consumers must expose `$this->store` (used to resolve cursor sort keys).
+ * `RequestOptions` is passed explicitly to `applyCursorPagination()` rather
+ * than read from a field, so any class with a store reference (Lookup,
+ * SpecialPage, or otherwise) can use the trait without surfacing the
+ * options instance as a field.
+ *
+ * The trait only emits the cursor WHERE predicate and ORDER BY (and falls
+ * back to OFFSET when no cursor is active). Populating cursor metadata
+ * (`firstCursor`, `lastCursor`, `cursorHasMore`) on the caller's
+ * `RequestOptions` after `fetchResultSet()` is the consumer's
+ * responsibility, since only the consumer knows how to trim the lookahead
+ * row and reverse on backward navigation.
  *
  * @since 7.0
  *
  * @property SQLStore $store
- * @property RequestOptions $requestOptions
  */
 trait KeysetPaginationTrait {
 
@@ -49,12 +61,17 @@ trait KeysetPaginationTrait {
 	 *
 	 * @param SelectQueryBuilder $queryBuilder
 	 * @param Database $db
+	 * @param RequestOptions $requestOptions
 	 *
 	 * @return void
 	 */
-	private function applyCursorPagination( SelectQueryBuilder $queryBuilder, Database $db ): void {
-		$cursorAfter = $this->requestOptions->getCursorAfter();
-		$cursorBefore = $this->requestOptions->getCursorBefore();
+	private function applyCursorPagination(
+		SelectQueryBuilder $queryBuilder,
+		Database $db,
+		RequestOptions $requestOptions
+	): void {
+		$cursorAfter = $requestOptions->getCursorAfter();
+		$cursorBefore = $requestOptions->getCursorBefore();
 
 		if ( $cursorAfter !== null ) {
 			$sort = $this->resolveCursorSort( $cursorAfter );
@@ -78,8 +95,8 @@ trait KeysetPaginationTrait {
 			$queryBuilder->orderBy( [ 'smw_sort', 'smw_id' ], SelectQueryBuilder::SORT_DESC );
 		} else {
 			$queryBuilder->orderBy( [ 'smw_sort', 'smw_id' ], SelectQueryBuilder::SORT_ASC );
-			if ( $this->requestOptions->offset > 0 ) {
-				$queryBuilder->offset( $this->requestOptions->offset );
+			if ( $requestOptions->offset > 0 ) {
+				$queryBuilder->offset( $requestOptions->offset );
 			}
 		}
 	}

--- a/src/SQLStore/Lookup/PropertyUsageListLookup.php
+++ b/src/SQLStore/Lookup/PropertyUsageListLookup.php
@@ -104,7 +104,7 @@ class PropertyUsageListLookup implements ListLookup {
 			$queryBuilder->limit( $this->requestOptions->limit + 1 );
 		}
 
-		$this->applyCursorPagination( $queryBuilder, $db );
+		$this->applyCursorPagination( $queryBuilder, $db, $this->requestOptions );
 
 		return $queryBuilder->fetchResultSet();
 	}

--- a/src/SQLStore/Lookup/PropertyUsageListLookup.php
+++ b/src/SQLStore/Lookup/PropertyUsageListLookup.php
@@ -3,7 +3,6 @@
 namespace SMW\SQLStore\Lookup;
 
 use MediaWiki\Message\Message;
-use RuntimeException;
 use SMW\DataItems\Error;
 use SMW\DataItems\Property;
 use SMW\Exception\PropertyLabelNotResolvedException;
@@ -29,7 +28,7 @@ class PropertyUsageListLookup implements ListLookup {
 	public function __construct(
 		private readonly Store $store,
 		private readonly PropertyStatisticsStore $propertyStatisticsStore,
-		private readonly ?RequestOptions $requestOptions = null,
+		private readonly RequestOptions $requestOptions,
 	) {
 	}
 
@@ -37,13 +36,8 @@ class PropertyUsageListLookup implements ListLookup {
 	 * @since 2.2
 	 *
 	 * @return Property[]|Error[]|int[]
-	 * @throws RuntimeException
 	 */
 	public function fetchList(): array {
-		if ( $this->requestOptions === null ) {
-			throw new RuntimeException( "Missing requestOptions" );
-		}
-
 		return $this->getPropertyList( $this->doQueryPropertyTable() );
 	}
 
@@ -71,7 +65,7 @@ class PropertyUsageListLookup implements ListLookup {
 	 * @return string
 	 */
 	public function getHash(): string {
-		return __METHOD__ . '#' . ( $this->requestOptions !== null ? $this->requestOptions->getHash() : '' );
+		return __METHOD__ . '#' . $this->requestOptions->getHash();
 	}
 
 	private function doQueryPropertyTable() {

--- a/src/SQLStore/Lookup/UnusedPropertyListLookup.php
+++ b/src/SQLStore/Lookup/UnusedPropertyListLookup.php
@@ -104,7 +104,7 @@ class UnusedPropertyListLookup implements ListLookup {
 			$queryBuilder->limit( $this->requestOptions->limit + 1 );
 		}
 
-		$this->applyCursorPagination( $queryBuilder, $db );
+		$this->applyCursorPagination( $queryBuilder, $db, $this->requestOptions );
 
 		return $queryBuilder->fetchResultSet();
 	}

--- a/src/SQLStore/Lookup/UnusedPropertyListLookup.php
+++ b/src/SQLStore/Lookup/UnusedPropertyListLookup.php
@@ -3,7 +3,6 @@
 namespace SMW\SQLStore\Lookup;
 
 use MediaWiki\Message\Message;
-use RuntimeException;
 use SMW\DataItems\Error;
 use SMW\DataItems\Property;
 use SMW\Exception\PropertyLabelNotResolvedException;
@@ -30,7 +29,7 @@ class UnusedPropertyListLookup implements ListLookup {
 	public function __construct(
 		private readonly Store $store,
 		private readonly PropertyStatisticsStore $propertyStatisticsStore,
-		private readonly ?RequestOptions $requestOptions = null,
+		private readonly RequestOptions $requestOptions,
 	) {
 	}
 
@@ -38,13 +37,8 @@ class UnusedPropertyListLookup implements ListLookup {
 	 * @since 2.2
 	 *
 	 * @return Property[]
-	 * @throws RuntimeException
 	 */
 	public function fetchList(): array {
-		if ( $this->requestOptions === null ) {
-			throw new RuntimeException( "Missing requestOptions" );
-		}
-
 		return $this->buildPropertyList( $this->selectPropertiesFromTable() );
 	}
 
@@ -72,7 +66,7 @@ class UnusedPropertyListLookup implements ListLookup {
 	 * @return string
 	 */
 	public function getHash(): string {
-		return __METHOD__ . '#' . ( $this->requestOptions !== null ? $this->requestOptions->getHash() : '' );
+		return __METHOD__ . '#' . $this->requestOptions->getHash();
 	}
 
 	private function selectPropertiesFromTable() {

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -214,7 +214,7 @@ class SQLStoreFactory {
 		$propertyUsageListLookup = new PropertyUsageListLookup(
 			$this->store,
 			$this->newPropertyStatisticsStore(),
-			$requestOptions
+			$requestOptions ?? new RequestOptions()
 		);
 
 		return $this->newCachedListLookup(
@@ -237,7 +237,7 @@ class SQLStoreFactory {
 		$unusedPropertyListLookup = new UnusedPropertyListLookup(
 			$this->store,
 			$this->newPropertyStatisticsStore(),
-			$requestOptions
+			$requestOptions ?? new RequestOptions()
 		);
 
 		return $this->newCachedListLookup(

--- a/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
@@ -100,16 +100,6 @@ class PropertyUsageListLookupTest extends TestCase {
 		);
 	}
 
-	public function testTryTofetchListForMissingOptionsThrowsException() {
-		$instance = new PropertyUsageListLookup(
-			$this->store,
-			$this->propertyStatisticsStore
-		);
-
-		$this->expectException( 'RuntimeException' );
-		$instance->fetchList();
-	}
-
 	/**
 	 * @dataProvider usageCountProvider
 	 */

--- a/tests/phpunit/Unit/SQLStore/Lookup/UnusedPropertyListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/UnusedPropertyListLookupTest.php
@@ -47,7 +47,11 @@ class UnusedPropertyListLookupTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			UnusedPropertyListLookup::class,
-			new UnusedPropertyListLookup( $this->store, $this->propertyStatisticsStore, null )
+			new UnusedPropertyListLookup(
+				$this->store,
+				$this->propertyStatisticsStore,
+				new RequestOptions()
+			)
 		);
 	}
 
@@ -96,16 +100,6 @@ class UnusedPropertyListLookupTest extends TestCase {
 			$lookupIdentifier,
 			$instance->getHash()
 		);
-	}
-
-	public function testTryTofetchListForMissingOptionsThrowsException() {
-		$instance = new UnusedPropertyListLookup(
-			$this->store,
-			$this->propertyStatisticsStore
-		);
-
-		$this->expectException( 'RuntimeException' );
-		$instance->fetchList();
 	}
 
 	public function testfetchListForValidProperty() {


### PR DESCRIPTION
## Summary

- **Commit 1**: Change `KeysetPaginationTrait::applyCursorPagination()` to accept `RequestOptions` as a third parameter instead of reading from `$this->requestOptions`. Updates all three existing consumers and removes the transient-field hack from `PropertySubjectsLookup` (introduced in #6796).
- **Commit 2 (drive-by)**: Tighten the constructor signatures of `PropertyUsageListLookup` and `UnusedPropertyListLookup` from `?RequestOptions = null` to non-nullable `RequestOptions`. Removes now-unreachable null guards and the matching unit tests. Factory keeps its nullable signature for backward compatibility; defaults to `new RequestOptions()` internally.
- Unblocks the rest of the OFFSET-to-keyset migration on consumers that don't naturally hold a `RequestOptions` field (Special:Concepts, Special:Types, etc. in [#6795](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6795)).

## Background

After #6794 (trait predicate fix) and #6796 (Property:Foo), three consumers use the trait:

- `PropertyUsageListLookup` (Special:Properties) and `UnusedPropertyListLookup` (Special:UnusedProperties) both naturally hold a constructor-injected `?RequestOptions` field. The trait read it directly via `$this->requestOptions`.
- `PropertySubjectsLookup` (Property:Foo) is constructed once and called many times via `fetchFromTable( $pid, $proptable, $dataItem, $requestOptions )`. To satisfy the trait's `$this->requestOptions` requirement, the lookup declared a `private ?RequestOptions $requestOptions = null` transient field, assigned it before calling `applyCursorPagination()`, and reset it to null afterwards. This pattern was acknowledged in #6796 as a hack.

Phase 2 of the migration adds more consumers shaped like `PropertySubjectsLookup` (Specials with their own `fetchFromTable` methods, not Lookup classes). Rather than repeat the transient-field hack at each consumer, the trait now accepts options as a parameter.

## Commit 1: trait signature change

```php
// Before
private function applyCursorPagination( SelectQueryBuilder $queryBuilder, Database $db ): void {
    $cursorAfter = $this->requestOptions->getCursorAfter();
    ...
}

// After
private function applyCursorPagination(
    SelectQueryBuilder $queryBuilder,
    Database $db,
    RequestOptions $requestOptions
): void {
    $cursorAfter = $requestOptions->getCursorAfter();
    ...
}
```

Consumer call sites:

- `PropertyUsageListLookup::doQueryPropertyTable()`: `$this->applyCursorPagination( $queryBuilder, $db, $this->requestOptions )`
- `UnusedPropertyListLookup::doQueryPropertyTable()`: same
- `PropertySubjectsLookup::doFetch()`: `$this->applyCursorPagination( $qb, $connection, $requestOptions )` (using the local cloned options variable). The transient field, the `$this->requestOptions = $requestOptions` assignment, and the `$this->requestOptions = null` reset are all deleted.

The trait docblock now documents the consumer contract more precisely:

- Consumers must expose `$this->store` (for cursor sort resolution).
- The trait only emits the WHERE predicate and ORDER BY. Populating cursor metadata (`firstCursor`, `lastCursor`, `cursorHasMore`) on the caller's RequestOptions after `fetchResultSet()` is the consumer's responsibility, since only the consumer knows how to trim the lookahead row and reverse on backward navigation.

## Commit 2: non-nullable RequestOptions in ListLookup consumers (drive-by)

`PropertyUsageListLookup` and `UnusedPropertyListLookup` declared `private readonly ?RequestOptions $requestOptions = null` but `fetchList()` required a non-null instance, guarded by a `RuntimeException`. After Commit 1, the constructor's nullable type is the only thing forcing static analysers to allow null at the trait call site.

Changes:

- Both constructors: `?RequestOptions = null` -> `RequestOptions` (required)
- Drop the runtime null guard in `fetchList()`
- Drop `testTryTofetchListForMissingOptionsThrowsException` in both unit tests (the throw is gone)
- Drop the `RuntimeException` use import and the `@throws` annotation
- Simplify `getHash()`: `$this->requestOptions !== null ? ... : ''` -> always-non-null

`SQLStoreFactory::newPropertyUsageCachedListLookup` and `newUnusedPropertyCachedListLookup` keep their `?RequestOptions = null` signatures for backward compatibility with existing callers (`Store::getPropertiesSpecial( $requestoptions = null )` and the factory's own `deleteCache()` path). When called with null, the factory now constructs a default `new RequestOptions()` before forwarding.

## Behaviour

No external behaviour change. Pure refactor.

- SQL emitted at all three call sites is byte-identical (WHERE predicates, ORDER BY, OFFSET fall-back).
- Cursor metadata write-back in `PropertySubjectsLookup` continues to use the caller's `RequestOptions` instance (preserved from #6796).
- All existing unit and integration tests pass unchanged (modulo the two deleted `testTryTofetchListForMissingOptionsThrowsException` tests).

## Test plan

- [x] `composer phpunit:unit` (full unit suite, 0 failures, 6 pre-existing skips)
- [x] Targeted suite (`KeysetPagination|PropertyUsageList|UnusedPropertyList|PropertySubjects|SQLStoreFactoryTest`): 107 tests / 404 assertions green
- [x] `composer analyze` clean
- [x] PHPCS clean on all changed files (`vendor/bin/phpcs -sp --no-cache`)
- [x] Browser smoke test against the dev wiki: `Special:Properties?limit=5` paginates correctly (next emits `?after=N`, prev emits `?before=N`), `Special:UnusedProperties` renders without errors
- [ ] CI green
- [ ] Reviewer verification

## Refs

- #6559 (performance audit)
- #6564 (initial keyset trait)
- #6794 (trait predicate fix)
- #6796 (Property:Foo / PropertySubjectsLookup, source of the transient-field hack now removed)
- #6795 (tracking issue, unblocks Phase 2 Specials)