### PR TITLE
QueryEngine: cursor pagination for single-property sort= queries

### DIFF
--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -181,16 +181,37 @@ class QueryCreator implements QueryContext {
 			return;
 		}
 
-		$customSortKeys = array_filter(
+		// `array_values` re-indexes so `[0]` is the first custom-sort
+		// property regardless of any preceding empty-string key (the
+		// `sort=,SomeProperty` page-pivoted form produces a `sortKeys`
+		// array whose `array_keys` is `['', 'SomeProperty']` — without
+		// re-indexing the filter returns `[1 => 'SomeProperty']` and
+		// `[0]` resolves to null, false-rejecting cursors on page 2).
+		$customSortKeys = array_values( array_filter(
 			array_keys( $sortKeys ),
 			static fn ( $key ) => $key !== ''
-		);
+		) );
 
 		if ( count( $customSortKeys ) > 1 ) {
 			$query->addErrors( [
 				'Cursor pagination (`cursor=`) is not supported with multi-property `sort=` in this release. Reduce to a single sort property, or use `offset=` instead.'
 			] );
 			return;
+		}
+
+		// Phase 3a is ASC-only. The keyset predicate is `>`-form;
+		// supporting `DESC` requires `<`-form + reversed ORDER BY
+		// (planned for Phase 3b). Reject `order=desc`/`random`
+		// explicitly so a future lift can extend the contract
+		// without breaking clients that silently ignored the order
+		// parameter today.
+		foreach ( $sortKeys as $_key => $order ) {
+			if ( $order === 'DESC' || $order === 'RANDOM' ) {
+				$query->addErrors( [
+					"Cursor pagination (`cursor=`) requires ascending order; `order=$order` is not supported in this release."
+				] );
+				return;
+			}
 		}
 
 		if ( $query->getQueryMode() === self::MODE_COUNT ) {

--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -152,21 +152,28 @@ class QueryCreator implements QueryContext {
 
 	/**
 	 * Decode the optional `cursor=<token>` user parameter and apply it
-	 * to the query, enforcing the constrained-spike contract: cursor
-	 * mode is only supported when the query has no custom `sort=`
-	 * property. A `cursor=` + `sort=Property` combination is rejected
-	 * by attaching an error message to the query (the engine then
-	 * surfaces it instead of running the query).
+	 * to the query, enforcing the Phase 3a contract:
 	 *
-	 * A malformed cursor token (any decode failure) is also surfaced
-	 * as an error rather than silently ignored, to avoid the
-	 * "expected next-page got first-page" surprise for bot clients.
+	 *   - Default sort (`sortKeys` has only the empty-string key or is
+	 *     empty): always allowed.
+	 *   - Single-property sort (`sort=Foo`, one non-empty key): allowed
+	 *     when the cursor's `sort_prop` field matches the request's
+	 *     sort key, or when the cursor has no `sort_prop` (bootstrap /
+	 *     empty payload for the first cursor-mode page).
+	 *   - Multi-property sort (`sort=A,B`): rejected (Phase 3b).
+	 *   - Custom sort + cursor with mismatching `sort_prop`: rejected.
+	 *     The cursor was minted for a different sort, applying it here
+	 *     would seek to a position that has no meaning in the new
+	 *     ordering.
+	 *
+	 * Malformed cursor tokens (any decode failure) are surfaced as an
+	 * error rather than silently ignored, to avoid the "expected
+	 * next-page got first-page" surprise for bot clients.
 	 *
 	 * @param Query $query
 	 * @param array $sortKeys As returned by `getSortKeys()['keys']`.
-	 *   An empty-string key (`'' => 'ASC'`) is the default "sort by
-	 *   page" and is allowed; any non-empty-string key is a custom
-	 *   property sort and is rejected.
+	 *   An empty-string key (`'' => 'ASC'`) is "sort by page"; a
+	 *   non-empty-string key is a property sort.
 	 */
 	private function applyCursorIfRequested( Query $query, array $sortKeys ): void {
 		$token = (string)$this->getParam( 'cursor', '' );
@@ -174,13 +181,16 @@ class QueryCreator implements QueryContext {
 			return;
 		}
 
-		foreach ( $sortKeys as $sortKey => $_order ) {
-			if ( $sortKey !== '' ) {
-				$query->addErrors( [
-					'Cursor pagination (`cursor=`) is not supported with a custom `sort=` property in this release. Remove `sort=` or use `offset=` instead.'
-				] );
-				return;
-			}
+		$customSortKeys = array_filter(
+			array_keys( $sortKeys ),
+			static fn ( $key ) => $key !== ''
+		);
+
+		if ( count( $customSortKeys ) > 1 ) {
+			$query->addErrors( [
+				'Cursor pagination (`cursor=`) is not supported with multi-property `sort=` in this release. Reduce to a single sort property, or use `offset=` instead.'
+			] );
+			return;
 		}
 
 		if ( $query->getQueryMode() === self::MODE_COUNT ) {
@@ -194,6 +204,19 @@ class QueryCreator implements QueryContext {
 		if ( $payload === null ) {
 			$query->addErrors( [
 				'Malformed `cursor=` token (rejected as unrecognised or from a newer schema version).'
+			] );
+			return;
+		}
+
+		// Reject mismatched sort_prop. The empty-payload bootstrap
+		// cursor has no `sort_prop` and therefore matches any sort,
+		// so a first-page cursor request works for both default- and
+		// custom-sort queries.
+		$payloadSortProp = $payload['sort_prop'] ?? '';
+		$requestSortProp = $customSortKeys[0] ?? '';
+		if ( $payloadSortProp !== '' && $payloadSortProp !== $requestSortProp ) {
+			$query->addErrors( [
+				"Cursor was minted for `sort=$payloadSortProp` but the request specifies `sort=$requestSortProp`. The cursor anchor has no meaning under a different sort; re-issue without `cursor=` or align the `sort=` parameter."
 			] );
 			return;
 		}

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -399,13 +399,49 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 
 		$sql_options = $this->getSQLOptions( $query, $rootid );
 		$cursorMode = $query->getCursorAfter() !== null;
+		$cursorSortColumn = null;
+		$cursorSortPropKey = '';
 
 		if ( $cursorMode ) {
-			// Override sort and offset for cursor mode. The trait-pattern
-			// keyset predicate is total-ordered on `(smw_sort, smw_id)`;
-			// any pre-existing ORDER BY would conflict with the predicate
-			// semantics, and OFFSET is replaced by the WHERE-anchored seek.
-			$sql_options['ORDER BY'] = "$qobj->alias.smw_sort, $qobj->alias.smw_id";
+			// The active sort key is determined by `$query->sortkeys`
+			// (set by `QueryCreator` from `sort=`), not by the
+			// incoming cursor payload. The cursor's `sort_prop` was
+			// already cross-checked against `sort=` in QueryCreator;
+			// here the engine just needs to know which sortfield
+			// column to anchor the keyset predicate on.
+			foreach ( $query->sortkeys as $propKey => $_order ) {
+				if ( $propKey !== '' ) {
+					$cursorSortPropKey = $propKey;
+					break;
+				}
+			}
+
+			if ( $cursorSortPropKey !== '' ) {
+				if ( !isset( $qobj->sortfields[$cursorSortPropKey] ) ) {
+					// User asked for `sort=Foo` but `Foo` could not be
+					// resolved to a sortfield column (invalid property,
+					// or the joined table never got set up). Surface
+					// explicitly rather than silently fall back to
+					// default sort, since the next cursor anchor would
+					// be meaningless.
+					$query->addErrors( [
+						"Cursor mode could not resolve `sort=$cursorSortPropKey` to a query sortfield."
+					] );
+					return $this->queryFactory->newQueryResult(
+						$this->store, $query, [], false
+					);
+				}
+				$cursorSortColumn = $qobj->sortfields[$cursorSortPropKey];
+			} else {
+				// Default sort (Phase 3 spike compatible).
+				$cursorSortColumn = "$qobj->alias.smw_sort";
+			}
+
+			// Override sort and offset for cursor mode. Keyset is total-ordered
+			// on `(<sort_column>, smw_id)`; any pre-existing ORDER BY would
+			// conflict with the predicate semantics, OFFSET is replaced by
+			// the WHERE-anchored seek.
+			$sql_options['ORDER BY'] = "$cursorSortColumn, $qobj->alias.smw_id";
 			unset( $sql_options['OFFSET'] );
 		}
 
@@ -414,7 +450,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		// the keyset predicate into `SubqueryQueryBuilder`'s derived-table
 		// rewrite, so cursor mode opts out of that optimisation in
 		// exchange for the much larger keyset speedup on the OFFSET side.
-		// Tracked as Phase 3a follow-up in #6795.
+		// Tracked as Phase 3c follow-up in #6795.
 		if ( $cursorMode || $this->engineOptions->get( 'smwgQUseLegacyQuery' ) ) {
 			$selectFields = [
 				'id' => "$qobj->alias.smw_id",
@@ -425,7 +461,10 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 				'sortkey' => "$qobj->alias.smw_sortkey",
 			];
 			if ( $cursorMode ) {
-				$selectFields['sort'] = "$qobj->alias.smw_sort";
+				// Alias the sort column under `sort` so the row loop can
+				// read `$row->sort` regardless of whether the user
+				// specified `sort=Property` or accepted the default.
+				$selectFields['sort'] = $cursorSortColumn;
 			}
 
 			$qb = $connection->newSelectQueryBuilder()
@@ -444,7 +483,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			}
 
 			if ( $cursorMode ) {
-				$this->applyKeysetPredicate( $qb, $query, $qobj, $connection );
+				$this->applyKeysetPredicate( $qb, $query, $qobj, $connection, $cursorSortColumn );
 			}
 
 			$res = $qb->fetchResultSet();
@@ -546,19 +585,27 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			$hasFurtherResults
 		);
 
-		// Cursor minted from a row whose `smw_sort` is NULL would be
+		// Cursor minted from a row whose sort value is NULL would be
 		// rejected by `applyKeysetPredicate()` on the next request
 		// (the `isset()` guard there treats null as "no anchor" and
 		// silently serves page 1, looping the crawler). Skip the
 		// cursor emission entirely for that case so the client at
-		// least stops paginating instead of looping. Phase 3a will
+		// least stops paginating instead of looping. Phase 3b will
 		// add explicit `IS NULL` handling once the cursor format
 		// supports compound sort tuples.
 		if ( $cursorMode && $hasFurtherResults && $lastCursorId !== null && $lastCursorSort !== null ) {
-			$queryResult->setNextCursor( CursorEncoder::encode( [
+			$payload = [
 				'sort' => $lastCursorSort,
 				'id'   => $lastCursorId,
-			] ) );
+			];
+			// Round-trip the sort property so the next request can
+			// reject a sort= that doesn't match the cursor's anchor.
+			// Omitted for default-sort queries to keep the spike's
+			// `{"v":1,"sort":...,"id":...}` payload shape compatible.
+			if ( $cursorSortPropKey !== '' ) {
+				$payload['sort_prop'] = $cursorSortPropKey;
+			}
+			$queryResult->setNextCursor( CursorEncoder::encode( $payload ) );
 		}
 
 		return $queryResult;
@@ -659,25 +706,30 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 	 * The predicate matches the form used by
 	 * `KeysetPaginationTrait::applyCursorPagination()`:
 	 *
-	 *     smw_sort > X OR (smw_sort = X AND smw_id > Y)
+	 *     <sortCol> > X OR (<sortCol> = X AND smw_id > Y)
 	 *
-	 * MariaDB recognises this as an index range seek on
-	 * `(smw_sort, smw_id)`; the row-constructor form
-	 * `(smw_sort, smw_id) > (X, Y)` plans a full index scan instead.
-	 * See issue #6559 and #6794 for the underlying motivation.
+	 * MariaDB recognises this as an index range seek; the row-constructor
+	 * form `(<sortCol>, smw_id) > (X, Y)` plans a full index scan
+	 * instead. See issue #6559 and #6794 for the underlying motivation.
 	 *
-	 * TODO Phase 3a: unify with `KeysetPaginationTrait::applyCursorPagination`.
+	 * `$sortColumn` is the SQL column expression for the active sort
+	 * field — `<alias>.smw_sort` for default sort, the
+	 * `$qobj->sortfields[$propKey]` expression for `sort=Property`
+	 * (Phase 3a). The caller resolves the expression.
+	 *
+	 * TODO Phase 3b/c: unify with `KeysetPaginationTrait::applyCursorPagination`.
 	 * The two diverge in (a) aliased vs unqualified column refs,
 	 * (b) forward-only vs forward+backward, and (c) decoded-payload
-	 * vs RequestOptions-int cursor sources. Once Phase 3a generalises
-	 * the cursor payload to compound sort tuples, the two paths
-	 * should converge on a shared predicate builder.
+	 * vs RequestOptions-int cursor sources. Once Phase 3b adds
+	 * compound sort tuples, the two paths should converge on a shared
+	 * predicate builder.
 	 */
 	private function applyKeysetPredicate(
 		SelectQueryBuilder $queryBuilder,
 		Query $query,
 		QuerySegment $qobj,
-		$connection
+		$connection,
+		string $sortColumn
 	): void {
 		$payload = $query->getCursorAfter();
 		if ( !isset( $payload['sort'] ) || !isset( $payload['id'] ) ) {
@@ -689,8 +741,8 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$alias = $qobj->alias;
 
 		$queryBuilder->where(
-			"$alias.smw_sort > $quotedSort " .
-			"OR ($alias.smw_sort = $quotedSort AND $alias.smw_id > $cursorId)"
+			"$sortColumn > $quotedSort " .
+			"OR ($sortColumn = $quotedSort AND $alias.smw_id > $cursorId)"
 		);
 	}
 

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -417,13 +417,17 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			}
 
 			if ( $cursorSortPropKey !== '' ) {
-				if ( !isset( $qobj->sortfields[$cursorSortPropKey] ) ) {
+				$sortExpr = $qobj->sortfields[$cursorSortPropKey] ?? '';
+				if ( $sortExpr === '' ) {
 					// User asked for `sort=Foo` but `Foo` could not be
 					// resolved to a sortfield column (invalid property,
 					// or the joined table never got set up). Surface
 					// explicitly rather than silently fall back to
 					// default sort, since the next cursor anchor would
-					// be meaningless.
+					// be meaningless. `=== ''` rather than `!isset`
+					// also catches the edge case where a future
+					// `OrderCondition` path assigns an empty
+					// expression.
 					$query->addErrors( [
 						"Cursor mode could not resolve `sort=$cursorSortPropKey` to a query sortfield."
 					] );
@@ -431,7 +435,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 						$this->store, $query, [], false
 					);
 				}
-				$cursorSortColumn = $qobj->sortfields[$cursorSortPropKey];
+				$cursorSortColumn = $sortExpr;
 			} else {
 				// Default sort (Phase 3 spike compatible).
 				$cursorSortColumn = "$qobj->alias.smw_sort";

--- a/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
@@ -178,6 +178,58 @@ class QueryCreatorTest extends TestCase {
 		$this->assertSame( [ 'v' => 1 ], $query->getCursorAfter() );
 	}
 
+	public function testCursorParamWithPagePivotedSortPreservesAnchor(): void {
+		// Regression for the `array_filter` key-preservation bug:
+		// `sort=,SomeProperty` produces `sortKeys = ['' => 'ASC',
+		// 'SomeProperty' => 'ASC']`. Without `array_values` after
+		// the filter, `$customSortKeys[0]` is null and any cursor
+		// minted on page 1 (which correctly emits
+		// `sort_prop=SomeProperty`) is falsely rejected on page 2
+		// onward. The cursor walk must work for this very common
+		// page-pivoted shape.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		// {"v":1,"sort":"value","sort_prop":"SomeProperty","id":42}
+		$token = 'eyJ2IjoxLCJzb3J0IjoidmFsdWUiLCJzb3J0X3Byb3AiOiJTb21lUHJvcGVydHkiLCJpZCI6NDJ9';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ '', 'SomeProperty' ],
+				'cursor' => $token,
+			]
+		);
+
+		$payload = $query->getCursorAfter();
+		$this->assertIsArray( $payload, 'Cursor with page-pivoted sort must NOT be rejected' );
+		$this->assertSame( 'SomeProperty', $payload['sort_prop'] );
+	}
+
+	public function testCursorParamWithOrderDescIsRejectedWithError(): void {
+		// Phase 3a is ASC-only. DESC support is planned for Phase 3b
+		// (requires `<`-form predicate + reversed ORDER BY).
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'SomeProperty' ],
+				'order'  => [ 'desc' ],
+				'cursor' => 'eyJ2IjoxfQ',
+			]
+		);
+
+		$this->assertNull( $query->getCursorAfter() );
+		$this->assertCursorErrorPresent(
+			$query->getErrors(),
+			'requires ascending order'
+		);
+	}
+
 	public function testCursorParamWithMultiSortIsRejectedWithError(): void {
 		// Phase 3b will support compound-sort cursors. Until then,
 		// `sort=A,B` + `cursor=` is rejected so cursor consumers can

--- a/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
@@ -106,7 +106,82 @@ class QueryCreatorTest extends TestCase {
 		);
 	}
 
