### PR TITLE
Sync config.md defaults with extension.json

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1367,13 +1367,13 @@ Array of query types available inside concept definitions.
 
 - `'property'`, property-based conditions.
 - `'category'`, category-based conditions.
+- `'concept'`, nested concept conditions.
 - `'namespace'`, namespace-based conditions.
 - `'conjunction'`, conjunction (`AND`) conditions.
 - `'disjunction'`, disjunction (`OR`) conditions.
-- `'concept'`, nested concept conditions.
 
 **Since:** 1.0
-**Default:** `[ 'property', 'category', 'namespace', 'conjunction', 'disjunction', 'concept' ]`
+**Default:** `[ 'property', 'category', 'concept', 'namespace', 'conjunction', 'disjunction' ]`
 
 ### Legacy constants
 
@@ -1383,10 +1383,10 @@ Deprecated in 7.x, removed in 8.0:
 |---|---|
 | `'property'` | `SMW_PROPERTY_QUERY` |
 | `'category'` | `SMW_CATEGORY_QUERY` |
+| `'concept'` | `SMW_CONCEPT_QUERY` |
 | `'namespace'` | `SMW_NAMESPACE_QUERY` |
 | `'conjunction'` | `SMW_CONJUNCTION_QUERY` |
 | `'disjunction'` | `SMW_DISJUNCTION_QUERY` |
-| `'concept'` | `SMW_CONCEPT_QUERY` |
 
 ## $smwgQConceptMaxDepth
 
@@ -1898,7 +1898,7 @@ fragmentation. Each listed key produces a separate cache entry per distinct
 value of that key.
 
 **Since:** 5.1
-**Default:** `["userlang", "dateformat"]`
+**Default:** `["userlang"]`
 
 ## $smwgSetParserCacheTimestamp
 


### PR DESCRIPTION
## Summary

A sanity check comparing every `**Default:**` line in `docs/config.md` against the authoritative `value` in `extension.json`'s `config` block (135 settings) surfaced two stale entries. `extension.json` is `config.md`'s own declared authoritative source, so both fixes land in `config.md`.

## Mismatches fixed

**`$smwgSetParserCacheKeys`** — `config.md` documented the default as `["userlang", "dateformat"]`. #6819 dropped `dateformat` from the `extension.json` default (now `["userlang"]`) and updated `RELEASE-NOTES-7.0.0.md`, but not `config.md`.

**`$smwgQConceptFeatures`** — the default array and bullet list placed `concept` last, whereas `extension.json`, `RELEASE-NOTES-7.0.0.md`, and the sibling `$smwgQFeatures` setting all place it third. Order does not affect the resulting bitmask (the array is OR-combined), but the documented form is corrected to match the manifest verbatim.

## Verification

- Presence check: all 135 `extension.json` settings remain documented in `config.md`.
- Default-value comparison: re-run after the fix reports zero remaining mismatches (excluding known-benign `path: true` placeholders and JSON-vs-PHP backslash escaping, which represent identical values).

Docs-only change; no code paths affected.