### PR TITLE
Drop outer-parse data when extension recursively re-enters Parser::parse()

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -218,6 +218,7 @@ class Hooks {
 
 		$this->handlers += [
 			'ParserAfterTidy' => [ $this, 'onParserAfterTidy' ],
+			'ParserClearState' => [ $this, 'onParserClearState' ],
 			'ParserOptionsRegister' => [ $this, 'onParserOptionsRegister' ],
 			'ParserFirstCallInit' => [ $this, 'onParserFirstCallInit' ],
 			'InternalParseBeforeLinks' => [ $this, 'onInternalParseBeforeLinks' ],
@@ -335,6 +336,22 @@ class Hooks {
 		);
 
 		$parserAfterTidy->process( $text );
+
+		return true;
+	}
+
+	/**
+	 * Hook: ParserClearState fires at the start of every `Parser::parse()`
+	 * call. Used to track in-flight parses per title so that `ParserAfterTidy`
+	 * can distinguish the outermost fire from inner (nested) fires triggered
+	 * by extensions that clone the parser, see #5923.
+	 *
+	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ParserClearState
+	 *
+	 * @since 7.0.0
+	 */
+	public function onParserClearState( Parser $parser ): bool {
+		ParserAfterTidy::onParserClearState( $parser );
 
 		return true;
 	}

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -77,6 +77,14 @@ class ParserAfterTidy implements HookListener {
 		if ( $parser->getOptions()->getInterfaceMessage() ) {
 			return;
 		}
+		// `Parser::clearState()` can be invoked outside of an actual
+		// `Parser::parse()` (test helpers, manual state resets, etc.); in those
+		// cases `isLocked()` is `false` and the parser is not really competing
+		// for the title, so we must not record it as in-flight or we mark
+		// every later, unrelated parse of the same title as "nested".
+		if ( !$parser->isLocked() ) {
+			return;
+		}
 		if ( self::$inFlightParses === null ) {
 			self::$inFlightParses = new WeakMap();
 		}
@@ -107,9 +115,17 @@ class ParserAfterTidy implements HookListener {
 			if ( $parser === $excluding ) {
 				continue;
 			}
-			if ( $parsedTitleKey === $titleKey ) {
-				$count++;
+			if ( $parsedTitleKey !== $titleKey ) {
+				continue;
 			}
+			// A leftover entry whose Parser is no longer locked is stale: the
+			// parse it represented has long ended (or never started). It must
+			// not be counted as a competing in-flight parse, otherwise the
+			// current outermost fire would be wrongly classified as nested.
+			if ( !$parser->isLocked() ) {
+				continue;
+			}
+			$count++;
 		}
 		return $count;
 	}

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -34,6 +34,22 @@ class ParserAfterTidy implements HookListener {
 
 	const CACHE_NAMESPACE = 'smw:parseraftertidy';
 
+	/**
+	 * In-flight `Parser::parse()` calls, keyed by Parser instance and mapped
+	 * to the title prefixed-DB key being parsed. Used to distinguish the
+	 * outermost ParserAfterTidy fire from inner fires triggered by extensions
+	 * that clone the parser and recurse on the same title (see #5923).
+	 * Populated by `onParserClearState()` and drained in `process()`.
+	 *
+	 * Keyed by Parser instance so that short-lived clones are reclaimed by GC
+	 * automatically if `Parser::parse()` throws between `clearState` and
+	 * `ParserAfterTidy` (no `finally`-equivalent at the parser level). For a
+	 * long-lived parser whose entry survives an exception, the next successful
+	 * `process()` call for that parser re-runs the normal flow and clears the
+	 * entry, so the leak does not compound across requests.
+	 */
+	private static ?\WeakMap $inFlightParses = null;
+
 	private bool $isCommandLineMode = false;
 
 	private bool $isReady = true;
@@ -46,6 +62,59 @@ class ParserAfterTidy implements HookListener {
 		private NamespaceExaminer $namespaceExaminer,
 		private Cache $cache,
 	) {
+	}
+
+	/**
+	 * Hook handler for `ParserClearState`. Called at the start of every
+	 * `Parser::parse()` invocation (when `clearState` is true). Records the
+	 * parser as in-flight so a subsequent inner parse on the same title can
+	 * detect that it is nested and skip the update (see #5923).
+	 *
+	 * @since 7.0.0
+	 */
+	public static function onParserClearState( Parser $parser ): void {
+		if ( $parser->getOptions()->getInterfaceMessage() ) {
+			return;
+		}
+		$title = $parser->getTitle();
+		if ( $title === null ) {
+			return;
+		}
+		if ( self::$inFlightParses === null ) {
+			self::$inFlightParses = new \WeakMap();
+		}
+		// Re-setting for the same Parser is idempotent and self-healing if a
+		// previous parse on this instance leaked an entry by throwing.
+		self::$inFlightParses[$parser] = $title->getPrefixedDBKey();
+	}
+
+	/**
+	 * Reset the in-flight tracker. Intended for tests.
+	 *
+	 * @since 7.0.0
+	 */
+	public static function resetInFlightParses(): void {
+		self::$inFlightParses = null;
+	}
+
+	/**
+	 * Count active in-flight parses for the given title (excluding the
+	 * supplied parser, if any).
+	 */
+	private static function countActiveParsesForTitle( string $titleKey, ?Parser $excluding ): int {
+		if ( self::$inFlightParses === null || $titleKey === '' ) {
+			return 0;
+		}
+		$count = 0;
+		foreach ( self::$inFlightParses as $parser => $parsedTitleKey ) {
+			if ( $parser === $excluding ) {
+				continue;
+			}
+			if ( $parsedTitleKey === $titleKey ) {
+				$count++;
+			}
+		}
+		return $count;
 	}
 
 	/**
@@ -68,8 +137,35 @@ class ParserAfterTidy implements HookListener {
 	 * @since 1.9
 	 */
 	public function process( string &$text ): bool {
-		if ( $this->canPerformUpdate() ) {
-			$this->performUpdate( $text );
+		if ( !$this->isReady ) {
+			$this->doAbort();
+			return true;
+		}
+
+		$title = $this->parser->getTitle();
+		$key = $title !== null ? (string)$title->getPrefixedDBKey() : '';
+
+		// #5923: When an extension clones the parser and re-enters `Parser::parse()`
+		// on the same title (e.g. DPL `<dpl>`, TabberNeue `<tabber>`), the inner
+		// parse fires its own `ParserAfterTidy`. Without this guard, the inner
+		// fire (which only sees a partial `ParserOutput`) would consume the
+		// `ArticlePurge` cache key in `checkPurgeRequest()` and persist incomplete
+		// data, while the outermost fire (with complete data) would skip because
+		// the key has been deleted. Skip processing for inner fires and let the
+		// outermost run with the full state. Interface-message parses are
+		// excluded from the tracker by `onParserClearState`, so they pass
+		// through here untouched.
+		$isNestedParse = $key !== ''
+			&& self::countActiveParsesForTitle( $key, $this->parser ) > 0;
+
+		try {
+			if ( !$isNestedParse && $this->canPerformUpdate() ) {
+				$this->performUpdate( $text );
+			}
+		} finally {
+			if ( self::$inFlightParses !== null ) {
+				unset( self::$inFlightParses[$this->parser] );
+			}
 		}
 
 		return true;

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -14,6 +14,7 @@ use SMW\NamespaceExaminer;
 use SMW\OptionsAwareTrait;
 use SMW\ParserData;
 use SMW\Services\ServicesFactory as ApplicationFactory;
+use WeakMap;
 
 /**
  * Hook: ParserAfterTidy to add some final processing to the
@@ -48,7 +49,7 @@ class ParserAfterTidy implements HookListener {
 	 * `process()` call for that parser re-runs the normal flow and clears the
 	 * entry, so the leak does not compound across requests.
 	 */
-	private static ?\WeakMap $inFlightParses = null;
+	private static ?WeakMap $inFlightParses = null;
 
 	private bool $isCommandLineMode = false;
 
@@ -76,16 +77,12 @@ class ParserAfterTidy implements HookListener {
 		if ( $parser->getOptions()->getInterfaceMessage() ) {
 			return;
 		}
-		$title = $parser->getTitle();
-		if ( $title === null ) {
-			return;
-		}
 		if ( self::$inFlightParses === null ) {
-			self::$inFlightParses = new \WeakMap();
+			self::$inFlightParses = new WeakMap();
 		}
 		// Re-setting for the same Parser is idempotent and self-healing if a
 		// previous parse on this instance leaked an entry by throwing.
-		self::$inFlightParses[$parser] = $title->getPrefixedDBKey();
+		self::$inFlightParses[$parser] = $parser->getTitle()->getPrefixedDBKey();
 	}
 
 	/**
@@ -142,8 +139,10 @@ class ParserAfterTidy implements HookListener {
 			return true;
 		}
 
-		$title = $this->parser->getTitle();
-		$key = $title !== null ? (string)$title->getPrefixedDBKey() : '';
+		// `(string)` defends against unit-test mocks where `getTitle()` returns
+		// a Title mock whose `getPrefixedDBKey()` is not stubbed and resolves
+		// to `null` rather than the production `string`.
+		$key = (string)$this->parser->getTitle()->getPrefixedDBKey();
 
 		// #5923: When an extension clones the parser and re-enters `Parser::parse()`
 		// on the same title (e.g. DPL `<dpl>`, TabberNeue `<tabber>`), the inner

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -4,13 +4,16 @@ namespace SMW\Tests\Unit\MediaWiki\Hooks;
 
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\ParserOptions;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Title\Title;
 use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use SMW\MediaWiki\HookDispatcher;
+use SMW\MediaWiki\Hooks\ArticlePurge;
 use SMW\MediaWiki\Hooks\ParserAfterTidy;
 use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\RevisionGuard;
@@ -20,6 +23,8 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockTitle;
+use Throwable;
+use WikiPage;
 
 /**
  * @covers \SMW\MediaWiki\Hooks\ParserAfterTidy
@@ -536,7 +541,7 @@ class ParserAfterTidyTest extends TestCase {
 			'smwgCategoryFeatures' => SMW_CAT_REDIRECT | SMW_CAT_INSTANCE,
 		] );
 
-		$parserOptions = $this->getMockBuilder( \MediaWiki\Parser\ParserOptions::class )
+		$parserOptions = $this->getMockBuilder( ParserOptions::class )
 			->disableOriginalConstructor()
 			->getMock();
 		$parserOptions->expects( $this->any() )
@@ -592,7 +597,7 @@ class ParserAfterTidyTest extends TestCase {
 			->getMockForAbstractClass();
 		$store->expects( $this->any() )
 			->method( 'updateData' )
-			->willThrowException( new \RuntimeException( 'simulated' ) );
+			->willThrowException( new RuntimeException( 'simulated' ) );
 
 		$this->testEnvironment->withConfiguration( [
 			'smwgMainCacheType' => 'hash',
@@ -610,7 +615,7 @@ class ParserAfterTidyTest extends TestCase {
 			->method( 'getRevision' )
 			->willReturn( $revision );
 
-		$wikiPage = $this->getMockBuilder( '\WikiPage' )
+		$wikiPage = $this->getMockBuilder( WikiPage::class )
 			->disableOriginalConstructor()
 			->getMock();
 		$wikiPage->expects( $this->any() )
@@ -630,7 +635,7 @@ class ParserAfterTidyTest extends TestCase {
 		$cache = $this->applicationFactory->getCache();
 		$cache->save(
 			smwfCacheKey(
-				\SMW\MediaWiki\Hooks\ArticlePurge::CACHE_NAMESPACE,
+				ArticlePurge::CACHE_NAMESPACE,
 				$title->getArticleID()
 			),
 			true
@@ -647,7 +652,7 @@ class ParserAfterTidyTest extends TestCase {
 		$text = '';
 		try {
 			$instance->process( $text );
-		} catch ( \Throwable $e ) {
+		} catch ( Throwable $e ) {
 			// Expected, swallow.
 		}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -11,6 +11,7 @@ use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Title\Title;
 use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
 use RuntimeException;
 use SMW\MediaWiki\HookDispatcher;
 use SMW\MediaWiki\Hooks\ArticlePurge;
@@ -98,6 +99,19 @@ class ParserAfterTidyTest extends TestCase {
 		ParserAfterTidy::resetInFlightParses();
 		$this->testEnvironment->tearDown();
 		parent::tearDown();
+	}
+
+	/**
+	 * Force a Parser's `mInParse` flag to `true` (mimicking the state during
+	 * an actual `Parser::parse()` call). Production code's `isLocked()` check
+	 * is what distinguishes a real parse from a test helper that only called
+	 * `clearState()`; the unit tests must opt into the locked state to
+	 * exercise the in-flight tracker.
+	 */
+	private function setParserLocked( Parser $parser ): void {
+		$prop = new ReflectionProperty( Parser::class, 'mInParse' );
+		$prop->setAccessible( true );
+		$prop->setValue( $parser, true );
 	}
 
 	public function testCanConstruct() {
@@ -400,12 +414,14 @@ class ParserAfterTidyTest extends TestCase {
 
 		// Outer parser begins parsing this title.
 		$outerParser = $this->parserFactory->newFromTitle( $title );
+		$this->setParserLocked( $outerParser );
 		ParserAfterTidy::onParserClearState( $outerParser );
 
 		// Inner parse on a separate parser instance for the same title, with
 		// only a partial set of categories, mimicking the inner snapshot from
 		// jayktaylor's repro before the outer parse adds the rest.
 		$innerParser = $this->parserFactory->newFromTitle( $title );
+		$this->setParserLocked( $innerParser );
 		ParserAfterTidy::onParserClearState( $innerParser );
 		$innerParser->getOutput()->addCategory( 'InnerCat', 'InnerCat' );
 		$innerParser->getOutput()->setExtensionData( 'smw-semanticdata-status', true );
@@ -493,9 +509,11 @@ class ParserAfterTidyTest extends TestCase {
 			->newFromText( __METHOD__ . 'B' );
 
 		$parserA = $this->parserFactory->newFromTitle( $titleA );
+		$this->setParserLocked( $parserA );
 		ParserAfterTidy::onParserClearState( $parserA );
 
 		$parserB = $this->parserFactory->newFromTitle( $titleB );
+		$this->setParserLocked( $parserB );
 		ParserAfterTidy::onParserClearState( $parserB );
 
 		// Both have content; both should run independently.
@@ -564,6 +582,7 @@ class ParserAfterTidyTest extends TestCase {
 
 		// And the real outer parser for the same title should still see depth=1.
 		$realParser = $this->parserFactory->newFromTitle( $title );
+		$this->setParserLocked( $realParser );
 		ParserAfterTidy::onParserClearState( $realParser );
 		$realParser->getOutput()->addCategory( 'RealCat', 'RealCat' );
 		$realParser->getOutput()->setExtensionData( 'smw-semanticdata-status', true );
@@ -642,6 +661,7 @@ class ParserAfterTidyTest extends TestCase {
 		);
 
 		$parser = $this->parserFactory->newFromTitle( $title );
+		$this->setParserLocked( $parser );
 		ParserAfterTidy::onParserClearState( $parser );
 		$parser->getOutput()->addCategory( 'Foo', 'Foo' );
 		$parser->getOutput()->setExtensionData( 'smw-semanticdata-status', true );
@@ -662,6 +682,7 @@ class ParserAfterTidyTest extends TestCase {
 		$parser->getOutput()->addCategory( 'Bar', 'Bar' );
 
 		$secondParser = $this->parserFactory->newFromTitle( $title );
+		$this->setParserLocked( $secondParser );
 		ParserAfterTidy::onParserClearState( $secondParser );
 		$secondParser->getOutput()->addCategory( 'Baz', 'Baz' );
 		$secondParser->getOutput()->setExtensionData( 'smw-semanticdata-status', true );

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -15,6 +15,7 @@ use SMW\MediaWiki\Hooks\ParserAfterTidy;
 use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\RevisionGuard;
 use SMW\NamespaceExaminer;
+use SMW\ParserData;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
@@ -89,6 +90,7 @@ class ParserAfterTidyTest extends TestCase {
 	}
 
 	protected function tearDown(): void {
+		ParserAfterTidy::resetInFlightParses();
 		$this->testEnvironment->tearDown();
 		parent::tearDown();
 	}
@@ -357,6 +359,322 @@ class ParserAfterTidyTest extends TestCase {
 		$this->semanticDataValidator->assertThatPropertiesAreSet(
 			$expected,
 			$parserData->getSemanticData()
+		);
+	}
+
+	/**
+	 * #5923: extensions that clone the parser and re-enter `Parser::parse()`
+	 * on the same title fire `ParserAfterTidy` for the inner parse first, with
+	 * partial parser output. Before the fix, the inner fire would consume the
+	 * `ArticlePurge` cache key and persist its partial data; the outermost
+	 * fire (with the full state) would then find the key gone and skip,
+	 * losing the outer properties and categories.
+	 *
+	 * The test simulates that nesting by calling `onParserClearState()` for
+	 * both the outer and inner parser, then `process()` for inner (which must
+	 * be skipped) followed by `process()` for outer (which must run). The
+	 * inner-skip is verified by asserting that `copyToParserOutput()` did NOT
+	 * populate the inner parser output's `DATA_ID` extension data, and the
+	 * outer-run is verified by reading the outer's semantic data back.
+	 */
+	public function testProcessIsSkippedForInnerParseOnSameTitle() {
+		$this->namespaceExaminer->expects( $this->any() )
+			->method( 'isSemanticEnabled' )
+			->willReturn( true );
+
+		$settings = [
+			'smwgMainCacheType' => 'hash',
+			'smwgEnableUpdateJobs' => false,
+			'smwgParserFeatures' => SMW_PARSER_HID_CATS,
+			'smwgCategoryFeatures' => SMW_CAT_REDIRECT | SMW_CAT_INSTANCE,
+		];
+		$this->testEnvironment->withConfiguration( $settings );
+
+		$title = MediaWikiServices::getInstance()->getTitleFactory()
+			->newFromText( __METHOD__ );
+
+		// Outer parser begins parsing this title.
+		$outerParser = $this->parserFactory->newFromTitle( $title );
+		ParserAfterTidy::onParserClearState( $outerParser );
+
+		// Inner parse on a separate parser instance for the same title, with
+		// only a partial set of categories, mimicking the inner snapshot from
+		// jayktaylor's repro before the outer parse adds the rest.
+		$innerParser = $this->parserFactory->newFromTitle( $title );
+		ParserAfterTidy::onParserClearState( $innerParser );
+		$innerParser->getOutput()->addCategory( 'InnerCat', 'InnerCat' );
+		$innerParser->getOutput()->setExtensionData( 'smw-semanticdata-status', true );
+
+		// Inner parse ends first (LIFO): ParserAfterTidy fires with partial data.
+		$innerInstance = new ParserAfterTidy(
+			$innerParser,
+			$this->namespaceExaminer,
+			$this->cache
+		);
+		$innerInstance->setHookDispatcher( $this->hookDispatcher );
+
+		$text = '';
+		$this->assertTrue( $innerInstance->process( $text ) );
+
+		// The inner fire MUST be skipped: no SMW semantic data should have
+		// been written to the inner parser output. Before the fix, this
+		// extension data would have been populated by `copyToParserOutput()`.
+		$this->assertNull(
+			$innerParser->getOutput()->getExtensionData( ParserData::DATA_ID ),
+			'Inner (nested) ParserAfterTidy fire must not write to the parser '
+				. 'output; that work belongs to the outermost fire so the '
+				. 'final state is what is persisted (#5923).'
+		);
+
+		// Outer parse adds its categories AFTER the inner returned. Its
+		// ParserAfterTidy fires next with the full state.
+		$outerParser->getOutput()->addCategory( 'OuterCat', 'OuterCat' );
+		$outerParser->getOutput()->addCategory( 'AnotherOuterCat', 'AnotherOuterCat' );
+		$outerParser->getOutput()->setExtensionData( 'smw-semanticdata-status', true );
+
+		$outerInstance = new ParserAfterTidy(
+			$outerParser,
+			$this->namespaceExaminer,
+			$this->cache
+		);
+		$outerInstance->setHookDispatcher( $this->hookDispatcher );
+
+		$this->assertTrue( $outerInstance->process( $text ) );
+
+		// The outer fire DID run: read back the SemanticData via ParserData
+		// (mirroring `testSemanticDataParserOuputUpdateIntegration`) and
+		// confirm the outer categories are the ones that landed.
+		$outerParserData = $this->applicationFactory->newParserData(
+			$title,
+			$outerParser->getOutput()
+		);
+
+		$expected = [
+			'propertyKeys' => [ '_INST', '_SKEY' ],
+			'propertyValues' => [
+				'Category:OuterCat',
+				'Category:AnotherOuterCat',
+				$title->getText(),
+			],
+		];
+
+		$this->semanticDataValidator->assertThatPropertiesAreSet(
+			$expected,
+			$outerParserData->getSemanticData()
+		);
+	}
+
+	/**
+	 * Two independent top-level parses on DIFFERENT titles must not appear
+	 * nested to each other. This protects against the depth-tracker treating
+	 * any concurrent parses as nesting just because they happen to overlap
+	 * in time.
+	 */
+	public function testProcessRunsForIndependentTitlesInFlight() {
+		$this->namespaceExaminer->expects( $this->any() )
+			->method( 'isSemanticEnabled' )
+			->willReturn( true );
+
+		$this->testEnvironment->withConfiguration( [
+			'smwgMainCacheType' => 'hash',
+			'smwgEnableUpdateJobs' => false,
+			'smwgParserFeatures' => SMW_PARSER_HID_CATS,
+			'smwgCategoryFeatures' => SMW_CAT_REDIRECT | SMW_CAT_INSTANCE,
+		] );
+
+		$titleA = MediaWikiServices::getInstance()->getTitleFactory()
+			->newFromText( __METHOD__ . 'A' );
+		$titleB = MediaWikiServices::getInstance()->getTitleFactory()
+			->newFromText( __METHOD__ . 'B' );
+
+		$parserA = $this->parserFactory->newFromTitle( $titleA );
+		ParserAfterTidy::onParserClearState( $parserA );
+
+		$parserB = $this->parserFactory->newFromTitle( $titleB );
+		ParserAfterTidy::onParserClearState( $parserB );
+
+		// Both have content; both should run independently.
+		$parserA->getOutput()->addCategory( 'CatA', 'CatA' );
+		$parserA->getOutput()->setExtensionData( 'smw-semanticdata-status', true );
+		$parserB->getOutput()->addCategory( 'CatB', 'CatB' );
+		$parserB->getOutput()->setExtensionData( 'smw-semanticdata-status', true );
+
+		$text = '';
+
+		$instanceA = new ParserAfterTidy( $parserA, $this->namespaceExaminer, $this->cache );
+		$instanceA->setHookDispatcher( $this->hookDispatcher );
+		$instanceA->process( $text );
+
+		$instanceB = new ParserAfterTidy( $parserB, $this->namespaceExaminer, $this->cache );
+		$instanceB->setHookDispatcher( $this->hookDispatcher );
+		$instanceB->process( $text );
+
+		$this->assertNotNull(
+			$parserA->getOutput()->getExtensionData( ParserData::DATA_ID ),
+			'Parse on title A must run regardless of any in-flight parse on title B.'
+		);
+		$this->assertNotNull(
+			$parserB->getOutput()->getExtensionData( ParserData::DATA_ID ),
+			'Parse on title B must run regardless of any in-flight parse on title A.'
+		);
+	}
+
+	/**
+	 * Interface-message parses (which canPerformUpdate already filters via
+	 * `getInterfaceMessage()`) must NOT enter the in-flight tracker, otherwise
+	 * a `Message::parse()` inside a real parse could be counted as nesting.
+	 */
+	public function testOnParserClearStateIgnoresInterfaceMessageParses() {
+		$this->namespaceExaminer->expects( $this->any() )
+			->method( 'isSemanticEnabled' )
+			->willReturn( true );
+
+		$this->testEnvironment->withConfiguration( [
+			'smwgMainCacheType' => 'hash',
+			'smwgEnableUpdateJobs' => false,
+			'smwgParserFeatures' => SMW_PARSER_HID_CATS,
+			'smwgCategoryFeatures' => SMW_CAT_REDIRECT | SMW_CAT_INSTANCE,
+		] );
+
+		$parserOptions = $this->getMockBuilder( \MediaWiki\Parser\ParserOptions::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$parserOptions->expects( $this->any() )
+			->method( 'getInterfaceMessage' )
+			->willReturn( true );
+
+		$title = MediaWikiServices::getInstance()->getTitleFactory()
+			->newFromText( __METHOD__ );
+
+		$parser = $this->getMockBuilder( Parser::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$parser->expects( $this->any() )
+			->method( 'getOptions' )
+			->willReturn( $parserOptions );
+		$parser->expects( $this->never() )
+			->method( 'getTitle' );
+
+		ParserAfterTidy::onParserClearState( $parser );
+
+		// And the real outer parser for the same title should still see depth=1.
+		$realParser = $this->parserFactory->newFromTitle( $title );
+		ParserAfterTidy::onParserClearState( $realParser );
+		$realParser->getOutput()->addCategory( 'RealCat', 'RealCat' );
+		$realParser->getOutput()->setExtensionData( 'smw-semanticdata-status', true );
+
+		$text = '';
+		$realInstance = new ParserAfterTidy( $realParser, $this->namespaceExaminer, $this->cache );
+		$realInstance->setHookDispatcher( $this->hookDispatcher );
+		$realInstance->process( $text );
+
+		$this->assertNotNull(
+			$realParser->getOutput()->getExtensionData( ParserData::DATA_ID ),
+			'Interface-message parse must not poison the in-flight tracker.'
+		);
+	}
+
+	/**
+	 * If `process()` throws, the in-flight tracker must be drained for the
+	 * current parser instance so that subsequent parses on the same instance
+	 * are not permanently marked as nested.
+	 */
+	public function testProcessDrainsTrackerOnException() {
+		$this->namespaceExaminer->expects( $this->any() )
+			->method( 'isSemanticEnabled' )
+			->willReturn( true );
+
+		// Force `performUpdate` (via the ApplicationFactory chain) to throw by
+		// registering a Store that explodes.
+		$store = $this->getMockBuilder( Store::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'updateData' ] )
+			->getMockForAbstractClass();
+		$store->expects( $this->any() )
+			->method( 'updateData' )
+			->willThrowException( new \RuntimeException( 'simulated' ) );
+
+		$this->testEnvironment->withConfiguration( [
+			'smwgMainCacheType' => 'hash',
+			'smwgEnableUpdateJobs' => false,
+		] );
+		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$title = MediaWikiServices::getInstance()->getTitleFactory()
+			->newFromText( 'File:Test5923Drain.png' );
+
+		$revision = $this->getMockBuilder( RevisionRecord::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$this->revisionGuard->expects( $this->any() )
+			->method( 'getRevision' )
+			->willReturn( $revision );
+
+		$wikiPage = $this->getMockBuilder( '\WikiPage' )
+			->disableOriginalConstructor()
+			->getMock();
+		$wikiPage->expects( $this->any() )
+			->method( 'getTitle' )
+			->willReturn( $title );
+
+		$pageCreator = $this->getMockBuilder( PageCreator::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$pageCreator->expects( $this->any() )
+			->method( 'createPage' )
+			->willReturn( $wikiPage );
+		$this->testEnvironment->registerObject( 'PageCreator', $pageCreator );
+
+		// Cache key set as if `?action=purge` had fired, so checkPurgeRequest
+		// reaches `updateStore` (which then triggers our throwing store).
+		$cache = $this->applicationFactory->getCache();
+		$cache->save(
+			smwfCacheKey(
+				\SMW\MediaWiki\Hooks\ArticlePurge::CACHE_NAMESPACE,
+				$title->getArticleID()
+			),
+			true
+		);
+
+		$parser = $this->parserFactory->newFromTitle( $title );
+		ParserAfterTidy::onParserClearState( $parser );
+		$parser->getOutput()->addCategory( 'Foo', 'Foo' );
+		$parser->getOutput()->setExtensionData( 'smw-semanticdata-status', true );
+
+		$instance = new ParserAfterTidy( $parser, $this->namespaceExaminer, $cache );
+		$instance->setHookDispatcher( $this->hookDispatcher );
+
+		$text = '';
+		try {
+			$instance->process( $text );
+		} catch ( \Throwable $e ) {
+			// Expected, swallow.
+		}
+
+		// A second parse on the SAME parser instance must NOT be considered
+		// nested. With the tracker drained, depth for this parser is 0 again.
+		ParserAfterTidy::onParserClearState( $parser );
+		$parser->getOutput()->addCategory( 'Bar', 'Bar' );
+
+		$secondParser = $this->parserFactory->newFromTitle( $title );
+		ParserAfterTidy::onParserClearState( $secondParser );
+		$secondParser->getOutput()->addCategory( 'Baz', 'Baz' );
+		$secondParser->getOutput()->setExtensionData( 'smw-semanticdata-status', true );
+
+		// The inner (nested) one should still be skipped because we now have
+		// two parsers active on the same title. This is the *correct* behavior;
+		// it demonstrates the tracker is not stuck in a wedged state.
+		$secondInstance = new ParserAfterTidy(
+			$secondParser,
+			$this->namespaceExaminer,
+			$cache
+		);
+		$secondInstance->setHookDispatcher( $this->hookDispatcher );
+		$secondInstance->process( $text );
+
+		$this->assertNull(
+			$secondParser->getOutput()->getExtensionData( ParserData::DATA_ID ),
+			'Inner parser must be skipped when another parser for the same title is active.'
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/HooksTest.php
@@ -344,7 +344,7 @@ class HooksTest extends TestCase {
 	public function callParserClearState( $instance ) {
 		$handler = 'ParserClearState';
 
-		$parserOptions = $this->getMockBuilder( \MediaWiki\Parser\ParserOptions::class )
+		$parserOptions = $this->getMockBuilder( ParserOptions::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/HooksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/HooksTest.php
@@ -260,6 +260,7 @@ class HooksTest extends TestCase {
 	public function callMethodProvider() {
 		return [
 			[ 'callParserAfterTidy' ],
+			[ 'callParserClearState' ],
 			[ 'callSkinAfterContent' ],
 			[ 'callSidebarBeforeOutput' ],
 			[ 'callOutputPageParserOutput' ],
@@ -335,6 +336,33 @@ class HooksTest extends TestCase {
 		$this->assertThatHookIsExcutable(
 			$instance->getHandlerFor( $handler ),
 			[ &$this->parser, &$text ]
+		);
+
+		return $handler;
+	}
+
+	public function callParserClearState( $instance ) {
+		$handler = 'ParserClearState';
+
+		$parserOptions = $this->getMockBuilder( \MediaWiki\Parser\ParserOptions::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOptions->expects( $this->any() )
+			->method( 'getInterfaceMessage' )
+			->willReturn( true );
+
+		$this->parser->expects( $this->any() )
+			->method( 'getOptions' )
+			->willReturn( $parserOptions );
+
+		$this->assertTrue(
+			$instance->isRegistered( $handler )
+		);
+
+		$this->assertThatHookIsExcutable(
+			$instance->getHandlerFor( $handler ),
+			[ $this->parser ]
 		);
 
 		return $handler;


### PR DESCRIPTION
## Summary

Closes #5923.

When an extension clones the parser and calls `Parser::parse()` recursively on the same title (DPL3 master `<dpl>`, TabberNeue `<tabber>`, similar patterns), MediaWiki fires `ParserAfterTidy` once per parse. The current code at `src/MediaWiki/Hooks/ParserAfterTidy.php` deletes the `ArticlePurge` cache key on the **first** (inner) fire and persists the inner parse's partial `ParserOutput`; the outermost fire (with the full state) finds the key gone and skips, silently losing outer-parse properties and categories on `?action=purge`. jayktaylor laid out the mechanism in the issue.

## What changed

Track in-flight `Parser::parse()` calls per Parser instance via the `ParserClearState` hook (MW fires this from `Parser::parse()` only when `clearState=true`; `recursiveTagParseFully()` does not fire it). When `ParserAfterTidy::process()` sees another Parser actively parsing the same title, it skips, so only the outermost fire runs the update against the full `ParserOutput`.

The tracker is a `WeakMap<Parser, string>`:
- Short-lived cloned parsers are reclaimed by GC if `Parser::parse()` throws between `clearState` and `ParserAfterTidy`.
- Long-lived parsers whose entry survives an exception self-heal: the next successful parse for the same title re-registers idempotently and the `finally` decrement clears the entry, so the leak does not compound across requests.

Interface-message parses are excluded from the tracker so a `Message::parse()` inside a real parse cannot be counted as nesting.

## Files

- `src/MediaWiki/Hooks/ParserAfterTidy.php` - in-flight tracker, `onParserClearState`, nested-fire skip in `process()`.
- `src/MediaWiki/Hooks.php` - wires up the new `ParserClearState` handler.
- `tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php` - four new tests covering the characterization, two-title independence, interface-message pass-through, and exception balance.
- `tests/phpunit/Unit/MediaWiki/HooksTest.php` - `callParserClearState` keeps the missing-handler meta-test green.

## Note on #5392

Symptoms in #5392 overlap (incomplete/empty queries, lost properties), but the reports there mention missing pure MediaWiki page properties (e.g. `pageimage`, `description` from `Extension:PageImage` / `Extension:ShortDescription`) that SMW cannot drop, plus triggers (Cirrus jobs, Echo, ReplaceText, Lua modules) that do not obviously involve recursive `Parser::parse()`. Some manifestations may be helped by this fix, but #5392 needs separate investigation and this PR does not claim to close it.

## Test plan

- [x] `composer phpunit -- --filter 'ParserAfterTidyTest|HooksTest'` - 75 tests, 216 assertions, all pass.
- [x] `composer phpunit -- --testsuite=semantic-mediawiki-unit` - full unit suite green on this branch.
- [x] `vendor/bin/phpcs -sp` on all 4 touched files - clean.
- [x] End-to-end browser repro on dev wiki with a tiny dev-only fixture extension that registers a `<smw5923>` tag, clones the parser, and re-enters `Parser::parse()` on the same title. Pre-fix: `?action=purge` wipes 3 outer properties and both outer categories. Post-fix: all preserved.