### PR TITLE
QueryEngine: cursor pagination for mixed sort directions

### DIFF
--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -195,9 +195,9 @@ class QueryCreator implements QueryContext {
 		) );
 
 		// Phase 3b-iii: mixed per-level directions are supported.
-		// `order=random` remains incompatible — there's no stable
-		// anchor to seek past — and a single RANDOM among other
-		// directions still rejects the whole request.
+		// `order=random` remains incompatible (no stable anchor to seek
+		// past), and a single RANDOM among other directions still
+		// rejects the whole request.
 		$requestSortOrders = $this->resolveRequestSortOrders( $sortKeys, $customSortKeys );
 		if ( in_array( 'RANDOM', $requestSortOrders, true ) ) {
 			$query->addErrors( [
@@ -313,27 +313,49 @@ class QueryCreator implements QueryContext {
 	 *   - array (["ASC","DESC"]): per-level, padded with ASC if
 	 *     shorter than the request's level count (defensive)
 	 *
+	 * Each value is validated against the allowed direction set and
+	 * coerced to "ASC" if it falls outside; this keeps any
+	 * user-controlled cursor payload out of downstream error messages
+	 * and out of the SQL builder's per-level operator selection.
+	 *
 	 * @param string|array|null $payloadSortOrder
 	 * @param int $levelCount Active sort level count from the request
 	 *
 	 * @return string[]
 	 */
-	private function normalisePayloadSortOrders( $payloadSortOrder, int $levelCount ): array {
+	private function normalisePayloadSortOrders( string|array|null $payloadSortOrder, int $levelCount ): array {
 		if ( $payloadSortOrder === null ) {
 			return array_fill( 0, $levelCount, 'ASC' );
 		}
 		if ( is_string( $payloadSortOrder ) ) {
-			return array_fill( 0, $levelCount, $payloadSortOrder );
+			return array_fill( 0, $levelCount, $this->coerceSortDirection( $payloadSortOrder ) );
 		}
 		// Already an array; pad with ASC to match the request length.
 		// A length mismatch will fail the mismatch check downstream
 		// (the values won't line up), surfacing the malformation as
 		// an `order=` mismatch error.
-		$normalised = array_values( $payloadSortOrder );
+		$normalised = [];
+		foreach ( array_values( $payloadSortOrder ) as $value ) {
+			$normalised[] = $this->coerceSortDirection( $value );
+		}
 		while ( count( $normalised ) < $levelCount ) {
 			$normalised[] = 'ASC';
 		}
 		return $normalised;
+	}
+
+	/**
+	 * Map an untrusted sort direction string from a cursor payload
+	 * onto the small allowed set ("ASC", "DESC", "RANDOM"). Anything
+	 * else collapses to "ASC" so attacker-controlled payload values
+	 * cannot reach error messages or the predicate builder.
+	 */
+	private function coerceSortDirection( mixed $value ): string {
+		if ( !is_string( $value ) ) {
+			return 'ASC';
+		}
+		$upper = strtoupper( $value );
+		return in_array( $upper, [ 'ASC', 'DESC', 'RANDOM' ], true ) ? $upper : 'ASC';
 	}
 
 	/**

--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -152,7 +152,7 @@ class QueryCreator implements QueryContext {
 
 	/**
 	 * Decode the optional `cursor=<token>` user parameter and apply it
-	 * to the query, enforcing the Phase 3a contract:
+	 * to the query, enforcing the Phase 3b-iii contract:
 	 *
 	 *   - Default sort (`sortKeys` has only the empty-string key or is
 	 *     empty): always allowed.
@@ -160,11 +160,13 @@ class QueryCreator implements QueryContext {
 	 *     when the cursor's `sort_prop` field matches the request's
 	 *     sort key, or when the cursor has no `sort_prop` (bootstrap /
 	 *     empty payload for the first cursor-mode page).
-	 *   - Multi-property sort (`sort=A,B`): rejected (Phase 3b).
+	 *   - Multi-property sort (`sort=A,B`): allowed, including mixed
+	 *     directions per level (`order=asc,desc`).
 	 *   - Custom sort + cursor with mismatching `sort_prop`: rejected.
 	 *     The cursor was minted for a different sort, applying it here
 	 *     would seek to a position that has no meaning in the new
 	 *     ordering.
+	 *   - `order=random`: rejected. No stable anchor to seek past.
 	 *
 	 * Malformed cursor tokens (any decode failure) are surfaced as an
 	 * error rather than silently ignored, to avoid the "expected
@@ -192,29 +194,12 @@ class QueryCreator implements QueryContext {
 			static fn ( $key ) => $key !== ''
 		) );
 
-		// Phase 3b-ii: multi-property sort is allowed when all custom
-		// sort keys share a uniform direction. Mixed direction
-		// (`sort=A,B|order=asc,desc`) is deferred to Phase 3b-iii
-		// because the keyset predicate would need per-level operator
-		// inversion, which complicates the compound-predicate
-		// generation enough to warrant its own PR.
-		if ( $customSortKeys !== [] ) {
-			$firstOrder = $sortKeys[$customSortKeys[0]];
-			foreach ( $customSortKeys as $key ) {
-				if ( $sortKeys[$key] !== $firstOrder ) {
-					$query->addErrors( [
-						'Cursor pagination (`cursor=`) is not supported with mixed `order=` per sort property in this release. Use a uniform `order=` (all ascending or all descending), or use `offset=` instead.'
-					] );
-					return;
-				}
-			}
-		}
-
-		// `order=random` is fundamentally incompatible with keyset
-		// pagination: there's no stable anchor to seek past.
-		$requestSortKey = $customSortKeys[0] ?? '';
-		$requestSortOrder = $this->resolveRequestSortOrder( $sortKeys, $requestSortKey );
-		if ( $requestSortOrder === 'RANDOM' ) {
+		// Phase 3b-iii: mixed per-level directions are supported.
+		// `order=random` remains incompatible — there's no stable
+		// anchor to seek past — and a single RANDOM among other
+		// directions still rejects the whole request.
+		$requestSortOrders = $this->resolveRequestSortOrders( $sortKeys, $customSortKeys );
+		if ( in_array( 'RANDOM', $requestSortOrders, true ) ) {
 			$query->addErrors( [
 				'Cursor pagination (`cursor=`) is not supported with `order=random`. Reverse the request to use `order=asc` or `order=desc`.'
 			] );
@@ -266,11 +251,24 @@ class QueryCreator implements QueryContext {
 		// `sort_order` field; treat their absence as ASC because
 		// those cursors were minted under ASC (the only mode
 		// available pre-3b).
+		//
+		// Shapes that may appear in `sort_order`:
+		//   - missing: pre-3b cursor, treat as ASC for all levels
+		//   - string (e.g. "DESC"): uniform across all levels
+		//   - array (e.g. ["ASC","DESC"]): one direction per level
+		// Both sides are normalised to per-level arrays for the
+		// comparison so a uniform 3b-i/3b-ii cursor round-trips
+		// against a mixed-direction request would correctly mismatch.
 		if ( isset( $payload['sort'] ) ) {
-			$payloadSortOrder = $payload['sort_order'] ?? 'ASC';
-			if ( $payloadSortOrder !== $requestSortOrder ) {
+			$payloadSortOrders = $this->normalisePayloadSortOrders(
+				$payload['sort_order'] ?? null,
+				count( $requestSortOrders )
+			);
+			if ( $payloadSortOrders !== $requestSortOrders ) {
+				$payloadDesc = implode( ',', $payloadSortOrders );
+				$requestDesc = implode( ',', $requestSortOrders );
 				$query->addErrors( [
-					"Cursor was minted for `order=$payloadSortOrder` but the request specifies `order=$requestSortOrder`. The cursor anchor seeks in the wrong direction under the new order; re-issue without `cursor=` or align the `order=` parameter."
+					"Cursor was minted for `order=$payloadDesc` but the request specifies `order=$requestDesc`. The cursor anchor seeks in the wrong direction under the new order; re-issue without `cursor=` or align the `order=` parameter."
 				] );
 				return;
 			}
@@ -280,20 +278,62 @@ class QueryCreator implements QueryContext {
 	}
 
 	/**
-	 * Resolve the canonical sort order for the active sort key. For a
-	 * custom-property sort (`sort=Foo`), use that key's order. For
-	 * default sort (`''` key only), use the empty key's order. Falls
-	 * back to ASC when neither is set.
+	 * Resolve the per-level sort orders for the active sort keys.
+	 * Returns an array with one direction per level, in declaration
+	 * order. For default sort (no custom sort keys), the returned
+	 * array has one element: the empty-key's order. Falls back to
+	 * ASC when an entry is unset.
 	 *
-	 * The returned string is always one of "ASC", "DESC", or "RANDOM".
-	 * Callers string-compare against these literals; values are
-	 * normalised upstream by `normalize_order()`.
+	 * Each element is one of "ASC", "DESC", or "RANDOM" (values are
+	 * normalised upstream by `normalize_order()`).
+	 *
+	 * @param array $sortKeys
+	 * @param array $customSortKeys Custom (non-empty) sort key names
+	 *   in declaration order, re-indexed from 0.
+	 *
+	 * @return string[]
 	 */
-	private function resolveRequestSortOrder( array $sortKeys, string $requestSortKey ): string {
-		if ( $requestSortKey !== '' && isset( $sortKeys[$requestSortKey] ) ) {
-			return $sortKeys[$requestSortKey];
+	private function resolveRequestSortOrders( array $sortKeys, array $customSortKeys ): array {
+		if ( $customSortKeys === [] ) {
+			return [ $sortKeys[''] ?? 'ASC' ];
 		}
-		return $sortKeys[''] ?? 'ASC';
+		$orders = [];
+		foreach ( $customSortKeys as $key ) {
+			$orders[] = $sortKeys[$key] ?? 'ASC';
+		}
+		return $orders;
+	}
+
+	/**
+	 * Normalise the cursor payload's `sort_order` field to a
+	 * per-level array. Handles three shapes:
+	 *
+	 *   - null (pre-3b cursor, no field): ASC for every level
+	 *   - string ("DESC"): uniform direction across every level
+	 *   - array (["ASC","DESC"]): per-level, padded with ASC if
+	 *     shorter than the request's level count (defensive)
+	 *
+	 * @param string|array|null $payloadSortOrder
+	 * @param int $levelCount Active sort level count from the request
+	 *
+	 * @return string[]
+	 */
+	private function normalisePayloadSortOrders( $payloadSortOrder, int $levelCount ): array {
+		if ( $payloadSortOrder === null ) {
+			return array_fill( 0, $levelCount, 'ASC' );
+		}
+		if ( is_string( $payloadSortOrder ) ) {
+			return array_fill( 0, $levelCount, $payloadSortOrder );
+		}
+		// Already an array; pad with ASC to match the request length.
+		// A length mismatch will fail the mismatch check downstream
+		// (the values won't line up), surfacing the malformation as
+		// an `order=` mismatch error.
+		$normalised = array_values( $payloadSortOrder );
+		while ( count( $normalised ) < $levelCount ) {
+			$normalised[] = 'ASC';
+		}
+		return $normalised;
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -401,40 +401,26 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$cursorMode = $query->getCursorAfter() !== null;
 		$cursorSortPropKeys = [];
 		$cursorSortColumns = [];
-		$cursorSortOrder = 'ASC';
+		$cursorSortOrders = [];
 
 		if ( $cursorMode ) {
 			// The active sort keys are determined by `$query->sortkeys`
 			// (set by `QueryCreator` from `sort=`), not by the incoming
 			// cursor payload. The cursor's `sort_prop` was already
 			// cross-checked against `sort=` in `QueryCreator`. Phase
-			// 3b-ii allows multiple custom sort keys with a uniform
-			// direction; `QueryCreator` rejected mixed-order requests.
-			//
-			// Defensive uniformity check: if a caller constructed the
-			// `Query` programmatically and bypassed `QueryCreator`,
-			// mixed directions could land here. Surface explicitly
-			// rather than emit a predicate that's inverted on prior
-			// levels.
-			$seenOrder = null;
+			// 3b-iii allows per-level directions across multiple custom
+			// sort keys; the engine carries them as a parallel array
+			// to `$cursorSortColumns` so the predicate builder can flip
+			// the operator at each level independently.
 			foreach ( $query->sortkeys as $propKey => $order ) {
 				if ( $propKey !== '' ) {
-					$normalised = $order === 'DESC' ? 'DESC' : 'ASC';
-					if ( $seenOrder !== null && $seenOrder !== $normalised ) {
-						$query->addErrors( [
-							'Cursor mode requires uniform sort order across all sort keys; mixed `ASC`/`DESC` would invert the keyset predicate on prior levels.'
-						] );
-						return $this->queryFactory->newQueryResult(
-							$this->store, $query, [], false
-						);
-					}
-					$seenOrder = $normalised;
 					$cursorSortPropKeys[] = $propKey;
-					$cursorSortOrder = $normalised;
+					$cursorSortOrders[] = $order === 'DESC' ? 'DESC' : 'ASC';
 				}
 			}
-			if ( $cursorSortPropKeys === [] && isset( $query->sortkeys[''] ) ) {
-				$cursorSortOrder = $query->sortkeys[''] === 'DESC' ? 'DESC' : 'ASC';
+			if ( $cursorSortPropKeys === [] ) {
+				$defaultOrder = ( $query->sortkeys[''] ?? 'ASC' ) === 'DESC' ? 'DESC' : 'ASC';
+				$cursorSortOrders = [ $defaultOrder ];
 			}
 
 			if ( $cursorSortPropKeys !== [] ) {
@@ -503,14 +489,18 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			}
 
 			// Override sort and offset for cursor mode. Keyset is
-			// total-ordered on `(<col_1>, ..., <col_n>, smw_id)`; all
-			// levels sort in the same direction so the tiebreak walks
-			// consistently with the primary sort.
+			// total-ordered on `(<col_1>, ..., <col_n>, smw_id)`.
+			// Each level uses its own direction; the smw_id tiebreak
+			// adopts the LAST level's direction so the tied-tuple walk
+			// chains naturally off the final sort column. For uniform
+			// requests, this collapses to "everything in one direction"
+			// (the pre-3b-iii behaviour).
 			$orderByParts = [];
-			foreach ( $cursorSortColumns as $col ) {
-				$orderByParts[] = "$col $cursorSortOrder";
+			foreach ( $cursorSortColumns as $i => $col ) {
+				$orderByParts[] = "$col {$cursorSortOrders[$i]}";
 			}
-			$orderByParts[] = "$qobj->alias.smw_id $cursorSortOrder";
+			$tiebreakDir = $cursorSortOrders[count( $cursorSortOrders ) - 1];
+			$orderByParts[] = "$qobj->alias.smw_id $tiebreakDir";
 			$sql_options['ORDER BY'] = implode( ', ', $orderByParts );
 			unset( $sql_options['OFFSET'] );
 		}
@@ -550,7 +540,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			}
 
 			if ( $cursorMode ) {
-				$this->applyKeysetPredicate( $qb, $query, $qobj, $connection, $cursorSortColumns, $cursorSortOrder );
+				$this->applyKeysetPredicate( $qb, $query, $qobj, $connection, $cursorSortColumns, $cursorSortOrders );
 			}
 
 			$res = $qb->fetchResultSet();
@@ -561,7 +551,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			$cursorPredicate = '';
 			if ( $cursorMode ) {
 				$cursorPredicate = $this->buildKeysetPredicateString(
-					$query, $qobj, $connection, $cursorSortColumns, $cursorSortOrder
+					$query, $qobj, $connection, $cursorSortColumns, $cursorSortOrders
 				);
 			}
 			$sql = $this->subqueryQueryBuilder->buildInstanceQuerySQL(
@@ -569,7 +559,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 				$sql_options,
 				'',
 				$cursorPredicate,
-				$cursorMode
+				$cursorMode ? $cursorSortColumns : []
 			);
 			$res = $connection->readQuery( $sql, __METHOD__, ISQLPlatform::QUERY_CHANGE_NONE );
 		}
@@ -696,12 +686,25 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 					? $cursorSortPropKeys[0]
 					: $cursorSortPropKeys;
 			}
-			// Round-trip the sort order: a cursor minted for DESC must
-			// be rejected by an ASC request (the predicate would seek
-			// in the wrong direction). Omitted for ASC to keep
-			// spike/3a/3b-i ASC cursors round-trippable as-is.
-			if ( $cursorSortOrder === 'DESC' ) {
+			// Round-trip the sort order: a cursor minted for a given
+			// direction must be rejected by a request specifying a
+			// different direction (the predicate would seek the wrong
+			// way at that level).
+			//
+			//   - All-ASC: omit `sort_order` (keeps spike/3a ASC
+			//     cursors round-trippable as-is).
+			//   - Uniform DESC: emit `sort_order` as the scalar string
+			//     "DESC" (keeps 3b-i/3b-ii uniform-DESC cursors
+			//     round-trippable as-is).
+			//   - Mixed per-level: emit `sort_order` as a per-level
+			//     array (Phase 3b-iii shape).
+			$uniformOrder = count( array_unique( $cursorSortOrders ) ) === 1
+				? $cursorSortOrders[0]
+				: null;
+			if ( $uniformOrder === 'DESC' ) {
 				$payload['sort_order'] = 'DESC';
+			} elseif ( $uniformOrder === null ) {
+				$payload['sort_order'] = $cursorSortOrders;
 			}
 			$queryResult->setNextCursor( CursorEncoder::encode( $payload ) );
 		}
@@ -801,21 +804,27 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 	 * just opts into deterministic ordering without seeking past
 	 * anything).
 	 *
-	 * Generalised compound form (Phase 3b-ii). For N sort columns
+	 * Generalised compound form (Phase 3b-iii). For N sort columns
 	 * `c_1 ... c_N` with anchor values `v_1 ... v_N`, anchor id `Y`,
-	 * and operator `OP` (`>` for ASC, `<` for DESC), the predicate is:
+	 * and per-level operators `op_1 ... op_N` (`>` for ASC, `<` for
+	 * DESC), the predicate is:
 	 *
-	 *     (c_1 OP v_1)
-	 *     OR (c_1 = v_1 AND c_2 OP v_2)
+	 *     (c_1 op_1 v_1)
+	 *     OR (c_1 = v_1 AND c_2 op_2 v_2)
 	 *     OR ...
-	 *     OR (c_1 = v_1 AND ... AND c_N OP v_N)
-	 *     OR (c_1 = v_1 AND ... AND c_N = v_N AND smw_id OP Y)
+	 *     OR (c_1 = v_1 AND ... AND c_N op_N v_N)
+	 *     OR (c_1 = v_1 AND ... AND c_N = v_N AND smw_id op_N Y)
 	 *
 	 * Each clause peels one level of "tied prefix", expanding the
-	 * range progressively. MariaDB recognises this as an index range
-	 * seek when an index covers the sort columns; the row-constructor
-	 * form `(c_1, ..., c_N, smw_id) OP (v_1, ..., v_N, Y)` plans a
-	 * full index scan instead. See issue #6559 and #6794.
+	 * range progressively. Operator at level k flips per direction so
+	 * mixed `order=asc,desc` walks each level the right way. The
+	 * smw_id tiebreak adopts the LAST level's direction so the
+	 * tied-tuple walk chains naturally off the final sort column.
+	 *
+	 * MariaDB recognises the explicit-OR form as an index range seek
+	 * when an index covers the sort columns; the row-constructor form
+	 * `(c_1, ..., c_N, smw_id) OP (v_1, ..., v_N, Y)` plans a full
+	 * index scan instead. See issue #6559 and #6794.
 	 *
 	 * For N=1 (Phase 3 spike + 3a + 3b-i compatibility), the form
 	 * collapses to the simple two-clause predicate.
@@ -823,9 +832,10 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 	 * `$sortColumns` is the list of SQL column expressions for the
 	 * active sort fields. The caller resolves them from
 	 * `$qobj->sortfields` (custom sort) or hardcodes
-	 * `[<alias>.smw_sort]` (default sort).
+	 * `[<alias>.smw_sort]` (default sort). `$sortOrders` is a parallel
+	 * array of "ASC" or "DESC" strings, one per column.
 	 *
-	 * TODO Phase 3c: unify with `KeysetPaginationTrait::applyCursorPagination`.
+	 * TODO Phase 3c follow-up: unify with `KeysetPaginationTrait::applyCursorPagination`.
 	 * Once a shared predicate builder exists, both this method and the
 	 * trait can delegate to it.
 	 */
@@ -835,10 +845,10 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		QuerySegment $qobj,
 		$connection,
 		array $sortColumns,
-		string $sortOrder = 'ASC'
+		array $sortOrders
 	): void {
 		$predicate = $this->buildKeysetPredicateString(
-			$query, $qobj, $connection, $sortColumns, $sortOrder
+			$query, $qobj, $connection, $sortColumns, $sortOrders
 		);
 		if ( $predicate !== '' ) {
 			$queryBuilder->where( $predicate );
@@ -859,7 +869,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		QuerySegment $qobj,
 		$connection,
 		array $sortColumns,
-		string $sortOrder = 'ASC'
+		array $sortOrders
 	): string {
 		$payload = $query->getCursorAfter();
 		if ( !isset( $payload['sort'] ) || !isset( $payload['id'] ) ) {
@@ -867,9 +877,9 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		}
 
 		// Normalise payload `sort` to an array. Phase 3 spike + 3a +
-		// 3b-i cursors carry scalar `sort`; 3b-ii multi-sort cursors
-		// carry an array. The shape is validated by the caller
-		// (`getInstanceQueryResult`) before reaching here — by the
+		// 3b-i cursors carry scalar `sort`; 3b-ii/3b-iii multi-sort
+		// cursors carry an array. The shape is validated by the caller
+		// (`getInstanceQueryResult`) before reaching here, so by the
 		// time this method runs, the count match is guaranteed.
 		$sortValues = is_array( $payload['sort'] ) ? $payload['sort'] : [ $payload['sort'] ];
 
@@ -879,8 +889,14 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		);
 		$cursorId = (int)$payload['id'];
 		$alias = $qobj->alias;
-		$op = $sortOrder === 'DESC' ? '<' : '>';
 		$n = count( $sortColumns );
+		$ops = [];
+		for ( $i = 0; $i < $n; $i++ ) {
+			$ops[] = ( $sortOrders[$i] ?? 'ASC' ) === 'DESC' ? '<' : '>';
+		}
+		// smw_id tiebreak follows the last level's direction so the
+		// tied-tuple walk is consistent with the ORDER BY clause.
+		$tiebreakOp = $n > 0 ? $ops[$n - 1] : '>';
 
 		// Build the N+1 OR clauses: clause k has equality on prior
 		// k levels and inequality on level k; the final clause adds
@@ -891,15 +907,15 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			for ( $j = 0; $j < $k; $j++ ) {
 				$parts[] = "$sortColumns[$j] = $quotedSorts[$j]";
 			}
-			$parts[] = "$sortColumns[$k] $op $quotedSorts[$k]";
+			$parts[] = "$sortColumns[$k] $ops[$k] $quotedSorts[$k]";
 			$clauses[] = '(' . implode( ' AND ', $parts ) . ')';
 		}
-		// Final tiebreak: all sort levels equal, smw_id by direction.
+		// Final tiebreak: all sort levels equal, smw_id by tiebreak direction.
 		$tiebreakParts = [];
 		for ( $j = 0; $j < $n; $j++ ) {
 			$tiebreakParts[] = "$sortColumns[$j] = $quotedSorts[$j]";
 		}
-		$tiebreakParts[] = "$alias.smw_id $op $cursorId";
+		$tiebreakParts[] = "$alias.smw_id $tiebreakOp $cursorId";
 		$clauses[] = '(' . implode( ' AND ', $tiebreakParts ) . ')';
 
 		return implode( ' OR ', $clauses );

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -515,13 +515,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 			unset( $sql_options['OFFSET'] );
 		}
 
-		// Cursor mode forces the legacy single-query SQL path even when
-		// `smwgQUseLegacyQuery=false`. The Phase 3 spike does not yet wire
-		// the keyset predicate into `SubqueryQueryBuilder`'s derived-table
-		// rewrite, so cursor mode opts out of that optimisation in
-		// exchange for the much larger keyset speedup on the OFFSET side.
-		// Tracked as Phase 3c follow-up in #6795.
-		if ( $cursorMode || $this->engineOptions->get( 'smwgQUseLegacyQuery' ) ) {
+		if ( $this->engineOptions->get( 'smwgQUseLegacyQuery' ) ) {
 			$selectFields = [
 				'id' => "$qobj->alias.smw_id",
 				't' => "$qobj->alias.smw_title",
@@ -561,10 +555,21 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 
 			$res = $qb->fetchResultSet();
 		} else {
+			// Phase 3c: cursor mode now uses `SubqueryQueryBuilder`'s
+			// derived-table rewrite. The cursor predicate is built as a
+			// raw SQL string and ANDed into the inner WHERE.
+			$cursorPredicate = '';
+			if ( $cursorMode ) {
+				$cursorPredicate = $this->buildKeysetPredicateString(
+					$query, $qobj, $connection, $cursorSortColumns, $cursorSortOrder
+				);
+			}
 			$sql = $this->subqueryQueryBuilder->buildInstanceQuerySQL(
 				$qobj,
 				$sql_options,
-				''
+				'',
+				$cursorPredicate,
+				$cursorMode
 			);
 			$res = $connection->readQuery( $sql, __METHOD__, ISQLPlatform::QUERY_CHANGE_NONE );
 		}
@@ -832,17 +837,40 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		array $sortColumns,
 		string $sortOrder = 'ASC'
 	): void {
+		$predicate = $this->buildKeysetPredicateString(
+			$query, $qobj, $connection, $sortColumns, $sortOrder
+		);
+		if ( $predicate !== '' ) {
+			$queryBuilder->where( $predicate );
+		}
+	}
+
+	/**
+	 * Build the explicit-OR keyset predicate as a raw SQL string. Used
+	 * by `applyKeysetPredicate()` (legacy path, attaches to
+	 * `SelectQueryBuilder`) and by `SubqueryQueryBuilder` (derived-table
+	 * path, ANDs into inner WHERE). Returns an empty string when the
+	 * cursor has no anchor (bootstrap `{"v":1}` payload).
+	 *
+	 * See `applyKeysetPredicate()` docblock for the predicate shape.
+	 */
+	private function buildKeysetPredicateString(
+		Query $query,
+		QuerySegment $qobj,
+		$connection,
+		array $sortColumns,
+		string $sortOrder = 'ASC'
+	): string {
 		$payload = $query->getCursorAfter();
 		if ( !isset( $payload['sort'] ) || !isset( $payload['id'] ) ) {
-			return;
+			return '';
 		}
 
 		// Normalise payload `sort` to an array. Phase 3 spike + 3a +
 		// 3b-i cursors carry scalar `sort`; 3b-ii multi-sort cursors
 		// carry an array. The shape is validated by the caller
 		// (`getInstanceQueryResult`) before reaching here — by the
-		// time `applyKeysetPredicate` runs, the count match is
-		// guaranteed.
+		// time this method runs, the count match is guaranteed.
 		$sortValues = is_array( $payload['sort'] ) ? $payload['sort'] : [ $payload['sort'] ];
 
 		$quotedSorts = array_map(
@@ -874,7 +902,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$tiebreakParts[] = "$alias.smw_id $op $cursorId";
 		$clauses[] = '(' . implode( ' AND ', $tiebreakParts ) . ')';
 
-		$queryBuilder->where( implode( ' OR ', $clauses ) );
+		return implode( ' OR ', $clauses );
 	}
 
 }

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -833,7 +833,8 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 	 * active sort fields. The caller resolves them from
 	 * `$qobj->sortfields` (custom sort) or hardcodes
 	 * `[<alias>.smw_sort]` (default sort). `$sortOrders` is a parallel
-	 * array of "ASC" or "DESC" strings, one per column.
+	 * array of "ASC" or "DESC" strings, one per column, and MUST be
+	 * the same length as `$sortColumns`.
 	 *
 	 * TODO Phase 3c follow-up: unify with `KeysetPaginationTrait::applyCursorPagination`.
 	 * Once a shared predicate builder exists, both this method and the
@@ -892,7 +893,7 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$n = count( $sortColumns );
 		$ops = [];
 		for ( $i = 0; $i < $n; $i++ ) {
-			$ops[] = ( $sortOrders[$i] ?? 'ASC' ) === 'DESC' ? '<' : '>';
+			$ops[] = $sortOrders[$i] === 'DESC' ? '<' : '>';
 		}
 		// smw_id tiebreak follows the last level's direction so the
 		// tied-tuple walk is consistent with the ORDER BY clause.

--- a/src/SQLStore/QueryEngine/SubqueryQueryBuilder.php
+++ b/src/SQLStore/QueryEngine/SubqueryQueryBuilder.php
@@ -48,19 +48,24 @@ class SubqueryQueryBuilder {
 	 *   keyset WHERE clause, anchored at the inner segment's alias. ANDed
 	 *   into the inner WHERE so the LIMIT'd subset is the cursor-anchored
 	 *   slice. Empty for non-cursor queries AND for bootstrap cursors
-	 *   (which carry no anchor yet); use `$cursorMode` to distinguish.
-	 * @param bool $cursorMode Phase 3c: true when the caller is paginating
-	 *   in cursor mode. Drives the `cursor_sort_N` outer projection
-	 *   aliases the QueryEngine row loop reads to mint the next anchor.
-	 *   Independent of `$cursorPredicate` (which is empty on bootstrap
-	 *   requests, the first page in cursor mode).
+	 *   (which carry no anchor yet); use `$cursorSortColumns` to detect
+	 *   cursor mode itself.
+	 * @param string[] $cursorSortColumns Phase 3c: ordered list of SQL
+	 *   column expressions (e.g. `t0.smw_sort`, `t1.o_serialized`)
+	 *   matching the keyset sort levels declared by the caller. Non-
+	 *   empty array signals cursor mode; the builder emits
+	 *   `cursor_sort_N` aliases (in this list's order) for the
+	 *   QueryEngine row loop to mint the next anchor. Order is
+	 *   independent of `$root->sortfields` iteration order so
+	 *   multi-property queries align correctly with what
+	 *   `$query->sortkeys` declared.
 	 */
 	public function buildInstanceQuerySQL(
 		QuerySegment $root,
 		array $sqlOptions,
 		string $outerWhere,
 		string $cursorPredicate = '',
-		bool $cursorMode = false
+		array $cursorSortColumns = []
 	): string {
 		if ( !isset( $sqlOptions['LIMIT'] ) ) {
 			throw new \InvalidArgumentException( 'sqlOptions[\'LIMIT\'] is required' );
@@ -76,12 +81,13 @@ class SubqueryQueryBuilder {
 			$sortfieldPairs,
 			$orderBy,
 			$this->innerLimit( $outerLimit ),
-			$cursorPredicate
+			$cursorPredicate,
+			$cursorSortColumns
 		);
 
 		$outerProjection = $this->buildOuterProjection(
 			$sortfieldPairs,
-			$cursorMode
+			$cursorSortColumns
 		);
 		$outerOrderBy = $this->rewriteOrderByForOuter(
 			$orderBy,
@@ -187,18 +193,32 @@ class SubqueryQueryBuilder {
 	 * @param string $cursorPredicate Phase 3c: raw SQL fragment ANDed
 	 *   into the inner WHERE. Anchored at the root segment's alias so
 	 *   column refs resolve inside the derived table.
+	 * @param string[] $cursorSortColumns Phase 3c: when non-empty, the
+	 *   inner SELECT projects each as `cursor_sort_N` so the outer
+	 *   query can surface anchor values in the order the engine row
+	 *   loop expects (matches `$query->sortkeys` declaration order,
+	 *   not `$root->sortfields` iteration order).
 	 */
 	private function buildInnerSelect(
 		QuerySegment $root,
 		array $sortfieldPairs,
 		string $orderBy,
 		int $innerLimit,
-		string $cursorPredicate = ''
+		string $cursorPredicate = '',
+		array $cursorSortColumns = []
 	): string {
 		$columns = [ "{$root->joinfield} AS s_id" ];
 
 		foreach ( $sortfieldPairs as [ 'expr' => $expr, 'alias' => $alias ] ) {
 			$columns[] = "$expr AS $alias";
+		}
+
+		// Cursor anchor projections. These are deliberately decoupled
+		// from `$sortfieldPairs` so multi-property queries with
+		// divergent sortfield iteration vs sortkey order still emit
+		// `cursor_sort_N` in the correct sequence.
+		foreach ( $cursorSortColumns as $i => $col ) {
+			$columns[] = "$col AS cursor_sort_$i";
 		}
 
 		// Combine existing WHERE with the cursor predicate. Both come
@@ -229,14 +249,14 @@ class SubqueryQueryBuilder {
 
 	/**
 	 * @param array<int, array{expr: string, alias: string}> $sortfieldPairs
-	 * @param bool $cursorMode When true, sortfield projections are also
-	 *   aliased as `cursor_sort_N`. This matches the column shape the
-	 *   QueryEngine row loop expects under cursor mode, so the loop does
-	 *   not need to branch on which builder produced the result.
+	 * @param string[] $cursorSortColumns Phase 3c: when non-empty, the
+	 *   outer projection surfaces `cursor_sort_N` columns directly from
+	 *   the inner SELECT, in this list's order. Independent of
+	 *   `$sortfieldPairs` ordering.
 	 */
 	private function buildOuterProjection(
 		array $sortfieldPairs,
-		bool $cursorMode = false
+		array $cursorSortColumns = []
 	): string {
 		$outer = self::OUTER_ALIAS;
 		$inner = self::INNER_ALIAS;
@@ -250,12 +270,18 @@ class SubqueryQueryBuilder {
 			"$outer.smw_sortkey AS sortkey",
 		];
 
-		foreach ( $sortfieldPairs as $i => $pair ) {
-			if ( $cursorMode ) {
-				$columns[] = "$inner.{$pair['alias']} AS cursor_sort_$i";
-			} else {
-				$columns[] = "$inner.{$pair['alias']}";
-			}
+		// sortfield aliases (driven by `$sortfieldPairs`) feed the
+		// outer ORDER BY's substitution from raw expression to inner
+		// alias. They are independent of the cursor anchor projection.
+		foreach ( $sortfieldPairs as $pair ) {
+			$columns[] = "$inner.{$pair['alias']}";
+		}
+
+		// cursor_sort_N projections follow `$cursorSortColumns` order
+		// (the engine's keyset sort-level ordering), which may differ
+		// from `$root->sortfields` iteration order.
+		foreach ( $cursorSortColumns as $i => $_col ) {
+			$columns[] = "$inner.cursor_sort_$i";
 		}
 
 		return implode( ', ', $columns );

--- a/src/SQLStore/QueryEngine/SubqueryQueryBuilder.php
+++ b/src/SQLStore/QueryEngine/SubqueryQueryBuilder.php
@@ -38,11 +38,29 @@ class SubqueryQueryBuilder {
 
 	/**
 	 * @since 7.0.0
+	 *
+	 * @param QuerySegment $root
+	 * @param array $sqlOptions Requires `LIMIT`; honours `OFFSET` and
+	 *   `ORDER BY`. In cursor mode, `OFFSET` should be unset by the
+	 *   caller (the keyset predicate or bootstrap ORDER BY replaces it).
+	 * @param string $outerWhere Filters applied on the outer SELECT.
+	 * @param string $cursorPredicate Phase 3c: raw SQL fragment for the
+	 *   keyset WHERE clause, anchored at the inner segment's alias. ANDed
+	 *   into the inner WHERE so the LIMIT'd subset is the cursor-anchored
+	 *   slice. Empty for non-cursor queries AND for bootstrap cursors
+	 *   (which carry no anchor yet); use `$cursorMode` to distinguish.
+	 * @param bool $cursorMode Phase 3c: true when the caller is paginating
+	 *   in cursor mode. Drives the `cursor_sort_N` outer projection
+	 *   aliases the QueryEngine row loop reads to mint the next anchor.
+	 *   Independent of `$cursorPredicate` (which is empty on bootstrap
+	 *   requests, the first page in cursor mode).
 	 */
 	public function buildInstanceQuerySQL(
 		QuerySegment $root,
 		array $sqlOptions,
-		string $outerWhere
+		string $outerWhere,
+		string $cursorPredicate = '',
+		bool $cursorMode = false
 	): string {
 		if ( !isset( $sqlOptions['LIMIT'] ) ) {
 			throw new \InvalidArgumentException( 'sqlOptions[\'LIMIT\'] is required' );
@@ -57,13 +75,18 @@ class SubqueryQueryBuilder {
 			$root,
 			$sortfieldPairs,
 			$orderBy,
-			$this->innerLimit( $outerLimit )
+			$this->innerLimit( $outerLimit ),
+			$cursorPredicate
 		);
 
-		$outerProjection = $this->buildOuterProjection( $sortfieldPairs );
+		$outerProjection = $this->buildOuterProjection(
+			$sortfieldPairs,
+			$cursorMode
+		);
 		$outerOrderBy = $this->rewriteOrderByForOuter(
 			$orderBy,
-			$sortfieldPairs
+			$sortfieldPairs,
+			$root->alias
 		);
 
 		$idTable = $this->connection->tableName( self::ID_TABLE );
@@ -161,12 +184,16 @@ class SubqueryQueryBuilder {
 	 * @param array<int, array{expr: string, alias: string}> $sortfieldPairs
 	 * @param string $orderBy
 	 * @param int $innerLimit
+	 * @param string $cursorPredicate Phase 3c: raw SQL fragment ANDed
+	 *   into the inner WHERE. Anchored at the root segment's alias so
+	 *   column refs resolve inside the derived table.
 	 */
 	private function buildInnerSelect(
 		QuerySegment $root,
 		array $sortfieldPairs,
 		string $orderBy,
-		int $innerLimit
+		int $innerLimit,
+		string $cursorPredicate = ''
 	): string {
 		$columns = [ "{$root->joinfield} AS s_id" ];
 
@@ -174,10 +201,22 @@ class SubqueryQueryBuilder {
 			$columns[] = "$expr AS $alias";
 		}
 
+		// Combine existing WHERE with the cursor predicate. Both come
+		// pre-formed; we just AND them. The predicate references the
+		// inner segment's raw columns (e.g. `t0.smw_sort`, `t0.smw_id`),
+		// which resolve inside the derived table because the inner FROM
+		// aliases the root table as `t0`.
+		$where = $root->where;
+		if ( $cursorPredicate !== '' ) {
+			$where = $where !== ''
+				? "($where) AND ($cursorPredicate)"
+				: $cursorPredicate;
+		}
+
 		$sql = 'SELECT DISTINCT ' . implode( ', ', $columns )
 			. ' FROM ' . $this->connection->tableName( $root->joinTable ) . " AS {$root->alias}"
 			. $root->from
-			. ( $root->where !== '' ? " WHERE {$root->where}" : '' );
+			. ( $where !== '' ? " WHERE $where" : '' );
 
 		if ( $orderBy !== '' ) {
 			$sql .= " ORDER BY $orderBy";
@@ -190,8 +229,15 @@ class SubqueryQueryBuilder {
 
 	/**
 	 * @param array<int, array{expr: string, alias: string}> $sortfieldPairs
+	 * @param bool $cursorMode When true, sortfield projections are also
+	 *   aliased as `cursor_sort_N`. This matches the column shape the
+	 *   QueryEngine row loop expects under cursor mode, so the loop does
+	 *   not need to branch on which builder produced the result.
 	 */
-	private function buildOuterProjection( array $sortfieldPairs ): string {
+	private function buildOuterProjection(
+		array $sortfieldPairs,
+		bool $cursorMode = false
+	): string {
 		$outer = self::OUTER_ALIAS;
 		$inner = self::INNER_ALIAS;
 
@@ -204,8 +250,12 @@ class SubqueryQueryBuilder {
 			"$outer.smw_sortkey AS sortkey",
 		];
 
-		foreach ( $sortfieldPairs as $pair ) {
-			$columns[] = "$inner.{$pair['alias']}";
+		foreach ( $sortfieldPairs as $i => $pair ) {
+			if ( $cursorMode ) {
+				$columns[] = "$inner.{$pair['alias']} AS cursor_sort_$i";
+			} else {
+				$columns[] = "$inner.{$pair['alias']}";
+			}
 		}
 
 		return implode( ', ', $columns );
@@ -220,14 +270,23 @@ class SubqueryQueryBuilder {
 	 * to prevent shorter expressions (e.g. "t0.smw_sort") from corrupting
 	 * longer ones that share a prefix (e.g. "t0.smw_sortkey").
 	 *
+	 * Phase 3c: the cursor-mode ORDER BY also references
+	 * `<rootAlias>.smw_id` (the tiebreak column). This rewrites that
+	 * reference to `outer_q.smw_id`, which the outer query has direct
+	 * access to via the JOIN on `smw_object_ids AS outer_q`.
+	 *
 	 * @param string $orderBy
 	 * @param array<int, array{expr: string, alias: string}> $sortfieldPairs
+	 * @param string $rootAlias Inner segment's table alias (e.g. `t0`),
+	 *   used to rewrite the smw_id reference for cursor mode. Empty
+	 *   string skips the smw_id rewrite.
 	 */
 	private function rewriteOrderByForOuter(
 		string $orderBy,
-		array $sortfieldPairs
+		array $sortfieldPairs,
+		string $rootAlias = ''
 	): string {
-		if ( $orderBy === '' || $sortfieldPairs === [] ) {
+		if ( $orderBy === '' ) {
 			return $orderBy;
 		}
 
@@ -240,9 +299,21 @@ class SubqueryQueryBuilder {
 
 		$rewritten = $orderBy;
 		$inner = self::INNER_ALIAS;
+		$outer = self::OUTER_ALIAS;
 
 		foreach ( $sortfieldPairs as [ 'expr' => $expr, 'alias' => $alias ] ) {
 			$rewritten = str_replace( $expr, "$inner.$alias", $rewritten );
+		}
+
+		// Cursor-mode `smw_id` tiebreak: maps from inner segment's
+		// `<alias>.smw_id` to outer `outer_q.smw_id` (which is the
+		// JOINed column the outer query has direct access to).
+		if ( $rootAlias !== '' ) {
+			$rewritten = str_replace(
+				"$rootAlias.smw_id",
+				"$outer.smw_id",
+				$rewritten
+			);
 		}
 
 		return $rewritten;

--- a/tests/phpunit/Integration/Query/SubqueryQueryEquivalenceDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SubqueryQueryEquivalenceDBIntegrationTest.php
@@ -12,6 +12,7 @@ use SMW\Query\Language\ThingDescription;
 use SMW\Query\Language\ValueDescription;
 use SMW\Query\Query;
 use SMW\Query\QueryResult;
+use SMW\SQLStore\QueryEngine\CursorEncoder;
 use SMW\Tests\SMWIntegrationTestCase;
 use SMW\Tests\Utils\UtilityFactory;
 
@@ -224,6 +225,161 @@ class SubqueryQueryEquivalenceDBIntegrationTest extends SMWIntegrationTestCase {
 		};
 
 		$this->assertQueryEquivalent( $factory, 'disjunction across two properties' );
+	}
+
+	public function testCursorWalkOverDefaultSortMatchesLegacyPath(): void {
+		$this->assertCursorWalkEquivalent(
+			function ( ?array $cursorPayload ): Query {
+				// `SomeProperty[+]` against every page that has any value
+				// for the number property, guaranteeing a non-empty
+				// instance set so the cursor walk lands on real rows.
+				$description = new SomeProperty(
+					$this->numberProperty,
+					new ThingDescription()
+				);
+				$query = new Query( $description );
+				$query->querymode = Query::MODE_INSTANCES;
+				$query->sort = true;
+				$query->setUnboundLimit( 2 );
+				$query->sortkeys = [ '' => 'ASC' ];
+				$query->setCursorAfter( $cursorPayload );
+				return $query;
+			},
+			'default-sort cursor walk'
+		);
+	}
+
+	public function testCursorWalkOverPropertySortMatchesLegacyPath(): void {
+		$this->assertCursorWalkEquivalent(
+			function ( ?array $cursorPayload ): Query {
+				$description = new SomeProperty(
+					$this->numberProperty,
+					new ThingDescription()
+				);
+				$query = new Query( $description );
+				$query->querymode = Query::MODE_INSTANCES;
+				$query->sort = true;
+				$query->setUnboundLimit( 2 );
+				$query->sortkeys = [ $this->numberProperty->getKey() => 'ASC' ];
+				$query->setCursorAfter( $cursorPayload );
+				return $query;
+			},
+			'property-sort cursor walk'
+		);
+	}
+
+	public function testCursorWalkDescendingMatchesLegacyPath(): void {
+		$this->assertCursorWalkEquivalent(
+			function ( ?array $cursorPayload ): Query {
+				$description = new SomeProperty(
+					$this->numberProperty,
+					new ThingDescription()
+				);
+				$query = new Query( $description );
+				$query->querymode = Query::MODE_INSTANCES;
+				$query->sort = true;
+				$query->setUnboundLimit( 2 );
+				$query->sortkeys = [ $this->numberProperty->getKey() => 'DESC' ];
+				$query->setCursorAfter( $cursorPayload );
+				return $query;
+			},
+			'property-sort DESC cursor walk'
+		);
+	}
+
+	public function testCursorRejectedForCompoundHashSortUnderBothPaths(): void {
+		// The `#` sort label produces a comma-joined multi-column
+		// expression in `$qobj->sortfields`. Cursor mode cannot emit a
+		// keyset predicate against a column list and must reject the
+		// request explicitly under both query paths. This guards the
+		// rejection edge in the subquery path against silent
+		// regression as the cursor-emission code evolves.
+		$factory = function (): Query {
+			$description = new SomeProperty(
+				$this->numberProperty,
+				new ThingDescription()
+			);
+			$query = new Query( $description );
+			$query->querymode = Query::MODE_INSTANCES;
+			$query->sort = true;
+			$query->setUnboundLimit( 5 );
+			$query->sortkeys = [ '#' => 'ASC' ];
+			$query->setCursorAfter( [ 'v' => 1 ] );
+			return $query;
+		};
+
+		foreach ( [ true, false ] as $legacy ) {
+			$this->testEnvironment->addConfiguration( 'smwgQUseLegacyQuery', $legacy );
+			$query = $factory();
+			$this->getStore()->getQueryResult( $query );
+			$errors = $query->getErrors();
+			$hasRejection = false;
+			foreach ( $errors as $error ) {
+				if ( str_contains( (string)$error, 'multi-column sort expression' ) ) {
+					$hasRejection = true;
+					break;
+				}
+			}
+			$this->assertTrue(
+				$hasRejection,
+				'Expected cursor mode to reject the `#` compound sort under legacy='
+					. ( $legacy ? '1' : '0' ) . '; got errors: ' . print_r( $errors, true )
+			);
+		}
+	}
+
+	/**
+	 * Walks the result set page by page in cursor mode, captures the
+	 * subject sequence under each path, and asserts the two sequences
+	 * match. Bootstrap is `{"v":1}` (no anchor) so the engine takes the
+	 * page-1 branch (no predicate); subsequent pages chain the cursor
+	 * minted from the previous page.
+	 */
+	private function assertCursorWalkEquivalent( callable $queryFactory, string $label ): void {
+		$walk = function ( bool $legacy ) use ( $queryFactory, $label ): array {
+			$this->testEnvironment->addConfiguration( 'smwgQUseLegacyQuery', $legacy );
+			$sequence = [];
+			$payload = [ 'v' => 1 ];
+			// Hard cap on iterations: defensive against an unexpected
+			// infinite loop while walking. A correctly-paginating engine
+			// terminates by returning a result without a next cursor.
+			for ( $i = 0; $i < 10; $i++ ) {
+				$query = $queryFactory( $payload );
+				$result = $this->getStore()->getQueryResult( $query );
+				$this->assertSame(
+					[],
+					$query->getErrors(),
+					"Query errors on iter $i (legacy=" . ( $legacy ? '1' : '0' ) . ") for: $label"
+				);
+				foreach ( $result->getResults() as $dataItem ) {
+					$sequence[] = $dataItem->getHash();
+				}
+				$nextToken = $result->getNextCursor();
+				if ( $nextToken === null ) {
+					break;
+				}
+				$payload = CursorEncoder::decode( $nextToken );
+				$this->assertIsArray( $payload, "Decoded cursor payload should be an array under $label" );
+			}
+			return $sequence;
+		};
+
+		$legacySequence = $walk( true );
+		$rewriteSequence = $walk( false );
+
+		$this->assertSame(
+			$legacySequence,
+			$rewriteSequence,
+			"Cursor walk sequence mismatch between legacy and rewrite for: $label"
+		);
+		// Guard against silent empty walks (would falsely satisfy
+		// equality). The seed includes pages with the number property,
+		// so we expect at least two subjects on every walk.
+		$this->assertGreaterThanOrEqual(
+			2,
+			count( $rewriteSequence ),
+			"Cursor walk produced fewer subjects than expected for: $label"
+		);
 	}
 
 	private function seedFixtures(): void {

--- a/tests/phpunit/Integration/Query/SubqueryQueryEquivalenceDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SubqueryQueryEquivalenceDBIntegrationTest.php
@@ -46,6 +46,10 @@ class SubqueryQueryEquivalenceDBIntegrationTest extends SMWIntegrationTestCase {
 
 	private Property $authorProperty;
 
+	private Property $mixedTieNumberProperty;
+
+	private Property $mixedTieAuthorProperty;
+
 	private WikiPage $alice;
 
 	private WikiPage $bob;
@@ -65,6 +69,19 @@ class SubqueryQueryEquivalenceDBIntegrationTest extends SMWIntegrationTestCase {
 
 		$this->authorProperty = new Property( 'EquivalenceAuthor' );
 		$this->authorProperty->setPropertyTypeId( '_wpg' );
+
+		// Dedicated property pair for the mixed-direction cursor walk
+		// test. Kept separate from `numberProperty`/`authorProperty` so
+		// the tied values needed to exercise per-level keyset operator
+		// flipping do not bleed into other tests' expected sequences
+		// (MariaDB does not promise stable tie ordering across query
+		// shapes, so legacy and rewrite paths can disagree on tie
+		// order without it being a real divergence).
+		$this->mixedTieNumberProperty = new Property( 'EquivalenceMixedTieNumber' );
+		$this->mixedTieNumberProperty->setPropertyTypeId( '_num' );
+
+		$this->mixedTieAuthorProperty = new Property( 'EquivalenceMixedTieAuthor' );
+		$this->mixedTieAuthorProperty->setPropertyTypeId( '_wpg' );
 
 		$this->alice = new WikiPage( 'EquivalenceAlice', NS_MAIN );
 		$this->bob = new WikiPage( 'EquivalenceBob', NS_MAIN );
@@ -297,11 +314,11 @@ class SubqueryQueryEquivalenceDBIntegrationTest extends SMWIntegrationTestCase {
 			function ( ?array $cursorPayload ): Query {
 				$description = new Conjunction( [
 					new SomeProperty(
-						$this->numberProperty,
+						$this->mixedTieNumberProperty,
 						new ThingDescription()
 					),
 					new SomeProperty(
-						$this->authorProperty,
+						$this->mixedTieAuthorProperty,
 						new ThingDescription()
 					),
 				] );
@@ -310,8 +327,8 @@ class SubqueryQueryEquivalenceDBIntegrationTest extends SMWIntegrationTestCase {
 				$query->sort = true;
 				$query->setUnboundLimit( 1 );
 				$query->sortkeys = [
-					$this->numberProperty->getKey() => 'ASC',
-					$this->authorProperty->getKey() => 'DESC',
+					$this->mixedTieNumberProperty->getKey() => 'ASC',
+					$this->mixedTieAuthorProperty->getKey() => 'DESC',
 				];
 				$query->setCursorAfter( $cursorPayload );
 				return $query;
@@ -456,9 +473,12 @@ class SubqueryQueryEquivalenceDBIntegrationTest extends SMWIntegrationTestCase {
 		$this->subjectsToBeCleared[] = $semanticData->getSubject();
 
 		// Pages used by the Phase 3b-iii mixed-direction cursor walk
-		// test. They share `numberProperty` ASC with `authorProperty`
-		// DESC: numbers are tied to force the walk through the second
-		// level's DESC operator, then through the smw_id tiebreak.
+		// test. They are scoped to `mixedTieNumberProperty` and
+		// `mixedTieAuthorProperty` so the tied num/author values stay
+		// invisible to other tests' `numberProperty`/`authorProperty`
+		// queries. Numbers are tied (5, 5, 7, 7) to force the walk
+		// through the second level's DESC operator and then through
+		// the smw_id tiebreak.
 		$mixedSet = [
 			[ 'name' => 'mixedA-num5-aliceBob', 'num' => 5, 'authors' => [ $this->alice, $this->bob ] ],
 			[ 'name' => 'mixedB-num5-aliceOnly', 'num' => 5, 'authors' => [ $this->alice ] ],
@@ -470,11 +490,11 @@ class SubqueryQueryEquivalenceDBIntegrationTest extends SMWIntegrationTestCase {
 				->setTitle( __CLASS__ . '-' . $fixture['name'] )
 				->newEmptySemanticData();
 			$semanticData->addPropertyObjectValue(
-				$this->numberProperty,
+				$this->mixedTieNumberProperty,
 				new Number( $fixture['num'] )
 			);
 			foreach ( $fixture['authors'] as $author ) {
-				$semanticData->addPropertyObjectValue( $this->authorProperty, $author );
+				$semanticData->addPropertyObjectValue( $this->mixedTieAuthorProperty, $author );
 			}
 			$this->getStore()->updateData( $semanticData );
 			$this->subjectsToBeCleared[] = $semanticData->getSubject();

--- a/tests/phpunit/Integration/Query/SubqueryQueryEquivalenceDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SubqueryQueryEquivalenceDBIntegrationTest.php
@@ -287,6 +287,39 @@ class SubqueryQueryEquivalenceDBIntegrationTest extends SMWIntegrationTestCase {
 		);
 	}
 
+	public function testCursorWalkMixedDirectionMatchesLegacyPath(): void {
+		// Phase 3b-iii: per-level directions across multiple sort keys.
+		// The keyset predicate flips its operator at each level
+		// independently; the smw_id tiebreak adopts the last level's
+		// direction. Walks under legacy and rewrite must produce
+		// identical subject sequences.
+		$this->assertCursorWalkEquivalent(
+			function ( ?array $cursorPayload ): Query {
+				$description = new Conjunction( [
+					new SomeProperty(
+						$this->numberProperty,
+						new ThingDescription()
+					),
+					new SomeProperty(
+						$this->authorProperty,
+						new ThingDescription()
+					),
+				] );
+				$query = new Query( $description );
+				$query->querymode = Query::MODE_INSTANCES;
+				$query->sort = true;
+				$query->setUnboundLimit( 1 );
+				$query->sortkeys = [
+					$this->numberProperty->getKey() => 'ASC',
+					$this->authorProperty->getKey() => 'DESC',
+				];
+				$query->setCursorAfter( $cursorPayload );
+				return $query;
+			},
+			'mixed-direction cursor walk (asc,desc)'
+		);
+	}
+
 	public function testCursorRejectedForCompoundHashSortUnderBothPaths(): void {
 		// The `#` sort label produces a comma-joined multi-column
 		// expression in `$qobj->sortfields`. Cursor mode cannot emit a
@@ -421,6 +454,31 @@ class SubqueryQueryEquivalenceDBIntegrationTest extends SMWIntegrationTestCase {
 		$semanticData->addPropertyObjectValue( $this->authorProperty, $this->alice );
 		$this->getStore()->updateData( $semanticData );
 		$this->subjectsToBeCleared[] = $semanticData->getSubject();
+
+		// Pages used by the Phase 3b-iii mixed-direction cursor walk
+		// test. They share `numberProperty` ASC with `authorProperty`
+		// DESC: numbers are tied to force the walk through the second
+		// level's DESC operator, then through the smw_id tiebreak.
+		$mixedSet = [
+			[ 'name' => 'mixedA-num5-aliceBob', 'num' => 5, 'authors' => [ $this->alice, $this->bob ] ],
+			[ 'name' => 'mixedB-num5-aliceOnly', 'num' => 5, 'authors' => [ $this->alice ] ],
+			[ 'name' => 'mixedC-num7-bobOnly', 'num' => 7, 'authors' => [ $this->bob ] ],
+			[ 'name' => 'mixedD-num7-aliceOnly', 'num' => 7, 'authors' => [ $this->alice ] ],
+		];
+		foreach ( $mixedSet as $fixture ) {
+			$semanticData = $this->semanticDataFactory
+				->setTitle( __CLASS__ . '-' . $fixture['name'] )
+				->newEmptySemanticData();
+			$semanticData->addPropertyObjectValue(
+				$this->numberProperty,
+				new Number( $fixture['num'] )
+			);
+			foreach ( $fixture['authors'] as $author ) {
+				$semanticData->addPropertyObjectValue( $this->authorProperty, $author );
+			}
+			$this->getStore()->updateData( $semanticData );
+			$this->subjectsToBeCleared[] = $semanticData->getSubject();
+		}
 	}
 
 	private function runUnderLegacyFlag( bool $legacy, callable $queryFactory ): QueryResult {

--- a/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
@@ -339,11 +339,11 @@ class QueryCreatorTest extends TestCase {
 		$this->assertSame( [ 'v' => 1 ], $query->getCursorAfter() );
 	}
 
-	public function testCursorParamWithMixedOrderMultiSortIsRejectedWithError(): void {
-		// Phase 3b-iii will lift this. Mixed direction per sort level
-		// requires per-level operator inversion in the keyset
-		// predicate, which is materially more complex than the
-		// uniform-direction case Phase 3b-ii ships.
+	public function testCursorParamWithMixedOrderMultiSortBootstrapIsAccepted(): void {
+		// Phase 3b-iii: mixed per-level directions are allowed. A
+		// bootstrap cursor (no anchor) opts into deterministic ordering
+		// without seeking past anything, so it is accepted against any
+		// direction combination.
 		$instance = new QueryCreator(
 			ApplicationFactory::getInstance()->getQueryFactory()
 		);
@@ -357,10 +357,89 @@ class QueryCreatorTest extends TestCase {
 			]
 		);
 
+		$this->assertNotNull( $query->getCursorAfter() );
+	}
+
+	public function testCursorParamWithMixedOrderMatchingPerLevelArrayIsAccepted(): void {
+		// Phase 3b-iii: a cursor minted under `order=asc,desc` carries
+		// `sort_order=["ASC","DESC"]`. The request's per-level
+		// directions must match element-wise.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		// base64url of:
+		// {"v":1,"sort":["v1","v2"],"sort_prop":["PropertyA","PropertyB"],"sort_order":["ASC","DESC"],"id":42}
+		$token = 'eyJ2IjoxLCJzb3J0IjpbInYxIiwidjIiXSwic29ydF9wcm9wIjpbIlByb3BlcnR5QSIsIlByb3BlcnR5QiJdLCJzb3J0X29yZGVyIjpbIkFTQyIsIkRFU0MiXSwiaWQiOjQyfQ';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'PropertyA', 'PropertyB' ],
+				'order'  => [ 'asc', 'desc' ],
+				'cursor' => $token,
+			]
+		);
+
+		$payload = $query->getCursorAfter();
+		$this->assertIsArray( $payload );
+		$this->assertSame( [ 'ASC', 'DESC' ], $payload['sort_order'] );
+	}
+
+	public function testCursorParamWithMixedOrderMismatchingPerLevelArrayIsRejected(): void {
+		// Phase 3b-iii: a cursor minted under one mix of per-level
+		// directions cannot be applied against a different mix.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		// Cursor minted for ["DESC","ASC"], request asks for ["ASC","DESC"].
+		// base64url of:
+		// {"v":1,"sort":["v1","v2"],"sort_prop":["PropertyA","PropertyB"],"sort_order":["DESC","ASC"],"id":42}
+		$token = 'eyJ2IjoxLCJzb3J0IjpbInYxIiwidjIiXSwic29ydF9wcm9wIjpbIlByb3BlcnR5QSIsIlByb3BlcnR5QiJdLCJzb3J0X29yZGVyIjpbIkRFU0MiLCJBU0MiXSwiaWQiOjQyfQ';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'PropertyA', 'PropertyB' ],
+				'order'  => [ 'asc', 'desc' ],
+				'cursor' => $token,
+			]
+		);
+
 		$this->assertNull( $query->getCursorAfter() );
 		$this->assertCursorErrorPresent(
 			$query->getErrors(),
-			'mixed `order=`'
+			'order='
+		);
+	}
+
+	public function testCursorParamWithUniformDescCursorAgainstMixedRequestIsRejected(): void {
+		// A 3b-i/3b-ii uniform-DESC cursor must not be silently accepted
+		// against a mixed-direction request. The string `"DESC"` normalises
+		// to per-level `["DESC","DESC"]`, which mismatches the request's
+		// `["ASC","DESC"]`.
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		// base64url of:
+		// {"v":1,"sort":["v1","v2"],"sort_prop":["PropertyA","PropertyB"],"sort_order":"DESC","id":42}
+		$token = 'eyJ2IjoxLCJzb3J0IjpbInYxIiwidjIiXSwic29ydF9wcm9wIjpbIlByb3BlcnR5QSIsIlByb3BlcnR5QiJdLCJzb3J0X29yZGVyIjoiREVTQyIsImlkIjo0Mn0';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'PropertyA', 'PropertyB' ],
+				'order'  => [ 'asc', 'desc' ],
+				'cursor' => $token,
+			]
+		);
+
+		$this->assertNull( $query->getCursorAfter() );
+		$this->assertCursorErrorPresent(
+			$query->getErrors(),
+			'order='
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/SubqueryQueryBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/SubqueryQueryBuilderTest.php
@@ -265,9 +265,10 @@ class SubqueryQueryBuilderTest extends TestCase {
 		];
 
 		$cursorPredicate = "(t0.smw_sort > 'foo') OR (t0.smw_sort = 'foo' AND t0.smw_id > 42)";
+		$cursorSortColumns = [ 't0.smw_sort' ];
 
 		$builder = new SubqueryQueryBuilder( $this->connection );
-		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '', $cursorPredicate, true );
+		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '', $cursorPredicate, $cursorSortColumns );
 
 		[ $innerHalf, $outerHalf ] = explode( ') AS inner_q', $sql, 2 );
 
@@ -278,40 +279,49 @@ class SubqueryQueryBuilderTest extends TestCase {
 		$this->assertStringNotContainsString( $cursorPredicate, $outerHalf );
 	}
 
-	public function testInstanceQueryWithCursorAliasesSortfieldsAsCursorSort() {
+	public function testInstanceQueryWithCursorProjectsCursorSortColumnsInDeclaredOrder() {
+		// The cursor anchor projection follows `$cursorSortColumns`
+		// order, NOT `$root->sortfields` iteration order. This matters
+		// for multi-property queries where the property table joins
+		// land in a different order than the user's `sort=` declaration.
 		$root = new QuerySegment();
 		$root->joinTable = 'smw_object_ids';
 		$root->alias = 't0';
 		$root->joinfield = 't0.smw_id';
 		$root->where = '';
+		// Sortfields iterated as _DOB, _DOA (e.g. because the author
+		// property's JOIN landed first), but the user wrote
+		// `sort=DOA,DOB`, so the cursor anchor must lead with _DOA.
 		$root->sortfields = [
-			'_DOA' => 't1.o_sortkey',
 			'_DOB' => 't2.o_sortkey',
+			'_DOA' => 't1.o_sortkey',
 		];
 
 		$sqlOptions = [
 			'LIMIT' => 10,
-			'ORDER BY' => 't1.o_sortkey ASC, t2.o_sortkey ASC, t0.smw_id ASC',
+			'ORDER BY' => 't1.o_sortkey ASC, t2.o_sortkey DESC, t0.smw_id DESC',
 		];
 
-		$cursorPredicate = "(t1.o_sortkey > 'a') OR (t1.o_sortkey = 'a' AND t2.o_sortkey > 'b')"
-			. " OR (t1.o_sortkey = 'a' AND t2.o_sortkey = 'b' AND t0.smw_id > 9)";
+		$cursorPredicate = "(t1.o_sortkey > 'a') OR (t1.o_sortkey = 'a' AND t2.o_sortkey < 'b')"
+			. " OR (t1.o_sortkey = 'a' AND t2.o_sortkey = 'b' AND t0.smw_id < 9)";
+
+		$cursorSortColumns = [ 't1.o_sortkey', 't2.o_sortkey' ];
 
 		$builder = new SubqueryQueryBuilder( $this->connection );
-		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '', $cursorPredicate, true );
+		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '', $cursorPredicate, $cursorSortColumns );
 
-		// Outer projection exposes each sortfield under a cursor_sort_N
-		// alias so the QueryEngine row loop reads the anchor values via
-		// `$row->cursor_sort_0`, `$row->cursor_sort_1`, ... regardless of
-		// which builder produced the result set.
-		$this->assertStringContainsString( 'inner_q.sf0 AS cursor_sort_0', $sql );
-		$this->assertStringContainsString( 'inner_q.sf1 AS cursor_sort_1', $sql );
+		// Inner SELECT aliases cursor sort columns in declared order.
+		$this->assertStringContainsString( 't1.o_sortkey AS cursor_sort_0', $sql );
+		$this->assertStringContainsString( 't2.o_sortkey AS cursor_sort_1', $sql );
+		// Outer SELECT surfaces them with the same alias.
+		$this->assertStringContainsString( 'inner_q.cursor_sort_0', $sql );
+		$this->assertStringContainsString( 'inner_q.cursor_sort_1', $sql );
 
 		// The outer ORDER BY rewrites the smw_id tiebreak from the inner
 		// segment's alias to the outer table.
 		[ , $afterJoin ] = explode( ') AS inner_q', $sql, 2 );
 		$orderBy = strstr( $afterJoin, 'ORDER BY' );
-		$this->assertStringContainsString( 'outer_q.smw_id ASC', $orderBy );
+		$this->assertStringContainsString( 'outer_q.smw_id DESC', $orderBy );
 		$this->assertStringNotContainsString( 't0.smw_id', $orderBy );
 	}
 
@@ -333,9 +343,10 @@ class SubqueryQueryBuilderTest extends TestCase {
 		];
 
 		$builder = new SubqueryQueryBuilder( $this->connection );
-		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '', '', true );
+		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '', '', [ 't0.smw_sort' ] );
 
-		$this->assertStringContainsString( 'inner_q.sf0 AS cursor_sort_0', $sql );
+		$this->assertStringContainsString( 't0.smw_sort AS cursor_sort_0', $sql );
+		$this->assertStringContainsString( 'inner_q.cursor_sort_0', $sql );
 	}
 
 	public function testInstanceQueryWithoutCursorDoesNotAliasCursorSort() {

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/SubqueryQueryBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/SubqueryQueryBuilderTest.php
@@ -251,6 +251,112 @@ class SubqueryQueryBuilderTest extends TestCase {
 		$this->assertStringContainsString( 'outer_q.smw_id = inner_q.s_id', $sql );
 	}
 
+	public function testInstanceQueryWithCursorPredicateAndedIntoInnerWhere() {
+		$root = new QuerySegment();
+		$root->joinTable = 'smw_object_ids';
+		$root->alias = 't0';
+		$root->joinfield = 't0.smw_id';
+		$root->where = "t0.smw_iw!=':smw'";
+		$root->sortfields = [ '' => 't0.smw_sort' ];
+
+		$sqlOptions = [
+			'LIMIT' => 20,
+			'ORDER BY' => 't0.smw_sort ASC, t0.smw_id ASC',
+		];
+
+		$cursorPredicate = "(t0.smw_sort > 'foo') OR (t0.smw_sort = 'foo' AND t0.smw_id > 42)";
+
+		$builder = new SubqueryQueryBuilder( $this->connection );
+		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '', $cursorPredicate, true );
+
+		[ $innerHalf, $outerHalf ] = explode( ') AS inner_q', $sql, 2 );
+
+		// Original WHERE and cursor predicate are both ANDed inside the
+		// derived table.
+		$this->assertStringContainsString( "(t0.smw_iw!=':smw') AND ($cursorPredicate)", $innerHalf );
+		// The cursor predicate must not appear outside the subquery.
+		$this->assertStringNotContainsString( $cursorPredicate, $outerHalf );
+	}
+
+	public function testInstanceQueryWithCursorAliasesSortfieldsAsCursorSort() {
+		$root = new QuerySegment();
+		$root->joinTable = 'smw_object_ids';
+		$root->alias = 't0';
+		$root->joinfield = 't0.smw_id';
+		$root->where = '';
+		$root->sortfields = [
+			'_DOA' => 't1.o_sortkey',
+			'_DOB' => 't2.o_sortkey',
+		];
+
+		$sqlOptions = [
+			'LIMIT' => 10,
+			'ORDER BY' => 't1.o_sortkey ASC, t2.o_sortkey ASC, t0.smw_id ASC',
+		];
+
+		$cursorPredicate = "(t1.o_sortkey > 'a') OR (t1.o_sortkey = 'a' AND t2.o_sortkey > 'b')"
+			. " OR (t1.o_sortkey = 'a' AND t2.o_sortkey = 'b' AND t0.smw_id > 9)";
+
+		$builder = new SubqueryQueryBuilder( $this->connection );
+		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '', $cursorPredicate, true );
+
+		// Outer projection exposes each sortfield under a cursor_sort_N
+		// alias so the QueryEngine row loop reads the anchor values via
+		// `$row->cursor_sort_0`, `$row->cursor_sort_1`, ... regardless of
+		// which builder produced the result set.
+		$this->assertStringContainsString( 'inner_q.sf0 AS cursor_sort_0', $sql );
+		$this->assertStringContainsString( 'inner_q.sf1 AS cursor_sort_1', $sql );
+
+		// The outer ORDER BY rewrites the smw_id tiebreak from the inner
+		// segment's alias to the outer table.
+		[ , $afterJoin ] = explode( ') AS inner_q', $sql, 2 );
+		$orderBy = strstr( $afterJoin, 'ORDER BY' );
+		$this->assertStringContainsString( 'outer_q.smw_id ASC', $orderBy );
+		$this->assertStringNotContainsString( 't0.smw_id', $orderBy );
+	}
+
+	public function testInstanceQueryWithBootstrapCursorAliasesCursorSortDespiteEmptyPredicate() {
+		// Bootstrap cursor ({"v":1}) carries no anchor, so the engine
+		// passes an empty cursor predicate. cursor_sort_N projections
+		// must still be emitted so the row loop can capture the anchor
+		// values for the *next* page.
+		$root = new QuerySegment();
+		$root->joinTable = 'smw_object_ids';
+		$root->alias = 't0';
+		$root->joinfield = 't0.smw_id';
+		$root->where = '';
+		$root->sortfields = [ '' => 't0.smw_sort' ];
+
+		$sqlOptions = [
+			'LIMIT' => 10,
+			'ORDER BY' => 't0.smw_sort ASC, t0.smw_id ASC',
+		];
+
+		$builder = new SubqueryQueryBuilder( $this->connection );
+		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '', '', true );
+
+		$this->assertStringContainsString( 'inner_q.sf0 AS cursor_sort_0', $sql );
+	}
+
+	public function testInstanceQueryWithoutCursorDoesNotAliasCursorSort() {
+		$root = new QuerySegment();
+		$root->joinTable = 'smw_object_ids';
+		$root->alias = 't0';
+		$root->joinfield = 't0.smw_id';
+		$root->where = '';
+		$root->sortfields = [ '_DOA' => 't1.o_sortkey' ];
+
+		$sqlOptions = [
+			'LIMIT' => 10,
+			'ORDER BY' => 't1.o_sortkey ASC',
+		];
+
+		$builder = new SubqueryQueryBuilder( $this->connection );
+		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '' );
+
+		$this->assertStringNotContainsString( 'cursor_sort_', $sql );
+	}
+
 	public function testCountQueryWithIdAnchoredRoot() {
 		$root = new QuerySegment();
 		$root->joinTable = 'smw_object_ids';


### PR DESCRIPTION
## Summary

Phase 3b-iii of the keyset pagination migration (#6795). Lifts the
uniform-direction restriction Phase 3b-ii left in place: cursor
pagination now supports `sort=A,B|order=asc,desc` (mixed per-level
directions).

Stacked on #6815 (Phase 3c). Base branch is
`feat/queryengine-keyset-3c-subquery`.

## What changed

- **`QueryCreator::applyCursorIfRequested`**: removes the uniformity
  rejection. The `sort_order` cross-check now normalises both the
  payload and the request to per-level arrays before comparison via
  two new helpers (`resolveRequestSortOrders`,
  `normalisePayloadSortOrders`). A new `coerceSortDirection` helper
  maps untrusted payload values onto `{ASC, DESC, RANDOM}` so
  attacker-controlled cursor data cannot reach error messages or
  the predicate builder.
- **`QueryEngine`**: `\$cursorSortOrder` (scalar) becomes
  `\$cursorSortOrders` (array, parallel to `\$cursorSortColumns`).
  The defensive uniformity check is dropped. `ORDER BY` emits
  per-level directions; the `smw_id` tiebreak adopts the LAST
  level's direction so the tied-tuple walk chains naturally off
  the final sort column. For uniform requests this collapses to
  the pre-3b-iii behaviour.
- **`buildKeysetPredicateString` / `applyKeysetPredicate`**:
  signature widens from `string \$sortOrder` to
  `array \$sortOrders`. Per-level operator selection (level k
  uses `>` for ASC, `<` for DESC). The tiebreak operator uses
  the last level's direction.
- **Cursor token `sort_order` field**: scalar string for uniform
  walks (backwards compatible with 3a/3b-i/3b-ii cursors), array
  per-level for mixed (new 3b-iii shape). All-ASC walks continue
  to omit the field entirely (round-trippable with spike/3a).
- **`SubqueryQueryBuilder`**: the \`cursor_sort_N\` outer projection
  is now driven by an explicit \`\$cursorSortColumns\` parameter in
  declared order, NOT by \`\$root->sortfields\` iteration order.
  This fixes a latent alignment bug where multi-property queries
  could write the wrong sort column into the next-cursor anchor
  when \`OrderCondition\` populated sortfields in join order
  rather than \`\$query->sortkeys\` declaration order. The bug
  was untriggered by existing 3b-ii tests but would have surfaced
  for real multi-property cursor walks.

## smw_id tiebreak direction

For mixed-direction requests, the cursor's \`smw_id\` tiebreak
follows the **last sort level's** direction. \`order=asc,desc\`
gives \`ORDER BY a ASC, b DESC, smw_id DESC\`. This mirrors how
SQL ORDER BY chains directions left-to-right and keeps the
uniform case unchanged (uniform-DESC still uses smw_id DESC).

## Test plan

- [x] New unit tests in \`QueryCreatorTest\`:
  - Bootstrap cursor (\`{\"v\":1}\`) accepted under mixed-direction
    request.
  - Cursor with matching per-level \`sort_order\` array accepted.
  - Cursor with mismatching per-level \`sort_order\` array rejected.
  - 3b-i/3b-ii uniform-DESC cursor (scalar \`sort_order\`) rejected
    against a mixed-direction request (backwards-compat boundary).
- [x] Rewritten unit test in \`SubqueryQueryBuilderTest\`:
  asserts \`cursor_sort_N\` projection follows the declared
  \`\$cursorSortColumns\` order even when \`\$root->sortfields\`
  iterates in a different order.
- [x] New DB integration test in
  \`SubqueryQueryEquivalenceDBIntegrationTest\`:
  - \`testCursorWalkMixedDirectionMatchesLegacyPath\` walks pages
    with \`[number ASC, author DESC]\` and asserts identical
    subject sequences under both \`smwgQUseLegacyQuery=true\` and
    \`=false\`. Seed adds 4 fixtures designed to force the walk
    through the second-level DESC operator and the smw_id
    tiebreak.
- [x] \`composer analyze\` clean (lint + PHPCS).
- [x] 576 tests pass across QueryCreator, QueryEngine,
  SubqueryQueryBuilder, SubqueryQueryEquivalence, and
  KeysetPagination filters.
- [x] Dev wiki smoke: uniform single-property DESC walk and
  default-sort walk both regress clean (no behaviour change for
  uniform-direction users). Mixed-direction smoke is not feasible
  on the seeded dev wiki (no two distinct sortable properties);
  the DB integration test covers that path against MariaDB.

## Migration / compat

No public API or schema change. Existing cursor tokens (default
sort, single-property, uniform DESC, uniform multi-property) all
round-trip. New mixed-direction cursors are not accepted by older
SMW versions, but the rejection is explicit (mismatched sort_order
error), not a silent walk into the wrong slice.