### PR TITLE
QueryEngine: cursor pagination for order=desc

### DIFF
--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -264,9 +264,9 @@ class QueryCreator implements QueryContext {
 	 * default sort (`''` key only), use the empty key's order. Falls
 	 * back to ASC when neither is set.
 	 *
-	 * @return 'ASC'|'DESC'|'RANDOM' Caller string-compares the result
-	 *   to these literals; values are normalised upstream by
-	 *   `normalize_order()`.
+	 * The returned string is always one of "ASC", "DESC", or "RANDOM".
+	 * Callers string-compare against these literals; values are
+	 * normalised upstream by `normalize_order()`.
 	 */
 	private function resolveRequestSortOrder( array $sortKeys, string $requestSortKey ): string {
 		if ( $requestSortKey !== '' && isset( $sortKeys[$requestSortKey] ) ) {

--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -181,16 +181,37 @@ class QueryCreator implements QueryContext {
 			return;
 		}
 
-		$customSortKeys = array_filter(
+		// `array_values` re-indexes so `[0]` is the first custom-sort
+		// property regardless of any preceding empty-string key (the
+		// `sort=,SomeProperty` page-pivoted form produces a `sortKeys`
+		// array whose `array_keys` is `['', 'SomeProperty']` — without
+		// re-indexing the filter returns `[1 => 'SomeProperty']` and
+		// `[0]` resolves to null, false-rejecting cursors on page 2).
+		$customSortKeys = array_values( array_filter(
 			array_keys( $sortKeys ),
 			static fn ( $key ) => $key !== ''
-		);
+		) );
 
 		if ( count( $customSortKeys ) > 1 ) {
 			$query->addErrors( [
 				'Cursor pagination (`cursor=`) is not supported with multi-property `sort=` in this release. Reduce to a single sort property, or use `offset=` instead.'
 			] );
 			return;
+		}
+
+		// Phase 3a is ASC-only. The keyset predicate is `>`-form;
+		// supporting `DESC` requires `<`-form + reversed ORDER BY
+		// (planned for Phase 3b). Reject `order=desc`/`random`
+		// explicitly so a future lift can extend the contract
+		// without breaking clients that silently ignored the order
+		// parameter today.
+		foreach ( $sortKeys as $_key => $order ) {
+			if ( $order === 'DESC' || $order === 'RANDOM' ) {
+				$query->addErrors( [
+					"Cursor pagination (`cursor=`) requires ascending order; `order=$order` is not supported in this release."
+				] );
+				return;
+			}
 		}
 
 		if ( $query->getQueryMode() === self::MODE_COUNT ) {

--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -199,19 +199,16 @@ class QueryCreator implements QueryContext {
 			return;
 		}
 
-		// Phase 3a is ASC-only. The keyset predicate is `>`-form;
-		// supporting `DESC` requires `<`-form + reversed ORDER BY
-		// (planned for Phase 3b). Reject `order=desc`/`random`
-		// explicitly so a future lift can extend the contract
-		// without breaking clients that silently ignored the order
-		// parameter today.
-		foreach ( $sortKeys as $_key => $order ) {
-			if ( $order === 'DESC' || $order === 'RANDOM' ) {
-				$query->addErrors( [
-					"Cursor pagination (`cursor=`) requires ascending order; `order=$order` is not supported in this release."
-				] );
-				return;
-			}
+		// `order=random` is fundamentally incompatible with keyset
+		// pagination: there's no stable anchor to seek past. Phase 3b
+		// adds `order=desc` support; `random` stays rejected.
+		$requestSortKey = $customSortKeys[0] ?? '';
+		$requestSortOrder = $this->resolveRequestSortOrder( $sortKeys, $requestSortKey );
+		if ( $requestSortOrder === 'RANDOM' ) {
+			$query->addErrors( [
+				'Cursor pagination (`cursor=`) is not supported with `order=random`. Reverse the request to use `order=asc` or `order=desc`.'
+			] );
+			return;
 		}
 
 		if ( $query->getQueryMode() === self::MODE_COUNT ) {
@@ -234,15 +231,44 @@ class QueryCreator implements QueryContext {
 		// so a first-page cursor request works for both default- and
 		// custom-sort queries.
 		$payloadSortProp = $payload['sort_prop'] ?? '';
-		$requestSortProp = $customSortKeys[0] ?? '';
-		if ( $payloadSortProp !== '' && $payloadSortProp !== $requestSortProp ) {
+		if ( $payloadSortProp !== '' && $payloadSortProp !== $requestSortKey ) {
 			$query->addErrors( [
-				"Cursor was minted for `sort=$payloadSortProp` but the request specifies `sort=$requestSortProp`. The cursor anchor has no meaning under a different sort; re-issue without `cursor=` or align the `sort=` parameter."
+				"Cursor was minted for `sort=$payloadSortProp` but the request specifies `sort=$requestSortKey`. The cursor anchor has no meaning under a different sort; re-issue without `cursor=` or align the `sort=` parameter."
 			] );
 			return;
 		}
 
+		// Reject mismatched sort_order, but only when the cursor has
+		// an actual anchor (the `sort` field). Bootstrap cursors
+		// without an anchor (e.g. `{"v":1}`) are direction-agnostic.
+		// Phase 3 spike + 3a cursors carry an anchor but no
+		// `sort_order` field; treat their absence as ASC because
+		// those cursors were minted under ASC (the only mode
+		// available pre-3b).
+		if ( isset( $payload['sort'] ) ) {
+			$payloadSortOrder = $payload['sort_order'] ?? 'ASC';
+			if ( $payloadSortOrder !== $requestSortOrder ) {
+				$query->addErrors( [
+					"Cursor was minted for `order=$payloadSortOrder` but the request specifies `order=$requestSortOrder`. The cursor anchor seeks in the wrong direction under the new order; re-issue without `cursor=` or align the `order=` parameter."
+				] );
+				return;
+			}
+		}
+
 		$query->setCursorAfter( $payload );
+	}
+
+	/**
+	 * Resolve the canonical sort order for the active sort key. For a
+	 * custom-property sort (`sort=Foo`), use that key's order. For
+	 * default sort (`''` key only), use the empty key's order. Falls
+	 * back to ASC when neither is set.
+	 */
+	private function resolveRequestSortOrder( array $sortKeys, string $requestSortKey ): string {
+		if ( $requestSortKey !== '' && isset( $sortKeys[$requestSortKey] ) ) {
+			return $sortKeys[$requestSortKey];
+		}
+		return $sortKeys[''] ?? 'ASC';
 	}
 
 	/**

--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -263,6 +263,10 @@ class QueryCreator implements QueryContext {
 	 * custom-property sort (`sort=Foo`), use that key's order. For
 	 * default sort (`''` key only), use the empty key's order. Falls
 	 * back to ASC when neither is set.
+	 *
+	 * @return 'ASC'|'DESC'|'RANDOM' Caller string-compares the result
+	 *   to these literals; values are normalised upstream by
+	 *   `normalize_order()`.
 	 */
 	private function resolveRequestSortOrder( array $sortKeys, string $requestSortKey ): string {
 		if ( $requestSortKey !== '' && isset( $sortKeys[$requestSortKey] ) ) {

--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -152,21 +152,28 @@ class QueryCreator implements QueryContext {
 
 	/**
 	 * Decode the optional `cursor=<token>` user parameter and apply it
-	 * to the query, enforcing the constrained-spike contract: cursor
-	 * mode is only supported when the query has no custom `sort=`
-	 * property. A `cursor=` + `sort=Property` combination is rejected
-	 * by attaching an error message to the query (the engine then
-	 * surfaces it instead of running the query).
+	 * to the query, enforcing the Phase 3a contract:
 	 *
-	 * A malformed cursor token (any decode failure) is also surfaced
-	 * as an error rather than silently ignored, to avoid the
-	 * "expected next-page got first-page" surprise for bot clients.
+	 *   - Default sort (`sortKeys` has only the empty-string key or is
+	 *     empty): always allowed.
+	 *   - Single-property sort (`sort=Foo`, one non-empty key): allowed
+	 *     when the cursor's `sort_prop` field matches the request's
+	 *     sort key, or when the cursor has no `sort_prop` (bootstrap /
+	 *     empty payload for the first cursor-mode page).
+	 *   - Multi-property sort (`sort=A,B`): rejected (Phase 3b).
+	 *   - Custom sort + cursor with mismatching `sort_prop`: rejected.
+	 *     The cursor was minted for a different sort, applying it here
+	 *     would seek to a position that has no meaning in the new
+	 *     ordering.
+	 *
+	 * Malformed cursor tokens (any decode failure) are surfaced as an
+	 * error rather than silently ignored, to avoid the "expected
+	 * next-page got first-page" surprise for bot clients.
 	 *
 	 * @param Query $query
 	 * @param array $sortKeys As returned by `getSortKeys()['keys']`.
-	 *   An empty-string key (`'' => 'ASC'`) is the default "sort by
-	 *   page" and is allowed; any non-empty-string key is a custom
-	 *   property sort and is rejected.
+	 *   An empty-string key (`'' => 'ASC'`) is "sort by page"; a
+	 *   non-empty-string key is a property sort.
 	 */
 	private function applyCursorIfRequested( Query $query, array $sortKeys ): void {
 		$token = (string)$this->getParam( 'cursor', '' );
@@ -174,13 +181,16 @@ class QueryCreator implements QueryContext {
 			return;
 		}
 
-		foreach ( $sortKeys as $sortKey => $_order ) {
-			if ( $sortKey !== '' ) {
-				$query->addErrors( [
-					'Cursor pagination (`cursor=`) is not supported with a custom `sort=` property in this release. Remove `sort=` or use `offset=` instead.'
-				] );
-				return;
-			}
+		$customSortKeys = array_filter(
+			array_keys( $sortKeys ),
+			static fn ( $key ) => $key !== ''
+		);
+
+		if ( count( $customSortKeys ) > 1 ) {
+			$query->addErrors( [
+				'Cursor pagination (`cursor=`) is not supported with multi-property `sort=` in this release. Reduce to a single sort property, or use `offset=` instead.'
+			] );
+			return;
 		}
 
 		if ( $query->getQueryMode() === self::MODE_COUNT ) {
@@ -194,6 +204,19 @@ class QueryCreator implements QueryContext {
 		if ( $payload === null ) {
 			$query->addErrors( [
 				'Malformed `cursor=` token (rejected as unrecognised or from a newer schema version).'
+			] );
+			return;
+		}
+
+		// Reject mismatched sort_prop. The empty-payload bootstrap
+		// cursor has no `sort_prop` and therefore matches any sort,
+		// so a first-page cursor request works for both default- and
+		// custom-sort queries.
+		$payloadSortProp = $payload['sort_prop'] ?? '';
+		$requestSortProp = $customSortKeys[0] ?? '';
+		if ( $payloadSortProp !== '' && $payloadSortProp !== $requestSortProp ) {
+			$query->addErrors( [
+				"Cursor was minted for `sort=$payloadSortProp` but the request specifies `sort=$requestSortProp`. The cursor anchor has no meaning under a different sort; re-issue without `cursor=` or align the `sort=` parameter."
 			] );
 			return;
 		}

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -399,13 +399,49 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 
 		$sql_options = $this->getSQLOptions( $query, $rootid );
 		$cursorMode = $query->getCursorAfter() !== null;
+		$cursorSortColumn = null;
+		$cursorSortPropKey = '';
 
 		if ( $cursorMode ) {
-			// Override sort and offset for cursor mode. The trait-pattern
-			// keyset predicate is total-ordered on `(smw_sort, smw_id)`;
-			// any pre-existing ORDER BY would conflict with the predicate
-			// semantics, and OFFSET is replaced by the WHERE-anchored seek.
-			$sql_options['ORDER BY'] = "$qobj->alias.smw_sort, $qobj->alias.smw_id";
+			// The active sort key is determined by `$query->sortkeys`
+			// (set by `QueryCreator` from `sort=`), not by the
+			// incoming cursor payload. The cursor's `sort_prop` was
+			// already cross-checked against `sort=` in QueryCreator;
+			// here the engine just needs to know which sortfield
+			// column to anchor the keyset predicate on.
+			foreach ( $query->sortkeys as $propKey => $_order ) {
+				if ( $propKey !== '' ) {
+					$cursorSortPropKey = $propKey;
+					break;
+				}
+			}
+
+			if ( $cursorSortPropKey !== '' ) {
+				if ( !isset( $qobj->sortfields[$cursorSortPropKey] ) ) {
+					// User asked for `sort=Foo` but `Foo` could not be
+					// resolved to a sortfield column (invalid property,
+					// or the joined table never got set up). Surface
+					// explicitly rather than silently fall back to
+					// default sort, since the next cursor anchor would
+					// be meaningless.
+					$query->addErrors( [
+						"Cursor mode could not resolve `sort=$cursorSortPropKey` to a query sortfield."
+					] );
+					return $this->queryFactory->newQueryResult(
+						$this->store, $query, [], false
+					);
+				}
+				$cursorSortColumn = $qobj->sortfields[$cursorSortPropKey];
+			} else {
+				// Default sort (Phase 3 spike compatible).
+				$cursorSortColumn = "$qobj->alias.smw_sort";
+			}
+
+			// Override sort and offset for cursor mode. Keyset is total-ordered
+			// on `(<sort_column>, smw_id)`; any pre-existing ORDER BY would
+			// conflict with the predicate semantics, OFFSET is replaced by
+			// the WHERE-anchored seek.
+			$sql_options['ORDER BY'] = "$cursorSortColumn, $qobj->alias.smw_id";
 			unset( $sql_options['OFFSET'] );
 		}
 
@@ -414,7 +450,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		// the keyset predicate into `SubqueryQueryBuilder`'s derived-table
 		// rewrite, so cursor mode opts out of that optimisation in
 		// exchange for the much larger keyset speedup on the OFFSET side.
-		// Tracked as Phase 3a follow-up in #6795.
+		// Tracked as Phase 3c follow-up in #6795.
 		if ( $cursorMode || $this->engineOptions->get( 'smwgQUseLegacyQuery' ) ) {
 			$selectFields = [
 				'id' => "$qobj->alias.smw_id",
@@ -425,7 +461,10 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 				'sortkey' => "$qobj->alias.smw_sortkey",
 			];
 			if ( $cursorMode ) {
-				$selectFields['sort'] = "$qobj->alias.smw_sort";
+				// Alias the sort column under `sort` so the row loop can
+				// read `$row->sort` regardless of whether the user
+				// specified `sort=Property` or accepted the default.
+				$selectFields['sort'] = $cursorSortColumn;
 			}
 
 			$qb = $connection->newSelectQueryBuilder()
@@ -444,7 +483,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			}
 
 			if ( $cursorMode ) {
-				$this->applyKeysetPredicate( $qb, $query, $qobj, $connection );
+				$this->applyKeysetPredicate( $qb, $query, $qobj, $connection, $cursorSortColumn );
 			}
 
 			$res = $qb->fetchResultSet();
@@ -546,19 +585,27 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			$hasFurtherResults
 		);
 
-		// Cursor minted from a row whose `smw_sort` is NULL would be
+		// Cursor minted from a row whose sort value is NULL would be
 		// rejected by `applyKeysetPredicate()` on the next request
 		// (the `isset()` guard there treats null as "no anchor" and
 		// silently serves page 1, looping the crawler). Skip the
 		// cursor emission entirely for that case so the client at
-		// least stops paginating instead of looping. Phase 3a will
+		// least stops paginating instead of looping. Phase 3b will
 		// add explicit `IS NULL` handling once the cursor format
 		// supports compound sort tuples.
 		if ( $cursorMode && $hasFurtherResults && $lastCursorId !== null && $lastCursorSort !== null ) {
-			$queryResult->setNextCursor( CursorEncoder::encode( [
+			$payload = [
 				'sort' => $lastCursorSort,
 				'id'   => $lastCursorId,
-			] ) );
+			];
+			// Round-trip the sort property so the next request can
+			// reject a sort= that doesn't match the cursor's anchor.
+			// Omitted for default-sort queries to keep the spike's
+			// `{"v":1,"sort":...,"id":...}` payload shape compatible.
+			if ( $cursorSortPropKey !== '' ) {
+				$payload['sort_prop'] = $cursorSortPropKey;
+			}
+			$queryResult->setNextCursor( CursorEncoder::encode( $payload ) );
 		}
 
 		return $queryResult;
@@ -659,25 +706,30 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 	 * The predicate matches the form used by
 	 * `KeysetPaginationTrait::applyCursorPagination()`:
 	 *
-	 *     smw_sort > X OR (smw_sort = X AND smw_id > Y)
+	 *     <sortCol> > X OR (<sortCol> = X AND smw_id > Y)
 	 *
-	 * MariaDB recognises this as an index range seek on
-	 * `(smw_sort, smw_id)`; the row-constructor form
-	 * `(smw_sort, smw_id) > (X, Y)` plans a full index scan instead.
-	 * See issue #6559 and #6794 for the underlying motivation.
+	 * MariaDB recognises this as an index range seek; the row-constructor
+	 * form `(<sortCol>, smw_id) > (X, Y)` plans a full index scan
+	 * instead. See issue #6559 and #6794 for the underlying motivation.
 	 *
-	 * TODO Phase 3a: unify with `KeysetPaginationTrait::applyCursorPagination`.
+	 * `$sortColumn` is the SQL column expression for the active sort
+	 * field — `<alias>.smw_sort` for default sort, the
+	 * `$qobj->sortfields[$propKey]` expression for `sort=Property`
+	 * (Phase 3a). The caller resolves the expression.
+	 *
+	 * TODO Phase 3b/c: unify with `KeysetPaginationTrait::applyCursorPagination`.
 	 * The two diverge in (a) aliased vs unqualified column refs,
 	 * (b) forward-only vs forward+backward, and (c) decoded-payload
-	 * vs RequestOptions-int cursor sources. Once Phase 3a generalises
-	 * the cursor payload to compound sort tuples, the two paths
-	 * should converge on a shared predicate builder.
+	 * vs RequestOptions-int cursor sources. Once Phase 3b adds
+	 * compound sort tuples, the two paths should converge on a shared
+	 * predicate builder.
 	 */
 	private function applyKeysetPredicate(
 		SelectQueryBuilder $queryBuilder,
 		Query $query,
 		QuerySegment $qobj,
-		$connection
+		$connection,
+		string $sortColumn
 	): void {
 		$payload = $query->getCursorAfter();
 		if ( !isset( $payload['sort'] ) || !isset( $payload['id'] ) ) {
@@ -689,8 +741,8 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$alias = $qobj->alias;
 
 		$queryBuilder->where(
-			"$alias.smw_sort > $quotedSort " .
-			"OR ($alias.smw_sort = $quotedSort AND $alias.smw_id > $cursorId)"
+			"$sortColumn > $quotedSort " .
+			"OR ($sortColumn = $quotedSort AND $alias.smw_id > $cursorId)"
 		);
 	}
 

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -417,13 +417,17 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			}
 
 			if ( $cursorSortPropKey !== '' ) {
-				if ( !isset( $qobj->sortfields[$cursorSortPropKey] ) ) {
+				$sortExpr = $qobj->sortfields[$cursorSortPropKey] ?? '';
+				if ( $sortExpr === '' ) {
 					// User asked for `sort=Foo` but `Foo` could not be
 					// resolved to a sortfield column (invalid property,
 					// or the joined table never got set up). Surface
 					// explicitly rather than silently fall back to
 					// default sort, since the next cursor anchor would
-					// be meaningless.
+					// be meaningless. `=== ''` rather than `!isset`
+					// also catches the edge case where a future
+					// `OrderCondition` path assigns an empty
+					// expression.
 					$query->addErrors( [
 						"Cursor mode could not resolve `sort=$cursorSortPropKey` to a query sortfield."
 					] );
@@ -431,7 +435,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 						$this->store, $query, [], false
 					);
 				}
-				$cursorSortColumn = $qobj->sortfields[$cursorSortPropKey];
+				$cursorSortColumn = $sortExpr;
 			} else {
 				// Default sort (Phase 3 spike compatible).
 				$cursorSortColumn = "$qobj->alias.smw_sort";

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -401,6 +401,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$cursorMode = $query->getCursorAfter() !== null;
 		$cursorSortColumn = null;
 		$cursorSortPropKey = '';
+		$cursorSortOrder = 'ASC';
 
 		if ( $cursorMode ) {
 			// The active sort key is determined by `$query->sortkeys`
@@ -409,11 +410,15 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			// already cross-checked against `sort=` in QueryCreator;
 			// here the engine just needs to know which sortfield
 			// column to anchor the keyset predicate on.
-			foreach ( $query->sortkeys as $propKey => $_order ) {
+			foreach ( $query->sortkeys as $propKey => $order ) {
 				if ( $propKey !== '' ) {
 					$cursorSortPropKey = $propKey;
+					$cursorSortOrder = $order === 'DESC' ? 'DESC' : 'ASC';
 					break;
 				}
+			}
+			if ( $cursorSortPropKey === '' && isset( $query->sortkeys[''] ) ) {
+				$cursorSortOrder = $query->sortkeys[''] === 'DESC' ? 'DESC' : 'ASC';
 			}
 
 			if ( $cursorSortPropKey !== '' ) {
@@ -444,8 +449,9 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			// Override sort and offset for cursor mode. Keyset is total-ordered
 			// on `(<sort_column>, smw_id)`; any pre-existing ORDER BY would
 			// conflict with the predicate semantics, OFFSET is replaced by
-			// the WHERE-anchored seek.
-			$sql_options['ORDER BY'] = "$cursorSortColumn, $qobj->alias.smw_id";
+			// the WHERE-anchored seek. Both columns sort in the same direction
+			// so the tiebreak walks consistently with the primary sort.
+			$sql_options['ORDER BY'] = "$cursorSortColumn $cursorSortOrder, $qobj->alias.smw_id $cursorSortOrder";
 			unset( $sql_options['OFFSET'] );
 		}
 
@@ -487,7 +493,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			}
 
 			if ( $cursorMode ) {
-				$this->applyKeysetPredicate( $qb, $query, $qobj, $connection, $cursorSortColumn );
+				$this->applyKeysetPredicate( $qb, $query, $qobj, $connection, $cursorSortColumn, $cursorSortOrder );
 			}
 
 			$res = $qb->fetchResultSet();
@@ -609,6 +615,13 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			if ( $cursorSortPropKey !== '' ) {
 				$payload['sort_prop'] = $cursorSortPropKey;
 			}
+			// Round-trip the sort order for the same reason: a cursor
+			// minted for DESC must be rejected by an ASC request (the
+			// predicate would seek in the wrong direction). Omitted for
+			// ASC to keep spike/3a cursors round-trippable as-is.
+			if ( $cursorSortOrder === 'DESC' ) {
+				$payload['sort_order'] = 'DESC';
+			}
 			$queryResult->setNextCursor( CursorEncoder::encode( $payload ) );
 		}
 
@@ -708,32 +721,33 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 	 * anything).
 	 *
 	 * The predicate matches the form used by
-	 * `KeysetPaginationTrait::applyCursorPagination()`:
+	 * `KeysetPaginationTrait::applyCursorPagination()`. For ASC:
 	 *
 	 *     <sortCol> > X OR (<sortCol> = X AND smw_id > Y)
 	 *
-	 * MariaDB recognises this as an index range seek; the row-constructor
+	 * For DESC (Phase 3b), the operators invert:
+	 *
+	 *     <sortCol> < X OR (<sortCol> = X AND smw_id < Y)
+	 *
+	 * MariaDB recognises both as index range seeks; the row-constructor
 	 * form `(<sortCol>, smw_id) > (X, Y)` plans a full index scan
 	 * instead. See issue #6559 and #6794 for the underlying motivation.
 	 *
 	 * `$sortColumn` is the SQL column expression for the active sort
-	 * field — `<alias>.smw_sort` for default sort, the
-	 * `$qobj->sortfields[$propKey]` expression for `sort=Property`
-	 * (Phase 3a). The caller resolves the expression.
+	 * field. The caller resolves it from `$qobj->sortfields` (custom
+	 * sort) or hardcodes `<alias>.smw_sort` (default sort).
 	 *
-	 * TODO Phase 3b/c: unify with `KeysetPaginationTrait::applyCursorPagination`.
-	 * The two diverge in (a) aliased vs unqualified column refs,
-	 * (b) forward-only vs forward+backward, and (c) decoded-payload
-	 * vs RequestOptions-int cursor sources. Once Phase 3b adds
-	 * compound sort tuples, the two paths should converge on a shared
-	 * predicate builder.
+	 * TODO Phase 3c: unify with `KeysetPaginationTrait::applyCursorPagination`.
+	 * Once a shared predicate builder exists, both this method and the
+	 * trait can delegate to it.
 	 */
 	private function applyKeysetPredicate(
 		SelectQueryBuilder $queryBuilder,
 		Query $query,
 		QuerySegment $qobj,
 		$connection,
-		string $sortColumn
+		string $sortColumn,
+		string $sortOrder = 'ASC'
 	): void {
 		$payload = $query->getCursorAfter();
 		if ( !isset( $payload['sort'] ) || !isset( $payload['id'] ) ) {
@@ -743,10 +757,11 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$quotedSort = $connection->addQuotes( $payload['sort'] );
 		$cursorId = (int)$payload['id'];
 		$alias = $qobj->alias;
+		$op = $sortOrder === 'DESC' ? '<' : '>';
 
 		$queryBuilder->where(
-			"$sortColumn > $quotedSort " .
-			"OR ($sortColumn = $quotedSort AND $alias.smw_id > $cursorId)"
+			"$sortColumn $op $quotedSort " .
+			"OR ($sortColumn = $quotedSort AND $alias.smw_id $op $cursorId)"
 		);
 	}
 

--- a/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
@@ -207,9 +207,10 @@ class QueryCreatorTest extends TestCase {
 		$this->assertSame( 'SomeProperty', $payload['sort_prop'] );
 	}
 
-	public function testCursorParamWithOrderDescIsRejectedWithError(): void {
-		// Phase 3a is ASC-only. DESC support is planned for Phase 3b
-		// (requires `<`-form predicate + reversed ORDER BY).
+	public function testCursorParamWithOrderDescIsAccepted(): void {
+		// Phase 3b lifts the 3a ASC-only constraint. A bootstrap cursor
+		// (no sort_order) is accepted against an `order=desc` request;
+		// the engine then mints subsequent cursors with `sort_order=DESC`.
 		$instance = new QueryCreator(
 			ApplicationFactory::getInstance()->getQueryFactory()
 		);
@@ -223,10 +224,56 @@ class QueryCreatorTest extends TestCase {
 			]
 		);
 
+		$this->assertSame( [ 'v' => 1 ], $query->getCursorAfter() );
+	}
+
+	public function testCursorParamWithMismatchedSortOrderIsRejectedWithError(): void {
+		// A cursor minted for DESC carries `sort_order=DESC`. Sending
+		// that cursor with an `order=asc` request must be rejected:
+		// the predicate would seek in the wrong direction.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		// {"v":1,"sort":"value","sort_prop":"SomeProperty","sort_order":"DESC","id":42}
+		$token = 'eyJ2IjoxLCJzb3J0IjoidmFsdWUiLCJzb3J0X3Byb3AiOiJTb21lUHJvcGVydHkiLCJzb3J0X29yZGVyIjoiREVTQyIsImlkIjo0Mn0';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'SomeProperty' ],
+				'order'  => [ 'asc' ],
+				'cursor' => $token,
+			]
+		);
+
 		$this->assertNull( $query->getCursorAfter() );
 		$this->assertCursorErrorPresent(
 			$query->getErrors(),
-			'requires ascending order'
+			'wrong direction'
+		);
+	}
+
+	public function testCursorParamWithOrderRandomIsRejectedWithError(): void {
+		// `order=random` has no stable anchor for keyset to seek past.
+		// Permanent rejection (no future phase will lift this).
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'SomeProperty' ],
+				'order'  => [ 'random' ],
+				'cursor' => 'eyJ2IjoxfQ',
+			]
+		);
+
+		$this->assertNull( $query->getCursorAfter() );
+		$this->assertCursorErrorPresent(
+			$query->getErrors(),
+			'`order=random`'
 		);
 	}
 

--- a/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
@@ -227,6 +227,50 @@ class QueryCreatorTest extends TestCase {
 		$this->assertSame( [ 'v' => 1 ], $query->getCursorAfter() );
 	}
 
+	public function testCursorParamWithImplicitAscPayloadIsRejectedByDescRequest(): void {
+		// Phase 3a / spike cursors carry no `sort_order` field; they were
+		// minted under ASC. A DESC request must reject them — the
+		// predicate would seek in the wrong direction. This is the
+		// backward-compat mirror of `testCursorParamWithMismatchedSortOrder`.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		// {"v":1,"sort":"value","sort_prop":"SomeProperty","id":42} — no sort_order
+		$token = 'eyJ2IjoxLCJzb3J0IjoidmFsdWUiLCJzb3J0X3Byb3AiOiJTb21lUHJvcGVydHkiLCJpZCI6NDJ9';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'SomeProperty' ],
+				'order'  => [ 'desc' ],
+				'cursor' => $token,
+			]
+		);
+
+		$this->assertNull( $query->getCursorAfter() );
+		$this->assertCursorErrorPresent( $query->getErrors(), 'wrong direction' );
+	}
+
+	public function testCursorParamWithDefaultSortDescIsAccepted(): void {
+		// Contract item 8: `sort=` (default page sort) + `order=desc`
+		// + bootstrap cursor is a valid combination. The engine then
+		// uses `smw_sort` column DESC.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'order'  => [ 'desc' ],
+				'cursor' => 'eyJ2IjoxfQ',
+			]
+		);
+
+		$this->assertSame( [ 'v' => 1 ], $query->getCursorAfter() );
+	}
+
 	public function testCursorParamWithMismatchedSortOrderIsRejectedWithError(): void {
 		// A cursor minted for DESC carries `sort_order=DESC`. Sending
 		// that cursor with an `order=asc` request must be rejected:

--- a/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
@@ -178,6 +178,58 @@ class QueryCreatorTest extends TestCase {
 		$this->assertSame( [ 'v' => 1 ], $query->getCursorAfter() );
 	}
 
+	public function testCursorParamWithPagePivotedSortPreservesAnchor(): void {
+		// Regression for the `array_filter` key-preservation bug:
+		// `sort=,SomeProperty` produces `sortKeys = ['' => 'ASC',
+		// 'SomeProperty' => 'ASC']`. Without `array_values` after
+		// the filter, `$customSortKeys[0]` is null and any cursor
+		// minted on page 1 (which correctly emits
+		// `sort_prop=SomeProperty`) is falsely rejected on page 2
+		// onward. The cursor walk must work for this very common
+		// page-pivoted shape.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		// {"v":1,"sort":"value","sort_prop":"SomeProperty","id":42}
+		$token = 'eyJ2IjoxLCJzb3J0IjoidmFsdWUiLCJzb3J0X3Byb3AiOiJTb21lUHJvcGVydHkiLCJpZCI6NDJ9';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ '', 'SomeProperty' ],
+				'cursor' => $token,
+			]
+		);
+
+		$payload = $query->getCursorAfter();
+		$this->assertIsArray( $payload, 'Cursor with page-pivoted sort must NOT be rejected' );
+		$this->assertSame( 'SomeProperty', $payload['sort_prop'] );
+	}
+
+	public function testCursorParamWithOrderDescIsRejectedWithError(): void {
+		// Phase 3a is ASC-only. DESC support is planned for Phase 3b
+		// (requires `<`-form predicate + reversed ORDER BY).
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'SomeProperty' ],
+				'order'  => [ 'desc' ],
+				'cursor' => 'eyJ2IjoxfQ',
+			]
+		);
+
+		$this->assertNull( $query->getCursorAfter() );
+		$this->assertCursorErrorPresent(
+			$query->getErrors(),
+			'requires ascending order'
+		);
+	}
+
 	public function testCursorParamWithMultiSortIsRejectedWithError(): void {
 		// Phase 3b will support compound-sort cursors. Until then,
 		// `sort=A,B` + `cursor=` is rejected so cursor consumers can

--- a/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
@@ -106,7 +106,82 @@ class QueryCreatorTest extends TestCase {
 		);
 	}
 
