### PR TITLE
tests: Quiet LegacyConstantNormalizer deprecation log spam

### DIFF
--- a/src/Setup/LegacyConstantNormalizer.php
+++ b/src/Setup/LegacyConstantNormalizer.php
@@ -237,6 +237,25 @@ class LegacyConstantNormalizer {
 	}
 
 	/**
+	 * Reverse-lookup: given the integer value of a legacy `SMW_*` /
+	 * `CONCEPT_CACHE_*` constant for a registered enum or flag setting,
+	 * return the equivalent kebab-string name. Used by test infrastructure
+	 * that needs to upgrade legacy constant names (e.g. JSONScript test
+	 * fixtures from external extensions) to the new form before they reach
+	 * {@see Settings::set()}, avoiding the deprecation path entirely.
+	 *
+	 * @since 7.0.0
+	 */
+	public static function getStringFormForConstant( string $key, int $constantValue ): ?string {
+		$map = self::ENUM_MAP[$key] ?? self::FLAG_MAP[$key] ?? null;
+		if ( $map === null ) {
+			return null;
+		}
+		$name = array_search( $constantValue, $map, true );
+		return $name === false ? null : $name;
+	}
+
+	/**
 	 * Reset the per-request deprecation suppression set. Intended for test
 	 * isolation; production callers should never need this.
 	 *

--- a/tests/phpunit/Integration/JSONScript/TestCases/format-category-0004.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/format-category-0004.json
@@ -178,10 +178,10 @@
 	"settings": {
 		"smwgEntityCollation": "identity",
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_REDI",
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC",
-			"SMW_SPARQL_QF_COLLATION"
+			"redirects",
+			"subproperties",
+			"subcategories",
+			"collation"
 		],
 		"wgContLang": "en",
 		"wgLang": "en",

--- a/tests/phpunit/Integration/JSONScript/TestCases/format-category-0005.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/format-category-0005.json
@@ -170,10 +170,10 @@
 	"settings": {
 		"smwgEntityCollation": "uppercase",
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_REDI",
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC",
-			"SMW_SPARQL_QF_COLLATION"
+			"redirects",
+			"subproperties",
+			"subcategories",
+			"collation"
 		],
 		"wgContLang": "en",
 		"wgLang": "en",

--- a/tests/phpunit/Integration/JSONScript/TestCases/format-category-0006.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/format-category-0006.json
@@ -214,10 +214,10 @@
 	"settings": {
 		"smwgEntityCollation": "numeric",
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_REDI",
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC",
-			"SMW_SPARQL_QF_COLLATION"
+			"redirects",
+			"subproperties",
+			"subcategories",
+			"collation"
 		],
 		"wgContLang": "en",
 		"wgLang": "en",

--- a/tests/phpunit/Integration/JSONScript/TestCases/format-category-0007.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/format-category-0007.json
@@ -216,10 +216,10 @@
 	"settings": {
 		"smwgEntityCollation": "uca-default-u-kn",
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_REDI",
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC",
-			"SMW_SPARQL_QF_COLLATION"
+			"redirects",
+			"subproperties",
+			"subcategories",
+			"collation"
 		],
 		"wgContLang": "en",
 		"wgLang": "en",

--- a/tests/phpunit/Integration/JSONScript/TestCases/format-list-ul-ol-0002.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/format-list-ul-ol-0002.json
@@ -110,7 +110,7 @@
 		"wgContLang": "en",
 		"wgLang": "en",
 		"smwgDVFeatures": [
-			"SMW_DV_NUMV_USPACE"
+			"number-value-usespaces"
 		],
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,

--- a/tests/phpunit/Integration/JSONScript/TestCases/format-table-0010.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/format-table-0010.json
@@ -61,7 +61,7 @@
 		"wgContLang": "en",
 		"wgLang": "en",
 		"smwgDVFeatures": [
-			"SMW_DV_NUMV_USPACE"
+			"number-value-usespaces"
 		],
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0102.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0102.json
@@ -242,9 +242,9 @@
 	"settings": {
 		"wgContLang": "en",
 		"smwgParserFeatures": [
-			"SMW_PARSER_STRICT",
-			"SMW_PARSER_INL_ERROR",
-			"SMW_PARSER_HID_CATS"
+			"strict",
+			"inline-errors",
+			"hidden-categories"
 		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0110.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0110.json
@@ -30,7 +30,7 @@
 	],
 	"settings": {
 		"smwgDVFeatures": [
-			"SMW_DV_PVUC"
+			"unique-constraint"
 		],
 		"wgContLang": "en",
 		"wgLang": "en"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0408.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0408.json
@@ -34,7 +34,7 @@
 			"_MDAT"
 		],
 		"smwgParserFeatures": [
-			"SMW_PARSER_NONE"
+			
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0413.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0413.json
@@ -871,7 +871,7 @@
 		"wgContLang": "en",
 		"wgLang": "en",
 		"smwgDVFeatures": [
-			"SMW_DV_TIMEV_CM"
+			"time-calendar-model"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0414.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0414.json
@@ -366,7 +366,7 @@
 		"wgContLang": "en",
 		"wgLang": "en",
 		"smwgDVFeatures": [
-			"SMW_DV_TIMEV_CM"
+			"time-calendar-model"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0419.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0419.json
@@ -271,7 +271,7 @@
 	],
 	"settings": {
 		"smwgDVFeatures": [
-			"SMW_DV_PVUC"
+			"unique-constraint"
 		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0420.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0420.json
@@ -97,7 +97,7 @@
 		"wgContLang": "en",
 		"wgLang": "en",
 		"smwgDVFeatures": [
-			"SMW_DV_TIMEV_CM"
+			"time-calendar-model"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0421.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0421.json
@@ -41,7 +41,7 @@
 	],
 	"settings": {
 		"smwgDVFeatures": [
-			"SMW_DV_PVUC"
+			"unique-constraint"
 		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0433.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0433.json
@@ -74,9 +74,9 @@
 	"settings": {
 		"wgContLang": "en",
 		"smwgParserFeatures": [
-			"SMW_PARSER_STRICT",
-			"SMW_PARSER_INL_ERROR",
-			"SMW_PARSER_HID_CATS"
+			"strict",
+			"inline-errors",
+			"hidden-categories"
 		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0443.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0443.json
@@ -185,7 +185,7 @@
 	],
 	"settings": {
 		"smwgDVFeatures": [
-			"SMW_DV_PVUC"
+			"unique-constraint"
 		],
 		"wgContLang": "en",
 		"wgLang": "en"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0444.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0444.json
@@ -190,10 +190,10 @@
 	"settings": {
 		"wgContLang": "en",
 		"smwgParserFeatures": [
-			"SMW_PARSER_STRICT",
-			"SMW_PARSER_INL_ERROR",
-			"SMW_PARSER_HID_CATS",
-			"SMW_PARSER_LINV"
+			"strict",
+			"inline-errors",
+			"hidden-categories",
+			"links-in-values"
 		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0448.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0448.json
@@ -58,9 +58,9 @@
 	"settings": {
 		"wgContLang": "en",
 		"smwgParserFeatures": [
-			"SMW_PARSER_STRICT",
-			"SMW_PARSER_INL_ERROR",
-			"SMW_PARSER_HID_CATS"
+			"strict",
+			"inline-errors",
+			"hidden-categories"
 		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0449.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0449.json
@@ -318,10 +318,10 @@
 	"settings": {
 		"wgContLang": "en",
 		"smwgParserFeatures": [
-			"SMW_PARSER_STRICT",
-			"SMW_PARSER_INL_ERROR",
-			"SMW_PARSER_HID_CATS",
-			"SMW_PARSER_LINV"
+			"strict",
+			"inline-errors",
+			"hidden-categories",
+			"links-in-values"
 		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0451.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0451.json
@@ -150,7 +150,7 @@
 		"wgContLang": "en",
 		"wgLang": "en",
 		"smwgDVFeatures": [
-			"SMW_DV_TIMEV_CM"
+			"time-calendar-model"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0454.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0454.json
@@ -31,10 +31,10 @@
 		"wgContLang": "en",
 		"wgLang": "en",
 		"smwgParserFeatures": [
-			"SMW_PARSER_STRICT",
-			"SMW_PARSER_INL_ERROR",
-			"SMW_PARSER_HID_CATS",
-			"SMW_PARSER_LINV"
+			"strict",
+			"inline-errors",
+			"hidden-categories",
+			"links-in-values"
 		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0455.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0455.json
@@ -232,8 +232,8 @@
 		"wgContLang": "en",
 		"wgLang": "en",
 		"smwgParserFeatures": [
-			"SMW_PARSER_UNSTRIP",
-			"SMW_PARSER_STRICT"
+			"unstrip",
+			"strict"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0909.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0909.json
@@ -246,7 +246,7 @@
 	"settings": {
 		"wgContLang": "en",
 		"wgLang": "en",
-		"smwgQueryProfiler": true,
+		"smwgQueryProfiler": [],
 		"smwgQFilterDuplicates": true,
 		"smwgQueryResultCacheType": "hash",
 		"smwgPageSpecialProperties": [

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0911.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0911.json
@@ -45,8 +45,8 @@
 		"wgLang": "en",
 		"smwgQueryResultCacheType": "hash",
 		"smwgQueryProfiler" : [
-			"SMW_QPRFL_DUR",
-			"SMW_QPRFL_PARAMS"
+			"duration",
+			"parameters"
 		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0913.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0913.json
@@ -116,10 +116,10 @@
 		"wgContLang": "en",
 		"wgLang": "en",
 		"smwgParserFeatures": [
-			"SMW_PARSER_STRICT",
-			"SMW_PARSER_INL_ERROR",
-			"SMW_PARSER_HID_CATS",
-			"SMW_PARSER_LINV"
+			"strict",
+			"inline-errors",
+			"hidden-categories",
+			"links-in-values"
 		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0915.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0915.json
@@ -91,9 +91,9 @@
 		"wgContLang": "en",
 		"wgLang": "en",
 		"smwgCategoryFeatures": [
-			"SMW_CAT_INSTANCE",
-			"SMW_CAT_REDIRECT",
-			"SMW_CAT_HIERARCHY"
+			"instance",
+			"redirect",
+			"hierarchy"
 		],
 		"smwgPageSpecialProperties": [
 			"_MDAT"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0921.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0921.json
@@ -59,7 +59,7 @@
 			"_MDAT"
 		],
 		"smwgDVFeatures": [
-			"SMW_DV_WPV_PIPETRICK"
+			"wpv-pipetrick"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0104.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0104.json
@@ -255,8 +255,8 @@
 		"smwgEnabledFulltextSearch": true,
 		"smwgFulltextDeferredUpdate": false,
 		"smwgFulltextSearchIndexableDataTypes": [
-			"SMW_FT_BLOB",
-			"SMW_FT_URI"
+			"blob",
+			"uri"
 		],
 		"smwgElasticsearchConfig": {
 			"indexer": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0105.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0105.json
@@ -318,9 +318,9 @@
 		"smwgEnabledFulltextSearch": true,
 		"smwgFulltextDeferredUpdate": false,
 		"smwgFulltextSearchIndexableDataTypes": [
-			"SMW_FT_BLOB",
-			"SMW_FT_URI",
-			"SMW_FT_WIKIPAGE"
+			"blob",
+			"uri",
+			"wikipage"
 		],
 		"smwgElasticsearchConfig": {
 			"indexer": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0106.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0106.json
@@ -70,9 +70,9 @@
 		"smwgEnabledFulltextSearch": true,
 		"smwgFulltextDeferredUpdate": false,
 		"smwgFulltextSearchIndexableDataTypes": [
-			"SMW_FT_BLOB",
-			"SMW_FT_URI",
-			"SMW_FT_WIKIPAGE"
+			"blob",
+			"uri",
+			"wikipage"
 		],
 		"smwgFixedProperties": [
 			"Has_fixed_text",

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0202.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0202.json
@@ -111,7 +111,7 @@
 	"settings": {
 		"smwgQueryResultCacheType": false,
 		"smwgQFilterDuplicates": false,
-		"smwgQConceptCaching": "CONCEPT_CACHE_NONE",
+		"smwgQConceptCaching": "none",
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,
 			"SMW_NS_PROPERTY": true,

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0203.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0203.json
@@ -54,7 +54,7 @@
 		}
 	],
 	"settings": {
-		"smwgQConceptCaching": "CONCEPT_CACHE_ALL",
+		"smwgQConceptCaching": "all",
 		"smwgNamespacesWithSemanticLinks": {
 			"NS_MAIN": true,
 			"SMW_NS_PROPERTY": true,

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0401.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0401.json
@@ -148,8 +148,8 @@
 	"settings": {
 		"smwgQSubpropertyDepth": 10,
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC"
+			"subproperties",
+			"subcategories"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0402.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0402.json
@@ -232,9 +232,9 @@
 	"settings": {
 		"smwgQSubpropertyDepth": 10,
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_REDI",
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC"
+			"redirects",
+			"subproperties",
+			"subcategories"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0604.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0604.json
@@ -176,9 +176,9 @@
 	],
 	"settings": {
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_REDI",
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC"
+			"redirects",
+			"subproperties",
+			"subcategories"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0609.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0609.json
@@ -63,8 +63,8 @@
 		"smwgQSubpropertyDepth": 10,
 		"smwgQSubcategoryDepth": 10,
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC"
+			"subproperties",
+			"subcategories"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0614.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0614.json
@@ -94,8 +94,8 @@
 		"smwgQSubpropertyDepth": 10,
 		"smwgQSubcategoryDepth": 10,
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC"
+			"subproperties",
+			"subcategories"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0615.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0615.json
@@ -133,8 +133,8 @@
 		"smwgQSubpropertyDepth": 10,
 		"smwgQSubcategoryDepth": 10,
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC"
+			"subproperties",
+			"subcategories"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0622.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0622.json
@@ -56,8 +56,8 @@
 		"smwgQSubpropertyDepth": 10,
 		"smwgQSubcategoryDepth": 10,
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC"
+			"subproperties",
+			"subcategories"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0623.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0623.json
@@ -73,8 +73,8 @@
 		"smwgQSubpropertyDepth": 10,
 		"smwgQSubcategoryDepth": 10,
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC"
+			"subproperties",
+			"subcategories"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0803.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0803.json
@@ -125,8 +125,8 @@
 		"smwgQSubpropertyDepth": 10,
 		"smwgQSubcategoryDepth": 10,
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC"
+			"subproperties",
+			"subcategories"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0904.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0904.json
@@ -127,8 +127,8 @@
 		"smwgQSubpropertyDepth": 10,
 		"smwgQSubcategoryDepth": 10,
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC"
+			"subproperties",
+			"subcategories"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0906.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0906.json
@@ -137,10 +137,10 @@
 			"SMW_NS_PROPERTY": true
 		},
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_NOCASE"
+			"no-case"
 		],
 		"smwgFieldTypeFeatures": [
-			"SMW_FIELDT_CHAR_NOCASE"
+			"char-nocase"
 		],
 		"smwgElasticsearchConfig" : {
 			"connection":{

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0907.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0907.json
@@ -92,11 +92,11 @@
 			"SMW_NS_PROPERTY": true
 		},
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_NOCASE"
+			"no-case"
 		],
 		"smwgFieldTypeFeatures": [
-			"SMW_FIELDT_CHAR_NOCASE",
-			"SMW_FIELDT_CHAR_LONG"
+			"char-nocase",
+			"char-long"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0908.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0908.json
@@ -191,11 +191,11 @@
 			"SMW_NS_PROPERTY": true
 		},
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_NOCASE"
+			"no-case"
 		],
 		"smwgFieldTypeFeatures": [
-			"SMW_FIELDT_CHAR_NOCASE",
-			"SMW_FIELDT_CHAR_LONG"
+			"char-nocase",
+			"char-long"
 		],
 		"smwgElasticsearchConfig" : {
 			"connection":{

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0910.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0910.json
@@ -90,8 +90,8 @@
 			"SMW_NS_PROPERTY": true
 		},
 		"smwgQSortFeatures": [
-			"SMW_QSORT",
-			"SMW_QSORT_UNCONDITIONAL"
+			"sort",
+			"unconditional"
 		],
 		"smwgElasticsearchConfig": {
 			"query": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-1108.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-1108.json
@@ -93,7 +93,7 @@
 	],
 	"settings": {
 		"smwgDVFeatures": [
-			"SMW_DV_PVUC"
+			"unique-constraint"
 		],
 		"wgContLang": "en",
 		"wgLang": "en"

--- a/tests/phpunit/Integration/JSONScript/TestCases/r-0019.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/r-0019.json
@@ -31,10 +31,10 @@
 	"settings": {
 		"smwgEntityCollation": "uppercase",
 		"smwgSparqlQFeatures": [
-			"SMW_SPARQL_QF_REDI",
-			"SMW_SPARQL_QF_SUBP",
-			"SMW_SPARQL_QF_SUBC",
-			"SMW_SPARQL_QF_COLLATION"
+			"redirects",
+			"subproperties",
+			"subcategories",
+			"collation"
 		],
 		"wgContLang": "en",
 		"wgLang": "en",

--- a/tests/phpunit/Integration/JSONScript/TestCases/special-browse-0002.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/special-browse-0002.json
@@ -71,8 +71,8 @@
 		},
 		"wgRestrictDisplayTitle": false,
 		"smwgDVFeatures": [
-			"SMW_DV_TIMEV_CM",
-			"SMW_DV_WPV_DTITLE"
+			"time-calendar-model",
+			"wpv-display-title"
 		]
 	},
 	"meta": {

--- a/tests/phpunit/Integration/Parser/InTextAnnotationParserTemplateTransclusionTest.php
+++ b/tests/phpunit/Integration/Parser/InTextAnnotationParserTemplateTransclusionTest.php
@@ -125,7 +125,7 @@ class InTextAnnotationParserTemplateTransclusionTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
+				'smwgParserFeatures' => [ 'inline-errors' ],
 				'smwgMainCacheType'      => 'hash'
 			],
 			'[[Foo::{{Bam}}]]',

--- a/tests/phpunit/JSONScriptServicesTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptServicesTestCaseRunner.php
@@ -73,11 +73,23 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 				'smwgEnabledFulltextSearch' => false,
 				'smwgSparqlReplicationPropertyExemptionList' => [],
 				'smwgPageSpecialProperties' => [ '_MDAT' ],
-				'smwgFieldTypeFeatures' => SMW_FIELDT_NONE,
-				// Read $smwgDVFeatures via Settings (not $GLOBALS) so the value is
-				// the post-normalization integer regardless of which form
-				// LocalSettings.php or extension.json supplied (#6586).
-				'smwgDVFeatures' => (int)ApplicationFactory::getInstance()->getSettings()->get( 'smwgDVFeatures' ) & ~SMW_DV_NUMV_USPACE,
+				'smwgFieldTypeFeatures' => [],
+				// Pin smwgDVFeatures to the extension.json default minus
+				// `number-value-usespaces` so JSON test cases that don't
+				// override the key see a stable baseline regardless of
+				// LocalSettings.php (#6586). Expressed in the new string-array
+				// form to avoid the LegacyConstantNormalizer deprecation path.
+				// Keep this list in sync with extension.json's `DVFeatures`
+				// default — adding a new flag there means adding it here too.
+				'smwgDVFeatures' => [
+					'provider-redirect',
+					'monolingual-langcode',
+					'pattern-validation',
+					'wpv-display-title',
+					'time-calendar-model',
+					'preferred-label',
+					'provider-link-hint',
+				],
 				'smwgCacheUsage' => [
 					'api.browse' => false
 				] + $GLOBALS['smwgCacheUsage'],

--- a/tests/phpunit/Unit/EncodingIntegrationTest.php
+++ b/tests/phpunit/Unit/EncodingIntegrationTest.php
@@ -42,9 +42,12 @@ class EncodingIntegrationTest extends TestCase {
 			ApplicationFactory::getInstance()->getNamespaceExaminer()
 		);
 
+		// Read post-normalization so isFlagSet sees the integer bitmask
+		// regardless of whether the test supplied the new array form or a
+		// legacy SMW_* integer constant.
 		$instance->setOptions(
 			[
-				'smwgBrowseFeatures' => $setup['settings']['smwgBrowseFeatures']
+				'smwgBrowseFeatures' => ApplicationFactory::getInstance()->getSettings()->get( 'smwgBrowseFeatures' )
 			]
 		);
 
@@ -76,7 +79,7 @@ class EncodingIntegrationTest extends TestCase {
 	private function newSidebarBeforeOutputSetup( $text ) {
 		$settings = [
 			'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-			'smwgBrowseFeatures'           => SMW_BROWSE_TLINK
+			'smwgBrowseFeatures'           => [ 'toolbox-link' ]
 		];
 
 		$message = $this->getMockBuilder( Message::class )

--- a/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
@@ -102,8 +102,11 @@ class CachedFactboxTest extends TestCase {
 
 		$instance->isEnabled( true );
 
+		// Read post-normalization so setShowFactbox sees the integer
+		// regardless of whether the provider supplied the new string form
+		// or a legacy SMW_FACTBOX_* constant.
 		$instance->setShowFactbox(
-			$parameters['smwgShowFactbox']
+			(int)ApplicationFactory::getInstance()->getSettings()->get( 'smwgShowFactbox' )
 		);
 
 		$instance->setLogger(
@@ -278,7 +281,7 @@ class CachedFactboxTest extends TestCase {
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgShowFactbox' => SMW_FACTBOX_NONEMPTY,
+				'smwgShowFactbox' => 'nonempty',
 				'outputPage'      => $outputPage,
 				'store'           => $store,
 				'parserOutput'    => $this->makeParserOutput( $semanticData )
@@ -334,7 +337,7 @@ class CachedFactboxTest extends TestCase {
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgShowFactbox' => SMW_FACTBOX_NONEMPTY,
+				'smwgShowFactbox' => 'nonempty',
 				'outputPage'      => $outputPage,
 				'store'           => $store,
 				'parserOutput'    => $this->makeParserOutput( $semanticData )
@@ -379,7 +382,7 @@ class CachedFactboxTest extends TestCase {
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => false ],
-				'smwgShowFactbox' => SMW_FACTBOX_HIDDEN,
+				'smwgShowFactbox' => 'hidden',
 				'outputPage'      => $outputPage,
 				'store'           => $store,
 				'parserOutput'    => $this->makeParserOutput( $semanticData )
@@ -443,7 +446,7 @@ class CachedFactboxTest extends TestCase {
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgShowFactbox' => SMW_FACTBOX_NONEMPTY,
+				'smwgShowFactbox' => 'nonempty',
 				'outputPage'      => $outputPage,
 				'store'           => $store,
 				'parserOutput'    => $this->makeParserOutput( null ),
@@ -487,7 +490,7 @@ class CachedFactboxTest extends TestCase {
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgShowFactbox' => SMW_FACTBOX_NONEMPTY,
+				'smwgShowFactbox' => 'nonempty',
 				'outputPage'      => $outputPage,
 				'store'           => $store,
 				'parserOutput'    => $this->makeParserOutput( null ),
@@ -531,7 +534,7 @@ class CachedFactboxTest extends TestCase {
 		$provider[] = [
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgShowFactbox' => SMW_FACTBOX_NONEMPTY,
+				'smwgShowFactbox' => 'nonempty',
 				'outputPage'      => $outputPage,
 				'store'           => $store,
 				'parserOutput'    => $this->makeParserOutput( null ),

--- a/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxMagicWordsTest.php
@@ -59,7 +59,7 @@ class FactboxMagicWordsTest extends TestCase {
 		$this->testEnvironment->withConfiguration(
 			[
 				'smwgNamespacesWithSemanticLinks' => [ $title->getNamespace() => true ],
-				'smwgParserFeatures' => SMW_PARSER_STRICT | SMW_PARSER_INL_ERROR
+				'smwgParserFeatures' => [ 'strict', 'inline-errors' ]
 			]
 		);
 
@@ -83,8 +83,8 @@ class FactboxMagicWordsTest extends TestCase {
 		$title = Title::newFromText( __METHOD__ );
 
 		$this->testEnvironment->withConfiguration( [
-			'smwgShowFactboxEdit' => SMW_FACTBOX_HIDDEN,
-			'smwgShowFactbox'     => SMW_FACTBOX_HIDDEN
+			'smwgShowFactboxEdit' => 'hidden',
+			'smwgShowFactbox'     => 'hidden'
 			]
 		);
 

--- a/tests/phpunit/Unit/Factbox/FactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxTest.php
@@ -38,7 +38,7 @@ class FactboxTest extends TestCase {
 		$this->testEnvironment = new TestEnvironment();
 		$this->stringValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newStringValidator();
 
-		$this->testEnvironment->addConfiguration( 'smwgShowFactbox', SMW_FACTBOX_NONEMPTY );
+		$this->testEnvironment->addConfiguration( 'smwgShowFactbox', 'nonempty' );
 
 		$this->displayTitleFinder = $this->getMockBuilder( DisplayTitleFinder::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
@@ -71,7 +71,7 @@ class ArticlePurgeTest extends TestCase {
 
 		$this->testEnvironment->addConfiguration(
 			'smwgFactboxFeatures',
-			SMW_FACTBOX_PURGE_REFRESH
+			[ 'purge-refresh' ]
 		);
 
 		$this->testEnvironment->addConfiguration(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
@@ -353,7 +353,7 @@ class InternalParseBeforeLinksTest extends TestCase {
 				'title'    => $title,
 				'settings' => [
 					'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-					'smwgParserFeatures' => SMW_PARSER_STRICT
+					'smwgParserFeatures' => [ 'strict' ]
 				],
 				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
 					' [[Bar::tincidunt semper]] facilisi {{volutpat}} Ut quis' .
@@ -375,7 +375,7 @@ class InternalParseBeforeLinksTest extends TestCase {
 				'title'    => $title,
 				'settings' => [
 					'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-					'smwgParserFeatures' => SMW_PARSER_STRICT
+					'smwgParserFeatures' => [ 'strict' ]
 				],
 				'text'  => '#REDIRECT [[Foo]]',
 				],
@@ -395,7 +395,7 @@ class InternalParseBeforeLinksTest extends TestCase {
 				'title'    => $title,
 				'settings' => [
 					'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-					'smwgParserFeatures' => SMW_PARSER_STRICT,
+					'smwgParserFeatures' => [ 'strict' ],
 					'smwgEnabledSpecialPage' => [ 'Ask', 'Foo' ]
 				],
 				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
@@ -418,7 +418,7 @@ class InternalParseBeforeLinksTest extends TestCase {
 				'title'    => $title,
 				'settings' => [
 					'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-					'smwgParserFeatures' => SMW_PARSER_STRICT,
+					'smwgParserFeatures' => [ 'strict' ],
 					'smwgEnabledSpecialPage' => [ 'Ask', 'Foo' ]
 				],
 				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .
@@ -441,7 +441,7 @@ class InternalParseBeforeLinksTest extends TestCase {
 				'title'    => $title,
 				'settings' => [
 					'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-					'smwgParserFeatures' => SMW_PARSER_STRICT,
+					'smwgParserFeatures' => [ 'strict' ],
 					'smwgEnabledSpecialPage' => []
 				],
 				'text'  => 'Lorem ipsum dolor sit &$% [[FooBar::dictumst|寒い]]' .

--- a/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -50,7 +50,7 @@ class OutputPageParserOutputTest extends TestCase {
 
 		$this->testEnvironment->withConfiguration(
 			[
-				'smwgShowFactbox'   => SMW_FACTBOX_NONEMPTY,
+				'smwgShowFactbox'   => 'nonempty',
 				'smwgMainCacheType' => 'hash'
 			]
 		);

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -334,8 +334,8 @@ class ParserAfterTidyTest extends TestCase {
 		$settings = [
 			'smwgMainCacheType'             => 'hash',
 			'smwgEnableUpdateJobs'      => false,
-			'smwgParserFeatures'        => SMW_PARSER_HID_CATS,
-			'smwgCategoryFeatures'      => SMW_CAT_REDIRECT | SMW_CAT_INSTANCE
+			'smwgParserFeatures'        => [ 'hidden-categories' ],
+			'smwgCategoryFeatures'      => [ 'redirect', 'instance' ]
 		];
 
 		$this->testEnvironment->withConfiguration( $settings );
@@ -404,8 +404,8 @@ class ParserAfterTidyTest extends TestCase {
 		$settings = [
 			'smwgMainCacheType' => 'hash',
 			'smwgEnableUpdateJobs' => false,
-			'smwgParserFeatures' => SMW_PARSER_HID_CATS,
-			'smwgCategoryFeatures' => SMW_CAT_REDIRECT | SMW_CAT_INSTANCE,
+			'smwgParserFeatures' => [ 'hidden-categories' ],
+			'smwgCategoryFeatures' => [ 'redirect', 'instance' ],
 		];
 		$this->testEnvironment->withConfiguration( $settings );
 
@@ -499,8 +499,8 @@ class ParserAfterTidyTest extends TestCase {
 		$this->testEnvironment->withConfiguration( [
 			'smwgMainCacheType' => 'hash',
 			'smwgEnableUpdateJobs' => false,
-			'smwgParserFeatures' => SMW_PARSER_HID_CATS,
-			'smwgCategoryFeatures' => SMW_CAT_REDIRECT | SMW_CAT_INSTANCE,
+			'smwgParserFeatures' => [ 'hidden-categories' ],
+			'smwgCategoryFeatures' => [ 'redirect', 'instance' ],
 		] );
 
 		$titleA = MediaWikiServices::getInstance()->getTitleFactory()
@@ -555,8 +555,8 @@ class ParserAfterTidyTest extends TestCase {
 		$this->testEnvironment->withConfiguration( [
 			'smwgMainCacheType' => 'hash',
 			'smwgEnableUpdateJobs' => false,
-			'smwgParserFeatures' => SMW_PARSER_HID_CATS,
-			'smwgCategoryFeatures' => SMW_CAT_REDIRECT | SMW_CAT_INSTANCE,
+			'smwgParserFeatures' => [ 'hidden-categories' ],
+			'smwgCategoryFeatures' => [ 'redirect', 'instance' ],
 		] );
 
 		$parserOptions = $this->getMockBuilder( ParserOptions::class )

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
@@ -26,7 +26,7 @@ class SpecialBrowseTest extends TestCase {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment( [
-			'smwgBrowseFeatures' => SMW_BROWSE_SHOW_INCOMING | SMW_BROWSE_USE_API
+			'smwgBrowseFeatures' => [ 'show-incoming', 'use-api' ]
 		] );
 
 		$store = $this->getMockBuilder( Store::class )

--- a/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
@@ -145,9 +145,14 @@ class InTextAnnotationParserTest extends TestCase {
 			new ParserOutput()
 		);
 
-		$this->linksProcessor->isStrictMode(
-			isset( $settings['smwgParserFeatures'] ) ? $settings['smwgParserFeatures'] : true
-		);
+		$this->testEnvironment->withConfiguration( $settings );
+
+		// Read post-normalization so downstream bitwise checks see the
+		// integer bitmask regardless of whether the data provider supplied
+		// the new array form or a legacy SMW_PARSER_* integer constant.
+		$parserFeatures = (int)ApplicationFactory::getInstance()->getSettings()->get( 'smwgParserFeatures' );
+
+		$this->linksProcessor->isStrictMode( $parserFeatures );
 
 		$instance = new InTextAnnotationParser(
 			$parserData,
@@ -160,16 +165,10 @@ class InTextAnnotationParserTest extends TestCase {
 			$this->hookDispatcher
 		);
 
-		$instance->showErrors(
-			isset( $settings['smwgParserFeatures'] ) ? $settings['smwgParserFeatures'] : true
-		);
+		$instance->showErrors( $parserFeatures );
 
 		$instance->isLinksInValues(
-			( ( $settings['smwgParserFeatures'] & SMW_PARSER_LINV ) == SMW_PARSER_LINV )
-		);
-
-		$this->testEnvironment->withConfiguration(
-			$settings
+			( $parserFeatures & SMW_PARSER_LINV ) === SMW_PARSER_LINV
 		);
 
 		$instance->parse( $text );
@@ -197,7 +196,7 @@ class InTextAnnotationParserTest extends TestCase {
 
 		$settings = [
 			'smwgNamespacesWithSemanticLinks' => [ $namespace => true ],
-			'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
+			'smwgParserFeatures' => [ 'inline-errors' ],
 		];
 
 		$this->testEnvironment->withConfiguration(
@@ -244,7 +243,7 @@ class InTextAnnotationParserTest extends TestCase {
 
 		$settings = [
 			'smwgNamespacesWithSemanticLinks' => [ $namespace => true ],
-			'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
+			'smwgParserFeatures' => [ 'inline-errors' ],
 		];
 
 		$this->testEnvironment->withConfiguration(
@@ -405,7 +404,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
+				'smwgParserFeatures' => [ 'inline-errors' ],
 			],
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
 			' [[FooBar::dictumst|寒い]] cursus. Nisl sit condimentum Quisque facilisis' .
@@ -427,7 +426,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_LINV,
+				'smwgParserFeatures' => [ 'inline-errors', 'links-in-values' ],
 			],
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
 			' [[FooBar::dictumst|寒い]] cursus. Nisl sit condimentum Quisque facilisis' .
@@ -451,7 +450,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
+				'smwgParserFeatures' => [ 'inline-errors' ],
 			],
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
 			' [[-FooBar::dictumst|重い]] cursus. Nisl sit condimentum Quisque facilisis' .
@@ -471,7 +470,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_NONE,
+				'smwgParserFeatures' => [],
 			],
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
 			' [[-FooBar::dictumst|軽い]] cursus. Nisl sit condimentum Quisque facilisis' .
@@ -494,7 +493,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_HELP,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_HELP => false ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
+				'smwgParserFeatures' => [ 'inline-errors' ],
 			],
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
 			' [[FooBar::dictumst|おもろい]] cursus. Nisl sit condimentum Quisque facilisis' .
@@ -516,7 +515,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_HELP,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_HELP => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
+				'smwgParserFeatures' => [ 'inline-errors' ],
 			],
 			'Lorem ipsum dolor sit &$% consectetuer auctor at quis' .
 			' Suspendisse tincidunt semper facilisi dolor Aenean.',
@@ -534,7 +533,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
+				'smwgParserFeatures' => [ 'inline-errors' ],
 			],
 			'[[Foo::?bar]], [[Foo::Baz?]], [[Quxey::B?am]]',
 			[
@@ -552,7 +551,7 @@ class InTextAnnotationParserTest extends TestCase {
 			SMW_NS_PROPERTY,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ SMW_NS_PROPERTY => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
+				'smwgParserFeatures' => [ 'inline-errors' ],
 			],
 			'[[has type::number]], [[has Type::page]] ',
 			[
@@ -569,7 +568,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
+				'smwgParserFeatures' => [ 'inline-errors' ],
 			],
 			'[[Foo::Bar::Foobar]], [[IPv6::fc00:123:8000::/64]] [[ABC::10.1002/::AID-MRM16::]]',
 			[
@@ -585,7 +584,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR,
+				'smwgParserFeatures' => [ 'inline-errors' ],
 			],
 			'[[Foo:::Foobar]] [[Bar:::ABC|DEF]] [[Foo:::0049 30 12345678/::Foo]] ',
 			[
@@ -601,7 +600,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_NONE
+				'smwgParserFeatures' => []
 			],
 			'[[Foo::Foobar::テスト]] [[Bar:::ABC|DEF]] [[Foo:::0049 30 12345678/::Foo]] ',
 			[
@@ -617,7 +616,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_NONE
+				'smwgParserFeatures' => [ 'inline-errors' ]
 			],
 			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[File:Example.png|Bar::Foobar|link=Foo]]',
 			[
@@ -631,7 +630,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT
+				'smwgParserFeatures' => [ 'inline-errors', 'strict' ]
 			],
 			'[[Foo|Bar::Foobar]] [[File:Example.png|alt=Bar::Foobar|Caption]] [[Foo::Foobar::テスト]] [[File:Example.png|Bar::Foobar|link=Foo]]',
 			[
@@ -647,7 +646,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT
+				'smwgParserFeatures' => [ 'inline-errors', 'strict' ]
 			],
 			'[[Foo::@@@]] [[Bar::@@@en|Foobar]]',
 			[
@@ -661,7 +660,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT
+				'smwgParserFeatures' => [ 'inline-errors', 'strict' ]
 			],
 			'[[Foo::@@@|#]] [[Bar::@@@en|#]]',
 			[
@@ -675,7 +674,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT | SMW_PARSER_LINV
+				'smwgParserFeatures' => [ 'inline-errors', 'strict', 'links-in-values' ]
 			],
 			'[[Text::Bar [http://example.org/Foo Foo]]] [[Code::Foo[1] Foobar]]',
 			[
@@ -691,7 +690,7 @@ class InTextAnnotationParserTest extends TestCase {
 			NS_MAIN,
 			[
 				'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
-				'smwgParserFeatures' => SMW_PARSER_INL_ERROR | SMW_PARSER_STRICT | SMW_PARSER_LINV
+				'smwgParserFeatures' => [ 'inline-errors', 'strict', 'links-in-values' ]
 			],
 			'<sup id="cite_ref-1" class="reference">[[#cite_note-1|&#91;1&#93;]]</sup>',
 			[

--- a/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
@@ -42,7 +42,7 @@ class AskParserFunctionTest extends TestCase {
 		$this->testEnvironment = new TestEnvironment();
 		$this->semanticDataValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
 
-		$this->testEnvironment->addConfiguration( 'smwgQueryProfiler', true );
+		$this->testEnvironment->addConfiguration( 'smwgQueryProfiler', [] );
 		$this->testEnvironment->addConfiguration( 'smwgQMaxLimit', 1000 );
 
 		$this->messageFormatter = $this->getMockBuilder( MessageFormatter::class )
@@ -375,7 +375,7 @@ class AskParserFunctionTest extends TestCase {
 			'propertyCount'  => 0
 		];
 
-		$this->testEnvironment->addConfiguration( 'smwgQueryProfiler', true );
+		$this->testEnvironment->addConfiguration( 'smwgQueryProfiler', [] );
 
 		$parserData = ApplicationFactory::getInstance()->newParserData(
 			MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __METHOD__, NS_SPECIAL ),
@@ -450,7 +450,7 @@ class AskParserFunctionTest extends TestCase {
 				'propertyValues' => [ 'list', 1, 1, '[[Modification date::+]]' ]
 			],
 			[
-				'smwgQueryProfiler' => true
+				'smwgQueryProfiler' => []
 			]
 		];
 
@@ -474,7 +474,7 @@ class AskParserFunctionTest extends TestCase {
 			],
 			[
 				'smwgCreateProtectionRight' => false,
-				'smwgQueryProfiler' => true
+				'smwgQueryProfiler' => []
 			]
 		];
 
@@ -497,7 +497,7 @@ class AskParserFunctionTest extends TestCase {
 				'propertyValues' => [ 'list', 2, 1, "[[Modification date::+]] [[$categoryNS:Foo]]" ]
 			],
 			[
-				'smwgQueryProfiler' => true
+				'smwgQueryProfiler' => []
 			]
 		];
 
@@ -520,7 +520,7 @@ class AskParserFunctionTest extends TestCase {
 				'propertyValues' => [ 'feed', 1, 0, "[[:$fileNS:Fooo]]" ]
 			],
 			[
-				'smwgQueryProfiler' => true
+				'smwgQueryProfiler' => []
 			]
 		];
 
@@ -543,7 +543,7 @@ class AskParserFunctionTest extends TestCase {
 				'propertyValues' => [ 'table', 2, 1, "[[Modification date::+]] [[$categoryNS:Foo]]" ]
 			],
 			[
-				'smwgQueryProfiler' => true
+				'smwgQueryProfiler' => []
 			]
 		];
 
@@ -570,7 +570,7 @@ class AskParserFunctionTest extends TestCase {
 				'propertyValues' => [ 'list', 1, 1, '[[Modification date::+]]', '{"limit":50,"offset":0,"sort":[""],"order":["asc"],"mode":1}' ]
 			],
 			[
-				'smwgQueryProfiler' => SMW_QPRFL_PARAMS
+				'smwgQueryProfiler' => [ 'parameters' ]
 			]
 		];
 

--- a/tests/phpunit/Unit/ParserFunctions/ShowParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/ShowParserFunctionTest.php
@@ -40,7 +40,7 @@ class ShowParserFunctionTest extends TestCase {
 		$this->testEnvironment = new TestEnvironment();
 		$this->semanticDataValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
 
-		$this->testEnvironment->addConfiguration( 'smwgQueryProfiler', true );
+		$this->testEnvironment->addConfiguration( 'smwgQueryProfiler', [] );
 		$this->testEnvironment->addConfiguration( 'smwgQueryResultCacheType', false );
 		$this->testEnvironment->addConfiguration( 'smwgQFilterDuplicates', false );
 

--- a/tests/phpunit/Unit/SettingsTest.php
+++ b/tests/phpunit/Unit/SettingsTest.php
@@ -8,6 +8,7 @@ use SMW\Exception\SettingsAlreadyLoadedException;
 use SMW\Listener\ChangeListener\ChangeListener;
 use SMW\MediaWiki\HookDispatcher;
 use SMW\Settings;
+use SMW\Tests\Utils\SilenceUserDeprecationTrait;
 
 /**
  * @covers \SMW\Settings
@@ -20,6 +21,8 @@ use SMW\Settings;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class SettingsTest extends TestCase {
+
+	use SilenceUserDeprecationTrait;
 
 	private $hookDispatcher;
 
@@ -188,7 +191,11 @@ class SettingsTest extends TestCase {
 
 			$instance = new Settings();
 			$instance->setHookDispatcher( $this->hookDispatcher );
-			$instance->loadFromGlobals();
+			// Legacy-form rows in the provider deliberately trip the
+			// LegacyConstantNormalizer deprecation; swallow the PHP-level
+			// user-deprecation so CI stderr stays clean. The deprecation
+			// emission itself is covered in LegacyConstantNormalizerTest.
+			$this->withSilencedUserDeprecation( static fn () => $instance->loadFromGlobals() );
 
 			$this->assertSame( $expected, $instance->get( $key ) );
 		} finally {
@@ -238,7 +245,7 @@ class SettingsTest extends TestCase {
 
 			$instance = new Settings();
 			$instance->setHookDispatcher( $this->hookDispatcher );
-			$instance->loadFromGlobals();
+			$this->withSilencedUserDeprecation( static fn () => $instance->loadFromGlobals() );
 
 			$this->assertSame( $expected, $instance->get( $key ) );
 		} finally {
@@ -280,7 +287,7 @@ class SettingsTest extends TestCase {
 
 			$instance = new Settings();
 			$instance->setHookDispatcher( $this->hookDispatcher );
-			$instance->loadFromGlobals();
+			$this->withSilencedUserDeprecation( static fn () => $instance->loadFromGlobals() );
 
 			$this->assertSame( SMW_FACTBOX_NONEMPTY, $instance->get( 'smwgShowFactbox' ) );
 			$this->assertTrue( $instance->isFlagSet( 'smwgFactboxFeatures', SMW_FACTBOX_CACHE ) );

--- a/tests/phpunit/Unit/Setup/LegacyConstantNormalizerTest.php
+++ b/tests/phpunit/Unit/Setup/LegacyConstantNormalizerTest.php
@@ -17,6 +17,29 @@ class LegacyConstantNormalizerTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		LegacyConstantNormalizer::resetDeprecationState();
+		// Many tests in this class deliberately invoke normalize() with
+		// legacy SMW_* integer constants and verify deprecation via
+		// wasDeprecationEmitted(). Suppress the PHP-level user-deprecation
+		// output so CI stderr stays clean; the behavioural assertion is
+		// unaffected because wasDeprecationEmitted() reads our own static
+		// flag, not the error handler.
+		//
+		// Trade-off: the suppression applies to every test in this class,
+		// including ones that don't exercise the deprecation path — so if a
+		// future code change accidentally emits E_USER_DEPRECATED from a
+		// non-legacy code path in LegacyConstantNormalizer, it would be
+		// silently swallowed here. Catching that would require either
+		// per-method wrapping (~20 sites) or moving the deprecation-emitting
+		// tests to their own subclass. Accepted as-is for now.
+		set_error_handler(
+			static fn ( int $severity ) => $severity === E_USER_DEPRECATED,
+			E_USER_DEPRECATED
+		);
+	}
+
+	protected function tearDown(): void {
+		restore_error_handler();
+		parent::tearDown();
 	}
 
 	public function testEnum_allKnownStrings_mapToTheirConstants() {
@@ -352,6 +375,44 @@ class LegacyConstantNormalizerTest extends TestCase {
 		LegacyConstantNormalizer::normalize( 'smwgFactboxFeatures', SMW_FACTBOX_CACHE );
 		$this->assertTrue( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgShowFactbox' ) );
 		$this->assertTrue( LegacyConstantNormalizer::wasDeprecationEmitted( 'smwgFactboxFeatures' ) );
+	}
+
+	public function testGetStringFormForConstant_enumKey_returnsKebab() {
+		$this->assertSame(
+			'nonempty',
+			LegacyConstantNormalizer::getStringFormForConstant( 'smwgShowFactbox', SMW_FACTBOX_NONEMPTY )
+		);
+		$this->assertSame(
+			'all',
+			LegacyConstantNormalizer::getStringFormForConstant( 'smwgQConceptCaching', CONCEPT_CACHE_ALL )
+		);
+	}
+
+	public function testGetStringFormForConstant_flagKey_returnsKebab() {
+		$this->assertSame(
+			'strict',
+			LegacyConstantNormalizer::getStringFormForConstant( 'smwgParserFeatures', SMW_PARSER_STRICT )
+		);
+		$this->assertSame(
+			'links-in-values',
+			LegacyConstantNormalizer::getStringFormForConstant( 'smwgParserFeatures', SMW_PARSER_LINV )
+		);
+	}
+
+	public function testGetStringFormForConstant_unknownKey_returnsNull() {
+		$this->assertNull(
+			LegacyConstantNormalizer::getStringFormForConstant( 'smwgSomeUnregisteredSetting', 42 )
+		);
+	}
+
+	public function testGetStringFormForConstant_unmappedIntForKnownKey_returnsNull() {
+		// smwgParserFeatures' map doesn't include `SMW_FACTBOX_HIDDEN` (a value
+		// from a different setting's map). Reverse-lookup must stay scoped to
+		// the supplied key and return null rather than a stray kebab name
+		// drawn from another setting that happens to share the integer.
+		$this->assertNull(
+			LegacyConstantNormalizer::getStringFormForConstant( 'smwgParserFeatures', 99999 )
+		);
 	}
 
 }

--- a/tests/phpunit/Utils/JSONScript/JsonTestCaseFileHandler.php
+++ b/tests/phpunit/Utils/JSONScript/JsonTestCaseFileHandler.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Utils\JSONScript;
 
 use Exception;
 use RuntimeException;
+use SMW\Setup\LegacyConstantNormalizer;
 use SMW\Tests\Utils\File\JsonFileReader;
 
 /**
@@ -333,7 +334,13 @@ class JsonTestCaseFileHandler {
 			return $smwgNamespacesWithSemanticLinks;
 		}
 
-		$constantFeaturesList = [
+		// Flag-bitmask settings. Test cases write values in the new
+		// kebab-string array form (e.g. `[ "strict", "inline-errors" ]`);
+		// older fixtures from external extensions may still use the
+		// legacy `SMW_*` constant names, which we transparently upgrade
+		// so the value reaches Settings::set() in the new form and never
+		// trips LegacyConstantNormalizer's deprecation path.
+		$flagSettings = [
 			'smwgSparqlQFeatures',
 			'smwgDVFeatures',
 			'smwgFulltextSearchIndexableDataTypes',
@@ -342,32 +349,22 @@ class JsonTestCaseFileHandler {
 			'smwgParserFeatures',
 			'smwgCategoryFeatures',
 			'smwgQSortFeatures',
-			'smwgQEqualitySupport'
 		];
 
-		foreach ( $constantFeaturesList as $constantFeatures ) {
-			if ( $key === $constantFeatures && isset( $settings[$key] ) ) {
-				$features = '';
+		if ( in_array( $key, $flagSettings, true ) && isset( $settings[$key] ) ) {
+			return $this->normalizeFlagSettingValue( $key, $settings[$key] );
+		}
 
-				if ( !is_array( $settings[$key] ) ) {
-					return $settings[$key];
-				}
-
-				foreach ( $settings[$key] as $value ) {
-					$features = constant( $value ) | (int)$features;
-				}
-
-				return $features;
-			}
+		if ( $key === 'smwgQEqualitySupport' && isset( $settings[$key] ) ) {
+			return $this->normalizeEnumSettingValue( $key, $settings[$key] );
 		}
 
 		if ( $key === 'wgDefaultUserOptions' && isset( $settings[$key] ) ) {
 			return array_merge( $GLOBALS['wgDefaultUserOptions'], $settings[$key] );
 		}
 
-		// Needs special attention due to constant usage
 		if ( $key === 'smwgQConceptCaching' && isset( $settings[$key] ) ) {
-			return constant( $settings[$key] );
+			return $this->normalizeEnumSettingValue( $key, $settings[$key] );
 		}
 
 		// Needs special attention due to constant usage
@@ -386,6 +383,46 @@ class JsonTestCaseFileHandler {
 
 		// Key is unknown, TestConfig will remove any remains during tearDown
 		return null;
+	}
+
+	/**
+	 * Coerce a flag-bitmask setting value into the new kebab-string array
+	 * form. Pass-through for arrays of kebab strings; for arrays containing
+	 * legacy `SMW_*` constant names (still used by some external-extension
+	 * JSONScript fixtures), reverse-translate each defined constant via
+	 * {@see LegacyConstantNormalizer::getStringFormForConstant()} so the
+	 * resulting value never reaches the deprecation path in Settings::set().
+	 */
+	private function normalizeFlagSettingValue( string $key, mixed $value ) {
+		if ( !is_array( $value ) ) {
+			return $value;
+		}
+		$out = [];
+		foreach ( $value as $element ) {
+			$out[] = $this->resolveLegacyConstantName( $key, $element );
+		}
+		return $out;
+	}
+
+	/**
+	 * Coerce an enum setting value into the new string form. Pass-through
+	 * for already-kebab strings; reverse-translate legacy `SMW_*` /
+	 * `CONCEPT_CACHE_*` constant names via
+	 * {@see LegacyConstantNormalizer::getStringFormForConstant()}.
+	 */
+	private function normalizeEnumSettingValue( string $key, mixed $value ) {
+		return $this->resolveLegacyConstantName( $key, $value );
+	}
+
+	private function resolveLegacyConstantName( string $key, mixed $value ) {
+		if ( !is_string( $value ) || !defined( $value ) ) {
+			return $value;
+		}
+		$resolved = constant( $value );
+		if ( !is_int( $resolved ) ) {
+			return $value;
+		}
+		return LegacyConstantNormalizer::getStringFormForConstant( $key, $resolved ) ?? $value;
 	}
 
 	/**

--- a/tests/phpunit/Utils/SilenceUserDeprecationTrait.php
+++ b/tests/phpunit/Utils/SilenceUserDeprecationTrait.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace SMW\Tests\Utils;
+
+/**
+ * Runs a callable with `E_USER_DEPRECATED` swallowed at the PHP error
+ * handler level. Used by unit tests that deliberately exercise SMW's
+ * legacy integer-constant config form (e.g. via
+ * {@see \SMW\Setup\LegacyConstantNormalizer}) so the resulting
+ * `wfDeprecatedMsg()` call does not leak into CI stderr while the test's
+ * own behavioural assertions still cover the deprecation contract.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+trait SilenceUserDeprecationTrait {
+
+	protected function withSilencedUserDeprecation( callable $fn ) {
+		$previous = set_error_handler(
+			static fn ( int $severity ) => $severity === E_USER_DEPRECATED,
+			E_USER_DEPRECATED
+		);
+		try {
+			return $fn();
+		} finally {
+			restore_error_handler();
+		}
+	}
+}


### PR DESCRIPTION
## Summary

PR #6586 routed `Settings::set()` through `LegacyConstantNormalizer::normalize()`, which emits `wfDeprecatedMsg` whenever a setting is set with a legacy `SMW_*` / `CONCEPT_CACHE_*` integer constant or the `true` sentinel for `smwgQueryProfiler`. The test suite and JSONScript fixtures still used the legacy form, producing roughly one PHP `Deprecated:` line per affected setting per PHPUnit process in CI (see https://github.com/SemanticMediaWiki/SemanticMediaWiki/actions/runs/25894169646 for the log spam).

This cleanup is test-only with one additive helper on `LegacyConstantNormalizer`. After this change `composer phpunit:unit` emits zero SMW deprecation lines.

## Changes

* **Add `LegacyConstantNormalizer::getStringFormForConstant()`** — a per-key reverse lookup over the existing `ENUM_MAP` / `FLAG_MAP`. Lets the JSONScript test handler upgrade legacy constant names from external-extension fixtures to the new kebab string form transparently.
* **Add `SilenceUserDeprecationTrait`** and use it in `SettingsTest`'s three legacy-form `loadFromGlobals()` tests. Install a class-wide `E_USER_DEPRECATED` filter in `LegacyConstantNormalizerTest::setUp/tearDown` for the ~20 deprecation-emitting tests there. Both still verify the deprecation contract via `wasDeprecationEmitted()`, which reads SMW's own static flag rather than the PHP error handler.
* **Rewrite `JsonTestCaseFileHandler::getSettingsFor()`** for the registered flag/enum settings: pass new kebab-form values through unchanged; for legacy `SMW_*` names (still produced by some external-extension fixtures), reverse-translate via the new helper so the value reaches `Settings::set()` already normalized and never hits the deprecation path. The `smwgNamespacesWithSemanticLinks` and `*CacheType` `constant()` branches are preserved as-is since those don't route through `LegacyConstantNormalizer`.
* **Migrate 48 JSONScript test-case JSON files** under `tests/phpunit/Integration/JSONScript/TestCases/` whose `settings` blocks referenced `SMW_*` / `CONCEPT_CACHE_*` constant names to the new kebab strings. Namespace constants (`SMW_NS_PROPERTY` etc.) and `*CacheType` constant names left untouched.
* **Convert incidental call sites** that passed legacy values to `addConfiguration` / `withConfiguration` / `new TestEnvironment([...])`: `JSONScriptServicesTestCaseRunner` line 80 (the line introduced in #6586), `InTextAnnotationParserTemplateTransclusionTest`, `InTextAnnotationParserTest`, `InternalParseBeforeLinksTest`, `EncodingIntegrationTest`, `FactboxTest`, `FactboxMagicWordsTest`, `CachedFactboxTest`, `ArticlePurgeTest`, `OutputPageParserOutputTest`, `ParserAfterTidyTest`, `SpecialBrowseTest`, `AskParserFunctionTest`, `ShowParserFunctionTest`. Where downstream code consumes the post-normalization integer (e.g. `setShowFactbox(int)` or `& SMW_PARSER_LINV` bitwise checks), the new pattern reads it back via `Settings::get($key)` after `withConfiguration()` so the test works with either form.

## Test plan

- [x] `composer analyze` (lint + PHPCS) is clean.
- [x] `composer phpunit:unit` passes (7027 tests, 14417 assertions, 6 unrelated skips) with zero SMW `Deprecated:` lines in stderr. Only the unrelated MW core `$wgHooks` deprecation remains.
- [x] 51 migrated JSONScript test-case files run cleanly together (1478 assertions, no `Deprecated:` output).
- [x] CI: confirm `actions/runs/...` for this branch shows the previous deprecation block is gone.

Refs #6586