### PR TITLE
Apply keyset cursor pagination to Browse API ArticleLookup

### DIFF
--- a/src/MediaWiki/Api/Browse/ArticleLookup.php
+++ b/src/MediaWiki/Api/Browse/ArticleLookup.php
@@ -53,11 +53,28 @@ class ArticleLookup extends Lookup {
 
 		$list = [];
 		$continueOffset = 0;
+		$continueCursor = 0;
+		$cursorMode = self::shouldUseCursorMode( $parameters );
+
 		if ( isset( $parameters['search'] ) ) {
-			[ $list, $continueOffset ] = $this->search( $limit, $offset, $parameters['search'], $namespace );
+			if ( $cursorMode ) {
+				$cursor = (int)$parameters['cursor'];
+				[ $list, $continueCursor ] = $this->searchByCursor(
+					$limit,
+					$cursor,
+					$parameters['search'],
+					$namespace
+				);
+			} else {
+				[ $list, $continueOffset ] = $this->search( $limit, $offset, $parameters['search'], $namespace );
+			}
 		}
 
-		// Changing this output format requires to set a new version
+		// Changing this output format requires to set a new version. The
+		// `query-continue-cursor` field is byte-additive: it is only emitted
+		// when the caller opted into cursor mode (by sending `cursor` in
+		// the request payload). Legacy clients that follow
+		// `query-continue-offset` see exactly the pre-cursor response shape.
 		$res = [
 			'query' => $list,
 			'query-continue-offset' => $continueOffset,
@@ -69,6 +86,10 @@ class ArticleLookup extends Lookup {
 			]
 		];
 
+		if ( $cursorMode ) {
+			$res['query-continue-cursor'] = $continueCursor;
+		}
+
 		$this->articleAugmentor->augment(
 			$res,
 			$parameters
@@ -79,58 +100,23 @@ class ArticleLookup extends Lookup {
 
 	private function search( int $limit, int $offset, $search, $namespace = null ): array {
 		$search = $this->getSearchTerm( $search, $namespace );
-
-		$escapeChar = '`';
-		$list = [];
-
-		$search = str_replace(
-			[ ' ', $escapeChar, '%', '_' ],
-			[ '_', "{$escapeChar}{$escapeChar}", "{$escapeChar}%", "{$escapeChar}_" ],
-			$search
-		);
-
 		$limit += 1;
-		$conditions = '';
-
-		$fields = [
-			'page_id',
-			'page_namespace',
-			'page_title'
-		];
-
-		$options = [
-			'LIMIT' => $limit,
-			'OFFSET' => $offset,
-			'ORDER BY' => "page_title,page_namespace"
-		];
-
-		$conds = [
-			'%' . $search . '%',
-			'%' . ucfirst( $search ) . '%',
-			'%' . strtoupper( $search ) . '%',
-			'%' . strtolower( $search ) . '%'
-		];
-
-		foreach ( $conds as $s ) {
-			$conditions .= ( $conditions !== '' ? ' OR ' : '' ) . "page_title LIKE ";
-			$conditions .= $this->connection->addQuotes( $s );
-			$conditions .= ' ESCAPE ' . $this->connection->addQuotes( $escapeChar );
-		}
-
-		if ( $namespace !== null ) {
-			$conditions = 'page_namespace=' . $this->connection->addQuotes( $namespace ) . ' AND (' . $conditions . ')';
-		}
 
 		$res = $this->connection->newSelectQueryBuilder()
-			->select( $fields )
+			->select( [ 'page_id', 'page_namespace', 'page_title' ] )
 			->from( 'page' )
-			->where( [ $conditions ] )
-			->options( $options )
+			->where( [ $this->buildSearchConditions( $search, $namespace ) ] )
+			->options( [
+				'LIMIT' => $limit,
+				'OFFSET' => $offset,
+				'ORDER BY' => "page_title,page_namespace"
+			] )
 			->caller( __METHOD__ )
 			->fetchResultSet();
 
 		$count = 0;
 		$continueOffset = 0;
+		$list = [];
 
 		foreach ( $res as $row ) {
 
@@ -142,19 +128,126 @@ class ArticleLookup extends Lookup {
 				break;
 			}
 
-			$label = str_replace( '_', ' ', $row->page_title );
-
-			$list[$key . '#' . $row->page_namespace] = [
-				 // Only keep the ID as internal field which is
-				 // removed by the Augmentor
-				'id'    => $row->page_id,
-				'label' => $label,
-				'key'   => $key,
-				'ns'    => $row->page_namespace
-			];
+			$list[$key . '#' . $row->page_namespace] = $this->rowToListEntry( $row );
 		}
 
 		return [ $list, $continueOffset ];
+	}
+
+	/**
+	 * Cursor-aware sibling of `search()`. Anchored at `page_id` (unique
+	 * primary-key column of the `page` table) and walks forward in the
+	 * same `(page_title, page_namespace)` total order. The keyset
+	 * predicate uses an explicit OR form so MariaDB seeks the
+	 * `name_title` index rather than full-scanning. See #6559 for the
+	 * underlying motivation.
+	 *
+	 * Does NOT reuse `KeysetPaginationTrait` because that trait is tied
+	 * to the `smw_object_ids` `(smw_sort, smw_id)` shape; here we walk
+	 * the MW core `page` table with a different sort tuple.
+	 *
+	 * @since 7.0.0
+	 */
+	private function searchByCursor( int $limit, int $cursor, $search, $namespace = null ): array {
+		$search = $this->getSearchTerm( $search, $namespace );
+		$conditions = $this->buildSearchConditions( $search, $namespace );
+
+		if ( $cursor > 0 ) {
+			$anchorRow = $this->connection->newSelectQueryBuilder()
+				->select( [ 'page_title', 'page_namespace' ] )
+				->from( 'page' )
+				->where( [ 'page_id' => $cursor ] )
+				->caller( __METHOD__ )
+				->fetchRow();
+
+			if ( $anchorRow ) {
+				$qTitle = $this->connection->addQuotes( $anchorRow->page_title );
+				$qNs = $this->connection->addQuotes( $anchorRow->page_namespace );
+				$keysetPredicate = "page_title > $qTitle OR ( page_title = $qTitle AND page_namespace > $qNs )";
+				$conditions = "( $keysetPredicate ) AND ( $conditions )";
+			}
+			// Stale cursor (page_id no longer exists): predicate is silently
+			// skipped, response falls back to the first page. Matches the
+			// convention established by `KeysetPaginationTrait`.
+		}
+
+		$res = $this->connection->newSelectQueryBuilder()
+			->select( [ 'page_id', 'page_namespace', 'page_title' ] )
+			->from( 'page' )
+			->where( [ $conditions ] )
+			->options( [
+				'LIMIT' => $limit + 1,
+				'ORDER BY' => "page_title,page_namespace"
+			] )
+			->caller( __METHOD__ )
+			->fetchResultSet();
+
+		$count = 0;
+		$continueCursor = 0;
+		$lastPageId = 0;
+		$list = [];
+
+		foreach ( $res as $row ) {
+
+			$count++;
+
+			if ( $count > $limit ) {
+				// Lookahead row triggers the break: surface the previous
+				// row's `page_id` as the next-page anchor.
+				$continueCursor = $lastPageId;
+				break;
+			}
+
+			$list[$row->page_title . '#' . $row->page_namespace] = $this->rowToListEntry( $row );
+			$lastPageId = (int)$row->page_id;
+		}
+
+		return [ $list, $continueCursor ];
+	}
+
+	/**
+	 * Build the disjunctive LIKE conditions over `page_title` (with
+	 * optional `page_namespace` AND), shared by the offset and cursor
+	 * paths.
+	 */
+	private function buildSearchConditions( string $search, $namespace ): string {
+		$escapeChar = '`';
+
+		$search = str_replace(
+			[ ' ', $escapeChar, '%', '_' ],
+			[ '_', "{$escapeChar}{$escapeChar}", "{$escapeChar}%", "{$escapeChar}_" ],
+			$search
+		);
+
+		$conds = [
+			'%' . $search . '%',
+			'%' . ucfirst( $search ) . '%',
+			'%' . strtoupper( $search ) . '%',
+			'%' . strtolower( $search ) . '%'
+		];
+
+		$conditions = '';
+		foreach ( $conds as $s ) {
+			$conditions .= ( $conditions !== '' ? ' OR ' : '' ) . 'page_title LIKE ';
+			$conditions .= $this->connection->addQuotes( $s );
+			$conditions .= ' ESCAPE ' . $this->connection->addQuotes( $escapeChar );
+		}
+
+		if ( $namespace !== null ) {
+			$conditions = 'page_namespace=' . $this->connection->addQuotes( $namespace ) . ' AND (' . $conditions . ')';
+		}
+
+		return $conditions;
+	}
+
+	private function rowToListEntry( object $row ): array {
+		return [
+			// Only keep the ID as internal field which is removed by the Augmentor
+			'id'    => $row->page_id,
+			'label' => str_replace( '_', ' ', $row->page_title ),
+			'key'   => $row->page_title,
+			'ns'    => $row->page_namespace
+		];
 	}
 
 	private function getSearchTerm( $search, &$namespace = null ) {

--- a/src/MediaWiki/Api/Browse/ListLookup.php
+++ b/src/MediaWiki/Api/Browse/ListLookup.php
@@ -186,26 +186,6 @@ class ListLookup extends Lookup {
 		return $requestOptions;
 	}
 
-	/**
-	 * Decides whether the request opts into cursor pagination. Cursor mode
-	 * is triggered by the *presence* of the `cursor` key in the request
-	 * payload (any value, including 0) rather than the absence of `offset`
-	 * (the trigger used by the URL-driven `Special:*` consumers). The
-	 * presence-of-key form is unambiguous for a JSON-payload API where
-	 * clients explicitly opt in.
-	 *
-	 * Extracted as a static helper so the predicate is unit-testable
-	 * without instantiating the lookup or its store.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param array $parameters The decoded `params` payload from the
-	 *   `smwbrowse` API request.
-	 */
-	public static function shouldUseCursorMode( array $parameters ): bool {
-		return array_key_exists( 'cursor', $parameters );
-	}
-
 	private function fetchFromTable( int|string $ns, RequestOptions $requestOptions, array $parameters ): array {
 		$limit = $requestOptions->getLimit() - 1;
 		$list = [];

--- a/src/MediaWiki/Api/Browse/Lookup.php
+++ b/src/MediaWiki/Api/Browse/Lookup.php
@@ -27,4 +27,24 @@ abstract class Lookup {
 	// phpcs:ignore Generic.NamingConventions.ConstructorName.OldStyle
 	abstract public function lookup( array $parameters );
 
+	/**
+	 * Decides whether the request opts into cursor pagination. Cursor mode
+	 * is triggered by *presence* of the `cursor` key in the request payload
+	 * (any value, including 0), not by truthiness. The presence-of-key form
+	 * is unambiguous for a JSON-payload API where clients explicitly opt
+	 * in: `cursor=0` is the canonical "first page in cursor mode" value
+	 * and a value > 0 is the previous response's `query-continue-cursor`.
+	 *
+	 * Absence of the key keeps the legacy OFFSET path for backward
+	 * compatibility with clients that follow `query-continue-offset`.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $parameters The decoded `params` payload from the
+	 *   `smwbrowse` API request.
+	 */
+	public static function shouldUseCursorMode( array $parameters ): bool {
+		return array_key_exists( 'cursor', $parameters );
+	}
+
 }

--- a/src/MediaWiki/Api/Browse/PSubjectLookup.php
+++ b/src/MediaWiki/Api/Browse/PSubjectLookup.php
@@ -103,22 +103,6 @@ class PSubjectLookup extends Lookup {
 		return $res;
 	}
 
-	/**
-	 * Decides whether the request opts into cursor pagination. Mirrors
-	 * the `ListLookup::shouldUseCursorMode()` predicate: cursor mode is
-	 * triggered by *presence* of the `cursor` key (any value, including
-	 * 0), not by truthiness. The presence-of-key form is unambiguous for
-	 * a JSON-payload API where clients explicitly opt in.
-	 *
-	 * @since 7.0.0
-	 *
-	 * @param array $parameters The decoded `params` payload from the
-	 *   `smwbrowse` API request.
-	 */
-	public static function shouldUseCursorMode( array $parameters ): bool {
-		return array_key_exists( 'cursor', $parameters );
-	}
-
 	private function findPropertySubjects( $property, $value, int $limit, int $offset, array $parameters ): array {
 		$list = [];
 		$dataItem = null;

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/ArticleLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/ArticleLookupTest.php
@@ -122,4 +122,165 @@ class ArticleLookupTest extends TestCase {
 		return $provider;
 	}
 
+	public function testLegacyResponseOmitsContinueCursorField(): void {
+		$instance = $this->newInstanceReturningRows( [ $this->newRow( 42, 'Foo', 0 ) ] );
+
+		$res = $instance->lookup( [ 'search' => 'Foo' ] );
+
+		// Legacy clients (no `cursor` opt-in) must see exactly the
+		// pre-cursor response shape. Existing JSONScript fixtures depend
+		// on a contiguous `"query-continue-offset":0,"version":1`
+		// substring; inserting a new field between them would break them.
+		$this->assertArrayNotHasKey( 'query-continue-cursor', $res );
+		$this->assertArrayHasKey( 'query-continue-offset', $res );
+	}
+
+	public function testCursorModeEmitsContinueCursorField(): void {
+		$instance = $this->newInstanceReturningRows( [ $this->newRow( 42, 'Foo', 0 ) ] );
+
+		$res = $instance->lookup( [
+			'search' => 'Foo',
+			'cursor' => 0,
+		] );
+
+		$this->assertArrayHasKey( 'query-continue-cursor', $res );
+		$this->assertSame( 0, $res['query-continue-cursor'] );
+	}
+
+	public function testCursorModeWithLookaheadRowEmitsContinueCursor(): void {
+		// 3 rows with limit=2 -> the third row is the lookahead; the
+		// loop must not include it in the response and must surface the
+		// SECOND row's page_id as the next-page anchor.
+		$rows = [
+			$this->newRow( 100, 'AAA', 0 ),
+			$this->newRow( 101, 'BBB', 0 ),
+			$this->newRow( 102, 'CCC', 0 ),
+		];
+		$instance = $this->newInstanceReturningRows( $rows );
+
+		$res = $instance->lookup( [
+			'search' => 'X',
+			'cursor' => 0,
+			'limit' => 2,
+		] );
+
+		$this->assertCount( 2, $res['query'] );
+		$this->assertSame( 101, $res['query-continue-cursor'] );
+		$this->assertSame( 0, $res['query-continue-offset'] );
+	}
+
+	public function testCursorWithNonZeroValueEmitsKeysetPredicate(): void {
+		$capturedWheres = [];
+		$instance = $this->newInstanceReturningRows(
+			[ $this->newRow( 42, 'Anchor_Title', 5 ) ],
+			$capturedWheres
+		);
+
+		$instance->lookup( [
+			'search' => 'X',
+			'cursor' => 99,
+		] );
+
+		// First captured where must be the anchor resolution.
+		$this->assertSame(
+			[ 'page_id' => 99 ],
+			$capturedWheres[0],
+			'cursor>0 must trigger a SELECT to resolve page_id 99 to (page_title, page_namespace)'
+		);
+
+		// Second captured where must be the main query with the keyset
+		// predicate ANDed onto the search conditions. The mock fetchRow
+		// returns the first row (the test row) as the anchor, so the
+		// predicate references that row's title/ns.
+		$this->assertStringContainsString(
+			'page_title > Anchor_Title',
+			$capturedWheres[1][0],
+			'Cursor mode must emit a > predicate on page_title using the anchor row'
+		);
+		$this->assertStringContainsString(
+			'page_title = Anchor_Title AND page_namespace > 5',
+			$capturedWheres[1][0],
+			'Cursor mode must emit a tiebreak predicate on page_namespace'
+		);
+	}
+
+	public function testStaleCursorFallsBackToFirstPageWithoutPredicate(): void {
+		// Anchor resolution returns no row (cursor is stale). The mock
+		// trait's `fetchRow` returns the first row from the array; pass
+		// an empty array so it returns false and the trait reads "stale".
+		$articleAugmentor = $this->getMockBuilder( ArticleAugmentor::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'addQuotes' )
+			->willReturnArgument( 0 );
+
+		$capturedWheres = [];
+		$callIndex = 0;
+		$mainRow = $this->newRow( 42, 'Foo', 0 );
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback(
+				function () use ( $mainRow, &$capturedWheres, &$callIndex ) {
+					$rows = $callIndex === 0 ? [] : [ $mainRow ];
+					$callIndex++;
+					return $this->createMockSelectQueryBuilder( $rows, $capturedWheres );
+				}
+			);
+
+		$instance = new ArticleLookup( $connection, $articleAugmentor );
+
+		$res = $instance->lookup( [
+			'search' => 'Foo',
+			'cursor' => 99999999,
+		] );
+
+		// Main query (index 1) must NOT contain a keyset predicate.
+		$mainWhere = is_string( $capturedWheres[1][0] ?? null ) ? $capturedWheres[1][0] : '';
+		$this->assertStringNotContainsString(
+			'page_title >',
+			$mainWhere,
+			'Stale cursor must skip the keyset predicate and serve the first page'
+		);
+		$this->assertCount( 1, $res['query'] );
+	}
+
+	private function newRow( int $id, string $title, int $namespace ): stdClass {
+		$row = new stdClass;
+		$row->page_id = $id;
+		$row->page_title = $title;
+		$row->page_namespace = $namespace;
+		return $row;
+	}
+
+	private function newInstanceReturningRows( array $rows, array &$capturedWheres = [] ): ArticleLookup {
+		$articleAugmentor = $this->getMockBuilder( ArticleAugmentor::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->any() )
+			->method( 'addQuotes' )
+			->willReturnArgument( 0 );
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturnCallback(
+				function () use ( $rows, &$capturedWheres ) {
+					return $this->createMockSelectQueryBuilder( $rows, $capturedWheres );
+				}
+			);
+
+		return new ArticleLookup( $connection, $articleAugmentor );
+	}
+
 }


### PR DESCRIPTION
## Summary

Completes the Browse API keyset cursor pagination sweep started in
#6804 (ListLookup) and #6806 (PSubjectLookup). Two commits:

1. **Hoist `shouldUseCursorMode()` to the `Lookup` base class.** After
   two consumers (`ListLookup`, `PSubjectLookup`) gained a verbatim
   copy of the static helper, the duplication became load-bearing.
   `ArticleLookup` makes a third consumer; the predicate now lives on
   the abstract parent and is inherited.
2. **Add opt-in cursor pagination to `smwbrowse&browse=page`.** Old
   clients see exactly the pre-cursor response shape; new clients opt
   in via `cursor` in the request payload and follow
   `query-continue-cursor` (a `page_id` keyset anchor).

Tracks #6795 (Phase 2). `Special:OWLExport`, `Special:PageProperty`,
`PropertyLabelSimilarity` and `ProximityPropertyValueLookup` remain.

## Why not reuse `KeysetPaginationTrait`?

`ArticleLookup` queries the MW core `page` table with `ORDER BY
page_title, page_namespace`, not `smw_object_ids`. The trait's
predicate is tied to `smw_sort` and `smw_id` columns. Reusing it
would require either (a) parametrising the column names across the
trait and every existing consumer (`SpecialConcepts`,
`PropertySubjectsLookup`, `PropertyUsageListLookup`,
`UnusedPropertyListLookup`), or (b) introducing a misleading shim.

Instead, `ArticleLookup` inlines a small bespoke keyset predicate
against `(page_title, page_namespace)` anchored at `page_id`:

```sql
page_title > 'X' OR ( page_title = 'X' AND page_namespace > Y )
```

The explicit-OR form preserves the MariaDB range-seek optimisation
that #6794 fixed for the trait. The sort tuple is unique via the
`page` primary key, so this is total-ordering. The anchor is
resolved via a small SELECT on `page_id = $cursor`; a stale cursor
(deleted row) silently degrades to the first page, matching the
trait's established convention.

## API contract

Mirrors the byte-additive contract validated by #6804 and #6806:

| Request field | Mode | Response continuation field |
|---|---|---|
| `cursor` absent | Legacy OFFSET (unchanged) | `query-continue-offset` |
| `cursor` present (any value) | Cursor mode opt-in | `query-continue-cursor` |
| `cursor` > 0 | Anchored at `page_id = cursor` | `query-continue-cursor` |
| `cursor` + `offset` | Cursor authoritative | `query-continue-cursor` |

The `query-continue-cursor` field is only emitted in cursor mode, so
JSONScript fixtures that match the contiguous
`""query-continue-offset"":0,""version"":1` substring are preserved.

## Implementation

- Legacy `search()` refactored to share LIKE-condition building with
  the new `searchByCursor()` via a private `buildSearchConditions()`
  helper. The legacy SQL is byte-identical to before; the
  data-driven `articleSearchProvider` tests pass without
  modification.
- Lookahead trim: `LIMIT $limit + 1`; when the loop hits the
  limit+1th row, it surfaces the previous row's `page_id` as the
  cursor anchor and breaks.
- `rowToListEntry()` helper unifies the row → list-entry mapping
  between both paths.
- The hoist deletes the per-class `shouldUseCursorMode()` static from
  `ListLookup` and `PSubjectLookup`. `self::` call sites resolve to
  the inherited parent method via PHP late static binding.

## Test plan

- [x] ``composer analyze`` clean
- [x] 8 ``ArticleLookupTest`` cases pass (3 pre-existing + 5 new):
  - Legacy response omits ``query-continue-cursor``
  - Cursor mode emits the field
  - Lookahead row triggers correct ``continueCursor`` (second row, not lookahead)
  - Cursor > 0 emits the keyset predicate against the resolved anchor
  - Stale cursor falls back to first page without the predicate
- [x] No regressions in the wider Browse API suite (45 cases incl.
  hoisted inheritance)
- [x] JSONScript ``api-smwbrowse-0001`` / ``0002`` / ``0003``
  fixtures pass (locks the legacy response shape)
- [x] Browser smoke against the dev wiki (``browse=page``,
  ``search=SmokePage``, 20 seeded articles, ``limit=6``):

  | Mode | Pages | Total visited | Notes |
  |---|---|---|---|
  | Legacy ``?offset=`` | 4 | 18 of 20 | Pre-existing skip bug |
  | Cursor ``?cursor=`` | 4 | 20 of 20 | Anchored at last displayed page_id |

## Latent (NOT fixed here)

The legacy ``search()`` path advances by ``offset + $limit`` where
``$limit`` was already incremented for the lookahead, so legacy
pagination skips one item per page boundary. Browser smoke confirmed
this against the dev wiki (cursor walks 20, legacy walks 18, missing
items 07 and 14). This is the same off-by-one observed in PSubject
(#6806). Preserved verbatim to keep PR scope tight; cursor mode
sidesteps it because it anchors at the last *displayed* row's
``page_id``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)