### PR TITLE
Reduce parser cache fragmentation from #ask queries

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -314,6 +314,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
   * Set `$smwgQUseLegacyQuery = true` in `LocalSettings.php` to fall back to the previous query shape if you encounter a regression after upgrading.
   * A redundant `DISTINCT` keyword was also dropped from the disjunction-query temp-table insert. Same result, less work for the database; no setting required.
 * On wikis with many distinct entities per page, SMW's internal caches could fill up during a single render and force repeated database lookups for the same pages. Cache sizes are now adjustable via the new `$smwgEntityCacheSizes` setting. Per-pool hit and miss counts are also emitted to MediaWiki's `StatsFactory` service, so wikis already configured to collect MediaWiki metrics (`$wgStatsTarget` and `$wgStatsFormat`) can see cache effectiveness in their existing dashboards and size caches based on real traffic instead of guessing.
+* `#ask` queries no longer fragment the parser cache by the user's date format preference. SMW formats dates by language, not by that preference, so the fragmentation produced no benefit. `dateformat` has been removed from the `$smwgSetParserCacheKeys` default, which now contains only `userlang`.
 
 ### Internal improvements
 

--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -315,6 +315,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
   * A redundant `DISTINCT` keyword was also dropped from the disjunction-query temp-table insert. Same result, less work for the database; no setting required.
 * On wikis with many distinct entities per page, SMW's internal caches could fill up during a single render and force repeated database lookups for the same pages. Cache sizes are now adjustable via the new `$smwgEntityCacheSizes` setting. Per-pool hit and miss counts are also emitted to MediaWiki's `StatsFactory` service, so wikis already configured to collect MediaWiki metrics (`$wgStatsTarget` and `$wgStatsFormat`) can see cache effectiveness in their existing dashboards and size caches based on real traffic instead of guessing.
 * `#ask` queries no longer fragment the parser cache by the user's date format preference. SMW formats dates by language, not by that preference, so the fragmentation produced no benefit. `dateformat` has been removed from the `$smwgSetParserCacheKeys` default, which now contains only `userlang`.
+* `#ask` queries whose result format produces language-neutral output (`json`, `rdf`, `count`, `debug`) no longer fragment the parser cache by `userlang`, unless the query produces errors (error messages are localised). Presentation formats such as `table` and `list`, whose output includes localised text, continue to fragment by `userlang` as before. Result printers can declare their own behaviour by overriding `ResultPrinter::dependsOnUserLanguage()`.
 
 ### Internal improvements
 

--- a/extension.json
+++ b/extension.json
@@ -1290,7 +1290,7 @@
 			"path": true
 		},
 		"SetParserCacheKeys": {
-			"value": ["userlang", "dateformat"],
+			"value": ["userlang"],
 			"description": "Session keys added to the parser cache key, each causing additional cache fragmentation.",
 			"merge_strategy": "provide_default"
 		},

--- a/src/ParserFunctions/AskParserFunction.php
+++ b/src/ParserFunctions/AskParserFunction.php
@@ -177,9 +177,6 @@ class AskParserFunction {
 		// 'userlang' will trigger a cache fragmentation by user language
 		$this->parserData->addExtraParserKey( 'userlang' );
 
-		// 'dateformat'  will trigger a cache fragmentation by date preference
-		$this->parserData->addExtraParserKey( 'dateformat' );
-
 		return $result;
 	}
 

