### PR TITLE
Inject dependencies into SQLStore classes, drop registerObject scaffolding from their tests

### DIFF
--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -27,8 +27,6 @@ class QueryDependencyLinksStore {
 
 	private Store $store;
 
-	private NamespaceExaminer $namespaceExaminer;
-
 	private bool $isEnabled = true;
 
 	/**
@@ -50,9 +48,9 @@ class QueryDependencyLinksStore {
 	public function __construct(
 		private QueryResultDependencyListResolver $queryResultDependencyListResolver,
 		private DependencyLinksTableUpdater $dependencyLinksTableUpdater,
+		private readonly NamespaceExaminer $namespaceExaminer,
 	) {
 		$this->store = $this->dependencyLinksTableUpdater->getStore();
-		$this->namespaceExaminer = ApplicationFactory::getInstance()->getNamespaceExaminer();
 	}
 
 	/**

--- a/src/SQLStore/QueryDependencyLinksStoreFactory.php
+++ b/src/SQLStore/QueryDependencyLinksStoreFactory.php
@@ -85,7 +85,8 @@ class QueryDependencyLinksStoreFactory {
 
 		$queryDependencyLinksStore = new QueryDependencyLinksStore(
 			$this->newQueryResultDependencyListResolver(),
-			$dependencyLinksTableUpdater
+			$dependencyLinksTableUpdater,
+			$applicationFactory->getNamespaceExaminer()
 		);
 
 		$queryDependencyLinksStore->setLogger(

--- a/src/SQLStore/QueryEngine/Fulltext/TextChangeUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextChangeUpdater.php
@@ -6,7 +6,7 @@ use Onoi\Cache\Cache;
 use Psr\Log\LoggerAwareTrait;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Connection\Database;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\MediaWiki\JobFactory;
 use SMW\SQLStore\ChangeOp\ChangeDiff;
 use SMW\SQLStore\ChangeOp\ChangeOp;
 use SMW\SQLStore\ChangeOp\TableChangeOp;
@@ -35,9 +35,10 @@ class TextChangeUpdater {
 	 * @since 2.5
 	 */
 	public function __construct(
-		private Database $connection,
-		private Cache $cache,
-		private SearchTableUpdater $searchTableUpdater,
+		private readonly Database $connection,
+		private readonly Cache $cache,
+		private readonly SearchTableUpdater $searchTableUpdater,
+		private readonly JobFactory $jobFactory,
 	) {
 	}
 
@@ -105,7 +106,7 @@ class TextChangeUpdater {
 			return;
 		}
 
-		$fulltextSearchTableUpdateJob = ApplicationFactory::getInstance()->newJobFactory()->newFulltextSearchTableUpdateJob(
+		$fulltextSearchTableUpdateJob = $this->jobFactory->newFulltextSearchTableUpdateJob(
 			$title,
 			[
 				'slot:id' => $changeOp->getSubject()->getHash()

--- a/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
+++ b/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
@@ -130,7 +130,8 @@ class FulltextSearchTableFactory {
 		$textChangeUpdater = new TextChangeUpdater(
 			$store->getConnection( 'mw.db' ),
 			$applicationFactory->getCache(),
-			$this->newSearchTableUpdater( $store )
+			$this->newSearchTableUpdater( $store ),
+			$applicationFactory->newJobFactory()
 		);
 
 		$textChangeUpdater->setLogger(

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -12,7 +12,6 @@ use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\SQLStore\PropertyTableIdReferenceFinder;
 use SMW\SQLStore\SQLStore;
-use SMW\Tests\TestEnvironment;
 use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
@@ -32,13 +31,10 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 	use MockWriteQueryBuilderTrait;
 
 	private $store;
-	private $testEnvironment;
 	private $eventDispatcher;
 
 	protected function setUp(): void {
 		parent::setUp();
-
-		$this->testEnvironment = new TestEnvironment();
 
 		$this->eventDispatcher = $this->getMockBuilder( EventDispatcher::class )
 			->disableOriginalConstructor()
@@ -59,20 +55,6 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 		$this->store->expects( $this->any() )
 			->method( 'getObjectIds' )
 			->willReturn( $idTable );
-
-		$jobQueueGroup = $this->getMockBuilder( '\JobQueueGroup' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$jobQueueGroup->expects( $this->any() )
-			->method( 'lazyPush' );
-
-		$this->testEnvironment->registerObject( 'JobQueueGroup', $jobQueueGroup );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksTableUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/DependencyLinksTableUpdaterTest.php
@@ -40,8 +40,6 @@ class DependencyLinksTableUpdaterTest extends TestCase {
 		$this->store = $this->getMockBuilder( Store::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -7,7 +7,6 @@ use PHPUnit\Framework\TestCase;
 use SMW\Connection\ConnectionManager;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\JobFactory;
 use SMW\NamespaceExaminer;
 use SMW\Query\Query;
 use SMW\Query\QueryResult;
@@ -39,7 +38,7 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 	private $store;
 	private $spyLogger;
-	private $jobFactory;
+	private $namespaceExaminer;
 	private $subject;
 	private $testEnvironment;
 
@@ -57,17 +56,13 @@ class QueryDependencyLinksStoreTest extends TestCase {
 			$this->spyLogger
 		);
 
-		$namespaceExaminer = $this->getMockBuilder( NamespaceExaminer::class )
+		$this->namespaceExaminer = $this->getMockBuilder( NamespaceExaminer::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$namespaceExaminer->expects( $this->any() )
+		$this->namespaceExaminer->expects( $this->any() )
 			->method( 'isSemanticEnabled' )
 			->willReturn( true );
-
-		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
-			->disableOriginalConstructor()
-			->getMock();
 
 		$title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
@@ -88,10 +83,6 @@ class QueryDependencyLinksStoreTest extends TestCase {
 		$this->subject->expects( $this->any() )
 			->method( 'getTitle' )
 			->willReturn( $title );
-
-		$this->testEnvironment->registerObject( 'JobFactory', $this->jobFactory );
-		$this->testEnvironment->registerObject( 'NamespaceExaminer', $namespaceExaminer );
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown(): void {
@@ -116,7 +107,7 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 		$this->assertInstanceOf(
 			QueryDependencyLinksStore::class,
-			new QueryDependencyLinksStore( $queryResultDependencyListResolver, $dependencyLinksTableUpdater )
+			new QueryDependencyLinksStore( $queryResultDependencyListResolver, $dependencyLinksTableUpdater, $this->namespaceExaminer )
 		);
 	}
 
@@ -159,7 +150,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
-			$dependencyLinksTableUpdater
+			$dependencyLinksTableUpdater,
+			$this->namespaceExaminer
 		);
 
 		$instance->setLogger(
@@ -206,7 +198,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
-			$dependencyLinksTableUpdater
+			$dependencyLinksTableUpdater,
+			$this->namespaceExaminer
 		);
 
 		$instance->setEnabled( false );
@@ -275,7 +268,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
-			$dependencyLinksTableUpdater
+			$dependencyLinksTableUpdater,
+			$this->namespaceExaminer
 		);
 
 		$requestOptions = new RequestOptions();
@@ -350,7 +344,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
-			$dependencyLinksTableUpdater
+			$dependencyLinksTableUpdater,
+			$this->namespaceExaminer
 		);
 
 		$requestOptions = new RequestOptions();
@@ -400,7 +395,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
-			$dependencyLinksTableUpdater
+			$dependencyLinksTableUpdater,
+			$this->namespaceExaminer
 		);
 
 		$instance->countDependencies( 42 );
@@ -435,7 +431,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
-			$dependencyLinksTableUpdater
+			$dependencyLinksTableUpdater,
+			$this->namespaceExaminer
 		);
 
 		$instance->setLogger(
@@ -475,7 +472,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
-			$dependencyLinksTableUpdater
+			$dependencyLinksTableUpdater,
+			$this->namespaceExaminer
 		);
 
 		$instance->setLogger(
@@ -546,7 +544,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
-			$dependencyLinksTableUpdater
+			$dependencyLinksTableUpdater,
+			$this->namespaceExaminer
 		);
 
 		$instance->setLogger(
@@ -589,8 +588,6 @@ class QueryDependencyLinksStoreTest extends TestCase {
 			->method( 'isSemanticEnabled' )
 			->willReturn( false );
 
-		$this->testEnvironment->registerObject( 'NamespaceExaminer', $namespaceExaminer );
-
 		$store = $this->getMockBuilder( Store::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
@@ -615,7 +612,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
-			$dependencyLinksTableUpdater
+			$dependencyLinksTableUpdater,
+			$namespaceExaminer
 		);
 
 		$instance->setEnabled( true );
@@ -722,7 +720,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
-			$dependencyLinksTableUpdater
+			$dependencyLinksTableUpdater,
+			$this->namespaceExaminer
 		);
 
 		$instance->setLogger(
@@ -799,7 +798,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
-			$dependencyLinksTableUpdater
+			$dependencyLinksTableUpdater,
+			$this->namespaceExaminer
 		);
 
 		$instance->setLogger(
@@ -893,7 +893,8 @@ class QueryDependencyLinksStoreTest extends TestCase {
 
 		$instance = new QueryDependencyLinksStore(
 			$queryResultDependencyListResolver,
-			$dependencyLinksTableUpdater
+			$dependencyLinksTableUpdater,
+			$this->namespaceExaminer
 		);
 
 		$instance->setLogger(

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryResultDependencyListResolverTest.php
@@ -22,7 +22,6 @@ use SMW\Query\QueryResult;
 use SMW\Query\Result\ItemJournal;
 use SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver;
 use SMW\Store;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\SQLStore\QueryDependency\QueryResultDependencyListResolver
@@ -35,14 +34,11 @@ use SMW\Tests\TestEnvironment;
  */
 class QueryResultDependencyListResolverTest extends TestCase {
 
-	private $testEnvironment;
 	private $store;
 	private $hierarchyLookup;
 
 	protected function setUp(): void {
 		parent::setUp();
-
-		$this->testEnvironment = new TestEnvironment();
 
 		$this->store = $this->getMockBuilder( Store::class )
 			->disableOriginalConstructor()
@@ -51,14 +47,6 @@ class QueryResultDependencyListResolverTest extends TestCase {
 		$this->hierarchyLookup = $this->getMockBuilder( HierarchyLookup::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-
-		parent::tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextChangeUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextChangeUpdaterTest.php
@@ -32,10 +32,8 @@ class TextChangeUpdaterTest extends TestCase {
 	private $cache;
 	private JobFactory $jobFactory;
 	private $logger;
-	private $testEnvironment;
 
 	protected function setUp(): void {
-		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
 
 		$this->logger = TestEnvironment::newSpyLogger();
@@ -55,14 +53,12 @@ class TextChangeUpdaterTest extends TestCase {
 		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'JobFactory', $this->jobFactory );
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			TextChangeUpdater::class,
-			new TextChangeUpdater( $this->connection, $this->cache, $this->searchTableUpdater )
+			new TextChangeUpdater( $this->connection, $this->cache, $this->searchTableUpdater, $this->jobFactory )
 		);
 	}
 
@@ -89,7 +85,8 @@ class TextChangeUpdaterTest extends TestCase {
 		$instance = new TextChangeUpdater(
 			$this->connection,
 			$this->cache,
-			$this->searchTableUpdater
+			$this->searchTableUpdater,
+			$this->jobFactory
 		);
 
 		$instance->setLogger(
@@ -146,7 +143,8 @@ class TextChangeUpdaterTest extends TestCase {
 		$instance = new TextChangeUpdater(
 			$this->connection,
 			$this->cache,
-			$this->searchTableUpdater
+			$this->searchTableUpdater,
+			$this->jobFactory
 		);
 
 		$instance->setLogger(
@@ -189,7 +187,8 @@ class TextChangeUpdaterTest extends TestCase {
 		$instance = new TextChangeUpdater(
 			$this->connection,
 			$this->cache,
-			$this->searchTableUpdater
+			$this->searchTableUpdater,
+			$this->jobFactory
 		);
 
 		$instance->setLogger(
@@ -234,7 +233,8 @@ class TextChangeUpdaterTest extends TestCase {
 		$instance = new TextChangeUpdater(
 			$this->connection,
 			$this->cache,
-			$this->searchTableUpdater
+			$this->searchTableUpdater,
+			$this->jobFactory
 		);
 
 		$instance->setLogger(


### PR DESCRIPTION
## Summary

Second slice of the follow-up to #6827: moving SMW classes off service-locator dependency access toward constructor injection so unit tests inject mocks directly rather than mutating a shared container through `TestEnvironment::registerObject()`.

This slice covers five `SQLStore` unit tests. Two are genuine constructor-injection conversions; three turned out to be dead `registerObject` scaffolding (the class never fetched the registered service from the locator).

## Changes

**Real conversions** (production code changed; the in-body locator call is removed, the dependency becomes a typed promoted constructor parameter, and the class's factory plus every call site are updated to pass it):

- `TextChangeUpdater` — `JobFactory` is now a constructor dependency instead of being fetched via `ApplicationFactory::getInstance()->newJobFactory()` inside `pushUpdates()`. `FulltextSearchTableFactory::newTextChangeUpdater()` supplies it.
- `QueryDependencyLinksStore` — `NamespaceExaminer` is now a constructor dependency instead of being fetched via `ApplicationFactory::getInstance()->getNamespaceExaminer()` in the constructor body. `QueryDependencyLinksStoreFactory` supplies it.

The injected objects are the same instances the locator previously returned, so behaviour is unchanged.

**Dead-scaffolding removals** (test-only; the `registerObject` call had no effect because the class obtains the service via its constructor, via a passed-in object, or not at all):

- `PropertyTableIdReferenceDisposerTest` — `JobQueueGroup`
- `QueryResultDependencyListResolverTest` — `Store` (obtained from `QueryResult::getStore()`)
- `DependencyLinksTableUpdaterTest` — `Store` (already a constructor parameter)

`TestEnvironment` is removed from a test only where `registerObject` was its sole use, and retained where it is still needed.

## Testing

- The unit suite (6839 tests) passes; phan exits clean; PHPCS is clean on all changed files.
- Test method counts are unchanged in every file; no assertions or test methods were removed.
- The integration / `@group Database` suite is expected to be covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)