-	public function testCursorParamWithCustomSortIsRejectedWithError(): void {
+	public function testCursorParamWithMatchingSortPropIsAccepted(): void {
+		// Phase 3a contract: `sort=SomeProperty` + cursor whose
+		// `sort_prop` matches is allowed. The cursor anchor stays
+		// meaningful under the requested sort.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		// base64url of {"v":1,"sort":"value","sort_prop":"SomeProperty","id":42}
+		$token = 'eyJ2IjoxLCJzb3J0IjoidmFsdWUiLCJzb3J0X3Byb3AiOiJTb21lUHJvcGVydHkiLCJpZCI6NDJ9';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'SomeProperty' ],
+				'cursor' => $token,
+			]
+		);
+
+		$payload = $query->getCursorAfter();
+		$this->assertIsArray( $payload );
+		$this->assertSame( 'SomeProperty', $payload['sort_prop'] );
+		$this->assertSame( 'value', $payload['sort'] );
+		$this->assertSame( 42, $payload['id'] );
+	}
+
+	public function testCursorParamWithMismatchingSortPropIsRejectedWithError(): void {
+		// Phase 3a contract: cursor anchored at `sort_prop=A` MUST NOT
+		// be applied when the request says `sort=B`. The anchor has no
+		// meaning under a different sort.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$token = 'eyJ2IjoxLCJzb3J0IjoidmFsdWUiLCJzb3J0X3Byb3AiOiJTb21lUHJvcGVydHkiLCJpZCI6NDJ9';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'DifferentProperty' ],
+				'cursor' => $token,
+			]
+		);
+
+		$this->assertNull( $query->getCursorAfter() );
+		$this->assertCursorErrorPresent(
+			$query->getErrors(),
+			'Cursor was minted for'
+		);
+	}
+
+	public function testCursorParamWithEmptyPayloadIsAcceptedForAnySingleSort(): void {
+		// Bootstrap case: a cursor with no `sort_prop` (the
+		// `{"v":1}` empty-payload bootstrap from Phase 3 spike)
+		// matches any single-property sort.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$emptyToken = 'eyJ2IjoxfQ';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'Modification_date' ],
+				'cursor' => $emptyToken,
+			]
+		);
+
+		$this->assertSame( [ 'v' => 1 ], $query->getCursorAfter() );
+	}
+
+	public function testCursorParamWithMultiSortIsRejectedWithError(): void {
+		// Phase 3b will support compound-sort cursors. Until then,
+		// `sort=A,B` + `cursor=` is rejected so cursor consumers can
+		// rely on the constrained single-sort schema.
 		$instance = new QueryCreator(
 			ApplicationFactory::getInstance()->getQueryFactory()
 		);
@@ -114,22 +189,15 @@ class QueryCreatorTest extends TestCase {
 		$query = $instance->create(
 			'[[Foo::Bar]]',
 			[
-				'sort'   => [ 'SomeProperty' ],
-				'cursor' => 'eyJ2IjoxLCJzb3J0IjoiRm9vIiwiaWQiOjQyfQ',
+				'sort'   => [ 'PropertyA', 'PropertyB' ],
+				'cursor' => 'eyJ2IjoxfQ',
 			]
 		);
 
-		// Cursor must NOT be applied when a custom `sort=` is present.
 		$this->assertNull( $query->getCursorAfter() );
-
-		// Error is surfaced so the engine can refuse the query. The
-		// query parser may also push unrelated parsing errors onto the
-		// list (e.g. `smw_noqueryfeature` depending on the test-runner
-		// `smwgQFeatures` config), so search the full list for our
-		// cursor-specific marker rather than asserting position.
 		$this->assertCursorErrorPresent(
 			$query->getErrors(),
-			'Cursor pagination'
+			'multi-property'
 		);
 	}
 


### PR DESCRIPTION
## Summary

Lifts the Phase 3 spike's (#6811) rejection of `cursor=` + `sort=Property`
for the single-property case. Multi-property `sort=A,B` is still
rejected (Phase 3b). Tracks #6795.

## Cursor format extension

| Phase | Payload |
|---|---|
| Phase 3 spike (default sort) | `{"v":1, "sort":"<smw_sort>", "id":N}` |
| Phase 3a (custom sort) | `{"v":1, "sort":"<value>", "sort_prop":"<key>", "id":N}` |
| Bootstrap (both modes) | `{"v":1}` |

The bootstrap empty payload still works for both default and custom
sort first-pages. Phase 3 spike cursors (no `sort_prop`) continue
to round-trip cleanly for default-sort queries.

## Contract

| Request | Mode | Behaviour |
|---|---|---|
| `sort=Foo` + cursor with matching `sort_prop=Foo` | Custom sort cursor | Accepted |
| `sort=Foo` + cursor with `sort_prop=Bar` | Mismatch | Error |
| `sort=Foo` + bootstrap cursor (no `sort_prop`) | First page | Accepted, mints new cursor with `sort_prop=Foo` |
| `sort=,Foo` (page-pivoted) + cursor | Same as single sort | Accepted |
| `sort=A,B` + cursor | Multi-property | Error (Phase 3b) |
| `sort=Foo` + `order=desc` + cursor | DESC | Error (Phase 3b) |
| `cursor=` + `format=count` | Count mode | Error |

## Engine source of truth

`QueryEngine` derives the active sort column from `$query->sortkeys`
(the canonical source set by `QueryCreator` from `sort=`), not from
the incoming cursor's `sort_prop`. The cursor's `sort_prop` is
purely a validation field: `QueryCreator` cross-checks it against
the request's `sort=` and rejects mismatches, so the cursor anchor
remains meaningful under the requested sort.

If the user's sort property can't be resolved to a sortfield column
(invalid property or join failed), cursor mode surfaces an explicit
error rather than silently downgrading to default sort — minting a
cursor whose `sort_prop` lies about the actual anchor column would
be a debug nightmare.

## Implementation

- `Query::sortkeys` is read directly; the active sort key is the
  first non-empty entry.
- `applyKeysetPredicate()` gains a `string $sortColumn` parameter
  for the SQL column expression. The Phase 3 spike's hardcoded
  `<alias>.smw_sort` is now passed in explicitly.
- The cursor `sort` field carries the raw column value (julian-day
  decimal for dates, blob string for text, etc.). All SMW sortfield
  types are string-encoded for storage and round-trip through JSON
  losslessly.

## Constrained scope (Phase 3b/3c follow-ups)

- Multi-property `sort=A,B` (Phase 3b).
- `order=desc` / `order=random` (Phase 3b).
- `SubqueryQueryBuilder` derived-table cursor support; cursor mode
  still forces the legacy single-query SQL path (Phase 3c).
- Forward-only; no `cursor-before`.

## Test plan

- [x] `composer analyze` clean
- [x] 10 `QueryCreatorTest` cursor cases pass (6 pre-existing + 4
  new): matching `sort_prop`, mismatching `sort_prop`, page-pivoted
  `sort=,Property` (Critical regression test), `order=desc`
  rejection, multi-sort rejection, plus the spike-era cases.
- [x] Browser smoke against the dev wiki (`?action=ask`, 32 items
  with `sort=Modification_date`):

  | Case | Result |
  |---|---|
  | Cursor walk + sort=Modification_date | 32 of 32 items in 4 pages |
  | Legacy walk + sort=Modification_date | 28 items, 1 duplicate (pre-existing OFFSET non-determinism on tied sort values, sidestepped by `(sort, id)` tiebreak) |
  | `sort=,Modification_date` page 2 cursor | Accepted (Critical fix verified) |
  | Cursor with mismatching `sort_prop` | Clear error |
  | `order=desc` + cursor | Clear error |
  | Spike default-sort cursor (no `sort_prop`) | Still works (backward-compat) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)