--- a/src/ParserFunctions/AskParserFunction.php
+++ b/src/ParserFunctions/AskParserFunction.php
@@ -64,6 +64,10 @@ class AskParserFunction {
 	 */
 	private array $params;
 
+	// Whether the query output depends on the interface language; set once the
+	// query has executed, in doFetchResultsFromFunctionParameters().
+	private bool $variesByUserLanguage = true;
+
 	/**
 	 * @since 1.9
 	 */
@@ -174,8 +178,12 @@ class AskParserFunction {
 
 		$this->parserData->copyToParserOutput();
 
-		// 'userlang' will trigger a cache fragmentation by user language
-		$this->parserData->addExtraParserKey( 'userlang' );
+		// `userlang` fragments the parser cache by interface language; add it
+		// only when the query output depends on that language (decided in
+		// doFetchResultsFromFunctionParameters).
+		if ( $this->variesByUserLanguage ) {
+			$this->parserData->addExtraParserKey( 'userlang' );
+		}
 
 		return $result;
 	}
@@ -249,6 +257,10 @@ class AskParserFunction {
 		$contextPage = $this->parserData->getSubject();
 		$action = $this->parserData->getOption( 'request.action' );
 		$status = [];
+
+		// Reset to the cache-safe default; the real value is set below once the
+		// query has executed. Early returns keep `userlang` recorded.
+		$this->variesByUserLanguage = true;
 
 		if ( $extraKeys[self::NO_TRACE] === true ) {
 			$contextPage = null;
@@ -330,6 +342,12 @@ class AskParserFunction {
 			SMW_OUTPUT_WIKI,
 			$context
 		);
+
+		// `userlang` is only needed in the parser cache key when the output
+		// actually depends on the interface language: either the result format
+		// renders localised text, or the query produced (localised) errors.
+		$this->variesByUserLanguage = $query->getOption( 'result.depends_on_userlang' ) !== false
+			|| $query->getErrors() !== [];
 
 		if ( $this->postProcHandler !== null && $this->context !== QueryProcessor::DEFERRED_QUERY ) {
 			$this->postProcHandler->addCheck( $query );

--- a/src/Query/QueryProcessor.php
+++ b/src/Query/QueryProcessor.php
@@ -11,6 +11,7 @@ use SMW\Query\Exception\ResultFormatNotFoundException;
 use SMW\Query\Processor\DefaultParamDefinition;
 use SMW\Query\Processor\ParamListProcessor;
 use SMW\Query\ResultPrinters\NullResultPrinter;
+use SMW\Query\ResultPrinters\ResultPrinter as ResultPrinterBase;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
@@ -310,7 +311,20 @@ class QueryProcessor implements QueryContext {
 			$context
 		);
 
+		// Record whether the result format's output varies with the interface
+		// language, so AskParserFunction can decide whether the `userlang`
+		// parser cache key is needed. dependsOnUserLanguage() lives on the
+		// abstract ResultPrinter base class, not the interface; a printer that
+		// does not extend the base defaults to the cache-safe `true`.
+		$query->setOption(
+			'result.depends_on_userlang',
+			$printer instanceof ResultPrinterBase ? $printer->dependsOnUserLanguage() : true
+		);
+
 		if ( $printer instanceof ResultPrinterDependency && $printer->hasMissingDependency() ) {
+			// The dependency error is localised, so it must vary by `userlang`
+			// regardless of what the printer reports for its normal output.
+			$query->setOption( 'result.depends_on_userlang', true );
 			return $printer->getDependencyError();
 		}
 

--- a/src/Query/ResultPrinters/JsonResultPrinter.php
+++ b/src/Query/ResultPrinters/JsonResultPrinter.php
@@ -30,6 +30,15 @@ class JsonResultPrinter extends FileExportPrinter {
 	}
 
 	/**
+	 * @see ResultPrinter::dependsOnUserLanguage
+	 *
+	 * {@inheritDoc}
+	 */
+	public function dependsOnUserLanguage(): bool {
+		return false;
+	}
+
+	/**
 	 * @see FileExportPrinter::getMimeType
 	 *
 	 * @since 1.8

--- a/src/Query/ResultPrinters/NullResultPrinter.php
+++ b/src/Query/ResultPrinters/NullResultPrinter.php
@@ -22,6 +22,15 @@ class NullResultPrinter extends ResultPrinter {
 	}
 
 	/**
+	 * @see ResultPrinter::dependsOnUserLanguage
+	 *
+	 * {@inheritDoc}
+	 */
+	public function dependsOnUserLanguage(): bool {
+		return false;
+	}
+
+	/**
 	 * @see ResultPrinter::getResultText
 	 *
 	 * {@inheritDoc}

--- a/src/Query/ResultPrinters/RdfResultPrinter.php
+++ b/src/Query/ResultPrinters/RdfResultPrinter.php
@@ -29,6 +29,15 @@ class RdfResultPrinter extends FileExportPrinter {
 	}
 
 	/**
+	 * @see ResultPrinter::dependsOnUserLanguage
+	 *
+	 * {@inheritDoc}
+	 */
+	public function dependsOnUserLanguage(): bool {
+		return false;
+	}
+
+	/**
 	 * @see FileExportPrinter::getMimeType
 	 *
 	 * @since 1.8

--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -698,6 +698,19 @@ abstract class ResultPrinter implements IResultPrinter {
 	}
 
 	/**
+	 * Whether this printer's rendered output varies with the viewing user's
+	 * interface language. When false, SMW can skip adding the `userlang` key
+	 * to the parser cache for queries using this format.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return bool
+	 */
+	public function dependsOnUserLanguage(): bool {
+		return true;
+	}
+
+	/**
 	 * @since 3.0
 	 *
 	 * @return bool

--- a/src/Query/ResultPrinters/ResultPrinter.php
+++ b/src/Query/ResultPrinters/ResultPrinter.php
@@ -703,8 +703,6 @@ abstract class ResultPrinter implements IResultPrinter {
 	 * to the parser cache for queries using this format.
 	 *
 	 * @since 7.0.0
-	 *
-	 * @return bool
 	 */
 	public function dependsOnUserLanguage(): bool {
 		return true;

--- a/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
@@ -427,6 +427,142 @@ class AskParserFunctionTest extends TestCase {
 		$instance->parse( $params );
 	}
 
+	/**
+	 * Characterization / regression guard: format=table (dependsOnUserLanguage=true)
+	 * must still add `userlang` to the parser cache key after the change.
+	 *
+	 * @covers \SMW\ParserFunctions\AskParserFunction::parse
+	 */
+	public function testParseTableFormatAddsUserlangKey() {
+		$this->testEnvironment->addConfiguration( 'smwgSetParserCacheKeys', [ 'userlang' ] );
+
+		$parserOutput = new ParserOutput();
+		$parserData = ApplicationFactory::getInstance()->newParserData(
+			MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __METHOD__ ),
+			$parserOutput
+		);
+
+		$instance = new AskParserFunction(
+			$parserData,
+			$this->messageFormatter,
+			$this->circularReferenceGuard,
+			$this->expensiveFuncExecutionWatcher
+		);
+
+		$instance->parse( [
+			'[[Modification date::+]]',
+			'format=table',
+		] );
+
+		$this->assertContains(
+			'userlang',
+			$parserOutput->getUsedOptions(),
+			'format=table depends on user language; userlang must be in the parser cache key'
+		);
+	}
+
+	/**
+	 * New behaviour: format=json with no errors must NOT add `userlang`.
+	 *
+	 * @covers \SMW\ParserFunctions\AskParserFunction::parse
+	 */
+	public function testParseJsonFormatWithoutErrorsOmitsUserlangKey() {
+		$this->testEnvironment->addConfiguration( 'smwgSetParserCacheKeys', [ 'userlang' ] );
+
+		$parserOutput = new ParserOutput();
+		$parserData = ApplicationFactory::getInstance()->newParserData(
+			MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __METHOD__ ),
+			$parserOutput
+		);
+
+		$instance = new AskParserFunction(
+			$parserData,
+			$this->messageFormatter,
+			$this->circularReferenceGuard,
+			$this->expensiveFuncExecutionWatcher
+		);
+
+		$instance->parse( [
+			'[[Modification date::+]]',
+			'format=json',
+		] );
+
+		$this->assertNotContains(
+			'userlang',
+			$parserOutput->getUsedOptions(),
+			'format=json output is language-neutral; userlang must not be in the parser cache key'
+		);
+	}
+
+	/**
+	 * format=count uses NullResultPrinter and takes the count code path; an
+	 * error-free count query is language-neutral and must NOT add `userlang`.
+	 *
+	 * @covers \SMW\ParserFunctions\AskParserFunction::parse
+	 */
+	public function testParseCountFormatOmitsUserlangKey() {
+		$this->testEnvironment->addConfiguration( 'smwgSetParserCacheKeys', [ 'userlang' ] );
+
+		$parserOutput = new ParserOutput();
+		$parserData = ApplicationFactory::getInstance()->newParserData(
+			MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __METHOD__ ),
+			$parserOutput
+		);
+
+		$instance = new AskParserFunction(
+			$parserData,
+			$this->messageFormatter,
+			$this->circularReferenceGuard,
+			$this->expensiveFuncExecutionWatcher
+		);
+
+		$instance->parse( [
+			'[[Modification date::+]]',
+			'format=count',
+		] );
+
+		$this->assertNotContains(
+			'userlang',
+			$parserOutput->getUsedOptions(),
+			'format=count output is language-neutral; userlang must not be in the parser cache key'
+		);
+	}
+
+	/**
+	 * format=json still adds `userlang` when the query produces errors, since
+	 * error messages are localized even though json output is language-neutral.
+	 *
+	 * @covers \SMW\ParserFunctions\AskParserFunction::parse
+	 */
+	public function testParseJsonFormatWithErrorsAddsUserlangKey() {
+		$this->testEnvironment->addConfiguration( 'smwgSetParserCacheKeys', [ 'userlang' ] );
+
+		$parserOutput = new ParserOutput();
+		$parserData = ApplicationFactory::getInstance()->newParserData(
+			MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __METHOD__ ),
+			$parserOutput
+		);
+
+		$instance = new AskParserFunction(
+			$parserData,
+			$this->messageFormatter,
+			$this->circularReferenceGuard,
+			$this->expensiveFuncExecutionWatcher
+		);
+
+		// Invalid query condition produces a localized error message; userlang is required.
+		$instance->parse( [
+			'[[--ABC|DEF::123]]',
+			'format=json',
+		] );
+
+		$this->assertContains(
+			'userlang',
+			$parserOutput->getUsedOptions(),
+			'format=json with errors renders localized text; userlang must be in the parser cache key'
+		);
+	}
+
 	public function queryDataProvider() {
 		$categoryNS = Localizer::getInstance()->getNsText( NS_CATEGORY );
 		$fileNS = Localizer::getInstance()->getNsText( NS_FILE );

--- a/tests/phpunit/Unit/Query/ResultPrinters/JsonResultPrinterTest.php
+++ b/tests/phpunit/Unit/Query/ResultPrinters/JsonResultPrinterTest.php
@@ -105,6 +105,12 @@ class JsonResultPrinterTest extends TestCase {
 		);
 	}
 
+	public function testDependsOnUserLanguage_ReturnsFalse() {
+		$instance = new JsonResultPrinter( 'json' );
+
+		$this->assertFalse( $instance->dependsOnUserLanguage() );
+	}
+
 	public function filenameDataProvider() {
 		$provider = [];
 

--- a/tests/phpunit/Unit/Query/ResultPrinters/NullResultPrinterTest.php
+++ b/tests/phpunit/Unit/Query/ResultPrinters/NullResultPrinterTest.php
@@ -40,4 +40,10 @@ class NullResultPrinterTest extends TestCase {
 		);
 	}
 
+	public function testDependsOnUserLanguage_ReturnsFalse() {
+		$instance = new NullResultPrinter( '' );
+
+		$this->assertFalse( $instance->dependsOnUserLanguage() );
+	}
+
 }

