### PR TITLE
Fix $smwgSetParserCacheKeys so disabled keys are dropped

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -302,6 +302,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Improved wording of the post-edit reload notice ([#6301](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6301))
 * Fixed maintenance log entries showing "performed unknown action" instead of a proper message, and improved log comment formatting from raw JSON to human-readable text ([#6146](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6146), [#6554](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6554))
 * Fixed `update.php` failing with "Data too long for column 'smw_hash'" on wikis with more than 200,000 entities. The pre-upgrade hex-to-binary conversion now always runs as a single server-side `UPDATE`, regardless of row count. Setting `$smwgIgnoreUpgradeKeyCheck = true` now also lets maintenance scripts run when the schema is in an intermediate state, providing a documented escape hatch for stalled upgrades. ([#6715](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6715))
+* Removing `userlang` or `dateformat` from `$smwgSetParserCacheKeys` now correctly stops SMW from adding that key to the parser cache key. Previously a removed key was still added through a different mechanism.
 
 ### Enhancements
 

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -177,14 +177,26 @@ class ParserData {
 	/**
 	 * @since 3.0
 	 */
-	public function addExtraParserKey( $key ): void {
-		$keysToCache = ApplicationFactory::getInstance()->getSettings()->get( 'smwgSetParserCacheKeys' ) ?? [];
+	public function addExtraParserKey( string $key ): void {
+		// Preference keys fragment the parser cache by a user preference and are
+		// opt-in via $smwgSetParserCacheKeys. Every other key (functional markers
+		// such as `localTime` and `smwq`, or keys added by other extensions) is
+		// always applied.
+		$configurableKeys = [ 'userlang', 'dateformat' ];
 
-		if ( in_array( $key, $keysToCache ) ) {
-			// Looks odd in 1.30 "Saved in parser cache ... idhash:19989-0!canonical!userlang!dateformat!userlang!dateformat!userlang!dateformat!userlang!dateformat and ..."
-			// therefore use the ParserOutput::recordOption instead
-			$this->parserOutput->recordOption( $key );
-		} elseif ( $this->parserOptions !== null ) {
+		if ( in_array( $key, $configurableKeys, true ) ) {
+			$keysToCache = ApplicationFactory::getInstance()->getSettings()->get( 'smwgSetParserCacheKeys' ) ?? [];
+
+			if ( in_array( $key, $keysToCache, true ) ) {
+				// recordOption() marks the option as cache-relevant so MediaWiki
+				// hashes its actual value into the parser cache key.
+				$this->parserOutput->recordOption( $key );
+			}
+
+			return;
+		}
+
+		if ( $this->parserOptions !== null ) {
 			$this->parserOptions->addExtraKey( $key );
 		}
 	}

--- a/tests/phpunit/Integration/ParserDataIntegrationTest.php
+++ b/tests/phpunit/Integration/ParserDataIntegrationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace SMW\Tests\Integration;
+
+use MediaWiki\Parser\ParserOptions;
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Title\Title;
+use SMW\ParserData;
+use SMW\Tests\SMWIntegrationTestCase;
+
+/**
+ * @covers \SMW\ParserData
+ * @group semantic-mediawiki
+ * @group Database
+ * @group medium
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ *
+ * @author mwjames
+ */
+class ParserDataIntegrationTest extends SMWIntegrationTestCase {
+
+	/**
+	 * Exercises real ParserOutput/ParserOptions instead of mocks to confirm
+	 * that `$smwgSetParserCacheKeys` governs the actual parser cache key: a
+	 * disabled key must leave the cache key untouched.
+	 */
+	public function testAddExtraParserKeyParserCacheEffectFollowsConfiguration() {
+		$title = Title::newFromText( __FUNCTION__ );
+
+		// Enabled: the key is recorded as a used parser option, which is what
+		// makes MediaWiki vary the parser cache by the option value.
+		$this->testEnvironment->withConfiguration( [ 'smwgSetParserCacheKeys' => [ 'userlang' ] ] );
+
+		$enabledOutput = new ParserOutput();
+		$enabled = new ParserData( $title, $enabledOutput );
+		$enabled->setParserOptions( ParserOptions::newFromAnon() );
+		$enabled->addExtraParserKey( 'userlang' );
+
+		$this->assertContains( 'userlang', $enabledOutput->getUsedOptions() );
+
+		// Disabled: the key must neither be recorded as a used option nor leak
+		// into the cache key through ParserOptions::addExtraKey().
+		$this->testEnvironment->withConfiguration( [ 'smwgSetParserCacheKeys' => [] ] );
+
+		$disabledOutput = new ParserOutput();
+		$disabledOptions = ParserOptions::newFromAnon();
+		$disabled = new ParserData( $title, $disabledOutput );
+		$disabled->setParserOptions( $disabledOptions );
+
+		$hashBefore = $disabledOptions->optionsHash( $disabledOutput->getUsedOptions(), $title );
+		$disabled->addExtraParserKey( 'userlang' );
+
+		$this->assertNotContains( 'userlang', $disabledOutput->getUsedOptions() );
+		$this->assertSame(
+			$hashBefore,
+			$disabledOptions->optionsHash( $disabledOutput->getUsedOptions(), $title )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/ParserDataTest.php
+++ b/tests/phpunit/Unit/ParserDataTest.php
@@ -480,4 +480,83 @@ class ParserDataTest extends TestCase {
 		$instance->addExtraParserKey( 'userlang' );
 	}
 
+	public function testAddExtraParserKeyForDisabledPreferenceKeyDoesNothing() {
+		$this->testEnvironment->withConfiguration( [ 'smwgSetParserCacheKeys' => [] ] );
+
+		$parserOptions = $this->getMockBuilder( ParserOptions::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOptions->expects( $this->never() )
+			->method( 'addExtraKey' );
+
+		$title = $this->getMockBuilder( Title::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput = $this->getMockBuilder( ParserOutput::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput->expects( $this->never() )
+			->method( 'recordOption' );
+
+		$instance = new ParserData( $title, $parserOutput );
+		$instance->setParserOptions( $parserOptions );
+		$instance->addExtraParserKey( 'userlang' );
+	}
+
+	public function testAddExtraParserKeyForFunctionalKeyIgnoresConfiguration() {
+		$this->testEnvironment->withConfiguration( [ 'smwgSetParserCacheKeys' => [] ] );
+
+		$parserOptions = $this->getMockBuilder( ParserOptions::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOptions->expects( $this->once() )
+			->method( 'addExtraKey' )
+			->with( 'smwq' );
+
+		$title = $this->getMockBuilder( Title::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput = $this->getMockBuilder( ParserOutput::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput->expects( $this->never() )
+			->method( 'recordOption' );
+
+		$instance = new ParserData( $title, $parserOutput );
+		$instance->setParserOptions( $parserOptions );
+		$instance->addExtraParserKey( 'smwq' );
+	}
+
+	public function testAddExtraParserKeyForDisabledDateformatDoesNothing() {
+		$this->testEnvironment->withConfiguration( [ 'smwgSetParserCacheKeys' => [] ] );
+
+		$parserOptions = $this->getMockBuilder( ParserOptions::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOptions->expects( $this->never() )
+			->method( 'addExtraKey' );
+
+		$title = $this->getMockBuilder( Title::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput = $this->getMockBuilder( ParserOutput::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserOutput->expects( $this->never() )
+			->method( 'recordOption' );
+
+		$instance = new ParserData( $title, $parserOutput );
+		$instance->setParserOptions( $parserOptions );
+		$instance->addExtraParserKey( 'dateformat' );
+	}
+
 }


### PR DESCRIPTION
## Problem

`$smwgSetParserCacheKeys` (config `SetParserCacheKeys`, default `["userlang", "dateformat"]`) is documented as the list of keys SMW adds to the MediaWiki parser cache key. Setting it to an empty array is expected to stop SMW from adding `userlang` and `dateformat`.

It did not. `ParserData::addExtraParserKey()` chose the *mechanism* from whether the key was in the config: a key absent from the config fell into an `elseif` branch and was still added via `ParserOptions::addExtraKey()`. So the config did not behave as documented; a removed key still landed in the parser cache key as a literal `!userlang` suffix.

## Fix

`addExtraParserKey()` now decides the mechanism by what the key is, not by whether it is configured:

- `userlang` and `dateformat` are preference keys, gated by `$smwgSetParserCacheKeys`. When present, the key is recorded via `ParserOutput::recordOption()`; when absent, nothing is added.
- Every other key (the functional markers `localTime` and `smwq`, plus any key added by other extensions) keeps the `ParserOptions::addExtraKey()` path, regardless of the config.

The default config still contains `userlang`/`dateformat`, so a default install behaves exactly as before. Only an admin who removes a key from the config sees a change, and now it is the documented one.

## Tests

- `ParserDataTest` (unit) covers the dispatch for each key class: a disabled preference key adds nothing, a functional key is applied regardless of config.
- `ParserDataIntegrationTest` (new) exercises a real `ParserOutput`/`ParserOptions` and asserts the actual `ParserOptions::optionsHash()`. With the config empty, `addExtraParserKey('userlang')` leaves the cache key untouched (`canonical!en`); under the previous behaviour the same call leaked the key in as `canonical!en!userlang`.
