### PR TITLE
Inject dependencies into DataValues classes, drop registerObject scaffolding from their tests

### DIFF
--- a/src/DataValues/AbstractMultiValue.php
+++ b/src/DataValues/AbstractMultiValue.php
@@ -148,13 +148,22 @@ abstract class AbstractMultiValue extends DataValue {
 			return [];
 		}
 
-		$dataItem = ApplicationFactory::getInstance()->getPropertySpecificationLookup()->getFieldListBy( $property );
+		if ( $this->dataValueServiceFactory !== null ) {
+			$dataItem = $this->dataValueServiceFactory->getPropertySpecificationLookup()->getFieldListBy( $property );
+		} else {
+			$dataItem = ApplicationFactory::getInstance()->getPropertySpecificationLookup()->getFieldListBy( $property );
+		}
 
 		if ( !$dataItem ) {
 			return [];
 		}
 
 		$propertyListValue = new PropertyListValue( '__pls' );
+
+		if ( $this->dataValueServiceFactory !== null ) {
+			$propertyListValue->setStore( $this->dataValueServiceFactory->getStore() );
+		}
+
 		$propertyListValue->setDataItem( $dataItem );
 
 		if ( !$propertyListValue->isValid() ) {

--- a/src/DataValues/PropertyListValue.php
+++ b/src/DataValues/PropertyListValue.php
@@ -99,10 +99,14 @@ class PropertyListValue extends DataValue {
 			}
 
 			if ( $property instanceof Property ) {
-				// Find a possible redirect
-				$this->m_diProperties[] = $this->store !== null
-					? $this->store->getRedirectTarget( $property )
-					: $property->getRedirectTarget();
+				// Find a possible redirect; inverse properties are returned
+				// unchanged (matching Property::getRedirectTarget() behaviour).
+				if ( $this->store !== null && !$property->isInverse() ) {
+					$property = $this->store->getRedirectTarget( $property );
+				} elseif ( $this->store === null ) {
+					$property = $property->getRedirectTarget();
+				}
+				$this->m_diProperties[] = $property;
 			}
 		}
 

--- a/src/DataValues/PropertyListValue.php
+++ b/src/DataValues/PropertyListValue.php
@@ -8,6 +8,7 @@ use SMW\DataItems\Property;
 use SMW\DataValueFactory;
 use SMW\Exception\DataItemException;
 use SMW\Localizer\Localizer;
+use SMW\Store;
 
 /**
  * This datavalue implements special processing suitable for defining the list
@@ -24,6 +25,15 @@ class PropertyListValue extends DataValue {
 	 * @var array of Property
 	 */
 	protected $m_diProperties;
+
+	private ?Store $store = null;
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function setStore( Store $store ): void {
+		$this->store = $store;
+	}
 
 	protected function parseUserValue( $value ): void {
 		$this->m_diProperties = [];
@@ -89,8 +99,10 @@ class PropertyListValue extends DataValue {
 			}
 
 			if ( $property instanceof Property ) {
-				 // Find a possible redirect
-				$this->m_diProperties[] = $property->getRedirectTarget();
+				// Find a possible redirect
+				$this->m_diProperties[] = $this->store !== null
+					? $this->store->getRedirectTarget( $property )
+					: $property->getRedirectTarget();
 			}
 		}
 

--- a/src/DataValues/ValueFormatters/PropertyValueFormatter.php
+++ b/src/DataValues/ValueFormatters/PropertyValueFormatter.php
@@ -10,7 +10,7 @@ use SMW\Formatters\Highlighter;
 use SMW\Localizer\Localizer;
 use SMW\Localizer\Message;
 use SMW\Property\SpecificationLookup;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\PropertyLabelFinder;
 
 /**
  * @license GPL-2.0-or-later
@@ -23,7 +23,10 @@ class PropertyValueFormatter extends DataValueFormatter {
 	/**
 	 * @since 3.0
 	 */