--- a/tests/phpunit/Unit/Query/ResultPrinters/RdfResultPrinterTest.php
+++ b/tests/phpunit/Unit/Query/ResultPrinters/RdfResultPrinterTest.php
@@ -53,4 +53,10 @@ class RdfResultPrinterTest extends TestCase {
 		);
 	}
 
+	public function testDependsOnUserLanguage_ReturnsFalse() {
+		$instance = new RdfResultPrinter( 'rdf' );
+
+		$this->assertFalse( $instance->dependsOnUserLanguage() );
+	}
+
 }

--- a/tests/phpunit/Unit/Query/ResultPrinters/TableResultPrinterTest.php
+++ b/tests/phpunit/Unit/Query/ResultPrinters/TableResultPrinterTest.php
@@ -41,4 +41,10 @@ class TableResultPrinterTest extends TestCase {
 		);
 	}
 
+	public function testDependsOnUserLanguage_ReturnsTrue() {
+		$instance = new TableResultPrinter( 'table' );
+
+		$this->assertTrue( $instance->dependsOnUserLanguage() );
+	}
+
 }


### PR DESCRIPTION
## Problem

For every `{{#ask}}`, SMW adds keys to the MediaWiki parser cache key, and each key fragments the cache. Two of those keys produce no benefit:

