### PR TITLE
QueryEngine: cursor pagination for multi-property sort

### DIFF
--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -192,16 +192,26 @@ class QueryCreator implements QueryContext {
 			static fn ( $key ) => $key !== ''
 		) );
 
-		if ( count( $customSortKeys ) > 1 ) {
-			$query->addErrors( [
-				'Cursor pagination (`cursor=`) is not supported with multi-property `sort=` in this release. Reduce to a single sort property, or use `offset=` instead.'
-			] );
-			return;
+		// Phase 3b-ii: multi-property sort is allowed when all custom
+		// sort keys share a uniform direction. Mixed direction
+		// (`sort=A,B|order=asc,desc`) is deferred to Phase 3b-iii
+		// because the keyset predicate would need per-level operator
+		// inversion, which complicates the compound-predicate
+		// generation enough to warrant its own PR.
+		if ( $customSortKeys !== [] ) {
+			$firstOrder = $sortKeys[$customSortKeys[0]];
+			foreach ( $customSortKeys as $key ) {
+				if ( $sortKeys[$key] !== $firstOrder ) {
+					$query->addErrors( [
+						'Cursor pagination (`cursor=`) is not supported with mixed `order=` per sort property in this release. Use a uniform `order=` (all ascending or all descending), or use `offset=` instead.'
+					] );
+					return;
+				}
+			}
 		}
 
 		// `order=random` is fundamentally incompatible with keyset
-		// pagination: there's no stable anchor to seek past. Phase 3b
-		// adds `order=desc` support; `random` stays rejected.
+		// pagination: there's no stable anchor to seek past.
 		$requestSortKey = $customSortKeys[0] ?? '';
 		$requestSortOrder = $this->resolveRequestSortOrder( $sortKeys, $requestSortKey );
 		if ( $requestSortOrder === 'RANDOM' ) {
@@ -228,14 +238,25 @@ class QueryCreator implements QueryContext {
 
 		// Reject mismatched sort_prop. The empty-payload bootstrap
 		// cursor has no `sort_prop` and therefore matches any sort,
-		// so a first-page cursor request works for both default- and
-		// custom-sort queries.
-		$payloadSortProp = $payload['sort_prop'] ?? '';
-		if ( $payloadSortProp !== '' && $payloadSortProp !== $requestSortKey ) {
-			$query->addErrors( [
-				"Cursor was minted for `sort=$payloadSortProp` but the request specifies `sort=$requestSortKey`. The cursor anchor has no meaning under a different sort; re-issue without `cursor=` or align the `sort=` parameter."
-			] );
-			return;
+		// so a first-page cursor request works for default-, single-,
+		// and multi-sort queries.
+		//
+		// Single-sort cursors carry `sort_prop` as a scalar string;
+		// multi-sort cursors (Phase 3b-ii) as an array of property
+		// keys. Both shapes normalise to an array here for comparison.
+		$payloadSortProp = $payload['sort_prop'] ?? null;
+		if ( $payloadSortProp !== null ) {
+			$payloadProps = is_array( $payloadSortProp ) ? $payloadSortProp : [ $payloadSortProp ];
+			if ( $payloadProps !== $customSortKeys ) {
+				$payloadDesc = is_array( $payloadSortProp )
+					? implode( ',', $payloadSortProp )
+					: $payloadSortProp;
+				$requestDesc = implode( ',', $customSortKeys );
+				$query->addErrors( [
+					"Cursor was minted for `sort=$payloadDesc` but the request specifies `sort=$requestDesc`. The cursor anchor has no meaning under a different sort; re-issue without `cursor=` or align the `sort=` parameter."
+				] );
+				return;
+			}
 		}
 
 		// Reject mismatched sort_order, but only when the cursor has

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -410,10 +410,27 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			// cross-checked against `sort=` in `QueryCreator`. Phase
 			// 3b-ii allows multiple custom sort keys with a uniform
 			// direction; `QueryCreator` rejected mixed-order requests.
+			//
+			// Defensive uniformity check: if a caller constructed the
+			// `Query` programmatically and bypassed `QueryCreator`,
+			// mixed directions could land here. Surface explicitly
+			// rather than emit a predicate that's inverted on prior
+			// levels.
+			$seenOrder = null;
 			foreach ( $query->sortkeys as $propKey => $order ) {
 				if ( $propKey !== '' ) {
+					$normalised = $order === 'DESC' ? 'DESC' : 'ASC';
+					if ( $seenOrder !== null && $seenOrder !== $normalised ) {
+						$query->addErrors( [
+							'Cursor mode requires uniform sort order across all sort keys; mixed `ASC`/`DESC` would invert the keyset predicate on prior levels.'
+						] );
+						return $this->queryFactory->newQueryResult(
+							$this->store, $query, [], false
+						);
+					}
+					$seenOrder = $normalised;
 					$cursorSortPropKeys[] = $propKey;
-					$cursorSortOrder = $order === 'DESC' ? 'DESC' : 'ASC';
+					$cursorSortOrder = $normalised;
 				}
 			}
 			if ( $cursorSortPropKeys === [] && isset( $query->sortkeys[''] ) ) {
@@ -437,12 +454,52 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 							$this->store, $query, [], false
 						);
 					}
+					if ( strpos( $sortExpr, ',' ) !== false ) {
+						// Defensive: `OrderCondition` writes a
+						// comma-separated multi-column expression for
+						// the special `#` sort key (matches multiple
+						// `smw_*` columns at once). The keyset
+						// predicate's `<sortExpr> OP <value>` can't
+						// usefully target a column list. Cursor mode
+						// for `#` is undefined; reject rather than
+						// emit malformed SQL.
+						$query->addErrors( [
+							"Cursor mode is not supported for the multi-column sort expression at `sort=$key`."
+						] );
+						return $this->queryFactory->newQueryResult(
+							$this->store, $query, [], false
+						);
+					}
 					$cursorSortColumns[] = $sortExpr;
 				}
 			} else {
 				// Default sort (Phase 3 spike compatible). The empty
 				// key maps to `smw_sort` and stays a single column.
 				$cursorSortColumns = [ "$qobj->alias.smw_sort" ];
+			}
+
+			// Validate the cursor payload's sort tuple length matches
+			// the active sort column count. `QueryCreator` cross-checks
+			// `sort_prop` shape against `sort=`, so reaching here with
+			// a mismatch means either a malformed payload or a `Query`
+			// constructed bypassing `QueryCreator`. Either way, silently
+			// running without the keyset predicate would return page 1
+			// of the full result set, looping a paginating client.
+			$cursorPayload = $query->getCursorAfter();
+			if ( isset( $cursorPayload['sort'] ) ) {
+				$payloadSortValues = is_array( $cursorPayload['sort'] )
+					? $cursorPayload['sort']
+					: [ $cursorPayload['sort'] ];
+				if ( count( $payloadSortValues ) !== count( $cursorSortColumns ) ) {
+					$query->addErrors( [
+						'Cursor payload shape does not match the query sort: cursor has ' .
+						count( $payloadSortValues ) . ' sort value(s) but query has ' .
+						count( $cursorSortColumns ) . ' sort column(s).'
+					] );
+					return $this->queryFactory->newQueryResult(
+						$this->store, $query, [], false
+					);
+				}
 			}
 
 			// Override sort and offset for cursor mode. Keyset is
@@ -782,17 +839,11 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 
 		// Normalise payload `sort` to an array. Phase 3 spike + 3a +
 		// 3b-i cursors carry scalar `sort`; 3b-ii multi-sort cursors
-		// carry an array.
+		// carry an array. The shape is validated by the caller
+		// (`getInstanceQueryResult`) before reaching here — by the
+		// time `applyKeysetPredicate` runs, the count match is
+		// guaranteed.
 		$sortValues = is_array( $payload['sort'] ) ? $payload['sort'] : [ $payload['sort'] ];
-		if ( count( $sortValues ) !== count( $sortColumns ) ) {
-			// Cursor shape mismatch: a multi-sort cursor sent to a
-			// single-sort request (or vice versa) made it through
-			// `QueryCreator`'s `sort_prop` check despite that — most
-			// likely a `sort_prop` field that's malformed.
-			// `QueryCreator` should have rejected; defensive
-			// no-op here rather than silently mispaginate.
-			return;
-		}
 
 		$quotedSorts = array_map(
 			static fn ( $v ) => $connection->addQuotes( $v ),

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -399,59 +399,62 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 
 		$sql_options = $this->getSQLOptions( $query, $rootid );
 		$cursorMode = $query->getCursorAfter() !== null;
-		$cursorSortColumn = null;
-		$cursorSortPropKey = '';
+		$cursorSortPropKeys = [];
+		$cursorSortColumns = [];
 		$cursorSortOrder = 'ASC';
 
 		if ( $cursorMode ) {
-			// The active sort key is determined by `$query->sortkeys`
-			// (set by `QueryCreator` from `sort=`), not by the
-			// incoming cursor payload. The cursor's `sort_prop` was
-			// already cross-checked against `sort=` in QueryCreator;
-			// here the engine just needs to know which sortfield
-			// column to anchor the keyset predicate on.
+			// The active sort keys are determined by `$query->sortkeys`
+			// (set by `QueryCreator` from `sort=`), not by the incoming
+			// cursor payload. The cursor's `sort_prop` was already
+			// cross-checked against `sort=` in `QueryCreator`. Phase
+			// 3b-ii allows multiple custom sort keys with a uniform
+			// direction; `QueryCreator` rejected mixed-order requests.
 			foreach ( $query->sortkeys as $propKey => $order ) {
 				if ( $propKey !== '' ) {
-					$cursorSortPropKey = $propKey;
+					$cursorSortPropKeys[] = $propKey;
 					$cursorSortOrder = $order === 'DESC' ? 'DESC' : 'ASC';
-					break;
 				}
 			}
-			if ( $cursorSortPropKey === '' && isset( $query->sortkeys[''] ) ) {
+			if ( $cursorSortPropKeys === [] && isset( $query->sortkeys[''] ) ) {
 				$cursorSortOrder = $query->sortkeys[''] === 'DESC' ? 'DESC' : 'ASC';
 			}
 
-			if ( $cursorSortPropKey !== '' ) {
-				$sortExpr = $qobj->sortfields[$cursorSortPropKey] ?? '';
-				if ( $sortExpr === '' ) {
-					// User asked for `sort=Foo` but `Foo` could not be
-					// resolved to a sortfield column (invalid property,
-					// or the joined table never got set up). Surface
-					// explicitly rather than silently fall back to
-					// default sort, since the next cursor anchor would
-					// be meaningless. `=== ''` rather than `!isset`
-					// also catches the edge case where a future
-					// `OrderCondition` path assigns an empty
-					// expression.
-					$query->addErrors( [
-						"Cursor mode could not resolve `sort=$cursorSortPropKey` to a query sortfield."
-					] );
-					return $this->queryFactory->newQueryResult(
-						$this->store, $query, [], false
-					);
+			if ( $cursorSortPropKeys !== [] ) {
+				foreach ( $cursorSortPropKeys as $key ) {
+					$sortExpr = $qobj->sortfields[$key] ?? '';
+					if ( $sortExpr === '' ) {
+						// User asked for `sort=Foo` but `Foo` could not
+						// be resolved to a sortfield column (invalid
+						// property, or the joined table never got set
+						// up). Surface explicitly rather than silently
+						// fall back, since the next cursor anchor would
+						// be meaningless.
+						$query->addErrors( [
+							"Cursor mode could not resolve `sort=$key` to a query sortfield."
+						] );
+						return $this->queryFactory->newQueryResult(
+							$this->store, $query, [], false
+						);
+					}
+					$cursorSortColumns[] = $sortExpr;
 				}
-				$cursorSortColumn = $sortExpr;
 			} else {
-				// Default sort (Phase 3 spike compatible).
-				$cursorSortColumn = "$qobj->alias.smw_sort";
+				// Default sort (Phase 3 spike compatible). The empty
+				// key maps to `smw_sort` and stays a single column.
+				$cursorSortColumns = [ "$qobj->alias.smw_sort" ];
 			}
 
-			// Override sort and offset for cursor mode. Keyset is total-ordered
-			// on `(<sort_column>, smw_id)`; any pre-existing ORDER BY would
-			// conflict with the predicate semantics, OFFSET is replaced by
-			// the WHERE-anchored seek. Both columns sort in the same direction
-			// so the tiebreak walks consistently with the primary sort.
-			$sql_options['ORDER BY'] = "$cursorSortColumn $cursorSortOrder, $qobj->alias.smw_id $cursorSortOrder";
+			// Override sort and offset for cursor mode. Keyset is
+			// total-ordered on `(<col_1>, ..., <col_n>, smw_id)`; all
+			// levels sort in the same direction so the tiebreak walks
+			// consistently with the primary sort.
+			$orderByParts = [];
+			foreach ( $cursorSortColumns as $col ) {
+				$orderByParts[] = "$col $cursorSortOrder";
+			}
+			$orderByParts[] = "$qobj->alias.smw_id $cursorSortOrder";
+			$sql_options['ORDER BY'] = implode( ', ', $orderByParts );
 			unset( $sql_options['OFFSET'] );
 		}
 
@@ -471,10 +474,13 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 				'sortkey' => "$qobj->alias.smw_sortkey",
 			];
 			if ( $cursorMode ) {
-				// Alias the sort column under `sort` so the row loop can
-				// read `$row->sort` regardless of whether the user
-				// specified `sort=Property` or accepted the default.
-				$selectFields['sort'] = $cursorSortColumn;
+				// Alias each sort column under `cursor_sort_N` so the
+				// row loop can read `$row->cursor_sort_0`,
+				// `$row->cursor_sort_1`, ... regardless of whether the
+				// user specified one or multiple sort properties.
+				foreach ( $cursorSortColumns as $i => $col ) {
+					$selectFields["cursor_sort_$i"] = $col;
+				}
 			}
 
 			$qb = $connection->newSelectQueryBuilder()
@@ -493,7 +499,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			}
 
 			if ( $cursorMode ) {
-				$this->applyKeysetPredicate( $qb, $query, $qobj, $connection, $cursorSortColumn, $cursorSortOrder );
+				$this->applyKeysetPredicate( $qb, $query, $qobj, $connection, $cursorSortColumns, $cursorSortOrder );
 			}
 
 			$res = $qb->fetchResultSet();
@@ -512,9 +518,10 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$logToTable = [];
 		$hasFurtherResults = false;
 
-		// Cursor-mode bookkeeping: track the `(smw_sort, smw_id)` of the
-		// last accepted row so we can mint the next-page anchor.
-		$lastCursorSort = null;
+		// Cursor-mode bookkeeping: track the sort values + smw_id of
+		// the last accepted row so we can mint the next-page anchor.
+		// Length matches `$cursorSortColumns` (one value per sort field).
+		$lastCursorSorts = null;
 		$lastCursorId = null;
 
 		// Number of fetched results ( != number of valid results in
@@ -558,7 +565,10 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 					$this->store->smwIds->setCache( $row->t, $row->ns, $row->iw, $row->so, $row->id, $row->sortkey );
 
 					if ( $cursorMode ) {
-						$lastCursorSort = $row->sort ?? null;
+						$lastCursorSorts = [];
+						foreach ( $cursorSortColumns as $i => $_col ) {
+							$lastCursorSorts[] = $row->{"cursor_sort_$i"} ?? null;
+						}
 						$lastCursorId = (int)$row->id;
 					}
 				} else {
@@ -598,27 +608,36 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		// Cursor minted from a row whose sort value is NULL would be
 		// rejected by `applyKeysetPredicate()` on the next request
 		// (the `isset()` guard there treats null as "no anchor" and
-		// silently serves page 1, looping the crawler). Skip the
-		// cursor emission entirely for that case so the client at
-		// least stops paginating instead of looping. Phase 3b will
-		// add explicit `IS NULL` handling once the cursor format
-		// supports compound sort tuples.
-		if ( $cursorMode && $hasFurtherResults && $lastCursorId !== null && $lastCursorSort !== null ) {
+		// silently serves page 1, looping the crawler). Same for
+		// multi-sort: if ANY sort level is NULL the cursor anchor is
+		// undefined. Skip emission so the client stops paginating
+		// instead of looping. Phase 3c can add explicit `IS NULL`
+		// handling when the cursor format supports nullability flags.
+		$hasNullSort = $lastCursorSorts !== null
+			&& in_array( null, $lastCursorSorts, true );
+		if ( $cursorMode && $hasFurtherResults && $lastCursorId !== null && $lastCursorSorts !== null && !$hasNullSort ) {
+			// Single-sort cursors keep the spike's scalar `sort`
+			// payload shape (round-trippable with Phase 3 spike + 3a
+			// + 3b-i cursors). Multi-sort cursors use array shape.
 			$payload = [
-				'sort' => $lastCursorSort,
+				'sort' => count( $lastCursorSorts ) === 1
+					? $lastCursorSorts[0]
+					: $lastCursorSorts,
 				'id'   => $lastCursorId,
 			];
-			// Round-trip the sort property so the next request can
-			// reject a sort= that doesn't match the cursor's anchor.
-			// Omitted for default-sort queries to keep the spike's
-			// `{"v":1,"sort":...,"id":...}` payload shape compatible.
-			if ( $cursorSortPropKey !== '' ) {
-				$payload['sort_prop'] = $cursorSortPropKey;
+			// `sort_prop` matches the shape of `sort`: scalar for
+			// single-sort (one custom key), array for multi-sort.
+			// Omitted entirely for default-sort queries to keep the
+			// spike's `{"v":1,"sort":...,"id":...}` shape compatible.
+			if ( $cursorSortPropKeys !== [] ) {
+				$payload['sort_prop'] = count( $cursorSortPropKeys ) === 1
+					? $cursorSortPropKeys[0]
+					: $cursorSortPropKeys;
 			}
-			// Round-trip the sort order for the same reason: a cursor
-			// minted for DESC must be rejected by an ASC request (the
-			// predicate would seek in the wrong direction). Omitted for
-			// ASC to keep spike/3a cursors round-trippable as-is.
+			// Round-trip the sort order: a cursor minted for DESC must
+			// be rejected by an ASC request (the predicate would seek
+			// in the wrong direction). Omitted for ASC to keep
+			// spike/3a/3b-i ASC cursors round-trippable as-is.
 			if ( $cursorSortOrder === 'DESC' ) {
 				$payload['sort_order'] = 'DESC';
 			}
@@ -720,22 +739,29 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 	 * just opts into deterministic ordering without seeking past
 	 * anything).
 	 *
-	 * The predicate matches the form used by
-	 * `KeysetPaginationTrait::applyCursorPagination()`. For ASC:
+	 * Generalised compound form (Phase 3b-ii). For N sort columns
+	 * `c_1 ... c_N` with anchor values `v_1 ... v_N`, anchor id `Y`,
+	 * and operator `OP` (`>` for ASC, `<` for DESC), the predicate is:
 	 *
-	 *     <sortCol> > X OR (<sortCol> = X AND smw_id > Y)
+	 *     (c_1 OP v_1)
+	 *     OR (c_1 = v_1 AND c_2 OP v_2)
+	 *     OR ...
+	 *     OR (c_1 = v_1 AND ... AND c_N OP v_N)
+	 *     OR (c_1 = v_1 AND ... AND c_N = v_N AND smw_id OP Y)
 	 *
-	 * For DESC (Phase 3b), the operators invert:
+	 * Each clause peels one level of "tied prefix", expanding the
+	 * range progressively. MariaDB recognises this as an index range
+	 * seek when an index covers the sort columns; the row-constructor
+	 * form `(c_1, ..., c_N, smw_id) OP (v_1, ..., v_N, Y)` plans a
+	 * full index scan instead. See issue #6559 and #6794.
 	 *
-	 *     <sortCol> < X OR (<sortCol> = X AND smw_id < Y)
+	 * For N=1 (Phase 3 spike + 3a + 3b-i compatibility), the form
+	 * collapses to the simple two-clause predicate.
 	 *
-	 * MariaDB recognises both as index range seeks; the row-constructor
-	 * form `(<sortCol>, smw_id) > (X, Y)` plans a full index scan
-	 * instead. See issue #6559 and #6794 for the underlying motivation.
-	 *
-	 * `$sortColumn` is the SQL column expression for the active sort
-	 * field. The caller resolves it from `$qobj->sortfields` (custom
-	 * sort) or hardcodes `<alias>.smw_sort` (default sort).
+	 * `$sortColumns` is the list of SQL column expressions for the
+	 * active sort fields. The caller resolves them from
+	 * `$qobj->sortfields` (custom sort) or hardcodes
+	 * `[<alias>.smw_sort]` (default sort).
 	 *
 	 * TODO Phase 3c: unify with `KeysetPaginationTrait::applyCursorPagination`.
 	 * Once a shared predicate builder exists, both this method and the
@@ -746,7 +772,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		Query $query,
 		QuerySegment $qobj,
 		$connection,
-		string $sortColumn,
+		array $sortColumns,
 		string $sortOrder = 'ASC'
 	): void {
 		$payload = $query->getCursorAfter();
@@ -754,15 +780,50 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			return;
 		}
 
-		$quotedSort = $connection->addQuotes( $payload['sort'] );
+		// Normalise payload `sort` to an array. Phase 3 spike + 3a +
+		// 3b-i cursors carry scalar `sort`; 3b-ii multi-sort cursors
+		// carry an array.
+		$sortValues = is_array( $payload['sort'] ) ? $payload['sort'] : [ $payload['sort'] ];
+		if ( count( $sortValues ) !== count( $sortColumns ) ) {
+			// Cursor shape mismatch: a multi-sort cursor sent to a
+			// single-sort request (or vice versa) made it through
+			// `QueryCreator`'s `sort_prop` check despite that — most
+			// likely a `sort_prop` field that's malformed.
+			// `QueryCreator` should have rejected; defensive
+			// no-op here rather than silently mispaginate.
+			return;
+		}
+
+		$quotedSorts = array_map(
+			static fn ( $v ) => $connection->addQuotes( $v ),
+			$sortValues
+		);
 		$cursorId = (int)$payload['id'];
 		$alias = $qobj->alias;
 		$op = $sortOrder === 'DESC' ? '<' : '>';
+		$n = count( $sortColumns );
 
-		$queryBuilder->where(
-			"$sortColumn $op $quotedSort " .
-			"OR ($sortColumn = $quotedSort AND $alias.smw_id $op $cursorId)"
-		);
+		// Build the N+1 OR clauses: clause k has equality on prior
+		// k levels and inequality on level k; the final clause adds
+		// the smw_id tiebreak after all equalities.
+		$clauses = [];
+		for ( $k = 0; $k < $n; $k++ ) {
+			$parts = [];
+			for ( $j = 0; $j < $k; $j++ ) {
+				$parts[] = "$sortColumns[$j] = $quotedSorts[$j]";
+			}
+			$parts[] = "$sortColumns[$k] $op $quotedSorts[$k]";
+			$clauses[] = '(' . implode( ' AND ', $parts ) . ')';
+		}
+		// Final tiebreak: all sort levels equal, smw_id by direction.
+		$tiebreakParts = [];
+		for ( $j = 0; $j < $n; $j++ ) {
+			$tiebreakParts[] = "$sortColumns[$j] = $quotedSorts[$j]";
+		}
+		$tiebreakParts[] = "$alias.smw_id $op $cursorId";
+		$clauses[] = '(' . implode( ' AND ', $tiebreakParts ) . ')';
+
+		$queryBuilder->where( implode( ' OR ', $clauses ) );
 	}
 
 }

--- a/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
@@ -321,10 +321,9 @@ class QueryCreatorTest extends TestCase {
 		);
 	}
 
-	public function testCursorParamWithMultiSortIsRejectedWithError(): void {
-		// Phase 3b will support compound-sort cursors. Until then,
-		// `sort=A,B` + `cursor=` is rejected so cursor consumers can
-		// rely on the constrained single-sort schema.
+	public function testCursorParamWithUniformMultiSortIsAccepted(): void {
+		// Phase 3b-ii: `sort=A,B` with a uniform `order=` is accepted.
+		// Bootstrap cursor matches because it carries no `sort_prop`.
 		$instance = new QueryCreator(
 			ApplicationFactory::getInstance()->getQueryFactory()
 		);
@@ -337,10 +336,82 @@ class QueryCreatorTest extends TestCase {
 			]
 		);
 
+		$this->assertSame( [ 'v' => 1 ], $query->getCursorAfter() );
+	}
+
+	public function testCursorParamWithMixedOrderMultiSortIsRejectedWithError(): void {
+		// Phase 3b-iii will lift this. Mixed direction per sort level
+		// requires per-level operator inversion in the keyset
+		// predicate, which is materially more complex than the
+		// uniform-direction case Phase 3b-ii ships.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'PropertyA', 'PropertyB' ],
+				'order'  => [ 'asc', 'desc' ],
+				'cursor' => 'eyJ2IjoxfQ',
+			]
+		);
+
 		$this->assertNull( $query->getCursorAfter() );
 		$this->assertCursorErrorPresent(
 			$query->getErrors(),
-			'multi-property'
+			'mixed `order=`'
+		);
+	}
+
+	public function testCursorParamWithMatchingArraySortPropIsAccepted(): void {
+		// Phase 3b-ii: a multi-sort cursor carries `sort_prop` as an
+		// array of property keys. The request's sort= must match
+		// element-wise.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		// base64url of {"v":1,"sort":["v1","v2"],"sort_prop":["PropertyA","PropertyB"],"id":42}
+		$token = 'eyJ2IjoxLCJzb3J0IjpbInYxIiwidjIiXSwic29ydF9wcm9wIjpbIlByb3BlcnR5QSIsIlByb3BlcnR5QiJdLCJpZCI6NDJ9';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'PropertyA', 'PropertyB' ],
+				'cursor' => $token,
+			]
+		);
+
+		$payload = $query->getCursorAfter();
+		$this->assertIsArray( $payload );
+		$this->assertSame( [ 'PropertyA', 'PropertyB' ], $payload['sort_prop'] );
+		$this->assertSame( [ 'v1', 'v2' ], $payload['sort'] );
+	}
+
+	public function testCursorParamWithShapeMismatchSortPropIsRejectedWithError(): void {
+		// A single-sort cursor (scalar `sort_prop`) sent to a multi-sort
+		// request (or vice-versa) must be rejected. The anchor has no
+		// meaning when the sort field set has changed.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		// Single-sort cursor (scalar sort_prop)
+		$singleSortToken = 'eyJ2IjoxLCJzb3J0IjoidiIsInNvcnRfcHJvcCI6IlByb3BlcnR5QSIsImlkIjo0Mn0';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'PropertyA', 'PropertyB' ],
+				'cursor' => $singleSortToken,
+			]
+		);
+
+		$this->assertNull( $query->getCursorAfter() );
+		$this->assertCursorErrorPresent(
+			$query->getErrors(),
+			'has no meaning'
 		);
 	}
 