-	public function __construct( private readonly SpecificationLookup $propertySpecificationLookup ) {
+	public function __construct(
+		private readonly SpecificationLookup $propertySpecificationLookup,
+		private readonly PropertyLabelFinder $propertyLabelFinder,
+	) {
 	}
 
 	/**
@@ -339,7 +342,7 @@ class PropertyValueFormatter extends DataValueFormatter {
 			$prefix = '-';
 		}
 
-		return $prefix . ApplicationFactory::getInstance()->getPropertyLabelFinder()->findPropertyLabelFromIdByLanguageCode(
+		return $prefix . $this->propertyLabelFinder->findPropertyLabelFromIdByLanguageCode(
 			$property->getKey(),
 			$this->dataValue->getOption( PropertyValue::OPT_USER_LANGUAGE )
 		);

--- a/src/DataValues/ValueValidators/ConstraintSchemaValueValidator.php
+++ b/src/DataValues/ValueValidators/ConstraintSchemaValueValidator.php
@@ -4,6 +4,7 @@ namespace SMW\DataValues\ValueValidators;
 
 use SMW\Constraint\ConstraintCheckRunner;
 use SMW\DataValues\DataValue;
+use SMW\MediaWiki\JobQueue;
 use SMW\MediaWiki\Jobs\DeferredConstraintCheckUpdateJob;
 use SMW\Schema\SchemaFinder;
 use SMW\Schema\SchemaList;
@@ -32,6 +33,7 @@ class ConstraintSchemaValueValidator implements ConstraintValueValidator {
 	public function __construct(
 		private readonly ConstraintCheckRunner $constraintCheckRunner,
 		private readonly SchemaFinder $schemaFinder,
+		private readonly JobQueue $jobQueue,
 	) {
 	}
 
@@ -114,7 +116,17 @@ class ConstraintSchemaValueValidator implements ConstraintValueValidator {
 			return;
 		}
 
-		DeferredConstraintCheckUpdateJob::pushJob( $contextPage->getTitle() );
+		$title = $contextPage->getTitle();
+
+		$job = new DeferredConstraintCheckUpdateJob(
+			$title,
+			DeferredConstraintCheckUpdateJob::newRootJobParams(
+				DeferredConstraintCheckUpdateJob::JOB_COMMAND,
+				$title
+			) + [ 'waitOnCommandLine' => true ]
+		);
+
+		$this->jobQueue->push( [ $job ] );
 	}
 
 }

--- a/src/DataValues/ValueValidators/PatternConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/PatternConstraintValueValidator.php
@@ -4,7 +4,7 @@ namespace SMW\DataValues\ValueValidators;
 
 use SMW\DataValues\DataValue;
 use SMW\DataValues\ValueParsers\AllowsPatternValueParser;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Property\SpecificationLookup;
 
 /**
  * To support regular expressions in connection with the `Allows pattern`
@@ -17,15 +17,15 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
  */
 class PatternConstraintValueValidator implements ConstraintValueValidator {
 
-	private AllowsPatternValueParser $allowsPatternValueParser;
-
 	private bool $hasConstraintViolation = false;
 
 	/**
 	 * @since 2.4
 	 */
-	public function __construct( AllowsPatternValueParser $allowsPatternValueParser ) {
-		$this->allowsPatternValueParser = $allowsPatternValueParser;
+	public function __construct(
+		private readonly AllowsPatternValueParser $allowsPatternValueParser,
+		private readonly SpecificationLookup $propertySpecificationLookup
+	) {
 	}
 
 	/**
@@ -52,8 +52,7 @@ class PatternConstraintValueValidator implements ConstraintValueValidator {
 			return $this->hasConstraintViolation;
 		}
 
-		$reference = ApplicationFactory::getInstance()
-			->getPropertySpecificationLookup()
+		$reference = $this->propertySpecificationLookup
 			->getAllowedPatternBy( $dataValue->getProperty() );
 		if ( $reference === '' ) {
 			return $this->hasConstraintViolation;

--- a/src/Services/DataValueServiceFactory.php
+++ b/src/Services/DataValueServiceFactory.php
@@ -18,6 +18,7 @@ use SMW\DataValues\ValueValidators\ConstraintValueValidator;
 use SMW\Property\RestrictionExaminer;
 use SMW\Property\SpecificationLookup;
 use SMW\Query\DescriptionBuilderRegistry;
+use SMW\Store;
 
 /**
  * @private
@@ -192,6 +193,15 @@ class DataValueServiceFactory {
 	 */
 	public function getPropertySpecificationLookup() {
 		return ServicesFactory::getInstance()->singleton( 'PropertySpecificationLookup' );
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @return Store
+	 */
+	public function getStore(): Store {
+		return ServicesFactory::getInstance()->getStore();
 	}
 
 	/**

--- a/src/Services/DataValueServiceFactory.php
+++ b/src/Services/DataValueServiceFactory.php
@@ -197,8 +197,6 @@ class DataValueServiceFactory {
 
 	/**
 	 * @since 7.0.0
-	 *
-	 * @return Store
 	 */
 	public function getStore(): Store {
 		return ServicesFactory::getInstance()->getStore();

--- a/src/Services/datavalues.php
+++ b/src/Services/datavalues.php
@@ -134,7 +134,8 @@ return [
 		);
 
 		$patternConstraintValueValidator = new PatternConstraintValueValidator(
-			$container->create( DataValueServiceFactory::TYPE_PARSER . AllowsPatternValue::TYPE_ID, $container )
+			$container->create( DataValueServiceFactory::TYPE_PARSER . AllowsPatternValue::TYPE_ID, $container ),
+			$propertySpecificationLookup
 		);
 
 		$compoundConstraintValueValidator->registerConstraintValueValidator(

--- a/src/Services/datavalues.php
+++ b/src/Services/datavalues.php
@@ -95,7 +95,11 @@ return [
 	 * @return PropertyValueFormatter
 	 */
 	DataValueServiceFactory::TYPE_FORMATTER . PropertyValue::TYPE_ID => static function ( ServicesContainer $container ): PropertyValueFormatter {
-		return new PropertyValueFormatter( ServicesFactory::getInstance()->singleton( 'PropertySpecificationLookup' ) );
+		$servicesFactory = ServicesFactory::getInstance();
+		return new PropertyValueFormatter(
+			$servicesFactory->singleton( 'PropertySpecificationLookup' ),
+			$servicesFactory->getPropertyLabelFinder()
+		);
 	},
 
 	/**
@@ -157,7 +161,8 @@ return [
 
 		$constraintSchemaValueValidator = new ConstraintSchemaValueValidator(
 			$constraintFactory->newConstraintCheckRunner(),
-			$servicesFactory->singleton( 'SchemaFactory' )->newSchemaFinder( $store )
+			$servicesFactory->singleton( 'SchemaFactory' )->newSchemaFinder( $store ),
+			$servicesFactory->getJobQueue()
 		);
 
 		$constraintSchemaValueValidator->isCommandLineMode(

--- a/tests/phpunit/Unit/DataValues/AllowsListValueTest.php
+++ b/tests/phpunit/Unit/DataValues/AllowsListValueTest.php
@@ -5,9 +5,7 @@ namespace SMW\Tests\Unit\DataValues;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItemFactory;
 use SMW\DataValues\AllowsListValue;
-use SMW\Property\SpecificationLookup;
 use SMW\Services\DataValueServiceFactory;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\DataValues\AllowsListValue
@@ -20,28 +18,15 @@ use SMW\Tests\TestEnvironment;
  */
 class AllowsListValueTest extends TestCase {
 
-	private $testEnvironment;
 	private $dataItemFactory;
 	private $dataValueServiceFactory;
-	private $propertySpecificationLookup;
 
 	protected function setUp(): void {
-		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
 
 		$this->dataValueServiceFactory = $this->getMockBuilder( DataValueServiceFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/DataValues/AllowsPatternValueTest.php
+++ b/tests/phpunit/Unit/DataValues/AllowsPatternValueTest.php
@@ -8,9 +8,7 @@ use SMW\DataValues\AllowsPatternValue;
 use SMW\DataValues\ValueParsers\AllowsPatternValueParser;
 use SMW\DataValues\ValueValidators\ConstraintValueValidator;
 use SMW\MediaWiki\MediaWikiNsContentReader;
-use SMW\Property\SpecificationLookup;
 use SMW\Services\DataValueServiceFactory;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\DataValues\AllowsPatternValue
@@ -23,27 +21,17 @@ use SMW\Tests\TestEnvironment;
  */
 class AllowsPatternValueTest extends TestCase {
 
-	private $testEnvironment;
 	private $dataItemFactory;
 	private $mediaWikiNsContentReader;
 	private $dataValueServiceFactory;
 	private $constraintValueValidator;
 
 	protected function setUp(): void {
-		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
 
 		$this->mediaWikiNsContentReader = $this->getMockBuilder( MediaWikiNsContentReader::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'MediaWikiNsContentReader', $this->mediaWikiNsContentReader );
-
-		$propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $propertySpecificationLookup );
 
 		$this->constraintValueValidator = $this->getMockBuilder( ConstraintValueValidator::class )
 			->disableOriginalConstructor()
@@ -60,10 +48,6 @@ class AllowsPatternValueTest extends TestCase {
 		$this->dataValueServiceFactory->expects( $this->any() )
 			->method( 'getConstraintValueValidator' )
 			->willReturn( $this->constraintValueValidator );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/DataValues/ConstraintSchemaValueTest.php
+++ b/tests/phpunit/Unit/DataValues/ConstraintSchemaValueTest.php
@@ -7,7 +7,6 @@ use SMW\DataItemFactory;
 use SMW\DataItems\WikiPage;
 use SMW\DataValues\ConstraintSchemaValue;
 use SMW\Property\SpecificationLookup;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\DataValues\ConstraintSchemaValue
@@ -20,25 +19,17 @@ use SMW\Tests\TestEnvironment;
  */
 class ConstraintSchemaValueTest extends TestCase {
 
-	private $testEnvironment;
 	private $dataItemFactory;
 	private $propertySpecificationLookup;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
 
 		$this->propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/DataValues/ExternalIdentifierValueTest.php
+++ b/tests/phpunit/Unit/DataValues/ExternalIdentifierValueTest.php
@@ -10,7 +10,6 @@ use SMW\DataValues\ExternalIdentifierValue;
 use SMW\DataValues\ValueValidators\ConstraintValueValidator;
 use SMW\Property\SpecificationLookup;
 use SMW\Services\DataValueServiceFactory;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\DataValues\ExternalIdentifierValue
@@ -23,7 +22,6 @@ use SMW\Tests\TestEnvironment;
  */
 class ExternalIdentifierValueTest extends TestCase {
 
-	private $testEnvironment;
 	private $dataItemFactory;
 	private $propertySpecificationLookup;
 	private $dataValueServiceFactory;
@@ -31,7 +29,6 @@ class ExternalIdentifierValueTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
 
 		$this->propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
@@ -61,12 +58,6 @@ class ExternalIdentifierValueTest extends TestCase {
 		$this->dataValueServiceFactory->expects( $this->any() )
 			->method( 'getDataValueFactory' )
 			->willReturn( DataValueFactory::getInstance() );
-
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/DataValues/InfoLinksProviderTest.php
+++ b/tests/phpunit/Unit/DataValues/InfoLinksProviderTest.php
@@ -9,6 +9,9 @@ use SMW\DataValues\DataValue;
 use SMW\DataValues\InfoLinksProvider;
 use SMW\DataValues\NumberValue;
 use SMW\DataValues\StringValue;
+use SMW\DataValues\ValueFormatters\NumberValueFormatter;
+use SMW\DataValues\ValueFormatters\StringValueFormatter;
+use SMW\DataValues\ValueFormatters\TimeValueFormatter;
 use SMW\DataValues\ValueValidators\ConstraintValueValidator;
 use SMW\Localizer\Message;
 use SMW\Property\SpecificationLookup;
@@ -55,7 +58,9 @@ class InfoLinksProviderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getPropertySpecificationLookup' )
+			->willReturn( $this->propertySpecificationLookup );
 	}
 
 	protected function tearDown(): void {
@@ -92,9 +97,18 @@ class InfoLinksProviderTest extends TestCase {
 
 		$instance = new InfoLinksProvider( $numberValue, $this->propertySpecificationLookup );
 
+		$numberValueFormatter = new NumberValueFormatter();
+		$numberValueFormatter->setDataValue( $numberValue );
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getValueFormatter' )
+			->willReturn( $numberValueFormatter );
+
 		$this->dataValueServiceFactory->expects( $this->any() )
 			->method( 'newInfoLinksProvider' )
 			->willReturn( $instance );
+
+		$numberValue->setDataValueServiceFactory( $this->dataValueServiceFactory );
 
 		$this->assertStringContainsString(
 			'/:Foo/1000.42|+]]</span>',
@@ -125,9 +139,18 @@ class InfoLinksProviderTest extends TestCase {
 
 		$instance = new InfoLinksProvider( $stringValue, $this->propertySpecificationLookup );
 
+		$stringValueFormatter = new StringValueFormatter();
+		$stringValueFormatter->setDataValue( $stringValue );
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getValueFormatter' )
+			->willReturn( $stringValueFormatter );
+
 		$this->dataValueServiceFactory->expects( $this->any() )
 			->method( 'newInfoLinksProvider' )
 			->willReturn( $instance );
+
+		$stringValue->setDataValueServiceFactory( $this->dataValueServiceFactory );
 
 		$this->assertStringContainsString(
 			'/:Foo/Text-20with-20-2D3A-2D3A-20content|+]]</span>',
@@ -151,6 +174,8 @@ class InfoLinksProviderTest extends TestCase {
 		$this->dataValueServiceFactory->expects( $this->any() )
 			->method( 'newInfoLinksProvider' )
 			->willReturn( $instance );
+
+		$sobValue->setDataValueServiceFactory( $this->dataValueServiceFactory );
 
 		$stringValidator->assertThatStringContains(
 			'<span class="smwbrowse">[[.*/:Text-20with-20::-20content|+]]</span>',
@@ -185,9 +210,18 @@ class InfoLinksProviderTest extends TestCase {
 
 		$instance = new InfoLinksProvider( $timeValue, $this->propertySpecificationLookup );
 
+		$timeValueFormatter = new TimeValueFormatter();
+		$timeValueFormatter->setDataValue( $timeValue );
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getValueFormatter' )
+			->willReturn( $timeValueFormatter );
+
 		$this->dataValueServiceFactory->expects( $this->any() )
 			->method( 'newInfoLinksProvider' )
 			->willReturn( $instance );
+
+		$timeValue->setDataValueServiceFactory( $this->dataValueServiceFactory );
 
 		$this->assertStringContainsString(
 			'/:Foo/12-20December-201970|+]]</span>',
@@ -232,9 +266,18 @@ class InfoLinksProviderTest extends TestCase {
 
 		$instance = new InfoLinksProvider( $stringValue, $this->propertySpecificationLookup );
 
+		$stringValueFormatter = new StringValueFormatter();
+		$stringValueFormatter->setDataValue( $stringValue );
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getValueFormatter' )
+			->willReturn( $stringValueFormatter );
+
 		$this->dataValueServiceFactory->expects( $this->any() )
 			->method( 'newInfoLinksProvider' )
 			->willReturn( $instance );
+
+		$stringValue->setDataValueServiceFactory( $this->dataValueServiceFactory );
 
 		$this->assertStringContainsString(
 			'<span class="smwttcontent">[SERVICELINK-B SERVICELINK-A]</span>',

--- a/tests/phpunit/Unit/DataValues/KeywordValueTest.php
+++ b/tests/phpunit/Unit/DataValues/KeywordValueTest.php
@@ -10,7 +10,6 @@ use SMW\DataValues\KeywordValue;
 use SMW\DataValues\ValueValidators\ConstraintValueValidator;
 use SMW\Property\SpecificationLookup;
 use SMW\Services\DataValueServiceFactory;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\DataValues\KeywordValue
@@ -23,7 +22,6 @@ use SMW\Tests\TestEnvironment;
  */
 class KeywordValueTest extends TestCase {
 
-	private $testEnvironment;
 	private $dataItemFactory;
 	private $propertySpecificationLookup;
 	private $dataValueServiceFactory;
@@ -31,7 +29,6 @@ class KeywordValueTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
 
 		$this->propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
@@ -61,12 +58,6 @@ class KeywordValueTest extends TestCase {
 		$this->dataValueServiceFactory->expects( $this->any() )
 			->method( 'getDataValueFactory' )
 			->willReturn( DataValueFactory::getInstance() );
-
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/DataValues/RecordValueTest.php
+++ b/tests/phpunit/Unit/DataValues/RecordValueTest.php
@@ -7,10 +7,11 @@ use SMW\DataItemFactory;
 use SMW\DataItems\Container;
 use SMW\DataItems\Error;
 use SMW\DataValues\RecordValue;
+use SMW\DataValues\ValueValidators\ConstraintValueValidator;
 use SMW\Property\SpecificationLookup;
 use SMW\Query\DescriptionBuilderRegistry;
+use SMW\Services\DataValueServiceFactory;
 use SMW\Store;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\DataValues\RecordValue
@@ -23,27 +24,47 @@ use SMW\Tests\TestEnvironment;
  */
 class RecordValueTest extends TestCase {
 
-	private $testEnvironment;
-	private $dataItemFactory;
-
-	private $propertySpecificationLookup;
+	private DataItemFactory $dataItemFactory;
+	private SpecificationLookup $propertySpecificationLookup;
+	private DataValueServiceFactory $dataValueServiceFactory;
+	private Store $store;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
 
 		$this->propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
-	}
+		$this->store = $this->getMockBuilder( Store::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getRedirectTarget' ] )
+			->getMockForAbstractClass();
 
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
+		$this->store->expects( $this->any() )
+			->method( 'getRedirectTarget' )
+			->willReturnArgument( 0 );
+
+		$constraintValueValidator = $this->getMockBuilder( ConstraintValueValidator::class )
+			->getMock();
+
+		$this->dataValueServiceFactory = $this->getMockBuilder( DataValueServiceFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getPropertySpecificationLookup' )
+			->willReturn( $this->propertySpecificationLookup );
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getStore' )
+			->willReturn( $this->store );
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getConstraintValueValidator' )
+			->willReturn( $constraintValueValidator );
 	}
 
 	public function testCanConstruct() {
@@ -59,22 +80,12 @@ class RecordValueTest extends TestCase {
 			$this->dataItemFactory->newDIProperty( 'Foobar' )
 		];
 
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
-			->getMockForAbstractClass();
-
 		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
 			->method( 'getFieldListBy' )
 			->willReturn( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) );
 
-		$store->expects( $this->any() )
-			->method( 'getRedirectTarget' )
-			->willReturnArgument( 0 );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
-
 		$instance = new RecordValue();
+		$instance->setDataValueServiceFactory( $this->dataValueServiceFactory );
 		$instance->setProperty(
 			$this->dataItemFactory->newDIProperty( 'Foo' )
 		);
@@ -91,22 +102,12 @@ class RecordValueTest extends TestCase {
 	}
 
 	public function testParseValue() {
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
-			->getMockForAbstractClass();
-
 		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
 			->method( 'getFieldListBy' )
 			->willReturn( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) );
 
-		$store->expects( $this->any() )
-			->method( 'getRedirectTarget' )
-			->willReturnArgument( 0 );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
-
 		$instance = new RecordValue();
+		$instance->setDataValueServiceFactory( $this->dataValueServiceFactory );
 		$instance->setProperty(
 			$this->dataItemFactory->newDIProperty( 'Foo' )
 		);
@@ -141,22 +142,12 @@ class RecordValueTest extends TestCase {
 	}
 
 	public function testParseValueWithErroredDv() {
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
-			->getMockForAbstractClass();
-
 		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
 			->method( 'getFieldListBy' )
 			->willReturn( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) );
 
-		$store->expects( $this->any() )
-			->method( 'getRedirectTarget' )
-			->willReturnArgument( 0 );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
-
 		$instance = new RecordValue();
+		$instance->setDataValueServiceFactory( $this->dataValueServiceFactory );
 		$instance->setProperty(
 			$this->dataItemFactory->newDIProperty( 'Foo' )
 		);

--- a/tests/phpunit/Unit/DataValues/ReferenceValueTest.php
+++ b/tests/phpunit/Unit/DataValues/ReferenceValueTest.php
@@ -7,9 +7,10 @@ use SMW\DataItemFactory;
 use SMW\DataItems\Container;
 use SMW\DataItems\Error;
 use SMW\DataValues\ReferenceValue;
+use SMW\DataValues\ValueValidators\ConstraintValueValidator;
 use SMW\Property\SpecificationLookup;
+use SMW\Services\DataValueServiceFactory;
 use SMW\Store;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\DataValues\ReferenceValue
@@ -22,26 +23,47 @@ use SMW\Tests\TestEnvironment;
  */
 class ReferenceValueTest extends TestCase {
 
-	private $testEnvironment;
-	private $dataItemFactory;
-	private $propertySpecificationLookup;
+	private DataItemFactory $dataItemFactory;
+	private SpecificationLookup $propertySpecificationLookup;
+	private DataValueServiceFactory $dataValueServiceFactory;
+	private Store $store;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
 
 		$this->propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
-	}
+		$this->store = $this->getMockBuilder( Store::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'getRedirectTarget' ] )
+			->getMockForAbstractClass();
 
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
+		$this->store->expects( $this->any() )
+			->method( 'getRedirectTarget' )
+			->willReturnArgument( 0 );
+
+		$constraintValueValidator = $this->getMockBuilder( ConstraintValueValidator::class )
+			->getMock();
+
+		$this->dataValueServiceFactory = $this->getMockBuilder( DataValueServiceFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getPropertySpecificationLookup' )
+			->willReturn( $this->propertySpecificationLookup );
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getStore' )
+			->willReturn( $this->store );
+
+		$this->dataValueServiceFactory->expects( $this->any() )
+			->method( 'getConstraintValueValidator' )
+			->willReturn( $constraintValueValidator );
 	}
 
 	public function testCanConstruct() {
@@ -57,22 +79,12 @@ class ReferenceValueTest extends TestCase {
 			$this->dataItemFactory->newDIProperty( 'Foobar' )
 		];
 
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
-			->getMockForAbstractClass();
-
 		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
 			->method( 'getFieldListBy' )
 			->willReturn( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) );
 
-		$store->expects( $this->any() )
-			->method( 'getRedirectTarget' )
-			->willReturnArgument( 0 );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
-
 		$instance = new ReferenceValue();
+		$instance->setDataValueServiceFactory( $this->dataValueServiceFactory );
 		$instance->setProperty(
 			$this->dataItemFactory->newDIProperty( 'Foo' )
 		);
@@ -89,22 +101,12 @@ class ReferenceValueTest extends TestCase {
 	}
 
 	public function testParseValue() {
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
-			->getMockForAbstractClass();
-
 		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
 			->method( 'getFieldListBy' )
 			->willReturn( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) );
 
-		$store->expects( $this->any() )
-			->method( 'getRedirectTarget' )
-			->willReturnArgument( 0 );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
-
 		$instance = new ReferenceValue();
+		$instance->setDataValueServiceFactory( $this->dataValueServiceFactory );
 		$instance->setProperty(
 			$this->dataItemFactory->newDIProperty( 'Foo' )
 		);
@@ -139,22 +141,12 @@ class ReferenceValueTest extends TestCase {
 	}
 
 	public function testParseValueWithErroredDv() {
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getRedirectTarget' ] )
-			->getMockForAbstractClass();
-
 		$this->propertySpecificationLookup->expects( $this->atLeastOnce() )
 			->method( 'getFieldListBy' )
 			->willReturn( $this->dataItemFactory->newDIBlob( 'Bar;Foobar' ) );
 
-		$store->expects( $this->any() )
-			->method( 'getRedirectTarget' )
-			->willReturnArgument( 0 );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
-
 		$instance = new ReferenceValue();
+		$instance->setDataValueServiceFactory( $this->dataValueServiceFactory );
 		$instance->setProperty(
 			$this->dataItemFactory->newDIProperty( 'Foo' )
 		);

--- a/tests/phpunit/Unit/DataValues/TemperatureValueTest.php
+++ b/tests/phpunit/Unit/DataValues/TemperatureValueTest.php
@@ -9,7 +9,6 @@ use SMW\DataValues\ValueFormatters\NumberValueFormatter;
 use SMW\DataValues\ValueValidators\ConstraintValueValidator;
 use SMW\Property\SpecificationLookup;
 use SMW\Services\DataValueServiceFactory;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\DataValues\TemperatureValue
@@ -22,7 +21,6 @@ use SMW\Tests\TestEnvironment;
  */
 class TemperatureValueTest extends TestCase {
 
-	private $testEnvironment;
 	private $dataItemFactory;
 	private $propertySpecificationLookup;
 	private $dataValueServiceFactory;
@@ -30,14 +28,11 @@ class TemperatureValueTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
 
 		$this->propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
 
 		$constraintValueValidator = $this->getMockBuilder( ConstraintValueValidator::class )
 			->disableOriginalConstructor()
@@ -54,10 +49,6 @@ class TemperatureValueTest extends TestCase {
 		$this->dataValueServiceFactory->expects( $this->any() )
 			->method( 'getPropertySpecificationLookup' )
 			->willReturn( $this->propertySpecificationLookup );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/DataValues/UniquenessConstraintValueTest.php
+++ b/tests/phpunit/Unit/DataValues/UniquenessConstraintValueTest.php
@@ -5,8 +5,6 @@ namespace SMW\Tests\Unit\DataValues;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItemFactory;
 use SMW\DataValues\UniquenessConstraintValue;
-use SMW\Property\SpecificationLookup;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\DataValues\UniquenessConstraintValue
@@ -19,23 +17,10 @@ use SMW\Tests\TestEnvironment;
  */
 class UniquenessConstraintValueTest extends TestCase {
 
-	private $testEnvironment;
 	private $dataItemFactory;
-	private $propertySpecificationLookup;
 
 	protected function setUp(): void {
-		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
-
-		$this->propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/PropertyValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/PropertyValueFormatterTest.php
@@ -43,8 +43,6 @@ class PropertyValueFormatterTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->testEnvironment->registerObject( 'PropertyLabelFinder', $this->propertyLabelFinder );
-
 		$this->propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -52,8 +50,6 @@ class PropertyValueFormatterTest extends TestCase {
 		$this->propertySpecificationLookup->expects( $this->any() )
 			->method( 'getPropertyDescriptionByLanguageCode' )
 			->willReturn( 'Some description' );
-
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
 
 		$constraintValueValidator = $this->getMockBuilder( ConstraintValueValidator::class )
 			->disableOriginalConstructor()
@@ -75,7 +71,7 @@ class PropertyValueFormatterTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			PropertyValueFormatter::class,
-			new PropertyValueFormatter( $this->propertySpecificationLookup )
+			new PropertyValueFormatter( $this->propertySpecificationLookup, $this->propertyLabelFinder )
 		);
 	}
 
@@ -85,7 +81,8 @@ class PropertyValueFormatterTest extends TestCase {
 			->getMock();
 
 		$instance = new PropertyValueFormatter(
-			$this->propertySpecificationLookup
+			$this->propertySpecificationLookup,
+			$this->propertyLabelFinder
 		);
 
 		$this->assertTrue(
@@ -103,7 +100,8 @@ class PropertyValueFormatterTest extends TestCase {
 		);
 
 		$instance = new PropertyValueFormatter(
-			$this->propertySpecificationLookup
+			$this->propertySpecificationLookup,
+			$this->propertyLabelFinder
 		);
 
 		$this->assertSame(
@@ -123,7 +121,8 @@ class PropertyValueFormatterTest extends TestCase {
 		);
 
 		$instance = new PropertyValueFormatter(
-			$this->propertySpecificationLookup
+			$this->propertySpecificationLookup,
+			$this->propertyLabelFinder
 		);
 
 		$this->assertEquals(
@@ -150,7 +149,8 @@ class PropertyValueFormatterTest extends TestCase {
 		);
 
 		$instance = new PropertyValueFormatter(
-			$this->propertySpecificationLookup
+			$this->propertySpecificationLookup,
+			$this->propertyLabelFinder
 		);
 
 		$this->assertStringContainsString(
@@ -180,7 +180,8 @@ class PropertyValueFormatterTest extends TestCase {
 		);
 
 		$instance = new PropertyValueFormatter(
-			$this->propertySpecificationLookup
+			$this->propertySpecificationLookup,
+			$this->propertyLabelFinder
 		);
 
 		$expected = $this->testEnvironment->replaceNamespaceWithLocalizedText(
@@ -234,7 +235,8 @@ class PropertyValueFormatterTest extends TestCase {
 		$propertyValue->setUserValue( $property );
 
 		$instance = new PropertyValueFormatter(
-			$this->propertySpecificationLookup
+			$this->propertySpecificationLookup,
+			$this->propertyLabelFinder
 		);
 
 		$expected = $this->testEnvironment->replaceNamespaceWithLocalizedText(
@@ -291,7 +293,8 @@ class PropertyValueFormatterTest extends TestCase {
 		$propertyValue->setCaption( $caption );
 
 		$instance = new PropertyValueFormatter(
-			$this->propertySpecificationLookup
+			$this->propertySpecificationLookup,
+			$this->propertyLabelFinder
 		);
 
 		$expected = $this->testEnvironment->replaceNamespaceWithLocalizedText(
@@ -328,7 +331,8 @@ class PropertyValueFormatterTest extends TestCase {
 		);
 
 		$instance = new PropertyValueFormatter(
-			$this->propertySpecificationLookup
+			$this->propertySpecificationLookup,
+			$this->propertyLabelFinder
 		);
 
 		$expected = $this->testEnvironment->replaceNamespaceWithLocalizedText(
@@ -344,7 +348,8 @@ class PropertyValueFormatterTest extends TestCase {
 
 	public function testTryToFormatOnMissingDataValueThrowsException() {
 		$instance = new PropertyValueFormatter(
-			$this->propertySpecificationLookup
+			$this->propertySpecificationLookup,
+			$this->propertyLabelFinder
 		);
 
 		$this->expectException( 'RuntimeException' );

--- a/tests/phpunit/Unit/DataValues/ValueFormatters/ReferenceValueFormatterTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueFormatters/ReferenceValueFormatterTest.php
@@ -6,7 +6,6 @@ use PHPUnit\Framework\TestCase;
 use SMW\DataItemFactory;
 use SMW\DataValues\ReferenceValue;
 use SMW\DataValues\ValueFormatters\ReferenceValueFormatter;
-use SMW\Property\SpecificationLookup;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -31,12 +30,6 @@ class ReferenceValueFormatterTest extends TestCase {
 		$this->dataItemFactory = new DataItemFactory();
 
 		$this->stringValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newStringValidator();
-
-		$propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $propertySpecificationLookup );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/DataValues/ValueValidators/ConstraintSchemaValueValidatorTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueValidators/ConstraintSchemaValueValidatorTest.php
@@ -11,7 +11,6 @@ use SMW\MediaWiki\JobQueue;
 use SMW\MediaWiki\Jobs\DeferredConstraintCheckUpdateJob;
 use SMW\Schema\SchemaFinder;
 use SMW\Schema\SchemaList;
-use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -48,16 +47,9 @@ class ConstraintSchemaValueValidatorTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$store = $this->getMockBuilder( SQLStore::class )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->jobQueue = $this->getMockBuilder( JobQueue::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
-		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown(): void {
@@ -68,14 +60,15 @@ class ConstraintSchemaValueValidatorTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			ConstraintSchemaValueValidator::class,
-			new ConstraintSchemaValueValidator( $this->constraintCheckRunner, $this->schemafinder )
+			new ConstraintSchemaValueValidator( $this->constraintCheckRunner, $this->schemafinder, $this->jobQueue )
 		);
 	}
 
 	public function testHasNoConstraintViolationOnNonRelatedValue() {
 		$instance = new ConstraintSchemaValueValidator(
 			$this->constraintCheckRunner,
-			$this->schemafinder
+			$this->schemafinder,
+			$this->jobQueue
 		);
 
 		$instance->validate( 'Foo' );
@@ -98,7 +91,8 @@ class ConstraintSchemaValueValidatorTest extends TestCase {
 
 		$instance = new ConstraintSchemaValueValidator(
 			$this->constraintCheckRunner,
-			$this->schemafinder
+			$this->schemafinder,
+			$this->jobQueue
 		);
 
 		$instance->validate( $dataValue );
@@ -141,7 +135,8 @@ class ConstraintSchemaValueValidatorTest extends TestCase {
 
 		$instance = new ConstraintSchemaValueValidator(
 			$this->constraintCheckRunner,
-			$this->schemafinder
+			$this->schemafinder,
+			$this->jobQueue
 		);
 
 		$instance->validate( $dataValue );
@@ -193,7 +188,8 @@ class ConstraintSchemaValueValidatorTest extends TestCase {
 
 		$instance = new ConstraintSchemaValueValidator(
 			$this->constraintCheckRunner,
-			$this->schemafinder
+			$this->schemafinder,
+			$this->jobQueue
 		);
 
 		$instance->validate( $dataValue );

--- a/tests/phpunit/Unit/DataValues/ValueValidators/PatternConstraintValueValidatorTest.php
+++ b/tests/phpunit/Unit/DataValues/ValueValidators/PatternConstraintValueValidatorTest.php
@@ -9,7 +9,6 @@ use SMW\DataValues\ValueParsers\AllowsPatternValueParser;
 use SMW\DataValues\ValueValidators\PatternConstraintValueValidator;
 use SMW\MediaWiki\MediaWikiNsContentReader;
 use SMW\Property\SpecificationLookup;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\DataValues\ValueValidators\PatternConstraintValueValidator
@@ -22,21 +21,17 @@ use SMW\Tests\TestEnvironment;
  */
 class PatternConstraintValueValidatorTest extends TestCase {
 
-	private $testEnvironment;
 	private $dataItemFactory;
 	private $propertySpecificationLookup;
 	private $mediaWikiNsContentReader;
 	private $allowsPatternValueParser;
 
 	protected function setUp(): void {
-		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
 
 		$this->mediaWikiNsContentReader = $this->getMockBuilder( MediaWikiNsContentReader::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'MediaWikiNsContentReader', $this->mediaWikiNsContentReader );
 
 		$this->allowsPatternValueParser = new AllowsPatternValueParser(
 			$this->mediaWikiNsContentReader
@@ -45,18 +40,12 @@ class PatternConstraintValueValidatorTest extends TestCase {
 		$this->propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			PatternConstraintValueValidator::class,
-			new PatternConstraintValueValidator( $this->allowsPatternValueParser )
+			new PatternConstraintValueValidator( $this->allowsPatternValueParser, $this->propertySpecificationLookup )
 		);
 	}
 
@@ -92,7 +81,8 @@ class PatternConstraintValueValidatorTest extends TestCase {
 			->willReturn( $this->dataItemFactory->newDIBlob( $testString ) );
 
 		$instance = new PatternConstraintValueValidator(
-			$this->allowsPatternValueParser
+			$this->allowsPatternValueParser,
+			$this->propertySpecificationLookup
 		);
 
 		$dataValue->setOption( 'smwgDVFeatures', SMW_DV_PVAP );

--- a/tests/phpunit/Unit/DataValues/WikiPageValueTest.php
+++ b/tests/phpunit/Unit/DataValues/WikiPageValueTest.php
@@ -5,8 +5,6 @@ namespace SMW\Tests\Unit\DataValues;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItemFactory;
 use SMW\DataValues\WikiPageValue;
-use SMW\Property\SpecificationLookup;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\DataValues\WikiPageValue
@@ -19,27 +17,12 @@ use SMW\Tests\TestEnvironment;
  */
 class WikiPageValueTest extends TestCase {
 
-	private $testEnvironment;
 	private $dataItemFactory;
-
-	private $propertySpecificationLookup;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->testEnvironment = new TestEnvironment();
 		$this->dataItemFactory = new DataItemFactory();
-
-		$this->propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
 	}
 
 	public function testCanConstruct() {


### PR DESCRIPTION
## Summary

Third slice of the follow-up to #6827: moving SMW classes off global service-locator dependency access toward constructor injection, so unit tests inject mocks directly rather than mutating a shared container through `TestEnvironment::registerObject()`.

This slice covers 15 `DataValues` unit tests. Most `registerObject` calls turned out to be dead scaffolding; five involved real production changes.

## Changes

**Real conversions** (production code changed; in-body locator calls removed, dependency supplied explicitly, behaviour preserved):

- `PatternConstraintValueValidator` — `PropertySpecificationLookup` is now a constructor dependency instead of being fetched via `ApplicationFactory::getInstance()->getPropertySpecificationLookup()`.
- `PropertyValueFormatter` — `PropertyLabelFinder` is now a constructor dependency instead of an in-body locator call.
- `ConstraintSchemaValueValidator` — `JobQueue` is now a constructor dependency; `triggerDeferredCheck()` pushes the deferred job through it directly. Behaviour is equivalent to the prior `DeferredConstraintCheckUpdateJob::pushJob()` path (same job, same params, deduplication preserved).
- `RecordValue` / `ReferenceValue` — these are `DataValue` subclasses with a fixed `__construct( $typeid )` signature, so they cannot take new constructor parameters. Instead `Store` and `PropertySpecificationLookup` are routed through the existing `DataValueServiceFactory` service seam (`AbstractMultiValue::getFieldProperties()`, `PropertyListValue`), falling back to the global locator when no factory is set. The `Property::getRedirectTarget()` inverse-property short-circuit is preserved.

`src/Services/datavalues.php` wires the new constructor arguments.

**Dead-scaffolding removals** (test-only): the remaining files. `DataValue` subclasses obtain `PropertySpecificationLookup` via `DataValueServiceFactory`, not the global locator, so those `registerObject` calls had no effect.

## Testing

- The unit suite (7092 tests) passes; PHPCS is clean on all changed files.
- Test method counts are unchanged in every file; no assertions or test methods were removed.
- phan and the integration / `@group Database` suite are expected to be covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)