### PR TITLE
Apply keyset cursor pagination to Special:Concepts

### DIFF
--- a/src/MediaWiki/Specials/SpecialConcepts.php
+++ b/src/MediaWiki/Specials/SpecialConcepts.php
@@ -6,8 +6,11 @@ use MediaWiki\Html\Html;
 use MediaWiki\SpecialPage\SpecialPage;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Collator;
+use SMW\MediaWiki\MessageBuilder;
 use SMW\MediaWiki\Page\ListBuilder;
+use SMW\RequestOptions;
 use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\SQLStore\Lookup\KeysetPaginationTrait;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Utils\HtmlTabs;
@@ -22,6 +25,8 @@ use SMW\Utils\Pager;
  * @author mwjames
  */
 class SpecialConcepts extends SpecialPage {
+
+	use KeysetPaginationTrait;
 
 	private ?Store $store = null;
 
@@ -43,18 +48,102 @@ class SpecialConcepts extends SpecialPage {
 			'ext.smw.page.styles'
 		] );
 
-		$limit = $this->getRequest()->getVal( 'limit', 50 );
-		$offset = $this->getRequest()->getVal( 'offset', 0 );
+		$request = $this->getRequest();
+		$limit = (int)$request->getVal( 'limit', 50 );
+		$offset = (int)$request->getVal( 'offset', 0 );
+		$after = $request->getInt( 'after', 0 );
+		$before = $request->getInt( 'before', 0 );
 
 		$this->store = ApplicationFactory::getInstance()->getStore();
 
-		$diWikiPages = $this->fetchFromTable( $limit, $offset );
-		$html = $this->getHtml( $diWikiPages, $limit, $offset );
+		// Cursor mode unless a legacy `?offset=N` URL is in play. Bots and
+		// fresh visitors fall into cursor mode; deep-indexed legacy URLs
+		// continue to render via the offset path.
+		$cursorMode = $offset === 0;
+
+		if ( $cursorMode ) {
+			$options = new RequestOptions();
+			$options->limit = $limit;
+			$options->setOption( RequestOptions::CURSOR_MODE, true );
+			if ( $after > 0 ) {
+				$options->setCursorAfter( $after );
+			} elseif ( $before > 0 ) {
+				$options->setCursorBefore( $before );
+			}
+			$diWikiPages = $this->doCursorFetch( $options );
+			$html = $this->getHtml( $diWikiPages, $limit, $offset, $options );
+		} else {
+			$diWikiPages = $this->fetchFromTable( $limit, $offset );
+			$html = $this->getHtml( $diWikiPages, $limit, $offset );
+		}
 
 		$this->addHelpLink( $this->msg( 'smw-helplink-concepts' )->escaped(), true );
 
 		$out->setPageTitle( $this->msg( 'concepts' )->text() );
 		$out->addHTML( $html );
+	}
+
+	/**
+	 * Cursor-aware fetch used by `execute()` when on the cursor URL path.
+	 * Applies `KeysetPaginationTrait::applyCursorPagination()` to the same
+	 * underlying query that `fetchFromTable()` emits, plus a `LIMIT + 1`
+	 * lookahead. Populates cursor metadata (`firstCursor`, `lastCursor`,
+	 * `cursorHasMore`) on the caller's `RequestOptions` for the pager
+	 * renderer to read.
+	 *
+	 * @since 7.0.0
+	 */
+	private function doCursorFetch( RequestOptions $options ): array {
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$qb = $connection->newSelectQueryBuilder()
+			->select( [ 'smw_id', 'smw_title' ] )
+			->tables( [
+				SQLStore::ID_TABLE,
+				SQLStore::CONCEPT_TABLE
+			] )
+			->joinConds( [
+				SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=s_id' ] ]
+			] )
+			->where( [
+				'smw_namespace' => SMW_NS_CONCEPT,
+				'smw_iw' => '',
+				'smw_subobject' => '',
+				'smw_proptable_hash IS NOT NULL',
+				'concept_features > 0'
+			] )
+			->caller( __METHOD__ );
+
+		if ( $options->limit > 0 ) {
+			$qb->limit( $options->limit + 1 );
+		}
+		$this->applyCursorPagination( $qb, $connection, $options );
+
+		$rows = [];
+		foreach ( $qb->fetchResultSet() as $row ) {
+			$rows[] = $row;
+		}
+
+		if ( $options->limit > 0 && count( $rows ) > $options->limit ) {
+			array_pop( $rows );
+			$options->setCursorHasMore( true );
+		}
+
+		if ( $options->getCursorBefore() !== null ) {
+			$rows = array_reverse( $rows );
+		}
+
+		if ( $rows !== [] ) {
+			$options->setFirstCursor( (int)$rows[0]->smw_id );
+			$options->setLastCursor( (int)$rows[count( $rows ) - 1]->smw_id );
+		}
+
+		$results = [];
+		foreach ( $rows as $row ) {
+			$results[] = new WikiPage( $row->smw_title, SMW_NS_CONCEPT );
+		}
+
+		return $results;
 	}
 
 	/**
@@ -114,10 +203,14 @@ class SpecialConcepts extends SpecialPage {
 	 * @param WikiPage[] $dataItems
 	 * @param int $limit
 	 * @param int $offset
+	 * @param RequestOptions|null $cursorOptions When non-null, the pager is
+	 *   rendered in cursor mode using `MessageBuilder::cursorPrevNextToText`
+	 *   and the cursor metadata on `$cursorOptions`. When null, the legacy
+	 *   offset pager (`Pager::pagination`) is rendered.
 	 *
 	 * @return string
 	 */
