### PR TITLE
Remove dead registerObject scaffolding from Query and SQLStore/Rebuilder tests

### DIFF
--- a/tests/phpunit/Unit/Query/DescriptionFactoryTest.php
+++ b/tests/phpunit/Unit/Query/DescriptionFactoryTest.php
@@ -24,8 +24,6 @@ use SMW\Query\Language\SomeProperty;
 use SMW\Query\Language\ThingDescription;
 use SMW\Query\Language\ValueDescription;
 use SMW\Services\DataValueServiceFactory;
-use SMW\Store;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers SMW\Query\DescriptionFactory
@@ -38,22 +36,10 @@ use SMW\Tests\TestEnvironment;
  */
 class DescriptionFactoryTest extends TestCase {
 
-	private $testEnvironment;
 	private $dataItemFactory;
 
 	protected function setUp(): void {
-		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
-
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$this->testEnvironment->registerObject( 'Store', $store );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/Query/Parser/LegacyParserTest.php
+++ b/tests/phpunit/Unit/Query/Parser/LegacyParserTest.php
@@ -11,8 +11,6 @@ use SMW\Query\Parser\DescriptionProcessor;
 use SMW\Query\Parser\LegacyParser as QueryParser;
 use SMW\Query\Parser\Tokenizer;
 use SMW\Query\QueryToken;
-use SMW\Store;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\Query\Parser\LegacyParser
@@ -25,32 +23,19 @@ use SMW\Tests\TestEnvironment;
  */
 class LegacyParserTest extends TestCase {
 
-	private $testEnvironment;
 	private $descriptionFactory;
 	private $queryParser;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->testEnvironment = new TestEnvironment();
 		$this->descriptionFactory = new DescriptionFactory();
-
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$this->testEnvironment->registerObject( 'Store', $store );
 
 		$this->queryParser = new QueryParser(
 			new DescriptionProcessor(),
 			new Tokenizer(),
 			new QueryToken()
 		);
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/Query/QuerySourceFactoryTest.php
+++ b/tests/phpunit/Unit/Query/QuerySourceFactoryTest.php
@@ -10,7 +10,6 @@ use SMW\SPARQLStore\SPARQLStore;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\StoreAware;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers SMW\Query\QuerySourceFactory
@@ -23,22 +22,12 @@ use SMW\Tests\TestEnvironment;
  */
 class QuerySourceFactoryTest extends TestCase {
 
-	private $testEnvironment;
 	private Store $store;
 
 	protected function setUp(): void {
-		$this->testEnvironment = new TestEnvironment();
-
 		$this->store = $this->getMockBuilder( Store::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/SQLStore/Rebuilder/EntityValidatorTest.php
+++ b/tests/phpunit/Unit/SQLStore/Rebuilder/EntityValidatorTest.php
@@ -8,8 +8,6 @@ use SMW\MediaWiki\RevisionGuard;
 use SMW\NamespaceExaminer;
 use SMW\SQLStore\Rebuilder\EntityValidator;
 use SMW\SQLStore\SQLStore;
-use SMW\Store;
-use SMW\Tests\TestEnvironment;
 use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use Wikimedia\Rdbms\IDatabase;
 use Wikimedia\Rdbms\IResultWrapper;
@@ -27,52 +25,14 @@ class EntityValidatorTest extends TestCase {
 
 	use MockSelectQueryBuilderTrait;
 
-	private $testEnvironment;
 	private NamespaceExaminer $namespaceExaminer;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->testEnvironment = new TestEnvironment(
-			[
-				'smwgAutoRefreshSubject' => true,
-				'smwgMainCacheType' => 'hash',
-				'smwgEnableUpdateJobs' => false,
-			]
-		);
-
 		$this->namespaceExaminer = $this->getMockBuilder( NamespaceExaminer::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$idTable = $this->getMockBuilder( '\stdClass' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'exists' ] )
-			->getMock();
-
-		$idTable->expects( $this->any() )
-			->method( 'exists' )
-			->willReturn( 0 );
-
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
-			->getMockForAbstractClass();
-
-		$store->expects( $this->any() )
-			->method( 'getPropertyValues' )
-			->willReturn( [] );
-
-		$store->expects( $this->any() )
-			->method( 'getObjectIds' )
-			->willReturn( $idTable );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/SQLStore/Rebuilder/RebuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/Rebuilder/RebuilderTest.php
@@ -11,7 +11,6 @@ use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\SQLStore\Rebuilder\EntityValidator;
 use SMW\SQLStore\Rebuilder\Rebuilder;
 use SMW\SQLStore\SQLStore;
-use SMW\Store;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
@@ -44,10 +43,6 @@ class RebuilderTest extends TestCase {
 			]
 		);
 
-		$jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->titleFactory = $this->getMockBuilder( TitleFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -59,32 +54,6 @@ class RebuilderTest extends TestCase {
 		$this->propertyTableIdReferenceDisposer = $this->getMockBuilder( PropertyTableIdReferenceDisposer::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
-
-		$idTable = $this->getMockBuilder( '\stdClass' )
-			->disableOriginalConstructor()
-			->setMethods( [ 'exists' ] )
-			->getMock();
-
-		$idTable->expects( $this->any() )
-			->method( 'exists' )
-			->willReturn( 0 );
-
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
-			->getMockForAbstractClass();
-
-		$store->expects( $this->any() )
-			->method( 'getPropertyValues' )
-			->willReturn( [] );
-
-		$store->expects( $this->any() )
-			->method( 'getObjectIds' )
-			->willReturn( $idTable );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown(): void {


### PR DESCRIPTION
## Summary

Removes dead `TestEnvironment::registerObject()` scaffolding from five unit tests. This is the first slice of a follow-up to #6827: a program to move SMW classes off service-locator dependency access toward constructor injection so unit tests inject mocks directly rather than mutating a shared container.

No production code is changed. All five `registerObject()` calls turned out to be inert: the classes under test either already receive the dependency through their constructor or never use the registered service at all. Each removal was verified against the class under test.

## Changes

Five test files, deletions only (`registerObject()` calls, the mocks built solely for them, now-unused `TestEnvironment` scaffolding, and now-unused imports):

- `QuerySourceFactoryTest` — `QuerySourceFactory` already receives `Store` via a promoted `readonly` constructor parameter.
- `DescriptionFactoryTest` — `DescriptionFactory` has no constructor and never references `Store`.
- `LegacyParserTest` — `LegacyParser`'s constructor takes only `DescriptionProcessor`, `Tokenizer`, and `QueryToken`; it never references `Store`.
- `RebuilderTest` — `Rebuilder` already receives `SQLStore` via its constructor; it never fetches `Store` or `JobQueue` from the service locator.
- `EntityValidatorTest` — `EntityValidator` already receives `SQLStore` via its constructor.

`TestEnvironment` is removed from a file only where `registerObject()` was its sole use, and retained where it is still needed (`RebuilderTest` config reset).

## Testing

- Per-class `composer phpunit` filters and the full unit suite (7053 tests) pass; PHPCS is clean on all changed files.
- Test method counts are unchanged in every file; no assertions or test methods were removed.
- The integration / `@group Database` suite is expected to be covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)