### PR TITLE
QueryEngine: opt-in keyset cursor pagination for default-sort #ask

### DIFF
--- a/src/MediaWiki/Api/Query.php
+++ b/src/MediaWiki/Api/Query.php
@@ -74,20 +74,23 @@ abstract class Query extends ApiBase {
 		$resultFormatter->setIsRawMode( ( strpos( strtolower( $outputFormat ), 'xml' ) !== false ) );
 		$resultFormatter->doFormat();
 
-		if ( $resultFormatter->getContinueOffset() ) {
+		// Cursor mode is authoritative: when the query ran with a cursor
+		// the response uses ONLY `query-continue-cursor` (or omits the
+		// continuation field entirely on the final page). Legacy mode
+		// emits `query-continue-offset` unchanged. Mixing the two would
+		// let a cursor-aware client accidentally chain into a
+		// `?offset=N&cursor=...` request, which has unspecified semantics.
+		$cursorMode = $queryResult->getQuery()->getCursorAfter() !== null;
+		$nextCursor = $queryResult->getNextCursor();
+
+		if ( $cursorMode ) {
+			if ( $nextCursor !== null ) {
+				$result->addValue( null, 'query-continue-cursor', $nextCursor );
+			}
+		} elseif ( $resultFormatter->getContinueOffset() ) {
 		// $result->disableSizeCheck();
 			$result->addValue( null, 'query-continue-offset', $resultFormatter->getContinueOffset() );
 		// $result->enableSizeCheck();
-		}
-
-		// Byte-additive: only emitted when the query ran in keyset cursor
-		// mode and there are further results. Legacy clients that follow
-		// `query-continue-offset` see exactly the pre-cursor response
-		// shape. Mirrors the contract established by the Browse API
-		// keyset PRs (#6804 / #6806 / #6808).
-		$nextCursor = $queryResult->getNextCursor();
-		if ( $nextCursor !== null ) {
-			$result->addValue( null, 'query-continue-cursor', $nextCursor );
 		}
 
 		$result->addValue(

--- a/src/MediaWiki/Api/Query.php
+++ b/src/MediaWiki/Api/Query.php
@@ -80,6 +80,16 @@ abstract class Query extends ApiBase {
 		// $result->enableSizeCheck();
 		}
 
+		// Byte-additive: only emitted when the query ran in keyset cursor
+		// mode and there are further results. Legacy clients that follow
+		// `query-continue-offset` see exactly the pre-cursor response
+		// shape. Mirrors the contract established by the Browse API
+		// keyset PRs (#6804 / #6806 / #6808).
+		$nextCursor = $queryResult->getNextCursor();
+		if ( $nextCursor !== null ) {
+			$result->addValue( null, 'query-continue-cursor', $nextCursor );
+		}
+
 		$result->addValue(
 			null,
 			$resultFormatter->getType(),

--- a/src/Query/Processor/DefaultParamDefinition.php
+++ b/src/Query/Processor/DefaultParamDefinition.php
@@ -85,6 +85,15 @@ class DefaultParamDefinition {
 			'upperbound' => $vars['smwgQUpperbound'],
 		];
 
+		// Opaque keyset cursor token (base64url-encoded JSON produced by
+		// `CursorEncoder`). When present, the query engine switches to
+		// keyset pagination and ignores `offset`. The constrained spike
+		// supports only default-sort queries; `sort=` + `cursor=`
+		// combinations are rejected during query construction.
+		$params['cursor'] = [
+			'default' => '',
+		];
+
 		$params['link'] = [
 			'default' => 'all',
 			'values' => [ 'all', 'subject', 'none' ],

--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -8,6 +8,7 @@ use SMW\Localizer\Localizer;
 use SMW\Query\Query;
 use SMW\Query\QueryContext;
 use SMW\QueryFactory;
+use SMW\SQLStore\QueryEngine\CursorEncoder;
 
 /**
  * @private
@@ -144,7 +145,53 @@ class QueryCreator implements QueryContext {
 			$sortKeys['keys']
 		);
 
+		$this->applyCursorIfRequested( $query, $sortKeys['keys'] );
+
 		return $query;
+	}
+
+	/**
+	 * Decode the optional `cursor=<token>` user parameter and apply it
+	 * to the query, enforcing the constrained-spike contract: cursor
+	 * mode is only supported when the query has no custom `sort=`
+	 * property. A `cursor=` + `sort=Property` combination is rejected
+	 * by attaching an error message to the query (the engine then
+	 * surfaces it instead of running the query).
+	 *
+	 * A malformed cursor token (any decode failure) is also surfaced
+	 * as an error rather than silently ignored, to avoid the
+	 * "expected next-page got first-page" surprise for bot clients.
+	 *
+	 * @param Query $query
+	 * @param array $sortKeys As returned by `getSortKeys()['keys']`.
+	 *   An empty-string key (`'' => 'ASC'`) is the default "sort by
+	 *   page" and is allowed; any non-empty-string key is a custom
+	 *   property sort and is rejected.
+	 */
+	private function applyCursorIfRequested( Query $query, array $sortKeys ): void {
+		$token = (string)$this->getParam( 'cursor', '' );
+		if ( $token === '' ) {
+			return;
+		}
+
+		foreach ( $sortKeys as $sortKey => $_order ) {
+			if ( $sortKey !== '' ) {
+				$query->addErrors( [
+					'Cursor pagination (`cursor=`) is not supported with a custom `sort=` property in this release. Remove `sort=` or use `offset=` instead.'
+				] );
+				return;
+			}
+		}
+
+		$payload = CursorEncoder::decode( $token );
+		if ( $payload === null ) {
+			$query->addErrors( [
+				'Malformed `cursor=` token (rejected as unrecognised or from a newer schema version).'
+			] );
+			return;
+		}
+
+		$query->setCursorAfter( $payload );
 	}
 
 	/**

--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -183,6 +183,13 @@ class QueryCreator implements QueryContext {
 			}
 		}
 
+		if ( $query->getQueryMode() === self::MODE_COUNT ) {
+			$query->addErrors( [
+				'Cursor pagination (`cursor=`) is not supported with `format=count`. Remove `cursor=` or switch to a non-count format.'
+			] );
+			return;
+		}
+
 		$payload = CursorEncoder::decode( $token );
 		if ( $payload === null ) {
 			$query->addErrors( [

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -82,6 +82,22 @@ class Query implements QueryContext {
 
 	private $limit;
 	private $offset = 0;
+
+	/**
+	 * Opaque cursor payload (decoded from a `CursorEncoder` token), or
+	 * `null` when not in cursor mode. Set via `setCursorAfter()` by the
+	 * `QueryCreator` after decoding the `cursor=<token>` user parameter.
+	 *
+	 * In cursor mode the query engine ignores `$offset` and applies a
+	 * keyset predicate derived from this payload instead. See
+	 * `KeysetPaginationTrait` (Phase 2) and the `QueryEngine` cursor
+	 * branch (Phase 3 spike) for the application sites.
+	 *
+	 * Stays `null` for all default-mode queries; legacy callers are
+	 * unaffected.
+	 */
+	private ?array $cursorAfter = null;
+
 	private array $errors = []; // keep any errors that occurred so far
 	private $queryString = false; // string (inline query) version (if fixed and known)
 	private bool $isInline; // query used inline? (required for finding right default parameters)
@@ -365,6 +381,34 @@ class Query implements QueryContext {
 	 */
 	public function setUnboundOffset( $offset ): void {
 		$this->offset = (int)$offset;
+	}
+
+	/**
+	 * Switch the query into keyset cursor mode by storing the decoded
+	 * cursor payload. When non-null, the `QueryEngine` ignores `$offset`
+	 * and applies a keyset WHERE predicate derived from the payload's
+	 * `sort` and `id` fields instead.
+	 *
+	 * Pass `null` (the default) to leave the query in the legacy
+	 * offset-paginated mode.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array|null $payload The decoded `CursorEncoder` payload,
+	 *   typically `[ 'v' => 1, 'sort' => '...', 'id' => <int> ]`.
+	 */
+	public function setCursorAfter( ?array $payload ): void {
+		$this->cursorAfter = $payload;
+	}
+
+	/**
+	 * The decoded cursor payload, or `null` when the query is in legacy
+	 * offset mode.
+	 *
+	 * @since 7.0.0
+	 */
+	public function getCursorAfter(): ?array {
+		return $this->cursorAfter;
 	}
 
 	public function getLimit() {

--- a/src/Query/Query.php
+++ b/src/Query/Query.php
@@ -564,6 +564,15 @@ class Query implements QueryContext {
 			'querymode' => $this->querymode
 		];
 
+		// Cursor mode anchors the result set at a different `(smw_sort,
+		// smw_id)` than the default page-1 query, so a cursor-anchored
+		// request must NOT collide in cache with the same #ask query
+		// run without a cursor. Include the decoded payload directly;
+		// `ResultCache` keys on this hash.
+		if ( $this->cursorAfter !== null ) {
+			$serialized['parameters']['cursor'] = $this->cursorAfter;
+		}
+
 		// Make to sure to distinguish queries and results from a foreign repository
 		if ( $this->querySource !== null && $this->querySource !== '' ) {
 			$serialized['parameters']['source'] = $this->querySource;

--- a/src/Query/QueryProcessor.php
+++ b/src/Query/QueryProcessor.php
@@ -165,6 +165,14 @@ class QueryProcessor implements QueryContext {
 			$limit = $GLOBALS['smwgQMaxLimit'];
 		}
 
+		// Opaque keyset cursor token (decoded later by `QueryCreator`).
+		// An empty string disables cursor mode and leaves the query on
+		// the legacy offset path.
+		$cursor = '';
+		if ( array_key_exists( 'cursor', $params ) ) {
+			$cursor = (string)$params['cursor']->getValue();
+		}
+
 		$queryCreator = ApplicationFactory::getInstance()->singleton( 'QueryCreator' );
 
 		$params = [
@@ -174,6 +182,7 @@ class QueryProcessor implements QueryContext {
 			'contextPage' => $contextPage,
 			'offset'      => $offset,
 			'limit'       => $limit,
+			'cursor'      => $cursor,
 			'source'      => $params['source']->getValue(),
 			'mainLabel'   => $params['mainlabel']->getValue(),
 			'sort'        => $params['sort']->getValue(),

--- a/src/Query/QueryResult.php
+++ b/src/Query/QueryResult.php
@@ -88,6 +88,16 @@ class QueryResult {
 
 	private FilterMap $filterMap;
 
+	/**
+	 * Opaque next-page cursor token, set by `QueryEngine` when the query
+	 * was run in keyset cursor mode and there are further results. Stays
+	 * `null` for legacy offset-mode queries and for cursor-mode queries
+	 * on the final page.
+	 *
+	 * @since 7.0.0
+	 */
+	private ?string $nextCursor = null;
+
 	public function __construct(
 		array $printRequests,
 		Query $query,
@@ -327,6 +337,29 @@ class QueryResult {
 	 */
 	public function hasFurtherResults(): bool {
 		return $this->mFurtherResults;
+	}
+
+	/**
+	 * Set the opaque next-page cursor token. Called by `QueryEngine`
+	 * when the query was run in keyset cursor mode and there are
+	 * further results to fetch.
+	 *
+	 * @since 7.0.0
+	 */
+	public function setNextCursor( string $token ): void {
+		$this->nextCursor = $token;
+	}
+
+	/**
+	 * The opaque next-page cursor token, or `null` when not applicable
+	 * (legacy offset-mode, or cursor mode but on the final page).
+	 * Consumers (the Ask API renderer) surface this as
+	 * `query-continue-cursor` in the response.
+	 *
+	 * @since 7.0.0
+	 */
+	public function getNextCursor(): ?string {
+		return $this->nextCursor;
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/CursorEncoder.php
+++ b/src/SQLStore/QueryEngine/CursorEncoder.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace SMW\SQLStore\QueryEngine;
+
+/**
+ * Opaque base64url-encoded JSON cursors for keyset pagination across the
+ * QueryEngine result surface.
+ *
+ * The encoded payload is a JSON object with a mandatory `"v"` version field
+ * plus the cursor anchor data:
+ *
+ * ```
+ * { "v": 1, "sort": "<last_row_sort_value>", "id": <last_row_smw_id> }
+ * ```
+ *
+ * Clients treat tokens as opaque. The format may grow new fields (e.g. a
+ * compound sort tuple for multi-property `sort=` support, a subquery
+ * disambiguator, etc.); the version field gates schema evolution. Old
+ * servers that don't recognise a version return `null` and the consumer
+ * decides whether to surface an error or fall back to the legacy offset
+ * path.
+ *
+ * Encoding uses base64url (RFC 4648 §5) — `-` / `_` for `+` / `/` and no
+ * `=` padding — so tokens are safe in URL query strings without
+ * percent-encoding.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class CursorEncoder {
+
+	public const CURRENT_VERSION = 1;
+
+	/**
+	 * Encode a cursor payload into an opaque base64url string. The `"v"`
+	 * field is auto-injected at the current version if the caller omits
+	 * it, so consumers can pass `[ 'id' => 42 ]` without thinking about
+	 * the version.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $payload The cursor anchor data. Will be JSON-encoded.
+	 *
+	 * @return string The opaque cursor token, safe to embed in URLs and
+	 *   JSON response fields without further escaping.
+	 */
+	public static function encode( array $payload ): string {
+		if ( !isset( $payload['v'] ) ) {
+			$payload['v'] = self::CURRENT_VERSION;
+		}
+
+		$json = json_encode( $payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
+		if ( $json === false ) {
+			throw new \InvalidArgumentException(
+				'CursorEncoder: failed to JSON-encode cursor payload'
+			);
+		}
+
+		return rtrim( strtr( base64_encode( $json ), '+/', '-_' ), '=' );
+	}
+
+	/**
+	 * Decode an opaque base64url cursor token back to its payload array.
+	 * Returns `null` for any input that isn't a well-formed token at the
+	 * current version: malformed base64, malformed JSON, missing version
+	 * field, or unknown future version. Callers MUST treat `null` as
+	 * "cursor not understood" and either surface an error or fall back
+	 * to the legacy offset path; they MUST NOT silently use a partial
+	 * decode.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string $token The opaque cursor token, typically from a URL
+	 *   parameter or a JSON request field.
+	 */
+	public static function decode( string $token ): ?array {
+		if ( $token === '' ) {
+			return null;
+		}
+
+		// Restore base64 padding stripped by `rtrim` in `encode()`.
+		$padded = $token . str_repeat( '=', ( 4 - strlen( $token ) % 4 ) % 4 );
+		$json = base64_decode( strtr( $padded, '-_', '+/' ), true );
+
+		if ( $json === false ) {
+			return null;
+		}
+
+		$payload = json_decode( $json, true );
+		if ( !is_array( $payload ) ) {
+			return null;
+		}
+
+		if ( !isset( $payload['v'] ) || $payload['v'] !== self::CURRENT_VERSION ) {
+			return null;
+		}
+
+		return $payload;
+	}
+
+}

--- a/src/SQLStore/QueryEngine/CursorEncoder.php
+++ b/src/SQLStore/QueryEngine/CursorEncoder.php
@@ -2,6 +2,8 @@
 
 namespace SMW\SQLStore\QueryEngine;
 
+use InvalidArgumentException;
+
 /**
  * Opaque base64url-encoded JSON cursors for keyset pagination across the
  * QueryEngine result surface.
@@ -20,14 +22,14 @@ namespace SMW\SQLStore\QueryEngine;
  * decides whether to surface an error or fall back to the legacy offset
  * path.
  *
- * Encoding uses base64url (RFC 4648 §5) — `-` / `_` for `+` / `/` and no
- * `=` padding — so tokens are safe in URL query strings without
- * percent-encoding.
+ * Encoding uses base64url (RFC 4648 §5): `-` / `_` substitute for `+` / `/`
+ * and `=` padding is stripped, so tokens are safe in URL query strings
+ * without percent-encoding.
  *
  * @license GPL-2.0-or-later
  * @since 7.0.0
  */
-class CursorEncoder {
+final class CursorEncoder {
 
 	public const CURRENT_VERSION = 1;
 
@@ -51,7 +53,7 @@ class CursorEncoder {
 
 		$json = json_encode( $payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE );
 		if ( $json === false ) {
-			throw new \InvalidArgumentException(
+			throw new InvalidArgumentException(
 				'CursorEncoder: failed to JSON-encode cursor payload'
 			);
 		}

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -18,6 +18,7 @@ use SMW\QueryEngine as QueryEngineInterface;
 use SMW\QueryFactory;
 use SMW\SQLStore\SQLStore;
 use Wikimedia\Rdbms\Platform\ISQLPlatform;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * Class that implements query answering for SQLStore.
@@ -545,7 +546,15 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			$hasFurtherResults
 		);
 
-		if ( $cursorMode && $hasFurtherResults && $lastCursorId !== null ) {
+		// Cursor minted from a row whose `smw_sort` is NULL would be
+		// rejected by `applyKeysetPredicate()` on the next request
+		// (the `isset()` guard there treats null as "no anchor" and
+		// silently serves page 1, looping the crawler). Skip the
+		// cursor emission entirely for that case so the client at
+		// least stops paginating instead of looping. Phase 3a will
+		// add explicit `IS NULL` handling once the cursor format
+		// supports compound sort tuples.
+		if ( $cursorMode && $hasFurtherResults && $lastCursorId !== null && $lastCursorSort !== null ) {
 			$queryResult->setNextCursor( CursorEncoder::encode( [
 				'sort' => $lastCursorSort,
 				'id'   => $lastCursorId,
@@ -656,8 +665,20 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 	 * `(smw_sort, smw_id)`; the row-constructor form
 	 * `(smw_sort, smw_id) > (X, Y)` plans a full index scan instead.
 	 * See issue #6559 and #6794 for the underlying motivation.
+	 *
+	 * TODO Phase 3a: unify with `KeysetPaginationTrait::applyCursorPagination`.
+	 * The two diverge in (a) aliased vs unqualified column refs,
+	 * (b) forward-only vs forward+backward, and (c) decoded-payload
+	 * vs RequestOptions-int cursor sources. Once Phase 3a generalises
+	 * the cursor payload to compound sort tuples, the two paths
+	 * should converge on a shared predicate builder.
 	 */
-	private function applyKeysetPredicate( $queryBuilder, Query $query, $qobj, $connection ): void {
+	private function applyKeysetPredicate(
+		SelectQueryBuilder $queryBuilder,
+		Query $query,
+		QuerySegment $qobj,
+		$connection
+	): void {
 		$payload = $query->getCursorAfter();
 		if ( !isset( $payload['sort'] ) || !isset( $payload['id'] ) ) {
 			return;

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -397,18 +397,39 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		}
 
 		$sql_options = $this->getSQLOptions( $query, $rootid );
+		$cursorMode = $query->getCursorAfter() !== null;
 
-		if ( $this->engineOptions->get( 'smwgQUseLegacyQuery' ) ) {
+		if ( $cursorMode ) {
+			// Override sort and offset for cursor mode. The trait-pattern
+			// keyset predicate is total-ordered on `(smw_sort, smw_id)`;
+			// any pre-existing ORDER BY would conflict with the predicate
+			// semantics, and OFFSET is replaced by the WHERE-anchored seek.
+			$sql_options['ORDER BY'] = "$qobj->alias.smw_sort, $qobj->alias.smw_id";
+			unset( $sql_options['OFFSET'] );
+		}
+
+		// Cursor mode forces the legacy single-query SQL path even when
+		// `smwgQUseLegacyQuery=false`. The Phase 3 spike does not yet wire
+		// the keyset predicate into `SubqueryQueryBuilder`'s derived-table
+		// rewrite, so cursor mode opts out of that optimisation in
+		// exchange for the much larger keyset speedup on the OFFSET side.
+		// Tracked as Phase 3a follow-up in #6795.
+		if ( $cursorMode || $this->engineOptions->get( 'smwgQUseLegacyQuery' ) ) {
+			$selectFields = [
+				'id' => "$qobj->alias.smw_id",
+				't' => "$qobj->alias.smw_title",
+				'ns' => "$qobj->alias.smw_namespace",
+				'iw' => "$qobj->alias.smw_iw",
+				'so' => "$qobj->alias.smw_subobject",
+				'sortkey' => "$qobj->alias.smw_sortkey",
+			];
+			if ( $cursorMode ) {
+				$selectFields['sort'] = "$qobj->alias.smw_sort";
+			}
+
 			$qb = $connection->newSelectQueryBuilder()
 				->select( array_merge(
-					[
-						'id' => "$qobj->alias.smw_id",
-						't' => "$qobj->alias.smw_title",
-						'ns' => "$qobj->alias.smw_namespace",
-						'iw' => "$qobj->alias.smw_iw",
-						'so' => "$qobj->alias.smw_subobject",
-						'sortkey' => "$qobj->alias.smw_sortkey",
-					],
+					$selectFields,
 					array_values( $qobj->sortfields ) # TODO strange to only keep values, but it was like that before rewriting select() with arrays
 				) )
 				->rawTables( array_merge( [ $qobj->alias => $qobj->joinTable ], $qobj->fromTables ) )
@@ -419,6 +440,10 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 
 			if ( $qobj->where !== '' ) {
 				$qb->where( [ $qobj->where ] );
+			}
+
+			if ( $cursorMode ) {
+				$this->applyKeysetPredicate( $qb, $query, $qobj, $connection );
 			}
 
 			$res = $qb->fetchResultSet();
@@ -436,6 +461,11 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 
 		$logToTable = [];
 		$hasFurtherResults = false;
+
+		// Cursor-mode bookkeeping: track the `(smw_sort, smw_id)` of the
+		// last accepted row so we can mint the next-page anchor.
+		$lastCursorSort = null;
+		$lastCursorId = null;
 
 		// Number of fetched results ( != number of valid results in
 		// array $results)
@@ -476,6 +506,11 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 					$results[] = $dataItem;
 					// These IDs are usually needed for displaying the page (esp. if more property values are displayed):
 					$this->store->smwIds->setCache( $row->t, $row->ns, $row->iw, $row->so, $row->id, $row->sortkey );
+
+					if ( $cursorMode ) {
+						$lastCursorSort = $row->sort ?? null;
+						$lastCursorId = (int)$row->id;
+					}
 				} else {
 					$missedCount++;
 					$logToTable[$row->t] = "skip result for {$row->t} existing cache entry / query " . $query->getHash();
@@ -509,6 +544,13 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			$results,
 			$hasFurtherResults
 		);
+
+		if ( $cursorMode && $hasFurtherResults && $lastCursorId !== null ) {
+			$queryResult->setNextCursor( CursorEncoder::encode( [
+				'sort' => $lastCursorSort,
+				'id'   => $lastCursorId,
+			] ) );
+		}
 
 		return $queryResult;
 	}
@@ -596,6 +638,39 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		}
 
 		$this->logger->info( $message, $context );
+	}
+
+	/**
+	 * Apply the explicit-OR keyset predicate from the query's cursor
+	 * payload to the query builder. Skipped when the payload has no
+	 * anchor (the "first page in cursor mode" case, where the cursor
+	 * just opts into deterministic ordering without seeking past
+	 * anything).
+	 *
+	 * The predicate matches the form used by
+	 * `KeysetPaginationTrait::applyCursorPagination()`:
+	 *
+	 *     smw_sort > X OR (smw_sort = X AND smw_id > Y)
+	 *
+	 * MariaDB recognises this as an index range seek on
+	 * `(smw_sort, smw_id)`; the row-constructor form
+	 * `(smw_sort, smw_id) > (X, Y)` plans a full index scan instead.
+	 * See issue #6559 and #6794 for the underlying motivation.
+	 */
+	private function applyKeysetPredicate( $queryBuilder, Query $query, $qobj, $connection ): void {
+		$payload = $query->getCursorAfter();
+		if ( !isset( $payload['sort'] ) || !isset( $payload['id'] ) ) {
+			return;
+		}
+
+		$quotedSort = $connection->addQuotes( $payload['sort'] );
+		$cursorId = (int)$payload['id'];
+		$alias = $qobj->alias;
+
+		$queryBuilder->where(
+			"$alias.smw_sort > $quotedSort " .
+			"OR ($alias.smw_sort = $quotedSort AND $alias.smw_id > $cursorId)"
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
@@ -90,4 +90,106 @@ class QueryCreatorTest extends TestCase {
 		return $provider;
 	}
 
+	public function testCursorParamWithDefaultSortDecodesAndAppliesPayload(): void {
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		// base64url of {"v":1,"sort":"Foo","id":42}
+		$token = 'eyJ2IjoxLCJzb3J0IjoiRm9vIiwiaWQiOjQyfQ';
+
+		$query = $instance->create( '[[Foo::Bar]]', [ 'cursor' => $token ] );
+
+		$this->assertSame(
+			[ 'v' => 1, 'sort' => 'Foo', 'id' => 42 ],
+			$query->getCursorAfter()
+		);
+	}
+
+	public function testCursorParamWithCustomSortIsRejectedWithError(): void {
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'SomeProperty' ],
+				'cursor' => 'eyJ2IjoxLCJzb3J0IjoiRm9vIiwiaWQiOjQyfQ',
+			]
+		);
+
+		// Cursor must NOT be applied when a custom `sort=` is present.
+		$this->assertNull( $query->getCursorAfter() );
+
+		// Error is surfaced so the engine can refuse the query. The
+		// query parser may also push unrelated parsing errors onto the
+		// list (e.g. `smw_noqueryfeature` depending on the test-runner
+		// `smwgQFeatures` config), so search the full list for our
+		// cursor-specific marker rather than asserting position.
+		$this->assertCursorErrorPresent(
+			$query->getErrors(),
+			'Cursor pagination'
+		);
+	}
+
+	public function testCursorParamWithCountModeIsRejectedWithError(): void {
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'queryMode' => Query::MODE_COUNT,
+				'cursor'    => 'eyJ2IjoxLCJzb3J0IjoiRm9vIiwiaWQiOjQyfQ',
+			]
+		);
+
+		$this->assertNull( $query->getCursorAfter() );
+		$this->assertCursorErrorPresent(
+			$query->getErrors(),
+			'`format=count`'
+		);
+	}
+
+	public function testMalformedCursorTokenIsRejectedWithError(): void {
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[ 'cursor' => '!!!not-a-valid-base64-token!!!' ]
+		);
+
+		$this->assertNull( $query->getCursorAfter() );
+		$this->assertCursorErrorPresent(
+			$query->getErrors(),
+			'Malformed'
+		);
+	}
+
+	public function testEmptyCursorParamDoesNotTriggerCursorMode(): void {
+		// Default value for `cursor` is empty string. Absence MUST keep
+		// the query on the legacy offset path.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$query = $instance->create( '[[Foo::Bar]]', [ 'cursor' => '' ] );
+
+		$this->assertNull( $query->getCursorAfter() );
+	}
+
+	private function assertCursorErrorPresent( array $errors, string $marker ): void {
+		foreach ( $errors as $err ) {
+			if ( is_string( $err ) && str_contains( $err, $marker ) ) {
+				$this->addToAssertionCount( 1 );
+				return;
+			}
+		}
+		$this->fail( "Expected cursor error containing '$marker', got: " . var_export( $errors, true ) );
+	}
+
 }

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/CursorEncoderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/CursorEncoderTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace SMW\Tests\Unit\SQLStore\QueryEngine;
+
+use PHPUnit\Framework\TestCase;
+use SMW\SQLStore\QueryEngine\CursorEncoder;
+
+/**
+ * @covers \SMW\SQLStore\QueryEngine\CursorEncoder
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class CursorEncoderTest extends TestCase {
+
+	public function testEncodeAutoInjectsCurrentVersion(): void {
+		$token = CursorEncoder::encode( [ 'id' => 42 ] );
+		$payload = CursorEncoder::decode( $token );
+
+		$this->assertIsArray( $payload );
+		$this->assertSame( CursorEncoder::CURRENT_VERSION, $payload['v'] );
+		$this->assertSame( 42, $payload['id'] );
+	}
+
+	public function testRoundtripPreservesScalarFields(): void {
+		$original = [
+			'v' => 1,
+			'sort' => 'Some sort value with spaces',
+			'id' => 12345,
+		];
+
+		$decoded = CursorEncoder::decode( CursorEncoder::encode( $original ) );
+
+		$this->assertSame( $original, $decoded );
+	}
+
+	public function testRoundtripPreservesNestedArrays(): void {
+		// Multi-sort cursor schema (Phase 3b extension) must round-trip
+		// through the v1 encoder unchanged. This locks the format's
+		// forward compatibility: adding new fields to the payload does
+		// not require an encoder change.
+		$original = [
+			'v' => 1,
+			'sort' => [ 'primary', 'secondary' ],
+			'id' => 99,
+		];
+
+		$this->assertSame(
+			$original,
+			CursorEncoder::decode( CursorEncoder::encode( $original ) )
+		);
+	}
+
+	public function testRoundtripPreservesUnicode(): void {
+		$original = [
+			'v' => 1,
+			'sort' => 'Bär · café · 日本語',
+			'id' => 1,
+		];
+
+		$this->assertSame(
+			$original,
+			CursorEncoder::decode( CursorEncoder::encode( $original ) )
+		);
+	}
+
+	public function testEncodedTokenIsUrlSafe(): void {
+		// Construct a payload likely to produce `+`, `/`, or `=` in
+		// standard base64 (long string, non-aligned length). The
+		// base64url variant must replace all of them.
+		$token = CursorEncoder::encode( [
+			'sort' => str_repeat( '?>', 50 ),
+			'id' => 42,
+		] );
+
+		$this->assertStringNotContainsString( '+', $token );
+		$this->assertStringNotContainsString( '/', $token );
+		$this->assertStringNotContainsString( '=', $token );
+	}
+
+	public function testDecodeRejectsEmptyToken(): void {
+		$this->assertNull( CursorEncoder::decode( '' ) );
+	}
+
+	public function testDecodeRejectsMalformedBase64(): void {
+		$this->assertNull( CursorEncoder::decode( '!!!not base64!!!' ) );
+	}
+
+	public function testDecodeRejectsMalformedJson(): void {
+		// Valid base64url but the decoded bytes are not JSON.
+		$token = rtrim( strtr( base64_encode( 'not json' ), '+/', '-_' ), '=' );
+		$this->assertNull( CursorEncoder::decode( $token ) );
+	}
+
+	public function testDecodeRejectsMissingVersionField(): void {
+		// Valid base64url, valid JSON, but no `v` field.
+		$token = rtrim( strtr( base64_encode( '{"id":42}' ), '+/', '-_' ), '=' );
+		$this->assertNull( CursorEncoder::decode( $token ) );
+	}
+
+	public function testDecodeRejectsUnknownVersion(): void {
+		// Forward-compat: a v=99 cursor (some future format) must be
+		// rejected by this server, not partially decoded. The consumer
+		// is responsible for surfacing the error or falling back.
+		$token = rtrim( strtr( base64_encode( '{"v":99,"id":42}' ), '+/', '-_' ), '=' );
+		$this->assertNull( CursorEncoder::decode( $token ) );
+	}
+
+	public function testDecodeRejectsScalarJsonPayload(): void {
+		// `json_decode("42", true)` returns the int 42, not an array.
+		$token = rtrim( strtr( base64_encode( '42' ), '+/', '-_' ), '=' );
+		$this->assertNull( CursorEncoder::decode( $token ) );
+	}
+
+}


### PR DESCRIPTION
## Summary

Phase 3 spike: opt-in keyset cursor pagination for default-sort `#ask`
queries through the `?action=ask` API. Establishes the opaque-cursor
format that Phase 3a/3b/3c will extend. Tracks #6795.

## Scope

Direct beneficiary is **API bots that opt into cursor mode** by
sending `cursor=<token>` in the `?action=ask` query string. Wikitext
`{{#ask}}` rendering, the inline "more results" link, `Special:Ask`,
and the Lua ``mw.smw.ask`` bridge are **not** yet wired up; each is an
explicit follow-up. Bots crawling wiki pages with hardcoded
`|offset=N` in static wikitext are also unaffected (the offset is
content, not a cursor).

## API contract

| Request | Mode | Response |
|---|---|---|
| `query=...\|cursor=<token>` | Cursor | `query-continue-cursor: <token>` |
| `query=...` (no cursor) | Legacy | `query-continue-offset: N` |
| `cursor=` + `sort=Property` | **Error** | "not supported with custom sort" |
| `cursor=` + `format=count` | **Error** | "not supported with count" |
| Malformed cursor | **Error** | "Malformed cursor token" |

`query-continue-offset` and `query-continue-cursor` are mutually
exclusive in responses. Legacy clients see no change.

## Cursor format

Opaque base64url-encoded JSON with a mandatory `"v"` version field:

```
{"v":1, "sort":"<smw_sort>", "id":<smw_id>}
```

Clients **must** treat tokens as opaque (round-trip only). The `"v"`
gate rejects unknown future versions; Phase 3a will grow the payload
schema (compound sort tuples, subquery disambiguator) without
breaking clients.

## Why opt-in (not opt-out like Special:Concepts)

The constrained scope rejects `cursor=` + `sort=Property` with an
error. If cursor were default-on, every existing `#ask` with a custom
sort would fail. Special:Concepts could default to cursor because it
has a fixed sort with no `sort=` parameter to collide. The asymmetry
is a spike-scope artifact, Phase 3a will lift the constraint and
allow the default flip.

## Constrained scope

Each restriction has a Phase 3a/3b follow-up:

- Default sort only; `sort=Property` rejected.
- Forces the legacy single-query SQL path (no SubqueryQueryBuilder
  cursor support); cursor mode loses the DISTINCT optimisation in
  exchange for the keyset speedup.
- Forward-only; no `cursor-before`.
- API surface only; Special:Ask UI deferred.
- NULL ``smw_sort`` rows don't mint a cursor (would loop crawlers).

## Side effect

Cursor mode forces ``ORDER BY smw_sort, smw_id``. Today, no-sort
`#ask` queries have no ``ORDER BY`` and rely on DB-natural ordering
(non-deterministic). Legacy offset queries are unchanged. The smoke
test surfaced this: legacy walked 26 of 30 items vs cursor's 30 of 30.

## Test plan

- [x] ``composer analyze`` clean
- [x] 11 ``CursorEncoder`` unit tests (roundtrip, version gate,
  URL-safety, all rejection paths, Unicode)
- [x] 5 ``QueryCreator`` unit tests (decode, ``sort=`` / count-mode /
  malformed rejection, empty-cursor passthrough)
- [x] Cache-key uniqueness: ``Query::getHash()`` produces 3 distinct
  hashes for ``{no cursor, cursor A, cursor B}``
- [x] Browser smoke matrix on the dev wiki (8 cases): cursor mode,
  legacy mode, all 3 error paths, field exclusivity, identity walk,
  cursor reaches 30/30 items

🤖 Generated with [Claude Code](https://claude.com/claude-code)