-	public function getHtml( array $dataItems, $limit, $offset ): string {
+	public function getHtml( array $dataItems, $limit, $offset, ?RequestOptions $cursorOptions = null ): string {
 		if ( $this->store === null ) {
 			$this->store = ApplicationFactory::getInstance()->getStore();
 		}
@@ -143,13 +236,29 @@ class SpecialConcepts extends SpecialPage {
 			$this->getLanguage()->isRTL()
 		);
 
+		if ( $cursorOptions !== null ) {
+			$msgBuilder = new MessageBuilder( $this->getLanguage() );
+			$isFirstPage = !$cursorOptions->hasCursor();
+			$paginationHtml = $msgBuilder->cursorPrevNextToText(
+				$this->getPageTitle(),
+				$limit,
+				$isFirstPage ? null : $cursorOptions->getFirstCursor(),
+				$cursorOptions->getLastCursor(),
+				[],
+				!$cursorOptions->getCursorHasMore(),
+				$cursorOptions->getCursorBefore() !== null
+			);
+		} else {
+			$paginationHtml = Pager::pagination( $this->getPageTitle(), $limit, $offset, $count );
+		}
+
 		$html = Html::rawElement(
 				'div',
 				[ 'id' => 'mw-pages' ],
 			Html::rawElement(
 				'div',
 				[ 'class' => 'smw-page-navigation' ],
-				Pager::pagination( $this->getPageTitle(), $limit, $offset, $count )
+				$paginationHtml
 			) . Html::element(
 				'div',
 				[ 'class' => $key, 'style' => 'margin-top:10px;margin-bottom:10px;' ],

--- a/src/MediaWiki/Specials/SpecialConcepts.php
+++ b/src/MediaWiki/Specials/SpecialConcepts.php
@@ -56,15 +56,11 @@ class SpecialConcepts extends SpecialPage {
 
 		$this->store = ApplicationFactory::getInstance()->getStore();
 
-		// Cursor mode unless a legacy `?offset=N` URL is in play. Bots and
-		// fresh visitors fall into cursor mode; deep-indexed legacy URLs
-		// continue to render via the offset path.
-		$cursorMode = $offset === 0;
+		$cursorMode = self::shouldUseCursorMode( $request->getVal( 'offset', null ) );
 
 		if ( $cursorMode ) {
 			$options = new RequestOptions();
 			$options->limit = $limit;
-			$options->setOption( RequestOptions::CURSOR_MODE, true );
 			if ( $after > 0 ) {
 				$options->setCursorAfter( $after );
 			} elseif ( $before > 0 ) {
@@ -95,24 +91,7 @@ class SpecialConcepts extends SpecialPage {
 	 */
 	private function doCursorFetch( RequestOptions $options ): array {
 		$connection = $this->store->getConnection( 'mw.db' );
-
-		$qb = $connection->newSelectQueryBuilder()
-			->select( [ 'smw_id', 'smw_title' ] )
-			->tables( [
-				SQLStore::ID_TABLE,
-				SQLStore::CONCEPT_TABLE
-			] )
-			->joinConds( [
-				SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=s_id' ] ]
-			] )
-			->where( [
-				'smw_namespace' => SMW_NS_CONCEPT,
-				'smw_iw' => '',
-				'smw_subobject' => '',
-				'smw_proptable_hash IS NOT NULL',
-				'concept_features > 0'
-			] )
-			->caller( __METHOD__ );
+		$qb = $this->newConceptQueryBuilder( $connection, __METHOD__ );
 
 		if ( $options->limit > 0 ) {
 			$qb->limit( $options->limit + 1 );
@@ -156,28 +135,31 @@ class SpecialConcepts extends SpecialPage {
 	 */
 	public function fetchFromTable( $limit, $offset ): array {
 		$connection = $this->store->getConnection( 'mw.db' );
+
+		$res = $this->newConceptQueryBuilder( $connection, __METHOD__ )
+			->options( [
+				'LIMIT' => $limit + 1,
+				'OFFSET' => $offset,
+			] )
+			->fetchResultSet();
+
 		$results = [];
+		foreach ( $res as $row ) {
+			$results[] = new WikiPage( $row->smw_title, SMW_NS_CONCEPT );
+		}
 
-		$fields = [
-			'smw_id',
-			'smw_title'
-		];
+		return $results;
+	}
 
-		$conditions = [
-			'smw_namespace' => SMW_NS_CONCEPT,
-			'smw_iw' => '',
-			'smw_subobject' => '',
-			'smw_proptable_hash IS NOT NULL',
-			'concept_features > 0'
-		];
-
-		$options = [
-			'LIMIT' => $limit + 1,
-			'OFFSET' => $offset,
-		];
-
-		$res = $connection->newSelectQueryBuilder()
-			->select( $fields )
+	/**
+	 * Shared base query for both `doCursorFetch()` and `fetchFromTable()`:
+	 * the JOIN onto `smw_object_ids` and the production filter. Each caller
+	 * appends its own LIMIT/OFFSET/ORDER BY (legacy via the options array,
+	 * cursor via the trait).
+	 */
+	private function newConceptQueryBuilder( $connection, string $caller ) {
+		return $connection->newSelectQueryBuilder()
+			->select( [ 'smw_id', 'smw_title' ] )
 			->tables( [
 				SQLStore::ID_TABLE,
 				SQLStore::CONCEPT_TABLE
@@ -185,16 +167,14 @@ class SpecialConcepts extends SpecialPage {
 			->joinConds( [
 				SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=s_id' ] ]
 			] )
-			->where( $conditions )
-			->options( $options )
-			->caller( __METHOD__ )
-			->fetchResultSet();
-
-		foreach ( $res as $row ) {
-			$results[] = new WikiPage( $row->smw_title, SMW_NS_CONCEPT );
-		}
-
-		return $results;
+			->where( [
+				'smw_namespace' => SMW_NS_CONCEPT,
+				'smw_iw' => '',
+				'smw_subobject' => '',
+				'smw_proptable_hash IS NOT NULL',
+				'concept_features > 0'
+			] )
+			->caller( $caller );
 	}
 
 	/**
@@ -278,6 +258,27 @@ class SpecialConcepts extends SpecialPage {
 			[ 'class' => 'smw-special-concept-docu plainlinks' ],
 			$this->msg( 'smw-special-concept-docu' )->parse()
 		) . $html;
+	}
+
+	/**
+	 * Decides whether the request should be served via the cursor path or
+	 * the legacy offset path. Cursor mode is the default; the legacy path
+	 * is taken whenever the `offset` URL param is present at all, even if
+	 * its value is empty, garbage, or negative. The reasoning: an `offset=`
+	 * param signals offset semantics on the client side, so we honour the
+	 * intent rather than silently switching modes when the value coerces
+	 * to 0.
+	 *
+	 * Extracted as a static helper so the predicate can be unit-tested
+	 * without spinning up the full request context.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string|null $offsetParamValue The raw value of `?offset=` from
+	 *   the request, or null if the param is absent.
+	 */
+	public static function shouldUseCursorMode( ?string $offsetParamValue ): bool {
+		return $offsetParamValue === null;
 	}
 
 	/**

--- a/tests/phpunit/Integration/MediaWiki/Specials/SpecialConceptsKeysetIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Specials/SpecialConceptsKeysetIntegrationTest.php
@@ -168,6 +168,7 @@ class SpecialConceptsKeysetIntegrationTest extends SMWIntegrationTestCase {
 			$guard++;
 		} while ( $cursorAfter !== null && $options->getCursorHasMore() && $guard < 1000 );
 
+		$this->assertLessThan( 1000, $guard, 'forward cursor loop did not terminate' );
 		$this->assertSame( $offsetSequence, $cursorSequence );
 	}
 
@@ -177,7 +178,7 @@ class SpecialConceptsKeysetIntegrationTest extends SMWIntegrationTestCase {
 		$this->assertNotEmpty( $offsetSequence );
 
 		$lastTitle = end( $offsetSequence );
-		$startId = $this->lookupSmwIdForTitle( $store, $lastTitle );
+		$startId = $this->lookupSmwIdForTitle( $store->getConnection( 'mw.db' ), $lastTitle );
 		$this->assertNotNull( $startId );
 
 		$cursorSequence = [];
@@ -201,6 +202,8 @@ class SpecialConceptsKeysetIntegrationTest extends SMWIntegrationTestCase {
 			$cursorBefore = $options->getFirstCursor();
 			$guard++;
 		} while ( $cursorBefore !== null && $options->getCursorHasMore() && $guard < 1000 );
+
+		$this->assertLessThan( 1000, $guard, 'backward cursor loop did not terminate' );
 
 		// setCursorBefore is strict less-than; the start row never appears
 		// in any page. Reinstate it for direct comparison with OFFSET.
@@ -274,6 +277,14 @@ class SpecialConceptsKeysetIntegrationTest extends SMWIntegrationTestCase {
 			$pageTitles,
 			'Stale cursor must fall back to the first page of results'
 		);
+		$this->assertNotNull(
+			$options->getFirstCursor(),
+			'firstCursor must be populated from the fallback page'
+		);
+		$this->assertNotNull(
+			$options->getLastCursor(),
+			'lastCursor must be populated from the fallback page'
+		);
 	}
 
 	private function buildCursorOptions( ?int $cursorAfter, ?int $cursorBefore ): RequestOptions {
@@ -345,12 +356,7 @@ class SpecialConceptsKeysetIntegrationTest extends SMWIntegrationTestCase {
 		return $titles;
 	}
 
-	private function lookupSmwIdForTitle( $dbOrStore, string $title ): ?int {
-		// Accept either a Store or a Database (parameter name reuse from PR 1).
-		$db = is_object( $dbOrStore ) && method_exists( $dbOrStore, 'getConnection' )
-			? $dbOrStore->getConnection( 'mw.db' )
-			: $dbOrStore;
-
+	private function lookupSmwIdForTitle( $db, string $title ): ?int {
 		$row = $db->newSelectQueryBuilder()
 			->select( 'smw_id' )
 			->from( SQLStore::ID_TABLE )

--- a/tests/phpunit/Integration/MediaWiki/Specials/SpecialConceptsKeysetIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Specials/SpecialConceptsKeysetIntegrationTest.php
@@ -1,0 +1,376 @@
+<?php
+
+namespace SMW\Tests\Integration\MediaWiki\Specials;
+
+use SMW\MediaWiki\Specials\SpecialConcepts;
+use SMW\RequestOptions;
+use SMW\SQLStore\SQLStore;
+use SMW\Tests\SMWIntegrationTestCase;
+use SMW\Tests\Utils\UtilityFactory;
+
+/**
+ * Locks the cursor traversal contract for `SpecialConcepts` (the keyset-aware
+ * private `doCursorFetch()` method exercised through the public
+ * `fetchFromTable()` shim and the cursor-mode URL flow in `execute()`).
+ *
+ * Seeds N concept pages directly into `smw_object_ids` + `smw_fpt_conc`
+ * (since the production write path for concepts is the
+ * `[[Concept:Foo]]` parser-function flow, which is more brittle in tests).
+ * Walks the result list forward and backward via cursors and asserts the
+ * sequences match an OFFSET control walk over the same data. Includes a
+ * deliberate tied-`smw_sort` pair to exercise the predicate's tiebreak path.
+ *
+ * @group semantic-mediawiki
+ * @group Database
+ * @group medium
+ *
+ * @covers \SMW\SQLStore\Lookup\KeysetPaginationTrait
+ * @covers \SMW\MediaWiki\Specials\SpecialConcepts
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class SpecialConceptsKeysetIntegrationTest extends SMWIntegrationTestCase {
+
+	private const SEED_COUNT = 12;
+	private const PAGE_SIZE = 3;
+	private const TIED_LOW_INDEX = 11;
+	private const TIED_HIGH_INDEX = 12;
+
+	private string $titlePrefix;
+	private string $tiedSortValue;
+
+	private array $seededIds = [];
+	private $mwHooksHandler;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$runId = bin2hex( random_bytes( 4 ) );
+		$this->titlePrefix = 'SpecialConceptsKeysetTest_' . $runId . '_Concept_';
+		$this->tiedSortValue = $this->titlePrefix . '02_TIE';
+
+		$this->mwHooksHandler = UtilityFactory::getInstance()->newMwHooksHandler();
+		$this->mwHooksHandler->deregisterListedHooks();
+
+		$store = $this->getStore();
+		$db = $store->getConnection( 'mw.db' );
+
+		for ( $i = 1; $i <= self::SEED_COUNT; $i++ ) {
+			$title = $this->titleForIndex( $i );
+			$sortValue = ( $i === self::TIED_LOW_INDEX || $i === self::TIED_HIGH_INDEX )
+				? $this->tiedSortValue
+				: $title;
+
+			$db->newInsertQueryBuilder()
+				->insertInto( SQLStore::ID_TABLE )
+				->row( [
+					'smw_namespace' => SMW_NS_CONCEPT,
+					'smw_title' => $title,
+					'smw_iw' => '',
+					'smw_subobject' => '',
+					'smw_sortkey' => $title,
+					'smw_sort' => $sortValue,
+					'smw_proptable_hash' => 'test-hash',
+					'smw_hash' => null,
+					'smw_rev' => null,
+					'smw_touched' => null,
+				] )
+				->caller( __METHOD__ )
+				->execute();
+
+			$smwId = (int)$db->insertId();
+			$this->seededIds[] = $smwId;
+
+			$db->newInsertQueryBuilder()
+				->insertInto( SQLStore::CONCEPT_TABLE )
+				->row( [
+					's_id' => $smwId,
+					'concept_txt' => '',
+					'concept_docu' => '',
+					'concept_features' => 1,
+					'concept_size' => 0,
+					'concept_depth' => 0,
+					'cache_date' => null,
+					'cache_count' => null,
+				] )
+				->caller( __METHOD__ )
+				->execute();
+		}
+	}
+
+	protected function tearDown(): void {
+		$store = $this->getStore();
+		$db = $store->getConnection( 'mw.db' );
+
+		if ( $this->seededIds !== [] ) {
+			$db->newDeleteQueryBuilder()
+				->deleteFrom( SQLStore::CONCEPT_TABLE )
+				->where( [ 's_id' => $this->seededIds ] )
+				->caller( __METHOD__ )
+				->execute();
+
+			$db->newDeleteQueryBuilder()
+				->deleteFrom( SQLStore::ID_TABLE )
+				->where( [ 'smw_id' => $this->seededIds ] )
+				->caller( __METHOD__ )
+				->execute();
+		}
+
+		$this->mwHooksHandler->restoreListedHooks();
+
+		parent::tearDown();
+	}
+
+	public function testSeedActuallyContainsATiedPair(): void {
+		$store = $this->getStore();
+		$offsetSequence = $this->collectOffsetSequence( $store );
+
+		$tiedLow = $this->titleForIndex( self::TIED_LOW_INDEX );
+		$tiedHigh = $this->titleForIndex( self::TIED_HIGH_INDEX );
+
+		$lowPos = array_search( $tiedLow, $offsetSequence, true );
+		$highPos = array_search( $tiedHigh, $offsetSequence, true );
+
+		$this->assertNotFalse( $lowPos, 'Lower-id tied concept must appear in OFFSET sequence' );
+		$this->assertNotFalse( $highPos, 'Higher-id tied concept must appear in OFFSET sequence' );
+		$this->assertSame(
+			2,
+			$lowPos,
+			'Lower-id tied concept must sort at position 3 (zero-indexed 2)'
+		);
+		$this->assertSame(
+			3,
+			$highPos,
+			'Higher-id tied concept must sort at position 4 (zero-indexed 3)'
+		);
+	}
+
+	public function testForwardCursorTraversalMatchesOffsetControl(): void {
+		$store = $this->getStore();
+		$offsetSequence = $this->collectOffsetSequence( $store );
+		$this->assertNotEmpty( $offsetSequence );
+
+		$cursorSequence = [];
+		$cursorAfter = null;
+		$guard = 0;
+
+		do {
+			$options = $this->buildCursorOptions( $cursorAfter, null );
+			$titles = $this->fetchTitlesViaCursor( $options );
+			foreach ( $titles as $title ) {
+				if ( $this->isTestTitle( $title ) ) {
+					$cursorSequence[] = $title;
+				}
+			}
+
+			$cursorAfter = $options->getLastCursor();
+			$guard++;
+		} while ( $cursorAfter !== null && $options->getCursorHasMore() && $guard < 1000 );
+
+		$this->assertSame( $offsetSequence, $cursorSequence );
+	}
+
+	public function testBackwardCursorTraversalMatchesReversedOffsetControl(): void {
+		$store = $this->getStore();
+		$offsetSequence = $this->collectOffsetSequence( $store );
+		$this->assertNotEmpty( $offsetSequence );
+
+		$lastTitle = end( $offsetSequence );
+		$startId = $this->lookupSmwIdForTitle( $store, $lastTitle );
+		$this->assertNotNull( $startId );
+
+		$cursorSequence = [];
+		$cursorBefore = $startId;
+		$guard = 0;
+
+		do {
+			$options = $this->buildCursorOptions( null, $cursorBefore );
+			$titles = $this->fetchTitlesViaCursor( $options );
+
+			$pageTitles = [];
+			foreach ( $titles as $title ) {
+				if ( $this->isTestTitle( $title ) ) {
+					$pageTitles[] = $title;
+				}
+			}
+			foreach ( array_reverse( $pageTitles ) as $title ) {
+				array_unshift( $cursorSequence, $title );
+			}
+
+			$cursorBefore = $options->getFirstCursor();
+			$guard++;
+		} while ( $cursorBefore !== null && $options->getCursorHasMore() && $guard < 1000 );
+
+		// setCursorBefore is strict less-than; the start row never appears
+		// in any page. Reinstate it for direct comparison with OFFSET.
+		$cursorSequence[] = $lastTitle;
+
+		$this->assertSame( $offsetSequence, $cursorSequence );
+	}
+
+	public function testForwardCursorOnLowerTiedRowReturnsHigherTiedRow(): void {
+		$store = $this->getStore();
+		$db = $store->getConnection( 'mw.db' );
+
+		$tiedLow = $this->titleForIndex( self::TIED_LOW_INDEX );
+		$tiedHigh = $this->titleForIndex( self::TIED_HIGH_INDEX );
+
+		$lowId = $this->lookupSmwIdForTitle( $db, $tiedLow );
+		$this->assertNotNull( $lowId );
+
+		$options = $this->buildCursorOptions( $lowId, null );
+		$titles = $this->fetchTitlesViaCursor( $options );
+
+		$pageTitles = array_values( array_filter( $titles, fn ( $t ) => $this->isTestTitle( $t ) ) );
+		$this->assertContains(
+			$tiedHigh,
+			$pageTitles,
+			'Forward page from lower-id tied row must include the higher-id tied row via tiebreak'
+		);
+	}
+
+	public function testBackwardCursorOnHigherTiedRowReturnsLowerTiedRow(): void {
+		$store = $this->getStore();
+		$db = $store->getConnection( 'mw.db' );
+
+		$tiedLow = $this->titleForIndex( self::TIED_LOW_INDEX );
+		$tiedHigh = $this->titleForIndex( self::TIED_HIGH_INDEX );
+
+		$highId = $this->lookupSmwIdForTitle( $db, $tiedHigh );
+		$this->assertNotNull( $highId );
+
+		$options = $this->buildCursorOptions( null, $highId );
+		$titles = $this->fetchTitlesViaCursor( $options );
+
+		$pageTitles = array_values( array_filter( $titles, fn ( $t ) => $this->isTestTitle( $t ) ) );
+		$this->assertContains(
+			$tiedLow,
+			$pageTitles,
+			'Backward page from higher-id tied row must include the lower-id tied row via tiebreak'
+		);
+	}
+
+	public function testCursorWithNonexistentIdFallsBackToFirstPage(): void {
+		$store = $this->getStore();
+		$db = $store->getConnection( 'mw.db' );
+
+		$maxRow = $db->newSelectQueryBuilder()
+			->select( 'MAX(smw_id) AS max_id' )
+			->from( SQLStore::ID_TABLE )
+			->caller( __METHOD__ )
+			->fetchRow();
+		$staleId = (int)$maxRow->max_id + 1_000_000;
+
+		$offsetSequence = $this->collectOffsetSequence( $store );
+		$firstPageExpected = array_slice( $offsetSequence, 0, self::PAGE_SIZE );
+
+		$options = $this->buildCursorOptions( $staleId, null );
+		$titles = $this->fetchTitlesViaCursor( $options );
+
+		$pageTitles = array_values( array_filter( $titles, fn ( $t ) => $this->isTestTitle( $t ) ) );
+		$this->assertSame(
+			$firstPageExpected,
+			$pageTitles,
+			'Stale cursor must fall back to the first page of results'
+		);
+	}
+
+	private function buildCursorOptions( ?int $cursorAfter, ?int $cursorBefore ): RequestOptions {
+		$options = new RequestOptions();
+		$options->limit = self::PAGE_SIZE;
+		$options->setOption( RequestOptions::CURSOR_MODE, true );
+		if ( $cursorAfter !== null ) {
+			$options->setCursorAfter( $cursorAfter );
+		}
+		if ( $cursorBefore !== null ) {
+			$options->setCursorBefore( $cursorBefore );
+		}
+		return $options;
+	}
+
+	/**
+	 * Drive the cursor path via reflection on `doCursorFetch`. Going through
+	 * the public `execute()` would mean parsing HTML; the underlying
+	 * cursor-aware method is the unit we want to lock down.
+	 */
+	private function fetchTitlesViaCursor( RequestOptions $options ): array {
+		$instance = new SpecialConcepts();
+		$reflection = new \ReflectionClass( $instance );
+
+		$storeProp = $reflection->getProperty( 'store' );
+		$storeProp->setAccessible( true );
+		$storeProp->setValue( $instance, $this->getStore() );
+
+		$doFetch = $reflection->getMethod( 'doCursorFetch' );
+		$doFetch->setAccessible( true );
+		$result = $doFetch->invoke( $instance, $options );
+
+		$titles = [];
+		foreach ( $result as $diWikiPage ) {
+			$titles[] = $diWikiPage->getDBkey();
+		}
+		return $titles;
+	}
+
+	/**
+	 * Oracle that mirrors the SQL filter Special:Concepts uses, plus an
+	 * explicit `ORDER BY smw_sort, smw_id` (which the production query is
+	 * missing today, see PR description). We can't reuse `fetchFromTable()`
+	 * as the oracle because it returns rows in undefined order on MariaDB.
+	 */
+	private function collectOffsetSequence( $store ): array {
+		$db = $store->getConnection( 'mw.db' );
+		$rows = $db->newSelectQueryBuilder()
+			->select( [ 'smw_id', 'smw_title' ] )
+			->tables( [ SQLStore::ID_TABLE, SQLStore::CONCEPT_TABLE ] )
+			->joinConds( [ SQLStore::ID_TABLE => [ 'INNER JOIN', [ 'smw_id=s_id' ] ] ] )
+			->where( [
+				'smw_namespace' => SMW_NS_CONCEPT,
+				'smw_iw' => '',
+				'smw_subobject' => '',
+				'smw_proptable_hash IS NOT NULL',
+				'concept_features > 0',
+			] )
+			->orderBy( [ 'smw_sort', 'smw_id' ] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
+
+		$titles = [];
+		foreach ( $rows as $row ) {
+			if ( $this->isTestTitle( $row->smw_title ) ) {
+				$titles[] = $row->smw_title;
+			}
+		}
+		return $titles;
+	}
+
+	private function lookupSmwIdForTitle( $dbOrStore, string $title ): ?int {
+		// Accept either a Store or a Database (parameter name reuse from PR 1).
+		$db = is_object( $dbOrStore ) && method_exists( $dbOrStore, 'getConnection' )
+			? $dbOrStore->getConnection( 'mw.db' )
+			: $dbOrStore;
+
+		$row = $db->newSelectQueryBuilder()
+			->select( 'smw_id' )
+			->from( SQLStore::ID_TABLE )
+			->where( [
+				'smw_title' => $title,
+				'smw_namespace' => SMW_NS_CONCEPT,
+				'smw_iw' => '',
+				'smw_subobject' => '',
+			] )
+			->caller( __METHOD__ )
+			->fetchRow();
+		return $row ? (int)$row->smw_id : null;
+	}
+
+	private function titleForIndex( int $i ): string {
+		return $this->titlePrefix . sprintf( '%02d', $i );
+	}
+
+	private function isTestTitle( string $title ): bool {
+		return str_starts_with( $title, $this->titlePrefix );
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialConceptsTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialConceptsTest.php
@@ -88,4 +88,25 @@ class SpecialConceptsTest extends TestCase {
 		);
 	}
 
+	/**
+	 * @dataProvider cursorModeProvider
+	 */
+	public function testShouldUseCursorMode( ?string $offsetParamValue, bool $expected ): void {
+		$this->assertSame(
+			$expected,
+			SpecialConcepts::shouldUseCursorMode( $offsetParamValue )
+		);
+	}
+
+	public static function cursorModeProvider(): array {
+		return [
+			'no offset param at all' => [ null, true ],
+			'explicit offset=0' => [ '0', false ],
+			'explicit offset=5' => [ '5', false ],
+			'empty offset value' => [ '', false ],
+			'negative offset' => [ '-1', false ],
+			'non-numeric garbage' => [ 'garbage', false ],
+		];
+	}
+
 }


### PR DESCRIPTION
## Summary

- Apply `KeysetPaginationTrait` to `SpecialConcepts` so concept listings paginate via `?after=<smw_id>` / `?before=<smw_id>` cursor URLs instead of OFFSET.
- Legacy `?offset=N` URLs continue to render correctly via the existing code path (strict additive).
- Part of the [#6795](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6795) Phase 2 migration.

## Change

`SpecialConcepts` gains `use KeysetPaginationTrait`. A new private `doCursorFetch( RequestOptions $options )` runs the same WHERE / JOIN filter `fetchFromTable()` uses, with the trait's cursor predicate and `ORDER BY smw_sort, smw_id` applied plus a `LIMIT + 1` lookahead. After fetching, rows are trimmed (cursorHasMore set when the lookahead row was present), reversed for backward navigation, and the first/last `smw_id` are written back as `firstCursor` / `lastCursor` on the caller's RequestOptions.

`execute()` parses `?after`, `?before`, `?offset`, `?limit` URL params and uses a new static helper `SpecialConcepts::shouldUseCursorMode( ?string $offsetParamValue )` to decide which path. Cursor mode is taken whenever the `offset` URL param is absent entirely; any URL that includes `offset=` (even with an empty, negative, or non-numeric value) stays on the legacy path. The helper is unit-testable in isolation.

`getHtml()` keeps its existing 3-arg signature and gains an optional 4th parameter `?RequestOptions $cursorOptions = null`. When non-null, the pager renders via `MessageBuilder::cursorPrevNextToText` (emitting cursor URLs); when null, the legacy `Pager::pagination` renders.

The SELECT / JOIN / WHERE filter is now shared between `doCursorFetch()` and `fetchFromTable()` via a new private `newConceptQueryBuilder()` helper, so the cursor and legacy paths cannot diverge on filter logic.

## Incidental fix

The legacy `fetchFromTable()` SQL emitted no explicit `ORDER BY`. Result order was undefined on MariaDB (insertion order in practice). The cursor path now imposes an explicit `ORDER BY smw_sort, smw_id` via the trait. Concept listings are deterministically sorted going forward through the cursor path; the legacy `?offset=` path is unchanged (preserving its undefined-order quirk).

## Tests

New integration test at `tests/phpunit/Integration/MediaWiki/Specials/SpecialConceptsKeysetIntegrationTest.php` (patterned on PR 1's `PropertySubjectsLookupKeysetIntegrationTest`):

- Seeds 12 concept pages directly into `smw_object_ids` + `smw_fpt_conc` (avoids the brittle parser-function write path)
- Forces a tied-`smw_sort` pair at the `PAGE_SIZE-1` boundary
- Forward + backward broad traversal vs an `ORDER BY` oracle
- Focused tiebreak in both directions
- Stale-cursor fall-back to first page (with `firstCursor` / `lastCursor` populated)
- Loop guards assert `$guard < 1000` so runaway tests fail with a meaningful message

New unit test data provider for `shouldUseCursorMode()` covers no-param, `offset=0`, `offset=5`, empty value, negative value, and non-numeric garbage.

Mutation-tested: both `smw_sort > X` (no tiebreak) and `smw_sort >= X AND smw_id > Y` (no OR) predicate breaks cause at least one test to fail.

## Behaviour

No external behaviour change to callers other than the new cursor URLs going forward.

- `Special:Concepts` (no params): cursor mode, emits `?after=<smw_id>` next link
- `?after=N` / `?before=N`: cursor navigation
- `?offset=N`: legacy offset mode, emits `?offset=` next links (untouched)
- `?offset=garbage` / `?offset=`: legacy offset mode (any `offset=` presence triggers legacy intent; previously would have switched silently to cursor mode when value coerced to 0)
- Public `fetchFromTable()` and `getHtml()` signatures preserved (cursorOptions is an optional 4th param)

## Test plan

- [x] `composer phpunit:unit` (full unit suite, 0 failures, 6 pre-existing skips)
- [x] Targeted suite (`SpecialConcepts`): 17 tests / 31 assertions green (10 unit + 7 integration)
- [x] `composer analyze` clean
- [x] PHPCS clean on all 3 changed files (`vendor/bin/phpcs -sp --no-cache`)
- [x] Browser smoke verified on the dev wiki: `Special:Concepts?limit=5` paginates forward and backward via `?after` / `?before`, legacy `?offset` URLs still render, no errors
- [x] Mutation tests confirm the suite catches tiebreak-blind predicate regressions
- [x] CI green
- [x] Reviewer verification

## Refs

- #6559 (performance audit, point 1)
- #6564 (initial keyset trait for Special:Properties)
- #6794 (trait predicate fix that makes the keyset path a true index seek)
- #6796 (Property:Foo, first joined-table consumer)
- #6801 (trait refactor: options-as-parameter; landed in master)
- #6795 (tracking issue for the full migration)