### PR TITLE
Extract shared KeysetPredicateBuilder for cursor pagination

### DIFF
--- a/src/SQLStore/KeysetPredicateBuilder.php
+++ b/src/SQLStore/KeysetPredicateBuilder.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace SMW\SQLStore;
+
+use InvalidArgumentException;
+use SMW\MediaWiki\Connection\Database;
+
+/**
+ * Builds the explicit-OR keyset (cursor) pagination predicate. This is the
+ * single source of the predicate form for both SQLStore cursor paths: the
+ * `#ask` query engine and the lookup-based pagination behind the Browse API
+ * and Special pages.
+ *
+ * For N sort levels `c_1 ... c_N` with anchor values `v_1 ... v_N`, a
+ * tiebreak column `id_col` with anchor `id_val`, and per-level operators
+ * `op_1 ... op_N` (`>` for ASC, `<` for DESC), the predicate is:
+ *
+ *     (c_1 op_1 v_1)
+ *     OR (c_1 = v_1 AND c_2 op_2 v_2)
+ *     OR ...
+ *     OR (c_1 = v_1 AND ... AND c_N op_N v_N)
+ *     OR (c_1 = v_1 AND ... AND c_N = v_N AND id_col op_tie id_val)
+ *
+ * Clause k matches rows tied with the anchor on the first k-1 levels and
+ * strictly past it on level k; the final clause matches rows tied on every
+ * sort level and past the anchor on the id tiebreak. Together the clauses
+ * select exactly the rows ordered strictly after the anchor.
+ *
+ * MariaDB recognises this form as an index range seek when an index covers
+ * the sort columns; the row-constructor form
+ * `(c_1, ..., c_N, id_col) OP (v_1, ..., v_N, id_val)` plans a full index
+ * scan instead. PostgreSQL and SQLite plan the OR form at least as well as
+ * the tuple form. See issue #6559 and #6794.
+ *
+ * For N=1 the form collapses to the two-clause predicate used by the
+ * single-column lookup pagination.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class KeysetPredicateBuilder {
+
+	/**
+	 * Build the explicit-OR keyset predicate as a raw SQL string.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param Database $connection Used only to quote anchor values.
+	 * @param array<int, array{column: string, value: mixed, order: string}> $levels
+	 *   Sort levels in major-to-minor order. `column` is a raw SQL column
+	 *   expression, `value` the anchor value at that level, `order` either
+	 *   "ASC" or "DESC" ("DESC" selects `<`, every other value selects
+	 *   `>`). Must be non-empty.
+	 * @param string $idColumn Raw SQL column expression for the id
+	 *   tiebreak (the strict total-order column, in practice smw_id).
+	 * @param int $idValue Anchor id, the tiebreak value of the cursor row.
+	 * @param string $idOrder Tiebreak direction, "ASC" or "DESC" (same
+	 *   mapping as a level's `order`). To keep the tiebreak consistent
+	 *   with the ORDER BY, pass the last sort level's direction.
+	 *
+	 * @return string
+	 */
+	public static function build(
+		Database $connection,
+		array $levels,
+		string $idColumn,
+		int $idValue,
+		string $idOrder
+	): string {
+		if ( $levels === [] ) {
+			throw new InvalidArgumentException( '$levels must not be empty' );
+		}
+
+		$columns = [];
+		$quotedValues = [];
+		$ops = [];
+		foreach ( $levels as $level ) {
+			$columns[] = $level['column'];
+			$quotedValues[] = $connection->addQuotes( $level['value'] );
+			$ops[] = $level['order'] === 'DESC' ? '<' : '>';
+		}
+		$idOp = $idOrder === 'DESC' ? '<' : '>';
+		$n = count( $columns );
+
+		// Build the N+1 OR clauses. Clause k (0-indexed) equates the
+		// first k levels to the anchor and applies the strict operator
+		// on level k; the final clause equates all N levels and applies
+		// the strict operator on the id tiebreak.
+		$clauses = [];
+		for ( $k = 0; $k < $n; $k++ ) {
+			$parts = [];
+			for ( $j = 0; $j < $k; $j++ ) {
+				$parts[] = "$columns[$j] = $quotedValues[$j]";
+			}
+			$parts[] = "$columns[$k] $ops[$k] $quotedValues[$k]";
+			$clauses[] = '(' . implode( ' AND ', $parts ) . ')';
+		}
+		$tiebreakParts = [];
+		for ( $j = 0; $j < $n; $j++ ) {
+			$tiebreakParts[] = "$columns[$j] = $quotedValues[$j]";
+		}
+		$tiebreakParts[] = "$idColumn $idOp $idValue";
+		$clauses[] = '(' . implode( ' AND ', $tiebreakParts ) . ')';
+
+		return implode( ' OR ', $clauses );
+	}
+
+}