- `dateformat` fragments the cache by the user's "Date format" preference, but SMW formats dates by language, not by that preference.
- `userlang` fragments the cache by interface language for every query, even though most result output is language-neutral.

## Changes

### 1. Remove `dateformat`

SMW date rendering (`TimeValue`, `IntlTimeFormatter`, `LocalLanguage`) is driven by language; no code path reads the per-user MediaWiki date-format preference. Verified by parsing a Date `{{#ask}}` query under the `dmy`, `mdy`, `ymd`, and `ISO 8601` preferences: the output is byte-identical in all four. The `addExtraParserKey( 'dateformat' )` call is removed from `AskParserFunction`, and `dateformat` is dropped from the `SetParserCacheKeys` default (now `["userlang"]`).

### 2. `dependsOnUserLanguage()` capability

A new `dependsOnUserLanguage(): bool` method on the abstract `ResultPrinter` base class reports whether a result format's output varies with the interface language. Default `true`; overridden to `false` for `count`/`debug` (`NullResultPrinter`), `json`, and `rdf`. It is deliberately not added to the `ResultPrinter` interface, so third-party printers implementing the interface directly are unaffected.

### 3. Record `userlang` conditionally

Comparing `{{#ask}}` output under `uselang=en` vs `uselang=de` shows the result data is language-neutral; only the "further results" link (presentation formats) and error messages (every format) are localized. `AskParserFunction` now adds the `userlang` cache key only when the result printer reports `dependsOnUserLanguage() === true`, or the executed query produced errors. `QueryProcessor::getResultFromQuery()` records the printer capability onto the `Query` object as the `result.depends_on_userlang` option; `AskParserFunction` reads that plus the query error state.

Presentation formats (`table`, `list`, ...) still fragment by `userlang`, as do all queries that produce errors. `count`/`json`/`rdf`/`debug` queries without errors no longer do.

## Out of scope

`InTextAnnotationParser`'s separate `userlang` call and the `localTime`/`smwq` cache keys are unchanged.

## Testing

Unit tests cover the printer capability and `AskParserFunction`'s conditional recording: `table` keeps `userlang`; `json` and `count` without errors omit it; `json` with errors keeps it. Browser smoke test: a page with a table query and a json query renders correctly under `uselang=en` and `uselang=de` with a clean console.

## Related

PR #6818 is a separate, independent change that fixes the `$smwgSetParserCacheKeys` opt-out mechanism. This PR can merge in either order relative to it.