### PR DESCRIPTION
## Summary

Lifts the Phase 3b-i (#6813) multi-sort rejection for uniform-direction
queries. Mixed per-sort orders (`sort=A,B|order=asc,desc`) stay
rejected for Phase 3b-iii. Tracks #6795.

**Stacked on #6813**. After 3b-i merges, this branch needs rebasing
onto master.

## Cursor payload schema (additive, backward-compatible)

| Phase | Anchor payload shape |
|---|---|
| Spike (default sort) | `{"v":1, "sort":"<smw_sort>", "id":N}` |
| 3a (single-property) | adds `"sort_prop":"<key>"` |
| 3b-i (DESC) | adds `"sort_order":"DESC"` |
| 3b-ii (multi-sort) | `"sort"` and `"sort_prop"` become **arrays** |

Spike + 3a + 3b-i scalar cursors keep working unchanged for
single-sort queries. The engine branches on `is_array($payload['sort'])`.

## Compound predicate

For N sort columns `c_1...c_N`, anchor values `v_1...v_N`, anchor
`id=Y`, operator `OP` (= `>` for ASC, `<` for DESC):

```
(c_1 OP v_1)
OR (c_1 = v_1 AND c_2 OP v_2)
OR ...
OR (c_1 = v_1 AND ... AND c_N OP v_N)
OR (c_1 = v_1 AND ... AND c_N = v_N AND smw_id OP Y)
```

N+1 OR clauses. For N=1 collapses to Phase 3 spike's two-clause form
(verified by trace + the spike's existing tests still pass).

## Contract additions

| Request | Result |
|---|---|
| `sort=A,B` + uniform `order=asc,asc` / `desc,desc` + cursor | Accepted |
| `sort=A,B` + mixed `order=asc,desc` + cursor | Error (Phase 3b-iii) |
| `sort=A,B` + cursor `sort_prop=["A","B"]` matching | Accepted |
| `sort=A` + cursor `sort_prop=["A","B"]` (shape mismatch) | Error |
| `sort=A,B` + cursor `sort_prop="A"` (scalar vs multi) | Error |
| `sort=A` (single) + cursor `sort_prop="A"` (scalar match) | Accepted (3a backward-compat) |

## Implementation

- `QueryCreator::applyCursorIfRequested()`: lifted
  `count(customSortKeys) > 1` rejection; added uniformity check on
  per-sort orders; normalises both `payloadSortProp` and
  `customSortKeys` to array form for strict `===` comparison.
- `QueryEngine::getInstanceQueryResult()`: refactored single-column
  cursor state to N-column form (`cursorSortPropKeys`,
  `cursorSortColumns`, `lastCursorSorts`). Each sort column projected
  as `cursor_sort_N`; row loop reads positionally; ORDER BY uniformly
  directional across all sort cols + smw_id.
- `QueryEngine::applyKeysetPredicate()`: signature now takes
  `array $sortColumns`; builds N+1 OR clauses.
- Engine-side defensive checks (post-review):
  - Uniform-direction assertion (catches programmatic Query bypass of
    QueryCreator).
  - Payload-shape validation at setup time (catches mismatched
    `count(sortValues) !== count(sortColumns)` before emitting any
    SQL — avoids silent page-1 fallback).
  - Multi-column sortfield expression guard (rejects the `#` sort
    key's comma-separated form).

## Test plan

- [x] `composer analyze` clean
- [x] 17 `QueryCreatorTest` cursor cases pass (4 new in this PR):
  - Uniform multi-sort accepted
  - Mixed-order multi-sort rejected
  - Matching array `sort_prop` accepted
  - Shape mismatch (scalar cursor + multi-sort request) rejected
- [x] Browser smoke (`sort=Modification_date,Has_property_description`,
  4 items, `limit=2`):

  | Case | Result |
  |---|---|
  | Uniform ASC walk | 2 pages, 4 items in forward order |
  | Uniform DESC walk (`order=desc,desc`) | 2 pages, exactly reversed |
  | Mixed `order=asc,desc` | Clear error |
  | Cursor payload | Array shape: `sort: [<date>, <desc>]`, `sort_prop: [_MDAT, _PDESC]` |

## Constrained scope (Phase 3b-iii / 3c follow-ups)

- Mixed per-sort orders (`sort=A,B|order=asc,desc`) still rejected.
- SubqueryQueryBuilder derived-table cursor support still missing
  (cursor mode forces legacy single-query SQL path).
- Forward-only; no `cursor-before`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)