### PR TITLE
QueryEngine: cursor pagination via SubqueryQueryBuilder

### DIFF
--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -515,13 +515,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			unset( $sql_options['OFFSET'] );
 		}
 
-		// Cursor mode forces the legacy single-query SQL path even when
-		// `smwgQUseLegacyQuery=false`. The Phase 3 spike does not yet wire
-		// the keyset predicate into `SubqueryQueryBuilder`'s derived-table
-		// rewrite, so cursor mode opts out of that optimisation in
-		// exchange for the much larger keyset speedup on the OFFSET side.
-		// Tracked as Phase 3c follow-up in #6795.
-		if ( $cursorMode || $this->engineOptions->get( 'smwgQUseLegacyQuery' ) ) {
+		if ( $this->engineOptions->get( 'smwgQUseLegacyQuery' ) ) {
 			$selectFields = [
 				'id' => "$qobj->alias.smw_id",
 				't' => "$qobj->alias.smw_title",
@@ -561,10 +555,21 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 
 			$res = $qb->fetchResultSet();
 		} else {
+			// Phase 3c: cursor mode now uses `SubqueryQueryBuilder`'s
+			// derived-table rewrite. The cursor predicate is built as a
+			// raw SQL string and ANDed into the inner WHERE.
+			$cursorPredicate = '';
+			if ( $cursorMode ) {
+				$cursorPredicate = $this->buildKeysetPredicateString(
+					$query, $qobj, $connection, $cursorSortColumns, $cursorSortOrder
+				);
+			}
 			$sql = $this->subqueryQueryBuilder->buildInstanceQuerySQL(
 				$qobj,
 				$sql_options,
-				''
+				'',
+				$cursorPredicate,
+				$cursorMode
 			);
 			$res = $connection->readQuery( $sql, __METHOD__, ISQLPlatform::QUERY_CHANGE_NONE );
 		}
@@ -832,17 +837,40 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		array $sortColumns,
 		string $sortOrder = 'ASC'
 	): void {
+		$predicate = $this->buildKeysetPredicateString(
+			$query, $qobj, $connection, $sortColumns, $sortOrder
+		);
+		if ( $predicate !== '' ) {
+			$queryBuilder->where( $predicate );
+		}
+	}
+
+	/**
+	 * Build the explicit-OR keyset predicate as a raw SQL string. Used
+	 * by `applyKeysetPredicate()` (legacy path, attaches to
+	 * `SelectQueryBuilder`) and by `SubqueryQueryBuilder` (derived-table
+	 * path, ANDs into inner WHERE). Returns an empty string when the
+	 * cursor has no anchor (bootstrap `{"v":1}` payload).
+	 *
+	 * See `applyKeysetPredicate()` docblock for the predicate shape.
+	 */
+	private function buildKeysetPredicateString(
+		Query $query,
+		QuerySegment $qobj,
+		$connection,
+		array $sortColumns,
+		string $sortOrder = 'ASC'
+	): string {
 		$payload = $query->getCursorAfter();
 		if ( !isset( $payload['sort'] ) || !isset( $payload['id'] ) ) {
-			return;
+			return '';
 		}
 
 		// Normalise payload `sort` to an array. Phase 3 spike + 3a +
 		// 3b-i cursors carry scalar `sort`; 3b-ii multi-sort cursors
 		// carry an array. The shape is validated by the caller
 		// (`getInstanceQueryResult`) before reaching here — by the
-		// time `applyKeysetPredicate` runs, the count match is
-		// guaranteed.
+		// time this method runs, the count match is guaranteed.
 		$sortValues = is_array( $payload['sort'] ) ? $payload['sort'] : [ $payload['sort'] ];
 
 		$quotedSorts = array_map(
@@ -874,7 +902,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$tiebreakParts[] = "$alias.smw_id $op $cursorId";
 		$clauses[] = '(' . implode( ' AND ', $tiebreakParts ) . ')';
 
-		$queryBuilder->where( implode( ' OR ', $clauses ) );
+		return implode( ' OR ', $clauses );
 	}
 
 }

--- a/src/SQLStore/QueryEngine/SubqueryQueryBuilder.php
+++ b/src/SQLStore/QueryEngine/SubqueryQueryBuilder.php
@@ -38,11 +38,29 @@ class SubqueryQueryBuilder {
 
 	/**
 	 * @since 7.0.0
+	 *
+	 * @param QuerySegment $root
+	 * @param array $sqlOptions Requires `LIMIT`; honours `OFFSET` and
+	 *   `ORDER BY`. In cursor mode, `OFFSET` should be unset by the
+	 *   caller (the keyset predicate or bootstrap ORDER BY replaces it).
+	 * @param string $outerWhere Filters applied on the outer SELECT.
+	 * @param string $cursorPredicate Phase 3c: raw SQL fragment for the
+	 *   keyset WHERE clause, anchored at the inner segment's alias. ANDed
+	 *   into the inner WHERE so the LIMIT'd subset is the cursor-anchored
+	 *   slice. Empty for non-cursor queries AND for bootstrap cursors
+	 *   (which carry no anchor yet); use `$cursorMode` to distinguish.
+	 * @param bool $cursorMode Phase 3c: true when the caller is paginating
+	 *   in cursor mode. Drives the `cursor_sort_N` outer projection
+	 *   aliases the QueryEngine row loop reads to mint the next anchor.
+	 *   Independent of `$cursorPredicate` (which is empty on bootstrap
+	 *   requests, the first page in cursor mode).
 	 */
 	public function buildInstanceQuerySQL(
 		QuerySegment $root,
 		array $sqlOptions,
-		string $outerWhere
+		string $outerWhere,
+		string $cursorPredicate = '',
+		bool $cursorMode = false
 	): string {
 		if ( !isset( $sqlOptions['LIMIT'] ) ) {
 			throw new \InvalidArgumentException( 'sqlOptions[\'LIMIT\'] is required' );
@@ -57,13 +75,18 @@ class SubqueryQueryBuilder {
 			$root,
 			$sortfieldPairs,
 			$orderBy,
-			$this->innerLimit( $outerLimit )
+			$this->innerLimit( $outerLimit ),
+			$cursorPredicate
 		);
 
-		$outerProjection = $this->buildOuterProjection( $sortfieldPairs );
+		$outerProjection = $this->buildOuterProjection(
+			$sortfieldPairs,
+			$cursorMode
+		);
 		$outerOrderBy = $this->rewriteOrderByForOuter(
 			$orderBy,
-			$sortfieldPairs
+			$sortfieldPairs,
+			$root->alias
 		);
 
 		$idTable = $this->connection->tableName( self::ID_TABLE );
@@ -161,12 +184,16 @@ class SubqueryQueryBuilder {
 	 * @param array<int, array{expr: string, alias: string}> $sortfieldPairs
 	 * @param string $orderBy
 	 * @param int $innerLimit
+	 * @param string $cursorPredicate Phase 3c: raw SQL fragment ANDed
+	 *   into the inner WHERE. Anchored at the root segment's alias so
+	 *   column refs resolve inside the derived table.
 	 */
 	private function buildInnerSelect(
 		QuerySegment $root,
 		array $sortfieldPairs,
 		string $orderBy,
-		int $innerLimit
+		int $innerLimit,
+		string $cursorPredicate = ''
 	): string {
 		$columns = [ "{$root->joinfield} AS s_id" ];
 
@@ -174,10 +201,22 @@ class SubqueryQueryBuilder {
 			$columns[] = "$expr AS $alias";
 		}
 
+		// Combine existing WHERE with the cursor predicate. Both come
+		// pre-formed; we just AND them. The predicate references the
+		// inner segment's raw columns (e.g. `t0.smw_sort`, `t0.smw_id`),
+		// which resolve inside the derived table because the inner FROM
+		// aliases the root table as `t0`.
+		$where = $root->where;
+		if ( $cursorPredicate !== '' ) {
+			$where = $where !== ''
+				? "($where) AND ($cursorPredicate)"
+				: $cursorPredicate;
+		}
+
 		$sql = 'SELECT DISTINCT ' . implode( ', ', $columns )
 			. ' FROM ' . $this->connection->tableName( $root->joinTable ) . " AS {$root->alias}"
 			. $root->from
-			. ( $root->where !== '' ? " WHERE {$root->where}" : '' );
+			. ( $where !== '' ? " WHERE $where" : '' );
 
 		if ( $orderBy !== '' ) {
 			$sql .= " ORDER BY $orderBy";
@@ -190,8 +229,15 @@ class SubqueryQueryBuilder {
 
 	/**
 	 * @param array<int, array{expr: string, alias: string}> $sortfieldPairs
+	 * @param bool $cursorMode When true, sortfield projections are also
+	 *   aliased as `cursor_sort_N`. This matches the column shape the
+	 *   QueryEngine row loop expects under cursor mode, so the loop does
+	 *   not need to branch on which builder produced the result.
 	 */
-	private function buildOuterProjection( array $sortfieldPairs ): string {
+	private function buildOuterProjection(
+		array $sortfieldPairs,
+		bool $cursorMode = false
+	): string {
 		$outer = self::OUTER_ALIAS;
 		$inner = self::INNER_ALIAS;
 
@@ -204,8 +250,12 @@ class SubqueryQueryBuilder {
 			"$outer.smw_sortkey AS sortkey",
 		];
 
-		foreach ( $sortfieldPairs as $pair ) {
-			$columns[] = "$inner.{$pair['alias']}";
+		foreach ( $sortfieldPairs as $i => $pair ) {
+			if ( $cursorMode ) {
+				$columns[] = "$inner.{$pair['alias']} AS cursor_sort_$i";
+			} else {
+				$columns[] = "$inner.{$pair['alias']}";
+			}
 		}
 
 		return implode( ', ', $columns );
@@ -220,14 +270,23 @@ class SubqueryQueryBuilder {
 	 * to prevent shorter expressions (e.g. "t0.smw_sort") from corrupting
 	 * longer ones that share a prefix (e.g. "t0.smw_sortkey").
 	 *
+	 * Phase 3c: the cursor-mode ORDER BY also references
+	 * `<rootAlias>.smw_id` (the tiebreak column). This rewrites that
+	 * reference to `outer_q.smw_id`, which the outer query has direct
+	 * access to via the JOIN on `smw_object_ids AS outer_q`.
+	 *
 	 * @param string $orderBy
 	 * @param array<int, array{expr: string, alias: string}> $sortfieldPairs
+	 * @param string $rootAlias Inner segment's table alias (e.g. `t0`),
+	 *   used to rewrite the smw_id reference for cursor mode. Empty
+	 *   string skips the smw_id rewrite.
 	 */
 	private function rewriteOrderByForOuter(
 		string $orderBy,
-		array $sortfieldPairs
+		array $sortfieldPairs,
+		string $rootAlias = ''
 	): string {
-		if ( $orderBy === '' || $sortfieldPairs === [] ) {
+		if ( $orderBy === '' ) {
 			return $orderBy;
 		}
 
@@ -240,9 +299,21 @@ class SubqueryQueryBuilder {
 
 		$rewritten = $orderBy;
 		$inner = self::INNER_ALIAS;
+		$outer = self::OUTER_ALIAS;
 
 		foreach ( $sortfieldPairs as [ 'expr' => $expr, 'alias' => $alias ] ) {
 			$rewritten = str_replace( $expr, "$inner.$alias", $rewritten );
+		}
+
+		// Cursor-mode `smw_id` tiebreak: maps from inner segment's
+		// `<alias>.smw_id` to outer `outer_q.smw_id` (which is the
+		// JOINed column the outer query has direct access to).
+		if ( $rootAlias !== '' ) {
+			$rewritten = str_replace(
+				"$rootAlias.smw_id",
+				"$outer.smw_id",
+				$rewritten
+			);
 		}
 
 		return $rewritten;

--- a/tests/phpunit/Integration/Query/SubqueryQueryEquivalenceDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SubqueryQueryEquivalenceDBIntegrationTest.php
@@ -12,6 +12,7 @@ use SMW\Query\Language\ThingDescription;
 use SMW\Query\Language\ValueDescription;
 use SMW\Query\Query;
 use SMW\Query\QueryResult;
+use SMW\SQLStore\QueryEngine\CursorEncoder;
 use SMW\Tests\SMWIntegrationTestCase;
 use SMW\Tests\Utils\UtilityFactory;
 
@@ -224,6 +225,161 @@ class SubqueryQueryEquivalenceDBIntegrationTest extends SMWIntegrationTestCase {
 		};
 
 		$this->assertQueryEquivalent( $factory, 'disjunction across two properties' );
+	}
+
+	public function testCursorWalkOverDefaultSortMatchesLegacyPath(): void {
+		$this->assertCursorWalkEquivalent(
+			function ( ?array $cursorPayload ): Query {
+				// `SomeProperty[+]` against every page that has any value
+				// for the number property, guaranteeing a non-empty
+				// instance set so the cursor walk lands on real rows.
+				$description = new SomeProperty(
+					$this->numberProperty,
+					new ThingDescription()
+				);
+				$query = new Query( $description );
+				$query->querymode = Query::MODE_INSTANCES;
+				$query->sort = true;
+				$query->setUnboundLimit( 2 );
+				$query->sortkeys = [ '' => 'ASC' ];
+				$query->setCursorAfter( $cursorPayload );
+				return $query;
+			},
+			'default-sort cursor walk'
+		);
+	}
+
+	public function testCursorWalkOverPropertySortMatchesLegacyPath(): void {
+		$this->assertCursorWalkEquivalent(
+			function ( ?array $cursorPayload ): Query {
+				$description = new SomeProperty(
+					$this->numberProperty,
+					new ThingDescription()
+				);
+				$query = new Query( $description );
+				$query->querymode = Query::MODE_INSTANCES;
+				$query->sort = true;
+				$query->setUnboundLimit( 2 );
+				$query->sortkeys = [ $this->numberProperty->getKey() => 'ASC' ];
+				$query->setCursorAfter( $cursorPayload );
+				return $query;
+			},
+			'property-sort cursor walk'
+		);
+	}
+
+	public function testCursorWalkDescendingMatchesLegacyPath(): void {
+		$this->assertCursorWalkEquivalent(
+			function ( ?array $cursorPayload ): Query {
+				$description = new SomeProperty(
+					$this->numberProperty,
+					new ThingDescription()
+				);
+				$query = new Query( $description );
+				$query->querymode = Query::MODE_INSTANCES;
+				$query->sort = true;
+				$query->setUnboundLimit( 2 );
+				$query->sortkeys = [ $this->numberProperty->getKey() => 'DESC' ];
+				$query->setCursorAfter( $cursorPayload );
+				return $query;
+			},
+			'property-sort DESC cursor walk'
+		);
+	}
+
+	public function testCursorRejectedForCompoundHashSortUnderBothPaths(): void {
+		// The `#` sort label produces a comma-joined multi-column
+		// expression in `$qobj->sortfields`. Cursor mode cannot emit a
+		// keyset predicate against a column list and must reject the
+		// request explicitly under both query paths. This guards the
+		// rejection edge in the subquery path against silent
+		// regression as the cursor-emission code evolves.
+		$factory = function (): Query {
+			$description = new SomeProperty(
+				$this->numberProperty,
+				new ThingDescription()
+			);
+			$query = new Query( $description );
+			$query->querymode = Query::MODE_INSTANCES;
+			$query->sort = true;
+			$query->setUnboundLimit( 5 );
+			$query->sortkeys = [ '#' => 'ASC' ];
+			$query->setCursorAfter( [ 'v' => 1 ] );
+			return $query;
+		};
+
+		foreach ( [ true, false ] as $legacy ) {
+			$this->testEnvironment->addConfiguration( 'smwgQUseLegacyQuery', $legacy );
+			$query = $factory();
+			$this->getStore()->getQueryResult( $query );
+			$errors = $query->getErrors();
+			$hasRejection = false;
+			foreach ( $errors as $error ) {
+				if ( str_contains( (string)$error, 'multi-column sort expression' ) ) {
+					$hasRejection = true;
+					break;
+				}
+			}
+			$this->assertTrue(
+				$hasRejection,
+				'Expected cursor mode to reject the `#` compound sort under legacy='
+					. ( $legacy ? '1' : '0' ) . '; got errors: ' . print_r( $errors, true )
+			);
+		}
+	}
+
+	/**
+	 * Walks the result set page by page in cursor mode, captures the
+	 * subject sequence under each path, and asserts the two sequences
+	 * match. Bootstrap is `{"v":1}` (no anchor) so the engine takes the
+	 * page-1 branch (no predicate); subsequent pages chain the cursor
+	 * minted from the previous page.
+	 */
+	private function assertCursorWalkEquivalent( callable $queryFactory, string $label ): void {
+		$walk = function ( bool $legacy ) use ( $queryFactory, $label ): array {
+			$this->testEnvironment->addConfiguration( 'smwgQUseLegacyQuery', $legacy );
+			$sequence = [];
+			$payload = [ 'v' => 1 ];
+			// Hard cap on iterations: defensive against an unexpected
+			// infinite loop while walking. A correctly-paginating engine
+			// terminates by returning a result without a next cursor.
+			for ( $i = 0; $i < 10; $i++ ) {
+				$query = $queryFactory( $payload );
+				$result = $this->getStore()->getQueryResult( $query );
+				$this->assertSame(
+					[],
+					$query->getErrors(),
+					"Query errors on iter $i (legacy=" . ( $legacy ? '1' : '0' ) . ") for: $label"
+				);
+				foreach ( $result->getResults() as $dataItem ) {
+					$sequence[] = $dataItem->getHash();
+				}
+				$nextToken = $result->getNextCursor();
+				if ( $nextToken === null ) {
+					break;
+				}
+				$payload = CursorEncoder::decode( $nextToken );
+				$this->assertIsArray( $payload, "Decoded cursor payload should be an array under $label" );
+			}
+			return $sequence;
+		};
+
+		$legacySequence = $walk( true );
+		$rewriteSequence = $walk( false );
+
+		$this->assertSame(
+			$legacySequence,
+			$rewriteSequence,
+			"Cursor walk sequence mismatch between legacy and rewrite for: $label"
+		);
+		// Guard against silent empty walks (would falsely satisfy
+		// equality). The seed includes pages with the number property,
+		// so we expect at least two subjects on every walk.
+		$this->assertGreaterThanOrEqual(
+			2,
+			count( $rewriteSequence ),
+			"Cursor walk produced fewer subjects than expected for: $label"
+		);
 	}
 
 	private function seedFixtures(): void {

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/SubqueryQueryBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/SubqueryQueryBuilderTest.php
@@ -251,6 +251,112 @@ class SubqueryQueryBuilderTest extends TestCase {
 		$this->assertStringContainsString( 'outer_q.smw_id = inner_q.s_id', $sql );
 	}
 
+	public function testInstanceQueryWithCursorPredicateAndedIntoInnerWhere() {
+		$root = new QuerySegment();
+		$root->joinTable = 'smw_object_ids';
+		$root->alias = 't0';
+		$root->joinfield = 't0.smw_id';
+		$root->where = "t0.smw_iw!=':smw'";
+		$root->sortfields = [ '' => 't0.smw_sort' ];
+
+		$sqlOptions = [
+			'LIMIT' => 20,
+			'ORDER BY' => 't0.smw_sort ASC, t0.smw_id ASC',
+		];
+
+		$cursorPredicate = "(t0.smw_sort > 'foo') OR (t0.smw_sort = 'foo' AND t0.smw_id > 42)";
+
+		$builder = new SubqueryQueryBuilder( $this->connection );
+		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '', $cursorPredicate, true );
+
+		[ $innerHalf, $outerHalf ] = explode( ') AS inner_q', $sql, 2 );
+
+		// Original WHERE and cursor predicate are both ANDed inside the
+		// derived table.
+		$this->assertStringContainsString( "(t0.smw_iw!=':smw') AND ($cursorPredicate)", $innerHalf );
+		// The cursor predicate must not appear outside the subquery.
+		$this->assertStringNotContainsString( $cursorPredicate, $outerHalf );
+	}
+
+	public function testInstanceQueryWithCursorAliasesSortfieldsAsCursorSort() {
+		$root = new QuerySegment();
+		$root->joinTable = 'smw_object_ids';
+		$root->alias = 't0';
+		$root->joinfield = 't0.smw_id';
+		$root->where = '';
+		$root->sortfields = [
+			'_DOA' => 't1.o_sortkey',
+			'_DOB' => 't2.o_sortkey',
+		];
+
+		$sqlOptions = [
+			'LIMIT' => 10,
+			'ORDER BY' => 't1.o_sortkey ASC, t2.o_sortkey ASC, t0.smw_id ASC',
+		];
+
+		$cursorPredicate = "(t1.o_sortkey > 'a') OR (t1.o_sortkey = 'a' AND t2.o_sortkey > 'b')"
+			. " OR (t1.o_sortkey = 'a' AND t2.o_sortkey = 'b' AND t0.smw_id > 9)";
+
+		$builder = new SubqueryQueryBuilder( $this->connection );
+		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '', $cursorPredicate, true );
+
+		// Outer projection exposes each sortfield under a cursor_sort_N
+		// alias so the QueryEngine row loop reads the anchor values via
+		// `$row->cursor_sort_0`, `$row->cursor_sort_1`, ... regardless of
+		// which builder produced the result set.
+		$this->assertStringContainsString( 'inner_q.sf0 AS cursor_sort_0', $sql );
+		$this->assertStringContainsString( 'inner_q.sf1 AS cursor_sort_1', $sql );
+
+		// The outer ORDER BY rewrites the smw_id tiebreak from the inner
+		// segment's alias to the outer table.
+		[ , $afterJoin ] = explode( ') AS inner_q', $sql, 2 );
+		$orderBy = strstr( $afterJoin, 'ORDER BY' );
+		$this->assertStringContainsString( 'outer_q.smw_id ASC', $orderBy );
+		$this->assertStringNotContainsString( 't0.smw_id', $orderBy );
+	}
+
+	public function testInstanceQueryWithBootstrapCursorAliasesCursorSortDespiteEmptyPredicate() {
+		// Bootstrap cursor ({"v":1}) carries no anchor, so the engine
+		// passes an empty cursor predicate. cursor_sort_N projections
+		// must still be emitted so the row loop can capture the anchor
+		// values for the *next* page.
+		$root = new QuerySegment();
+		$root->joinTable = 'smw_object_ids';
+		$root->alias = 't0';
+		$root->joinfield = 't0.smw_id';
+		$root->where = '';
+		$root->sortfields = [ '' => 't0.smw_sort' ];
+
+		$sqlOptions = [
+			'LIMIT' => 10,
+			'ORDER BY' => 't0.smw_sort ASC, t0.smw_id ASC',
+		];
+
+		$builder = new SubqueryQueryBuilder( $this->connection );
+		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '', '', true );
+
+		$this->assertStringContainsString( 'inner_q.sf0 AS cursor_sort_0', $sql );
+	}
+
+	public function testInstanceQueryWithoutCursorDoesNotAliasCursorSort() {
+		$root = new QuerySegment();
+		$root->joinTable = 'smw_object_ids';
+		$root->alias = 't0';
+		$root->joinfield = 't0.smw_id';
+		$root->where = '';
+		$root->sortfields = [ '_DOA' => 't1.o_sortkey' ];
+
+		$sqlOptions = [
+			'LIMIT' => 10,
+			'ORDER BY' => 't1.o_sortkey ASC',
+		];
+
+		$builder = new SubqueryQueryBuilder( $this->connection );
+		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '' );
+
+		$this->assertStringNotContainsString( 'cursor_sort_', $sql );
+	}
+
 	public function testCountQueryWithIdAnchoredRoot() {
 		$root = new QuerySegment();
 		$root->joinTable = 'smw_object_ids';


### PR DESCRIPTION
## Summary

Phase 3c of the keyset pagination migration (#6795). Removes the
limitation that cursor mode forced the legacy single-query SQL path:
cursor pagination now flows through `SubqueryQueryBuilder`'s
derived-table rewrite, regaining the DISTINCT optimisation that the
rewrite gives the non-cursor path.

Stacked on #6814 (Phase 3b-ii). Base branch is `feat/queryengine-keyset-3b-multi`.

## What changed

- Extracted the explicit-OR keyset predicate into a shared
  `QueryEngine::buildKeysetPredicateString()` helper. Returns a raw SQL
  fragment. Legacy path attaches via `applyKeysetPredicate()`; subquery
  path ANDs it into the inner WHERE.
- `SubqueryQueryBuilder::buildInstanceQuerySQL()` gains:
  - `string \$cursorPredicate = ''`: raw SQL fragment ANDed into the
    inner derived-table WHERE so the LIMIT'd subset is the
    cursor-anchored slice.
  - `bool \$cursorMode = false`: drives `cursor_sort_N` outer
    projection aliases the engine row loop reads to mint the next
    anchor. Independent of predicate emptiness because bootstrap
    cursors (`{\"v\":1}`) carry no anchor yet still need the aliases
    for page 1.
- Outer `ORDER BY` rewriter now substitutes `<rootAlias>.smw_id` to
  `outer_q.smw_id` so the cursor tiebreak resolves against the outer
  JOINed ID table.
- Engine row loop is unchanged: both builders now emit
  `cursor_sort_N` projections, so `\$row->cursor_sort_\$i` reads
  identically across paths.
- Removed the `\$cursorMode ||` gate in `QueryEngine` that forced
  cursor mode onto the legacy path.

## Why split this out

Without 3c, opting into cursor mode also opted out of the rewrite's
DISTINCT optimisation. For very wide outer projections combined with
ORDER BY, MariaDB's planner could pick a worse plan than the
derived-table form. Phase 3c keeps both optimisations on for cursor
queries.

## Test plan

- [x] New unit tests in `SubqueryQueryBuilderTest`:
  - Cursor predicate ANDed into inner WHERE
  - `cursor_sort_N` outer aliasing in multi-property sort
  - Bootstrap cursor (empty predicate but cursor mode) still aliases
  - Non-cursor queries do not emit `cursor_sort_*` aliases
- [x] New DB integration tests in `SubqueryQueryEquivalenceDBIntegrationTest`:
  - Default-sort cursor walk: legacy vs rewrite return identical subject sequences
  - Property-sort ASC cursor walk: identical sequences
  - Property-sort DESC cursor walk: identical sequences
  - Compound `#` sort rejection surfaces under both paths
- [x] `composer analyze` clean.
- [x] Dev wiki smoke (curl):
  - Default-sort walk: 5 pages, 13 subjects, matches no-cursor count
  - `sort=Modification date&order=desc` walk: 7 pages, full reverse sequence
  - `sort=#`: cursor request returns the rejection error correctly

## Migration / compat

No public API or schema change. Cursor token format is unchanged.
Legacy path (`smwgQUseLegacyQuery=true`) is unchanged.