-	public function testCursorParamWithCustomSortIsRejectedWithError(): void {
+	public function testCursorParamWithMatchingSortPropIsAccepted(): void {
+		// Phase 3a contract: `sort=SomeProperty` + cursor whose
+		// `sort_prop` matches is allowed. The cursor anchor stays
+		// meaningful under the requested sort.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		// base64url of {"v":1,"sort":"value","sort_prop":"SomeProperty","id":42}
+		$token = 'eyJ2IjoxLCJzb3J0IjoidmFsdWUiLCJzb3J0X3Byb3AiOiJTb21lUHJvcGVydHkiLCJpZCI6NDJ9';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'SomeProperty' ],
+				'cursor' => $token,
+			]
+		);
+
+		$payload = $query->getCursorAfter();
+		$this->assertIsArray( $payload );
+		$this->assertSame( 'SomeProperty', $payload['sort_prop'] );
+		$this->assertSame( 'value', $payload['sort'] );
+		$this->assertSame( 42, $payload['id'] );
+	}
+
+	public function testCursorParamWithMismatchingSortPropIsRejectedWithError(): void {
+		// Phase 3a contract: cursor anchored at `sort_prop=A` MUST NOT
+		// be applied when the request says `sort=B`. The anchor has no
+		// meaning under a different sort.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$token = 'eyJ2IjoxLCJzb3J0IjoidmFsdWUiLCJzb3J0X3Byb3AiOiJTb21lUHJvcGVydHkiLCJpZCI6NDJ9';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'DifferentProperty' ],
+				'cursor' => $token,
+			]
+		);
+
+		$this->assertNull( $query->getCursorAfter() );
+		$this->assertCursorErrorPresent(
+			$query->getErrors(),
+			'Cursor was minted for'
+		);
+	}
+
+	public function testCursorParamWithEmptyPayloadIsAcceptedForAnySingleSort(): void {
+		// Bootstrap case: a cursor with no `sort_prop` (the
+		// `{"v":1}` empty-payload bootstrap from Phase 3 spike)
+		// matches any single-property sort.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$emptyToken = 'eyJ2IjoxfQ';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'Modification_date' ],
+				'cursor' => $emptyToken,
+			]
+		);
+
+		$this->assertSame( [ 'v' => 1 ], $query->getCursorAfter() );
+	}
+
+	public function testCursorParamWithMultiSortIsRejectedWithError(): void {
+		// Phase 3b will support compound-sort cursors. Until then,
+		// `sort=A,B` + `cursor=` is rejected so cursor consumers can
+		// rely on the constrained single-sort schema.
 		$instance = new QueryCreator(
 			ApplicationFactory::getInstance()->getQueryFactory()
 		);
@@ -114,22 +189,15 @@ class QueryCreatorTest extends TestCase {
 		$query = $instance->create(
 			'[[Foo::Bar]]',
 			[
-				'sort'   => [ 'SomeProperty' ],
-				'cursor' => 'eyJ2IjoxLCJzb3J0IjoiRm9vIiwiaWQiOjQyfQ',
+				'sort'   => [ 'PropertyA', 'PropertyB' ],
+				'cursor' => 'eyJ2IjoxfQ',
 			]
 		);
 
-		// Cursor must NOT be applied when a custom `sort=` is present.
 		$this->assertNull( $query->getCursorAfter() );
-
-		// Error is surfaced so the engine can refuse the query. The
-		// query parser may also push unrelated parsing errors onto the
-		// list (e.g. `smw_noqueryfeature` depending on the test-runner
-		// `smwgQFeatures` config), so search the full list for our
-		// cursor-specific marker rather than asserting position.
 		$this->assertCursorErrorPresent(
 			$query->getErrors(),
-			'Cursor pagination'
+			'multi-property'
 		);
 	}
 


### PR DESCRIPTION
## Summary

Lifts the Phase 3a (#6812) `order=desc` rejection. `order=random` stays
rejected (no stable anchor to seek past). Multi-property `sort=A,B`
also stays rejected (full Phase 3b follow-up). Tracks #6795.

**Stacked on #6812** — rebase onto master after that merges.

## Cursor payload extension (additive)

| Phase | Anchor payload |
|---|---|
| Phase 3 spike | `{"v":1, "sort":"<smw_sort>", "id":N}` |
| Phase 3a | adds `"sort_prop":"<key>"` for custom-property sort |
| Phase 3b-i | adds `"sort_order":"DESC"` for descending; omitted = ASC |

The `sort_order` field is omitted for ASC so spike + 3a cursors
remain byte-identical and round-trip unchanged. Bootstrap cursors
(`{"v":1}` with no anchor) are direction-agnostic and matched
against any order.

## Contract additions

| Request | Result |
|---|---|
| `sort=Foo` + `order=desc` + cursor | Accepted; predicate uses `<`-form, ORDER BY DESC |
| `sort=` (default) + `order=desc` + cursor | Accepted; `smw_sort` column DESC |
| Cursor with `sort_order=DESC` + request `order=asc` | Error: "wrong direction" |
| Cursor without `sort_order` (spike/3a) + request `order=desc` | Error: implicit ASC payload rejected |
| `order=random` + cursor | Error (permanent — random has no anchor) |

## Implementation

- `QueryCreator::resolveRequestSortOrder()` picks the order from the
  active sort key (custom key if present, else empty key, else ASC).
- `QueryCreator::applyCursorIfRequested()` validates the cursor's
  `sort_order` against the request's order; bootstrap cursors (no
  anchor) skip the check.
- `QueryEngine::getInstanceQueryResult()` extracts `$cursorSortOrder`
  from `$query->sortkeys` alongside `$cursorSortPropKey`; ORDER BY
  applies the direction to both columns (sort + tiebreak); the
  next-cursor minting includes `sort_order` only for DESC.
- `QueryEngine::applyKeysetPredicate()` gains a `string $sortOrder`
  parameter; for DESC it inverts `>` → `<` in both predicate halves.

## Test plan

- [x] `composer analyze` clean
- [x] 14 `QueryCreatorTest` cursor cases pass (3 new in this PR plus
  the 11 from Phase 3a):
  - DESC accepted with bootstrap cursor
  - Implicit-ASC payload (spike/3a) rejected by DESC request
  - Default-sort + DESC + bootstrap accepted
  - Mismatched `sort_order` (DESC cursor + ASC request) rejected
  - `order=random` rejected
- [x] Browser smoke against the dev wiki:

  | Case | Result |
  |---|---|
  | DESC cursor walk (`sort=Modification_date|order=desc`) | 11 of 11 items in reverse order |
  | ASC walk same query | 11 of 11 items |
  | Identity check | DESC walk is **exact reverse** of ASC walk |
  | Direction mismatch (DESC cursor + ASC request) | Clear error: "wrong direction" |

## Constrained scope (Phase 3b-ii / 3c follow-ups)

- Multi-property `sort=A,B` still rejected.
- SubqueryQueryBuilder derived-table cursor support still missing
  (cursor mode forces legacy single-query SQL path).
- Forward-only; no `cursor-before`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)