### PR TITLE
Apply keyset cursor pagination to Browse API PSubjectLookup

### DIFF
--- a/src/MediaWiki/Api/Browse/PSubjectLookup.php
+++ b/src/MediaWiki/Api/Browse/PSubjectLookup.php
@@ -72,7 +72,7 @@ class PSubjectLookup extends Lookup {
 			return [];
 		}
 
-		[ $list, $continueOffset ] = $this->findPropertySubjects(
+		[ $list, $continueOffset, $continueCursor ] = $this->findPropertySubjects(
 			$property,
 			$value,
 			$limit,
@@ -80,7 +80,11 @@ class PSubjectLookup extends Lookup {
 			$parameters
 		);
 
-		// Changing this output format requires to set a new version
+		// Changing this output format requires to set a new version. The
+		// `query-continue-cursor` field is byte-additive: it is only emitted
+		// when the caller opted into cursor mode (by sending `cursor` in
+		// the request payload). Legacy clients that follow
+		// `query-continue-offset` see exactly the pre-cursor response shape.
 		$res = [
 			'query' => $list,
 			'query-continue-offset' => $continueOffset,
@@ -92,7 +96,27 @@ class PSubjectLookup extends Lookup {
 			]
 		];
 
+		if ( self::shouldUseCursorMode( $parameters ) ) {
+			$res['query-continue-cursor'] = $continueCursor;
+		}
+
 		return $res;
+	}
+
+	/**
+	 * Decides whether the request opts into cursor pagination. Mirrors
+	 * the `ListLookup::shouldUseCursorMode()` predicate: cursor mode is
+	 * triggered by *presence* of the `cursor` key (any value, including
+	 * 0), not by truthiness. The presence-of-key form is unambiguous for
+	 * a JSON-payload API where clients explicitly opt in.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $parameters The decoded `params` payload from the
+	 *   `smwbrowse` API request.
+	 */
+	public static function shouldUseCursorMode( array $parameters ): bool {
+		return array_key_exists( 'cursor', $parameters );
 	}
 
 	private function findPropertySubjects( $property, $value, int $limit, int $offset, array $parameters ): array {
@@ -106,8 +130,10 @@ class PSubjectLookup extends Lookup {
 		}
 
 		$continueOffset = 0;
+		$continueCursor = 0;
 		$count = 0;
 		$requestOptions = $this->newRequestOptions( $parameters );
+		$cursorMode = (bool)$requestOptions->getOption( RequestOptions::CURSOR_MODE );
 
 		$res = $this->store->getPropertySubjects(
 			$property,
@@ -132,12 +158,20 @@ class PSubjectLookup extends Lookup {
 			$count = count( $res );
 		}
 
-		if ( $count > $limit ) {
+		if ( $cursorMode ) {
+			// `PropertySubjectsLookup::postProcessCursorResult()` already
+			// trimmed the lookahead row and wrote the cursor metadata back
+			// onto `$requestOptions`. The trimmed list arrives ready to
+			// display; we just surface the cursor anchor for the next page.
+			if ( $requestOptions->getCursorHasMore() ) {
+				$continueCursor = $requestOptions->getLastCursor() ?? 0;
+			}
+		} elseif ( $count > $limit ) {
 			$continueOffset = $offset + $count;
 			array_pop( $list );
 		}
 
-		return [ $list, $continueOffset ];
+		return [ $list, $continueOffset, $continueCursor ];
 	}
 
 	private function newRequestOptions( array $parameters ): RequestOptions {
@@ -155,8 +189,25 @@ class PSubjectLookup extends Lookup {
 
 		$requestOptions = new RequestOptions();
 		$requestOptions->sort = true;
-		$requestOptions->setLimit( $limit + 1 );
-		$requestOptions->setOffset( $offset );
+
+		if ( self::shouldUseCursorMode( $parameters ) ) {
+			// Cursor mode is authoritative: any `offset` co-sent with
+			// `cursor` is ignored so the response doesn't accidentally seek
+			// past the cursor by the legacy offset amount.
+			// `PropertySubjectsLookup` adds its own `LIMIT + 1` lookahead in
+			// cursor mode, so the caller passes the plain page size.
+			$requestOptions->setLimit( $limit );
+			$requestOptions->setOption( RequestOptions::CURSOR_MODE, true );
+			$cursor = (int)$parameters['cursor'];
+			if ( $cursor > 0 ) {
+				$requestOptions->setCursorAfter( $cursor );
+			}
+		} else {
+			// Legacy offset path: `+1` lookahead is manually trimmed in
+			// `findPropertySubjects()`.
+			$requestOptions->setLimit( $limit + 1 );
+			$requestOptions->setOffset( $offset );
+		}
 
 		if ( isset( $parameters['search'] ) && $parameters['search'] !== '' ) {
 			$search = (string)$parameters['search'];

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/PSubjectLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/PSubjectLookupTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Unit\MediaWiki\Api\Browse;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Api\Browse\PSubjectLookup;
+use SMW\RequestOptions;
 use SMW\SQLStore\SQLStore;
 
 /**
@@ -76,6 +77,133 @@ class PSubjectLookupTest extends TestCase {
 				'Foo bar'
 			]
 		];
+	}
+
+	public function testLegacyResponseOmitsContinueCursorField(): void {
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->willReturn( [ new WikiPage( 'Foo bar', NS_MAIN ) ] );
+
+		$instance = new PSubjectLookup( $this->store );
+
+		$res = $instance->lookup( [
+			'search' => 'Foo',
+			'property' => 'Bar',
+		] );
+
+		// Legacy clients (no `cursor` opt-in) must see exactly the
+		// pre-cursor response shape. Existing JSONScript fixtures depend
+		// on a contiguous `"query-continue-offset":0,"version":1`
+		// substring; inserting a new field between them would break them.
+		$this->assertArrayNotHasKey( 'query-continue-cursor', $res );
+		$this->assertArrayHasKey( 'query-continue-offset', $res );
+	}
+
+	public function testCursorModeOptInSetsCursorModeOptionOnRequestOptions(): void {
+		$capturedOptions = null;
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->willReturnCallback(
+				static function ( $property, $value, $options ) use ( &$capturedOptions ) {
+					$capturedOptions = $options;
+					return [ new WikiPage( 'Foo bar', NS_MAIN ) ];
+				}
+			);
+
+		$instance = new PSubjectLookup( $this->store );
+
+		$instance->lookup( [
+			'search' => 'Foo',
+			'property' => 'Bar',
+			'cursor' => 0,
+		] );
+
+		$this->assertNotNull( $capturedOptions );
+		$this->assertTrue(
+			(bool)$capturedOptions->getOption( RequestOptions::CURSOR_MODE ),
+			'cursor request param must flip CURSOR_MODE on the options passed to getPropertySubjects'
+		);
+	}
+
+	public function testCursorWithNonZeroValueSetsCursorAfter(): void {
+		$capturedOptions = null;
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->willReturnCallback(
+				static function ( $property, $value, $options ) use ( &$capturedOptions ) {
+					$capturedOptions = $options;
+					return [ new WikiPage( 'Foo bar', NS_MAIN ) ];
+				}
+			);
+
+		$instance = new PSubjectLookup( $this->store );
+
+		$instance->lookup( [
+			'search' => 'Foo',
+			'property' => 'Bar',
+			'cursor' => 12345,
+		] );
+
+		$this->assertSame( 12345, $capturedOptions->getCursorAfter() );
+	}
+
+	public function testCursorModeSurfacesLastCursorFromRequestOptions(): void {
+		// Simulate `PropertySubjectsLookup::postProcessCursorResult()` writing
+		// hasMore + lastCursor back onto the caller's RequestOptions.
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->willReturnCallback(
+				static function ( $property, $value, $options ) {
+					$options->setCursorHasMore( true );
+					$options->setLastCursor( 777 );
+					return [
+						new WikiPage( 'Foo bar', NS_MAIN ),
+						new WikiPage( 'Foo baz', NS_MAIN ),
+					];
+				}
+			);
+
+		$instance = new PSubjectLookup( $this->store );
+
+		$res = $instance->lookup( [
+			'search' => 'Foo',
+			'property' => 'Bar',
+			'cursor' => 0,
+		] );
+
+		$this->assertSame( 777, $res['query-continue-cursor'] );
+		$this->assertSame( 0, $res['query-continue-offset'] );
+	}
+
+	public function testCursorModeWithNoFurtherRowsEmitsZeroCursor(): void {
+		// `PropertySubjectsLookup` leaves hasMore=false when there is no
+		// lookahead row to trim; PSubjectLookup must surface 0 rather than
+		// a stale id.
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->willReturn( [ new WikiPage( 'Foo bar', NS_MAIN ) ] );
+
+		$instance = new PSubjectLookup( $this->store );
+
+		$res = $instance->lookup( [
+			'search' => 'Foo',
+			'property' => 'Bar',
+			'cursor' => 0,
+		] );
+
+		$this->assertArrayHasKey( 'query-continue-cursor', $res );
+		$this->assertSame( 0, $res['query-continue-cursor'] );
+	}
+
+	public function testShouldUseCursorModeRespectsPresenceNotTruthiness(): void {
+		$this->assertTrue( PSubjectLookup::shouldUseCursorMode( [ 'cursor' => 0 ] ) );
+		$this->assertTrue( PSubjectLookup::shouldUseCursorMode( [ 'cursor' => '' ] ) );
+		$this->assertTrue( PSubjectLookup::shouldUseCursorMode( [ 'cursor' => null ] ) );
+		$this->assertTrue( PSubjectLookup::shouldUseCursorMode( [ 'cursor' => 12345 ] ) );
+		$this->assertFalse( PSubjectLookup::shouldUseCursorMode( [] ) );
+		$this->assertFalse( PSubjectLookup::shouldUseCursorMode( [ 'offset' => 50 ] ) );
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/PSubjectLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/PSubjectLookupTest.php
@@ -117,6 +117,7 @@ class PSubjectLookupTest extends TestCase {
 			'search' => 'Foo',
 			'property' => 'Bar',
 			'cursor' => 0,
+			'limit' => 20,
 		] );
 
 		$this->assertNotNull( $capturedOptions );
@@ -124,6 +125,67 @@ class PSubjectLookupTest extends TestCase {
 			(bool)$capturedOptions->getOption( RequestOptions::CURSOR_MODE ),
 			'cursor request param must flip CURSOR_MODE on the options passed to getPropertySubjects'
 		);
+
+		// Cursor mode caller passes the plain page size. `PropertySubjectsLookup`
+		// adds its own LIMIT+1 lookahead internally. A regression that pre-adds +1
+		// here would silently corrupt the trim threshold inside the lookup
+		// (SQL ends up with LIMIT+2 and the wrong row gets popped).
+		$this->assertSame(
+			20,
+			$capturedOptions->getLimit(),
+			'Cursor mode must pass plain $limit (PropertySubjectsLookup adds its own +1)'
+		);
+	}
+
+	public function testCursorModeWithCoSentOffsetIgnoresOffset(): void {
+		$capturedOptions = null;
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->willReturnCallback(
+				static function ( $property, $value, $options ) use ( &$capturedOptions ) {
+					$capturedOptions = $options;
+					return [ new WikiPage( 'Foo bar', NS_MAIN ) ];
+				}
+			);
+
+		$instance = new PSubjectLookup( $this->store );
+
+		$instance->lookup( [
+			'search' => 'Foo',
+			'property' => 'Bar',
+			'cursor' => 0,
+			'offset' => 999,
+		] );
+
+		// Cursor mode is authoritative. Co-sent `offset` MUST be ignored so the
+		// response doesn't seek past the cursor by the legacy offset amount.
+		$this->assertSame( 0, $capturedOptions->getOffset() );
+	}
+
+	public function testLegacyModePassesLimitPlusOneForManualLookahead(): void {
+		$capturedOptions = null;
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->willReturnCallback(
+				static function ( $property, $value, $options ) use ( &$capturedOptions ) {
+					$capturedOptions = $options;
+					return [ new WikiPage( 'Foo bar', NS_MAIN ) ];
+				}
+			);
+
+		$instance = new PSubjectLookup( $this->store );
+
+		$instance->lookup( [
+			'search' => 'Foo',
+			'property' => 'Bar',
+			'limit' => 20,
+		] );
+
+		// Legacy path manually trims the lookahead row in `findPropertySubjects`,
+		// so the caller asks the lookup for $limit + 1.
+		$this->assertSame( 21, $capturedOptions->getLimit() );
 	}
 
 	public function testCursorWithNonZeroValueSetsCursorAfter(): void {
@@ -178,12 +240,21 @@ class PSubjectLookupTest extends TestCase {
 	}
 
 	public function testCursorModeWithNoFurtherRowsEmitsZeroCursor(): void {
-		// `PropertySubjectsLookup` leaves hasMore=false when there is no
-		// lookahead row to trim; PSubjectLookup must surface 0 rather than
-		// a stale id.
+		// `PropertySubjectsLookup` always writes `lastCursor` when results are
+		// non-empty but only writes `hasMore=true` when there is a lookahead
+		// row to trim. PSubjectLookup must surface 0 when hasMore is false
+		// even if a `lastCursor` happens to be set — otherwise a final-page
+		// response would emit an id that, if followed, would loop the client
+		// back through already-seen rows.
 		$this->store->expects( $this->any() )
 			->method( 'getPropertySubjects' )
-			->willReturn( [ new WikiPage( 'Foo bar', NS_MAIN ) ] );
+			->willReturnCallback(
+				static function ( $property, $value, $options ) {
+					// hasMore deliberately NOT set; lastCursor deliberately IS set.
+					$options->setLastCursor( 555 );
+					return [ new WikiPage( 'Foo bar', NS_MAIN ) ];
+				}
+			);
 
 		$instance = new PSubjectLookup( $this->store );
 
@@ -194,7 +265,11 @@ class PSubjectLookupTest extends TestCase {
 		] );
 
 		$this->assertArrayHasKey( 'query-continue-cursor', $res );
-		$this->assertSame( 0, $res['query-continue-cursor'] );
+		$this->assertSame(
+			0,
+			$res['query-continue-cursor'],
+			'When hasMore is false, continueCursor must be 0 even if lastCursor is set'
+		);
 	}
 
 	public function testShouldUseCursorModeRespectsPresenceNotTruthiness(): void {


### PR DESCRIPTION
## Summary

Adds opt-in cursor pagination to the `smwbrowse&browse=psubject` API
endpoint, the second Browse API consumer after `ListLookup` (#6804).
The additive contract is byte-identical to the one established there:
old clients see the pre-cursor response shape unchanged; new clients
opt in by sending `cursor` in the request payload and follow
`query-continue-cursor` in the response.

`PSubjectLookup` routes through `Store::getPropertySubjects()` which is
already cursor-aware (#6796), so this is API-surface plumbing only.

Tracks #6795 (Phase 2). `ArticleLookup` follows as a separate PR.

## Contract

Request payload (decoded JSON):

| Field | Behaviour |
|---|---|
| `cursor` absent | Legacy OFFSET mode (response shape unchanged) |
| `cursor` present (any value, including 0) | Cursor mode opt-in |
| `cursor` > 0 | Interpreted as `cursorAfter` (previous response's `query-continue-cursor`) |
| `cursor` present AND `offset` present | `offset` ignored; cursor mode is authoritative |

Response is byte-additive: `query-continue-cursor` is emitted ONLY in
cursor mode. JSONScript fixtures matching the contiguous
`"query-continue-offset":0,"version":1` substring (`api-smwbrowse-0001`)
are preserved.

## Implementation

- `PSubjectLookup::shouldUseCursorMode()` static helper mirrors
  `ListLookup::shouldUseCursorMode()` — presence-not-truthiness opt-in.
- `newRequestOptions()` sets `RequestOptions::CURSOR_MODE` and clears
  offset when `cursor` is present. Passes plain `$limit` (the underlying
  `PropertySubjectsLookup` adds its own LIMIT+1 lookahead in cursor mode).
- `findPropertySubjects()` reads back `getCursorHasMore()` /
  `getLastCursor()` from the post-fetch `RequestOptions` (written by
  `PropertySubjectsLookup::postProcessCursorResult`) and surfaces the
  smw_id anchor as `continueCursor`.

## Pre-existing legacy bug (worth flagging, NOT fixed by this PR)

The legacy offset path has had a long-standing off-by-one:
`$continueOffset = $offset + $count` advances by `$count` (limit+1,
including the popped lookahead row) instead of `$limit`. So legacy
pagination silently skips one item per page transition. Browser smoke
confirmed this against the dev wiki: 25 subjects total, legacy walks
**23** items (skips items 09 and 18 at page boundaries), cursor mode
walks all **25**. Cursor mode sidesteps the bug because it anchors at
the last *displayed* row's smw_id rather than the lookahead.

This PR preserves the legacy behaviour verbatim to keep scope tight.
The bug deserves its own fix in a separate PR.

## Test plan

- [x] `composer analyze` clean
- [x] 11 unit tests in `PSubjectLookupTest` (2 pre-existing + 9 new):
  - Legacy response omits `query-continue-cursor`
  - Cursor opt-in sets `CURSOR_MODE` on options passed to lookup
  - Cursor mode passes plain `$limit` (locks the LIMIT+1-only-once rule)
  - Cursor mode with co-sent offset ignores offset
  - Legacy mode passes `$limit + 1` for manual lookahead
  - Cursor > 0 sets `cursorAfter`
  - Cursor metadata round-trip surfaces `lastCursor` from options
  - `hasMore=false` emits cursor=0 even when `lastCursor` is set (no infinite-loop risk)
  - `shouldUseCursorMode` presence-not-truthiness predicate
- [x] No regressions in the wider Browse API suite (34 cases)
- [x] JSONScript `api-smwbrowse-0001` integration test passes
  (locks the legacy fixture shape against the conditional-emission
  contract)
- [x] Browser smoke against the dev wiki (`browse=psubject`,
  `property=Demo Text Prop 01`, 25 subject pages):

  | Mode | Pages | Total visited | Notes |
  |---|---|---|---|
  | Legacy `?offset=` | 3 | 23 of 25 | Pre-existing skip bug |
  | Cursor `?cursor=` | 4 | 25 of 25 | All items via last-displayed-row anchor |

🤖 Generated with [Claude Code](https://claude.com/claude-code)