### PR TITLE
Replace deprecated mw.Uri with native URL

### DIFF
--- a/res/smw/data/ext.smw.dataItem.uri.js
+++ b/res/smw/data/ext.smw.dataItem.uri.js
@@ -35,9 +35,9 @@
 	var uri = function ( fullurl ) {
 		this.fullurl = fullurl !== '' && fullurl !==  undefined ? fullurl : null;
 
-		// Get mw.Uri inheritance
+		// Parse the URL using the native browser URL class
 		if ( this.fullurl !== null ) {
-			this.uri = new mw.Uri( this.fullurl );
+			this.uri = new URL( this.fullurl );
 		}
 
 		return this;


### PR DESCRIPTION
## Issue

`mediawiki.Uri` (the `mw.Uri` class) was deprecated in MediaWiki 1.43 in favour of the native browser [`URL`](https://developer.mozilla.org/en-US/docs/Web/API/URL) class. See [Migrating mw.Uri to URL](https://www.mediawiki.org/wiki/Migrating_mw.Uri_to_URL).

`res/smw/data/ext.smw.dataItem.uri.js` was the only place in SMW referencing `mw.Uri`.

## Change

Replaced `new mw.Uri( this.fullurl )` with `new URL( this.fullurl )`.

Notes:

- Both `mw.Uri` and `URL` throw on an invalid URL at construction, so invalid input still fails fast on construction.
- The `this.uri` property is assigned but never read within SMW (`getUri()` and `getHtml()` operate on `this.fullurl`, the original string). The assignment is kept for behavioural parity and in case external consumers rely on it.
- The `ext.smw.api` ResourceLoader module never declared `mediawiki.Uri` as a dependency, so there is nothing to remove from `extension.json`.
- Existing QUnit tests (`tests/qunit/smw/data/ext.smw.dataItem.uri.test.js`) only exercise valid `http://` URLs or the empty string (guarded by a `!== null` check), so `new URL()` does not throw for them.

Fixes #6188

🤖 Generated with [Claude Code](https://claude.com/claude-code)