--- a/src/SQLStore/Lookup/KeysetPaginationTrait.php
+++ b/src/SQLStore/Lookup/KeysetPaginationTrait.php
@@ -4,6 +4,7 @@ namespace SMW\SQLStore\Lookup;
 
 use SMW\MediaWiki\Connection\Database;
 use SMW\RequestOptions;
+use SMW\SQLStore\KeysetPredicateBuilder;
 use SMW\SQLStore\SQLStore;
 use Wikimedia\Rdbms\SelectQueryBuilder;
 
@@ -50,22 +51,17 @@ trait KeysetPaginationTrait {
 	 *
 	 * When no cursor is active, falls back to offset-based pagination.
 	 *
-	 * Both cursor branches express the (smw_sort, smw_id) total order via an
-	 * explicit OR rather than a row-constructor comparison such as
-	 * `(smw_sort, smw_id) > (?, ?)`. MariaDB does not optimise row-constructor
-	 * comparisons into an index range seek; it plans a full index scan with a
-	 * WHERE filter, so cost grows linearly with cursor depth. The explicit-OR
-	 * form is recognised as a range predicate and seeks the (smw_sort, smw_id)
-	 * index directly. PostgreSQL and SQLite plan the OR form at least as well
-	 * as the tuple form. See issue #6559.
+	 * The (smw_sort, smw_id) keyset predicate is built by
+	 * `KeysetPredicateBuilder` (shared with the `#ask` query engine); see
+	 * that class for the predicate form and why the explicit-OR shape is
+	 * used over a row-constructor comparison.
 	 *
 	 * The cursor direction (after/before) and the sort direction
 	 * (`$requestOptions->ascending`) compose independently. "After" always
-	 * means "the next page in display order" — when ascending, the next
-	 * page contains values larger than the cursor; when descending, it
-	 * contains values smaller. "Before" inverts the predicate and is
-	 * served in reverse of the display order so the consumer can
-	 * `array_reverse()` for display.
+	 * means the next page in display order: when ascending, that page
+	 * holds values larger than the cursor; when descending, smaller.
+	 * "Before" inverts the predicate and is served in reverse of the
+	 * display order, so the consumer can `array_reverse()` it for display.
 	 *
 	 * @param SelectQueryBuilder $queryBuilder
 	 * @param Database $db
@@ -84,28 +80,34 @@ trait KeysetPaginationTrait {
 
 		$displayOrder = $ascending ? SelectQueryBuilder::SORT_ASC : SelectQueryBuilder::SORT_DESC;
 		$reverseOrder = $ascending ? SelectQueryBuilder::SORT_DESC : SelectQueryBuilder::SORT_ASC;
-		// "Forward" = larger values in ASC, smaller in DESC.
-		$forwardOp = $ascending ? '>' : '<';
-		$backwardOp = $ascending ? '<' : '>';
+		// "Forward" walks the display order: larger values in ASC,
+		// smaller in DESC. "Backward" (the before-cursor) walks the
+		// inverse, so the predicate seeks with the opposite direction.
+		$forwardDir = $ascending ? 'ASC' : 'DESC';
+		$backwardDir = $ascending ? 'DESC' : 'ASC';
 
 		if ( $cursorAfter !== null ) {
 			$sort = $this->resolveCursorSort( $cursorAfter );
 			if ( $sort !== null ) {
-				$quotedSort = $db->addQuotes( $sort );
-				$queryBuilder->andWhere(
-					'smw_sort ' . $forwardOp . ' ' . $quotedSort .
-					' OR (smw_sort = ' . $quotedSort . ' AND smw_id ' . $forwardOp . ' ' . $cursorAfter . ')'
-				);
+				$queryBuilder->andWhere( KeysetPredicateBuilder::build(
+					$db,
+					[ [ 'column' => 'smw_sort', 'value' => $sort, 'order' => $forwardDir ] ],
+					'smw_id',
+					$cursorAfter,
+					$forwardDir
+				) );
 			}
 			$queryBuilder->orderBy( [ 'smw_sort', 'smw_id' ], $displayOrder );
 		} elseif ( $cursorBefore !== null ) {
 			$sort = $this->resolveCursorSort( $cursorBefore );
 			if ( $sort !== null ) {
-				$quotedSort = $db->addQuotes( $sort );
-				$queryBuilder->andWhere(
-					'smw_sort ' . $backwardOp . ' ' . $quotedSort .
-					' OR (smw_sort = ' . $quotedSort . ' AND smw_id ' . $backwardOp . ' ' . $cursorBefore . ')'
-				);
+				$queryBuilder->andWhere( KeysetPredicateBuilder::build(
+					$db,
+					[ [ 'column' => 'smw_sort', 'value' => $sort, 'order' => $backwardDir ] ],
+					'smw_id',
+					$cursorBefore,
+					$backwardDir
+				) );
 			}
 			$queryBuilder->orderBy( [ 'smw_sort', 'smw_id' ], $reverseOrder );
 		} else {

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -16,6 +16,7 @@ use SMW\Query\Query;
 use SMW\Query\QueryResult;
 use SMW\QueryEngine as QueryEngineInterface;
 use SMW\QueryFactory;
+use SMW\SQLStore\KeysetPredicateBuilder;
 use SMW\SQLStore\SQLStore;
 use Wikimedia\Rdbms\Platform\ISQLPlatform;
 use Wikimedia\Rdbms\SelectQueryBuilder;
@@ -798,47 +799,13 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 	}
 
 	/**
-	 * Apply the explicit-OR keyset predicate from the query's cursor
-	 * payload to the query builder. Skipped when the payload has no
-	 * anchor (the "first page in cursor mode" case, where the cursor
-	 * just opts into deterministic ordering without seeking past
-	 * anything).
+	 * Attach the keyset predicate for the query's cursor payload to the
+	 * `SelectQueryBuilder` (the legacy single-query path). A no-op when
+	 * the payload has no anchor: that is the first page in cursor mode,
+	 * where the cursor only opts into a deterministic ordering and there
+	 * is nothing to seek past yet.
 	 *
-	 * Generalised compound form (Phase 3b-iii). For N sort columns
-	 * `c_1 ... c_N` with anchor values `v_1 ... v_N`, anchor id `Y`,
-	 * and per-level operators `op_1 ... op_N` (`>` for ASC, `<` for
-	 * DESC), the predicate is:
-	 *
-	 *     (c_1 op_1 v_1)
-	 *     OR (c_1 = v_1 AND c_2 op_2 v_2)
-	 *     OR ...
-	 *     OR (c_1 = v_1 AND ... AND c_N op_N v_N)
-	 *     OR (c_1 = v_1 AND ... AND c_N = v_N AND smw_id op_N Y)
-	 *
-	 * Each clause peels one level of "tied prefix", expanding the
-	 * range progressively. Operator at level k flips per direction so
-	 * mixed `order=asc,desc` walks each level the right way. The
-	 * smw_id tiebreak adopts the LAST level's direction so the
-	 * tied-tuple walk chains naturally off the final sort column.
-	 *
-	 * MariaDB recognises the explicit-OR form as an index range seek
-	 * when an index covers the sort columns; the row-constructor form
-	 * `(c_1, ..., c_N, smw_id) OP (v_1, ..., v_N, Y)` plans a full
-	 * index scan instead. See issue #6559 and #6794.
-	 *
-	 * For N=1 (Phase 3 spike + 3a + 3b-i compatibility), the form
-	 * collapses to the simple two-clause predicate.
-	 *
-	 * `$sortColumns` is the list of SQL column expressions for the
-	 * active sort fields. The caller resolves them from
-	 * `$qobj->sortfields` (custom sort) or hardcodes
-	 * `[<alias>.smw_sort]` (default sort). `$sortOrders` is a parallel
-	 * array of "ASC" or "DESC" strings, one per column, and MUST be
-	 * the same length as `$sortColumns`.
-	 *
-	 * TODO Phase 3c follow-up: unify with `KeysetPaginationTrait::applyCursorPagination`.
-	 * Once a shared predicate builder exists, both this method and the
-	 * trait can delegate to it.
+	 * Thin wrapper over `buildKeysetPredicateString()`.
 	 */
 	private function applyKeysetPredicate(
 		SelectQueryBuilder $queryBuilder,
@@ -857,13 +824,27 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 	}
 
 	/**
-	 * Build the explicit-OR keyset predicate as a raw SQL string. Used
-	 * by `applyKeysetPredicate()` (legacy path, attaches to
-	 * `SelectQueryBuilder`) and by `SubqueryQueryBuilder` (derived-table
-	 * path, ANDs into inner WHERE). Returns an empty string when the
-	 * cursor has no anchor (bootstrap `{"v":1}` payload).
+	 * Build the keyset predicate for the query's cursor payload as a raw
+	 * SQL string. Used by `applyKeysetPredicate()` (legacy path, attaches
+	 * to `SelectQueryBuilder`) and by `SubqueryQueryBuilder` (derived-table
+	 * path, ANDs into the inner WHERE).
 	 *
-	 * See `applyKeysetPredicate()` docblock for the predicate shape.
+	 * Returns an empty string when the cursor has no anchor (the bootstrap
+	 * `{"v":1}` payload), so the first cursor-mode page runs without a
+	 * seek predicate.
+	 *
+	 * `$sortColumns` holds the SQL column expressions for the active sort
+	 * fields, resolved by the caller from `$qobj->sortfields` (custom
+	 * sort) or hardcoded to `[<alias>.smw_sort]` (default sort).
+	 * `$sortOrders` is a parallel array of "ASC"/"DESC", one entry per
+	 * column, so mixed `order=asc,desc` requests seek each level the
+	 * right way. The smw_id tiebreak adopts the last level's direction so
+	 * the tied-tuple walk chains off the final sort column.
+	 *
+	 * This method handles only the cursor-payload extraction; clause
+	 * assembly is delegated to `KeysetPredicateBuilder`, shared with
+	 * `KeysetPaginationTrait` so every SQLStore cursor path emits the
+	 * same predicate form.
 	 */
 	private function buildKeysetPredicateString(
 		Query $query,
@@ -884,42 +865,24 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		// time this method runs, the count match is guaranteed.
 		$sortValues = is_array( $payload['sort'] ) ? $payload['sort'] : [ $payload['sort'] ];
 
-		$quotedSorts = array_map(
-			static fn ( $v ) => $connection->addQuotes( $v ),
-			$sortValues
+		$levels = [];
+		foreach ( $sortColumns as $i => $column ) {
+			$levels[] = [
+				'column' => $column,
+				'value' => $sortValues[$i],
+				'order' => $sortOrders[$i],
+			];
+		}
+
+		// Tiebreak direction is the last sort level's, matching the
+		// `smw_id` term of the ORDER BY built in getInstanceQueryResult().
+		return KeysetPredicateBuilder::build(
+			$connection,
+			$levels,
+			"$qobj->alias.smw_id",
+			(int)$payload['id'],
+			$sortOrders[count( $sortOrders ) - 1]
 		);
-		$cursorId = (int)$payload['id'];
-		$alias = $qobj->alias;
-		$n = count( $sortColumns );
-		$ops = [];
-		for ( $i = 0; $i < $n; $i++ ) {
-			$ops[] = $sortOrders[$i] === 'DESC' ? '<' : '>';
-		}
-		// smw_id tiebreak follows the last level's direction so the
-		// tied-tuple walk is consistent with the ORDER BY clause.
-		$tiebreakOp = $n > 0 ? $ops[$n - 1] : '>';
-
-		// Build the N+1 OR clauses: clause k has equality on prior
-		// k levels and inequality on level k; the final clause adds
-		// the smw_id tiebreak after all equalities.
-		$clauses = [];
-		for ( $k = 0; $k < $n; $k++ ) {
-			$parts = [];
-			for ( $j = 0; $j < $k; $j++ ) {
-				$parts[] = "$sortColumns[$j] = $quotedSorts[$j]";
-			}
-			$parts[] = "$sortColumns[$k] $ops[$k] $quotedSorts[$k]";
-			$clauses[] = '(' . implode( ' AND ', $parts ) . ')';
-		}
-		// Final tiebreak: all sort levels equal, smw_id by tiebreak direction.
-		$tiebreakParts = [];
-		for ( $j = 0; $j < $n; $j++ ) {
-			$tiebreakParts[] = "$sortColumns[$j] = $quotedSorts[$j]";
-		}
-		$tiebreakParts[] = "$alias.smw_id $tiebreakOp $cursorId";
-		$clauses[] = '(' . implode( ' AND ', $tiebreakParts ) . ')';
-
-		return implode( ' OR ', $clauses );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/KeysetPredicateBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/KeysetPredicateBuilderTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace SMW\Tests\Unit\SQLStore;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
+use SMW\MediaWiki\Connection\Database;
+use SMW\SQLStore\KeysetPredicateBuilder;
+
+/**
+ * @covers \SMW\SQLStore\KeysetPredicateBuilder
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class KeysetPredicateBuilderTest extends TestCase {
+
+	private $connection;
+
+	protected function setUp(): void {
+		$this->connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->connection->method( 'addQuotes' )
+			->willReturnCallback( static fn ( $v ) => "'$v'" );
+	}
+
+	public function testSingleLevelAscending() {
+		$sql = KeysetPredicateBuilder::build(
+			$this->connection,
+			[ [ 'column' => 'smw_sort', 'value' => 'Alpha', 'order' => 'ASC' ] ],
+			'smw_id',
+			42,
+			'ASC'
+		);
+
+		$this->assertSame(
+			"(smw_sort > 'Alpha') OR (smw_sort = 'Alpha' AND smw_id > 42)",
+			$sql
+		);
+	}
+
+	public function testSingleLevelDescending() {
+		$sql = KeysetPredicateBuilder::build(
+			$this->connection,
+			[ [ 'column' => 'smw_sort', 'value' => 'Alpha', 'order' => 'DESC' ] ],
+			'smw_id',
+			42,
+			'DESC'
+		);
+
+		$this->assertSame(
+			"(smw_sort < 'Alpha') OR (smw_sort = 'Alpha' AND smw_id < 42)",
+			$sql
+		);
+	}
+
+	public function testMultiLevelUniformAscending() {
+		$sql = KeysetPredicateBuilder::build(
+			$this->connection,
+			[
+				[ 'column' => 't1.o_sortkey', 'value' => 'a', 'order' => 'ASC' ],
+				[ 'column' => 't2.o_sortkey', 'value' => 'b', 'order' => 'ASC' ],
+			],
+			't0.smw_id',
+			9,
+			'ASC'
+		);
+
+		$this->assertSame(
+			"(t1.o_sortkey > 'a')"
+				. " OR (t1.o_sortkey = 'a' AND t2.o_sortkey > 'b')"
+				. " OR (t1.o_sortkey = 'a' AND t2.o_sortkey = 'b' AND t0.smw_id > 9)",
+			$sql
+		);
+	}
+
+	public function testMultiLevelMixedDirections() {
+		// Phase 3b-iii shape: level 0 ASC, level 1 DESC, tiebreak follows
+		// the last level (DESC).
+		$sql = KeysetPredicateBuilder::build(
+			$this->connection,
+			[
+				[ 'column' => 't1.o_sortkey', 'value' => 'a', 'order' => 'ASC' ],
+				[ 'column' => 't2.o_sortkey', 'value' => 'b', 'order' => 'DESC' ],
+			],
+			't0.smw_id',
+			9,
+			'DESC'
+		);
+
+		$this->assertSame(
+			"(t1.o_sortkey > 'a')"
+				. " OR (t1.o_sortkey = 'a' AND t2.o_sortkey < 'b')"
+				. " OR (t1.o_sortkey = 'a' AND t2.o_sortkey = 'b' AND t0.smw_id < 9)",
+			$sql
+		);
+	}
+
+	public function testNonDescOrderValueIsTreatedAsAscending() {
+		$sql = KeysetPredicateBuilder::build(
+			$this->connection,
+			[ [ 'column' => 'smw_sort', 'value' => 'Alpha', 'order' => 'asc' ] ],
+			'smw_id',
+			1,
+			'whatever'
+		);
+
+		$this->assertSame(
+			"(smw_sort > 'Alpha') OR (smw_sort = 'Alpha' AND smw_id > 1)",
+			$sql
+		);
+	}
+
+	public function testEmptyLevelsThrows() {
+		$this->expectException( InvalidArgumentException::class );
+
+		KeysetPredicateBuilder::build( $this->connection, [], 'smw_id', 1, 'ASC' );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/PropertyUsageListLookupTest.php
@@ -503,7 +503,8 @@ class PropertyUsageListLookupTest extends TestCase {
 
 		$instance->fetchList();
 
-		$cursorClause = "smw_sort > 'Alpha' OR (smw_sort = 'Alpha' AND smw_id > 42)";
+		// Each OR clause is fully parenthesised by KeysetPredicateBuilder.
+		$cursorClause = "(smw_sort > 'Alpha') OR (smw_sort = 'Alpha' AND smw_id > 42)";
 		$this->assertContains( $cursorClause, $capturedWhereClauses,
 			'Expected cursor WHERE clause not found in andWhere calls' );
 	}


### PR DESCRIPTION
## Summary

Pure refactor. Extracts a shared `SMW\SQLStore\KeysetPredicateBuilder`
from two keyset (cursor) pagination predicate builders that had grown
independently.

## Background

SMW has two SQL query paths that both do cursor pagination via an
explicit-OR keyset predicate (chosen over a row-constructor comparison
because MariaDB plans the OR form as an index range seek, see #6559):

- `QueryEngine::buildKeysetPredicateString` for the `#ask` query
  paths: N sort levels, per-level ASC/DESC directions.
- `KeysetPaginationTrait::applyCursorPagination` for the Browse API
  and Special pages: single `smw_sort` column, bidirectional
  (after/before cursors).

Keeping two copies of the clause-assembly logic meant a future fix to
one (for example NULL-sort handling) would silently miss the other.
The `TODO` flagging this lived in `QueryEngine`.

## What changed

- New `SMW\SQLStore\KeysetPredicateBuilder::build()` takes resolved
  sort levels (column, value, per-level order), a tiebreak column and
  id, and returns the predicate string. The N=1 case is the
  single-column lookup form; the N-level case is the `#ask` form.
- `QueryEngine::buildKeysetPredicateString` keeps cursor-payload
  extraction (decode, normalise the scalar-or-array `sort` field) and
  delegates clause assembly.
- `KeysetPaginationTrait::applyCursorPagination` keeps
  after/before/offset branching, the `resolveCursorSort` id-to-value
  lookup, and `ORDER BY`. The before-cursor passes inverted per-level
  orders.
- The now-completed `TODO` in `QueryEngine` is removed.

## Behaviour

No change. The QueryEngine path is byte-identical (it already
fully-parenthesised every OR clause). The trait path differs only in
that the builder fully parenthesises every clause whereas the trait
previously left the first clause bare; the result is logically
identical and was already wrapped as a whole by the query builder's
`makeList`. The one characterization test asserting the exact trait
predicate string is updated to match.

## Test plan

- [x] New `KeysetPredicateBuilderTest`: single-level ASC/DESC,
  multi-level uniform, multi-level mixed directions, non-DESC order
  coercion, empty-levels rejection.
- [x] 606 existing tests pass across `QueryEngine`, `QueryCreator`,
  `SubqueryQuery`, `KeysetPagination` integration, and every
  trait-consumer lookup (`PropertyUsageListLookup`,
  `UnusedPropertyListLookup`, `PropertySubjectsLookup`, `ListLookup`,
  `SpecialConcepts`).
- [x] `KeysetPaginationIntegrationTest` (DB-backed forward and
  backward cursor walks vs an OFFSET control) passes, exercising the
  trait to builder path directly.
- [x] PHPCS clean.
- [x] Dev wiki smoke: `#ask` cursor walk and `Special:Properties`
  both work.

## Migration / compat

No public API or schema change. The builder is autoloaded via
`extension.json`'s `AutoloadNamespaces`, so no `extension.json` change.