### PR TITLE
Inject dependencies into MediaWiki hook handlers, drop registerObject scaffolding from their tests

### DIFF
--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -415,7 +415,8 @@ class Hooks {
 		$outputPageParserOutput = new OutputPageParserOutput(
 			$applicationFactory->getNamespaceExaminer(),
 			$permissionExaminer,
-			$applicationFactory->getFactboxText()
+			$applicationFactory->getFactboxText(),
+			$applicationFactory->getFactboxFactory()
 		);
 
 		$preferenceExaminer = $applicationFactory->newPreferenceExaminer( $outputPage->getUser() );

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -788,7 +788,8 @@ class Hooks {
 		$applicationFactory = ApplicationFactory::getInstance();
 
 		$articleDelete = new ArticleDelete(
-			$applicationFactory->getStore()
+			$applicationFactory->getStore(),
+			$applicationFactory->newJobFactory()
 		);
 
 		$articleDelete->setEventDispatcher(
@@ -1236,7 +1237,8 @@ class Hooks {
 		$applicationFactory = ApplicationFactory::getInstance();
 
 		$articleDelete = new ArticleDelete(
-			$applicationFactory->getStore()
+			$applicationFactory->getStore(),
+			$applicationFactory->newJobFactory()
 		);
 
 		$articleDelete->setEventDispatcher(

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -744,7 +744,8 @@ class Hooks {
 		$applicationFactory = ApplicationFactory::getInstance();
 
 		$pageMoveComplete = new PageMoveComplete(
-			$applicationFactory->getNamespaceExaminer()
+			$applicationFactory->getNamespaceExaminer(),
+			$applicationFactory->getStore()
 		);
 
 		$pageMoveComplete->setEventDispatcher(

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -388,8 +388,11 @@ class Hooks {
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/SkinAfterContent
 	 */
 	public function onSkinAfterContent( string &$data, $skin = null ): bool {
+		$applicationFactory = ApplicationFactory::getInstance();
+
 		$skinAfterContent = new SkinAfterContent(
-			$skin
+			$skin,
+			$applicationFactory->getFactboxFactory()
 		);
 
 		$skinAfterContent->setOptions(

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -812,7 +812,8 @@ class Hooks {
 		$applicationFactory = ApplicationFactory::getInstance();
 
 		$linksUpdateConstructed = new LinksUpdateComplete(
-			$applicationFactory->getNamespaceExaminer()
+			$applicationFactory->getNamespaceExaminer(),
+			$applicationFactory
 		);
 
 		$linksUpdateConstructed->setLogger(

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -312,7 +312,8 @@ class Hooks {
 		$parserAfterTidy = new ParserAfterTidy(
 			$parser,
 			$applicationFactory->getNamespaceExaminer(),
-			$applicationFactory->getCache()
+			$applicationFactory->getCache(),
+			$applicationFactory
 		);
 
 		$parserAfterTidy->setLogger(

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -760,7 +760,7 @@ class Hooks {
 		$applicationFactory = ApplicationFactory::getInstance();
 		$settings = $applicationFactory->getSettings();
 
-		$articlePurge = new ArticlePurge();
+		$articlePurge = new ArticlePurge( $applicationFactory->getCache() );
 
 		$articlePurge->setEventDispatcher(
 			$applicationFactory->getEventDispatcher()

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -160,7 +160,9 @@ class Hooks {
 	 */
 	public static function registerExtensionCheck( array &$vars ): void {
 		$vars['wgHooks']['BeforePageDisplay']['smw-extension-check'] = static function ( OutputPage $outputPage ): bool {
-			$beforePageDisplay = new BeforePageDisplay();
+			$beforePageDisplay = new BeforePageDisplay(
+				MediaWikiServices::getInstance()->getUserOptionsLookup()
+			);
 
 			$beforePageDisplay->setOptions(
 				[
@@ -453,7 +455,9 @@ class Hooks {
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/BeforePageDisplay
 	 */
 	public function onBeforePageDisplay( OutputPage &$outputPage, Skin &$skin ): bool {
-		$beforePageDisplay = new BeforePageDisplay();
+		$beforePageDisplay = new BeforePageDisplay(
+			MediaWikiServices::getInstance()->getUserOptionsLookup()
+		);
 		$setupFile = new SetupFile();
 
 		$beforePageDisplay->setOptions(
@@ -883,7 +887,8 @@ class Hooks {
 	public function onFileUpload( File $file, ?bool $reupload ): bool {
 		$fileUpload = new FileUpload(
 			ApplicationFactory::getInstance()->getNamespaceExaminer(),
-			MediaWikiServices::getInstance()->getHookContainer()
+			MediaWikiServices::getInstance()->getHookContainer(),
+			ApplicationFactory::getInstance()->newPageCreator()
 		);
 
 		return $fileUpload->process( $file, $reupload );

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -590,7 +590,8 @@ class Hooks {
 			$editInfo,
 			$pageInfoProvider,
 			$applicationFactory->singleton( 'PropertyAnnotatorFactory' ),
-			$applicationFactory->singleton( 'SchemaFactory' )
+			$applicationFactory->singleton( 'SchemaFactory' ),
+			$applicationFactory->getStore()
 		);
 
 		$revisionFromEditComplete->setEventDispatcher(

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -1276,8 +1276,11 @@ class Hooks {
 	 * an IP or user has been processed ..."
 	 */
 	public function onBlockIpComplete( $block, $performer, $priorBlock ): bool {
+		$applicationFactory = ApplicationFactory::getInstance();
+
 		$userChange = new UserChange(
-			ApplicationFactory::getInstance()->getNamespaceExaminer()
+			$applicationFactory->getNamespaceExaminer(),
+			$applicationFactory->newJobFactory()
 		);
 
 		$userChange->setOrigin( 'BlockIpComplete' );
@@ -1294,8 +1297,11 @@ class Hooks {
 	 * processed ..."
 	 */
 	public function onUnblockUserComplete( $block, $performer ): bool {
+		$applicationFactory = ApplicationFactory::getInstance();
+
 		$userChange = new UserChange(
-			ApplicationFactory::getInstance()->getNamespaceExaminer()
+			$applicationFactory->getNamespaceExaminer(),
+			$applicationFactory->newJobFactory()
 		);
 
 		$userChange->setOrigin( 'UnblockUserComplete' );
@@ -1311,8 +1317,11 @@ class Hooks {
 	 * "... called after user groups are changed ..."
 	 */
 	public function onUserGroupsChanged( $user ): bool {
+		$applicationFactory = ApplicationFactory::getInstance();
+
 		$userChange = new UserChange(
-			ApplicationFactory::getInstance()->getNamespaceExaminer()
+			$applicationFactory->getNamespaceExaminer(),
+			$applicationFactory->newJobFactory()
 		);
 
 		$userChange->setOrigin( 'UserGroupsChanged' );

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -7,6 +7,7 @@ use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\MediaWiki\HookListener;
+use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\Jobs\UpdateDispatcherJob;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
@@ -28,7 +29,10 @@ class ArticleDelete implements HookListener {
 	/**
 	 * @since 3.0
 	 */
-	public function __construct( private Store $store ) {
+	public function __construct(
+		private Store $store,
+		private readonly JobFactory $jobFactory,
+	) {
 	}
 
 	/**
@@ -68,7 +72,6 @@ class ArticleDelete implements HookListener {
 		$subject = WikiPage::newFromTitle( $title );
 
 		$semanticDataSerializer = $applicationFactory->newSerializerFactory()->newSemanticDataSerializer();
-		$jobFactory = $applicationFactory->newJobFactory();
 
 		// Instead of Store::getSemanticData, construct the SemanticData by
 		// attaching only the incoming properties indicating which entities
@@ -104,7 +107,7 @@ class ArticleDelete implements HookListener {
 		// Restricted to the available SemanticData
 		$parameters[UpdateDispatcherJob::RESTRICTED_DISPATCH_POOL] = true;
 
-		$updateDispatcherJob = $jobFactory->newUpdateDispatcherJob( $title, $parameters );
+		$updateDispatcherJob = $this->jobFactory->newUpdateDispatcherJob( $title, $parameters );
 		$updateDispatcherJob->insert();
 
 		$this->store->deleteSubject( $title );

--- a/src/MediaWiki/Hooks/ArticlePurge.php
+++ b/src/MediaWiki/Hooks/ArticlePurge.php
@@ -33,7 +33,7 @@ class ArticlePurge implements HookListener {
 	const CACHE_NAMESPACE = 'smw:arc';
 
 	/**
-	 * @since 1.9
+	 * @since 7.0.0
 	 */
 	public function __construct( private readonly Cache $cache ) {
 	}

--- a/src/MediaWiki/Hooks/ArticlePurge.php
+++ b/src/MediaWiki/Hooks/ArticlePurge.php
@@ -3,6 +3,7 @@
 namespace SMW\MediaWiki\Hooks;
 
 use MediaWiki\Title\Title;
+use Onoi\Cache\Cache;
 use SMW\DataItems\Property;
 use SMW\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\MediaWiki\HookListener;
@@ -33,6 +34,12 @@ class ArticlePurge implements HookListener {
 
 	/**
 	 * @since 1.9
+	 */
+	public function __construct( private readonly Cache $cache ) {
+	}
+
+	/**
+	 * @since 1.9
 	 *
 	 * @return true
 	 */
@@ -43,10 +50,9 @@ class ArticlePurge implements HookListener {
 		$articleID = $title->getArticleID();
 
 		$settings = $applicationFactory->getSettings();
-		$cache = $applicationFactory->getCache();
 
 		if ( $articleID > 0 ) {
-			$cache->save(
+			$this->cache->save(
 				smwfCacheKey( self::CACHE_NAMESPACE, $articleID ),
 				$settings->get( 'smwgAutoRefreshOnPurge' )
 			);

--- a/src/MediaWiki/Hooks/BeforePageDisplay.php
+++ b/src/MediaWiki/Hooks/BeforePageDisplay.php
@@ -6,11 +6,11 @@ use MediaWiki\Html\Html;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Skin\SkinComponentUtils;
 use MediaWiki\Title\Title;
+use MediaWiki\User\Options\UserOptionsLookup;
 use Skin;
 use SMW\Localizer\Message;
 use SMW\MediaWiki\HookListener;
 use SMW\OptionsAwareTrait;
-use SMW\Services\ServicesFactory;
 
 /**
  * BeforePageDisplay hook which allows last minute changes to the
@@ -26,6 +26,14 @@ use SMW\Services\ServicesFactory;
 class BeforePageDisplay implements HookListener {
 
 	use OptionsAwareTrait;
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function __construct(
+		private readonly UserOptionsLookup $userOptionsLookup,
+	) {
+	}
 
 	/**
 	 * @since 3.1
@@ -64,8 +72,7 @@ class BeforePageDisplay implements HookListener {
 		$title = $outputPage->getTitle();
 		$user = $outputPage->getUser();
 		// #2726
-		$userOptionsLookup = ServicesFactory::getInstance()->singleton( 'UserOptionsLookup' );
-		if ( $userOptionsLookup->getOption( $user, 'smw-prefs-general-options-suggester-textinput' ) ) {
+		if ( $this->userOptionsLookup->getOption( $user, 'smw-prefs-general-options-suggester-textinput' ) ) {
 			$outputPage->addModules( 'ext.smw.suggester.textInput' );
 		}
 

--- a/src/MediaWiki/Hooks/FileUpload.php
+++ b/src/MediaWiki/Hooks/FileUpload.php
@@ -8,6 +8,7 @@ use MediaWiki\Parser\ParserOptions;
 use MediaWiki\User\User;
 use SMW\Localizer\Localizer;
 use SMW\MediaWiki\HookListener;
+use SMW\MediaWiki\PageCreator;
 use SMW\NamespaceExaminer;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 
@@ -23,9 +24,13 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
  */
 class FileUpload implements HookListener {
 
+	/**
+	 * @since 7.0.0
+	 */
 	public function __construct(
 		private readonly NamespaceExaminer $namespaceExaminer,
 		private readonly HookContainer $hookContainer,
+		private readonly PageCreator $pageCreator,
 	) {
 	}
 
@@ -92,7 +97,7 @@ class FileUpload implements HookListener {
 	}
 
 	private function makeFilePage( File $file ) {
-		$filePage = ApplicationFactory::getInstance()->newPageCreator()->createFilePage(
+		$filePage = $this->pageCreator->createFilePage(
 			$file->getTitle()
 		);
 

--- a/src/MediaWiki/Hooks/LinksUpdateComplete.php
+++ b/src/MediaWiki/Hooks/LinksUpdateComplete.php
@@ -10,7 +10,7 @@ use SMW\DataModel\SemanticData;
 use SMW\MediaWiki\HookListener;
 use SMW\MediaWiki\RevisionGuardAwareTrait;
 use SMW\NamespaceExaminer;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Services\ServicesFactory;
 
 /**
  * LinksUpdateComplete hook is called at the end of LinksUpdate()
@@ -34,7 +34,10 @@ class LinksUpdateComplete implements HookListener {
 	/**
 	 * @since 3.0
 	 */
-	public function __construct( private NamespaceExaminer $namespaceExaminer ) {
+	public function __construct(
+		private readonly NamespaceExaminer $namespaceExaminer,
+		private readonly ServicesFactory $servicesFactory,
+	) {
 	}
 
 	/**
@@ -65,7 +68,7 @@ class LinksUpdateComplete implements HookListener {
 			return true;
 		}
 
-		$parserData = ApplicationFactory::getInstance()->newParserData(
+		$parserData = $this->servicesFactory->newParserData(
 			$title,
 			$linksUpdate->getParserOutput()
 		);
@@ -125,7 +128,7 @@ class LinksUpdateComplete implements HookListener {
 	}
 
 	private function reparseAndFetchSemanticData( Title $title ) {
-		$contentParser = ApplicationFactory::getInstance()->newContentParser( $title );
+		$contentParser = $this->servicesFactory->newContentParser( $title );
 		$parserOutput = $contentParser->parse()->getOutput();
 
 		if ( $parserOutput === null ) {

--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -5,6 +5,7 @@ namespace SMW\MediaWiki\Hooks;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Title\Title;
+use SMW\Factbox\FactboxFactory;
 use SMW\Factbox\FactboxText;
 use SMW\MediaWiki\HookListener;
 use SMW\MediaWiki\IndicatorRegistry;
@@ -40,6 +41,7 @@ class OutputPageParserOutput implements HookListener {
 		private readonly NamespaceExaminer $namespaceExaminer,
 		private readonly PermissionExaminer $permissionExaminer,
 		private readonly FactboxText $factboxText,
+		private readonly FactboxFactory $factboxFactory,
 	) {
 	}
 
@@ -118,9 +120,7 @@ class OutputPageParserOutput implements HookListener {
 			return '';
 		}
 
-		$applicationFactory = ApplicationFactory::getInstance();
-
-		$cachedFactbox = $applicationFactory->singleton( 'FactboxFactory' )->newCachedFactbox();
+		$cachedFactbox = $this->factboxFactory->newCachedFactbox();
 
 		$cachedFactbox->prepare(
 			$outputPage,

--- a/src/MediaWiki/Hooks/PageMoveComplete.php
+++ b/src/MediaWiki/Hooks/PageMoveComplete.php
@@ -8,7 +8,7 @@ use MediaWiki\User\UserIdentity;
 use SMW\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\MediaWiki\HookListener;
 use SMW\NamespaceExaminer;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Store;
 
 /**
  * PageMoveComplete occurs whenever a request to move an article
@@ -31,7 +31,10 @@ class PageMoveComplete implements HookListener {
 	/**
 	 * @since  1.9
 	 */
-	public function __construct( private NamespaceExaminer $namespaceExaminer ) {
+	public function __construct(
+		private readonly NamespaceExaminer $namespaceExaminer,
+		private readonly Store $store,
+	) {
 	}
 
 	/**
@@ -44,11 +47,9 @@ class PageMoveComplete implements HookListener {
 		int $oldId,
 		int $newId
 	): bool {
-		$applicationFactory = ApplicationFactory::getInstance();
-
 		// Delete all data for a non-enabled target NS
 		if ( !$this->namespaceExaminer->isSemanticEnabled( $newTitle->getNamespace() ) || $newId == 0 ) {
-			$applicationFactory->getStore()->deleteSubject(
+			$this->store->deleteSubject(
 				Title::newFromLinkTarget( $oldTitle )
 			);
 		}

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -62,6 +62,7 @@ class ParserAfterTidy implements HookListener {
 		private Parser &$parser,
 		private NamespaceExaminer $namespaceExaminer,
 		private Cache $cache,
+		private readonly ApplicationFactory $servicesFactory,
 	) {
 	}
 
@@ -256,9 +257,7 @@ class ParserAfterTidy implements HookListener {
 	}
 
 	private function performUpdate( string &$text ): void {
-		$applicationFactory = ApplicationFactory::getInstance();
-
-		$parserData = $applicationFactory->newParserData(
+		$parserData = $this->servicesFactory->newParserData(
 			$this->parser->getTitle(),
 			$this->parser->getOutput()
 		);
@@ -266,7 +265,7 @@ class ParserAfterTidy implements HookListener {
 		$semanticData = $parserData->getSemanticData();
 
 		$this->addPropertyAnnotations(
-			$applicationFactory->singleton( 'PropertyAnnotatorFactory' ),
+			$this->servicesFactory->singleton( 'PropertyAnnotatorFactory' ),
 			$semanticData
 		);
 

--- a/src/MediaWiki/Hooks/RevisionFromEditComplete.php
+++ b/src/MediaWiki/Hooks/RevisionFromEditComplete.php
@@ -15,6 +15,7 @@ use SMW\Property\AnnotatorFactory as PropertyAnnotatorFactory;
 use SMW\Schema\Schema;
 use SMW\Schema\SchemaFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Store;
 
 /**
  * Hook: RevisionFromEditComplete called when a revision was inserted
@@ -42,10 +43,11 @@ class RevisionFromEditComplete implements HookListener {
 	 * @since 1.9
 	 */
 	public function __construct(
-		private EditInfo $editInfo,
-		private PageInfoProvider $pageInfoProvider,
-		private PropertyAnnotatorFactory $propertyAnnotatorFactory,
-		private SchemaFactory $schemaFactory,
+		private readonly EditInfo $editInfo,
+		private readonly PageInfoProvider $pageInfoProvider,
+		private readonly PropertyAnnotatorFactory $propertyAnnotatorFactory,
+		private readonly SchemaFactory $schemaFactory,
+		private readonly Store $store,
 	) {
 	}
 
@@ -61,9 +63,7 @@ class RevisionFromEditComplete implements HookListener {
 			return true;
 		}
 
-		$applicationFactory = ApplicationFactory::getInstance();
-
-		$parserData = $applicationFactory->newParserData(
+		$parserData = ApplicationFactory::getInstance()->newParserData(
 			$title,
 			$parserOutput
 		);
@@ -82,7 +82,7 @@ class RevisionFromEditComplete implements HookListener {
 
 		// If the concept was altered make sure to delete the cache
 		if ( $title->getNamespace() === SMW_NS_CONCEPT ) {
-			$applicationFactory->getStore()->deleteConceptCache( $title );
+			$this->store->deleteConceptCache( $title );
 		}
 
 		$parserData->copyToParserOutput();

--- a/src/MediaWiki/Hooks/SkinAfterContent.php
+++ b/src/MediaWiki/Hooks/SkinAfterContent.php
@@ -3,9 +3,9 @@
 namespace SMW\MediaWiki\Hooks;
 
 use Skin;
+use SMW\Factbox\FactboxFactory;
 use SMW\MediaWiki\HookListener;
 use SMW\OptionsAwareTrait;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
  * SkinAfterContent hook to add text after the page content and
@@ -25,7 +25,10 @@ class SkinAfterContent implements HookListener {
 	/**
 	 * @since  1.9
 	 */
-	public function __construct( private ?Skin $skin = null ) {
+	public function __construct(
+		private readonly ?Skin $skin = null,
+		private readonly ?FactboxFactory $factboxFactory = null,
+	) {
 	}
 
 	/**
@@ -58,7 +61,7 @@ class SkinAfterContent implements HookListener {
 	}
 
 	private function addFactboxTo( string &$data ): void {
-		$cachedFactbox = ApplicationFactory::getInstance()->singleton( 'FactboxFactory' )->newCachedFactbox();
+		$cachedFactbox = $this->factboxFactory->newCachedFactbox();
 
 		$data .= $cachedFactbox->retrieveContent(
 			$this->skin->getOutput()

--- a/src/MediaWiki/Hooks/SkinAfterContent.php
+++ b/src/MediaWiki/Hooks/SkinAfterContent.php
@@ -26,8 +26,8 @@ class SkinAfterContent implements HookListener {
 	 * @since  1.9
 	 */
 	public function __construct(
-		private readonly ?Skin $skin = null,
-		private readonly ?FactboxFactory $factboxFactory = null,
+		private readonly ?Skin $skin,
+		private readonly FactboxFactory $factboxFactory,
 	) {
 	}
 

--- a/src/MediaWiki/Hooks/UserChange.php
+++ b/src/MediaWiki/Hooks/UserChange.php
@@ -5,9 +5,9 @@ namespace SMW\MediaWiki\Hooks;
 use MediaWiki\Title\Title;
 use MediaWiki\User\UserIdentity;
 use SMW\MediaWiki\HookListener;
+use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\Jobs\UpdateJob;
 use SMW\NamespaceExaminer;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
  * @see https://www.mediawiki.org/wiki/Manual:Hooks/BlockIpComplete
@@ -32,7 +32,10 @@ class UserChange implements HookListener {
 	/**
 	 * @since 3.0
 	 */
-	public function __construct( private readonly NamespaceExaminer $namespaceExaminer ) {
+	public function __construct(
+		private readonly NamespaceExaminer $namespaceExaminer,
+		private readonly JobFactory $jobFactory,
+	) {
 	}
 
 	/**
@@ -64,7 +67,7 @@ class UserChange implements HookListener {
 			$user = $user->getName();
 		}
 
-		$updateJob = ApplicationFactory::getInstance()->newJobFactory()->newUpdateJob(
+		$updateJob = $this->jobFactory->newUpdateJob(
 			Title::newFromText( $user, NS_USER ),
 			[
 				UpdateJob::FORCED_UPDATE => true,

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
@@ -43,13 +43,6 @@ class ArticleDeleteTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->testEnvironment->registerObject( 'JobFactory', $this->jobFactory );
-		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
-
 		$this->eventDispatcher = $this->getMockBuilder( EventDispatcher::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -65,7 +58,7 @@ class ArticleDeleteTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$instance = new ArticleDelete( $store );
+		$instance = new ArticleDelete( $store, $this->jobFactory );
 
 		$this->assertInstanceOf(
 			ArticleDelete::class,
@@ -110,7 +103,8 @@ class ArticleDeleteTest extends TestCase {
 				[ $this->equalTo( 'InvalidateEntityCache' ) ] );
 
 		$instance = new ArticleDelete(
-			$store
+			$store,
+			$this->jobFactory
 		);
 
 		$instance->setEventDispatcher(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
@@ -10,9 +10,6 @@ use SMW\Localizer\Message;
 use SMW\MediaWiki\EditInfo;
 use SMW\MediaWiki\Hooks\ArticleProtectComplete;
 use SMW\Property\Annotators\EditProtectedPropertyAnnotator;
-use SMW\Property\SpecificationLookup;
-use SMW\SQLStore\SQLStore;
-use SMW\Store;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -40,30 +37,6 @@ class ArticleProtectCompleteTest extends TestCase {
 
 		$this->spyLogger = $this->testEnvironment->getUtilityFactory()->newSpyLogger();
 		$this->semanticDataFactory = $this->testEnvironment->getUtilityFactory()->newSemanticDataFactory();
-
-		$propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'findAssociatedRev' ] )
-			->getMock();
-
-		$store = $this->getMockBuilder( SQLStore::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
-			->getMock();
-
-		$store->expects( $this->any() )
-			->method( 'getObjectIds' )
-			->willReturn( $idTable );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $propertySpecificationLookup );
 
 		$this->editInfo = $this->getMockBuilder( EditInfo::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
@@ -39,7 +39,6 @@ class ArticlePurgeTest extends TestCase {
 		$this->testEnvironment = new TestEnvironment( $settings );
 
 		$this->cache = $this->applicationFactory->newCacheFactory()->newFixedInMemoryCache();
-		$this->applicationFactory->registerObject( 'Cache', $this->cache );
 
 		$this->eventDispatcher = $this->getMockBuilder( EventDispatcher::class )
 			->disableOriginalConstructor()
@@ -79,7 +78,7 @@ class ArticlePurgeTest extends TestCase {
 			$setup['smwgQueryResultCacheRefreshOnPurge']
 		);
 
-		$instance = new ArticlePurge();
+		$instance = new ArticlePurge( $this->cache );
 
 		$instance->setEventDispatcher(
 			$this->eventDispatcher

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleViewHeaderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleViewHeaderTest.php
@@ -13,7 +13,6 @@ use SMW\MediaWiki\Hooks\ArticleViewHeader;
 use SMW\NamespaceExaminer;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\Store;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\MediaWiki\Hooks\ArticleViewHeader
@@ -26,15 +25,12 @@ use SMW\Tests\TestEnvironment;
  */
 class ArticleViewHeaderTest extends TestCase {
 
-	private $testEnvironment;
 	private $store;
 	private $namespaceExaminer;
 	private $dependencyValidator;
 
 	protected function setUp(): void {
 		parent::setUp();
-
-		$this->testEnvironment = new TestEnvironment();
 
 		$this->namespaceExaminer = $this->getMockBuilder( NamespaceExaminer::class )
 			->disableOriginalConstructor()
@@ -56,13 +52,6 @@ class ArticleViewHeaderTest extends TestCase {
 		$this->dependencyValidator = $this->getMockBuilder( DependencyValidator::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/MediaWiki/Hooks/BeforePageDisplayTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/BeforePageDisplayTest.php
@@ -10,7 +10,6 @@ use MediaWiki\User\Options\UserOptionsLookup;
 use MediaWiki\User\User;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Hooks\BeforePageDisplay;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\MediaWiki\Hooks\BeforePageDisplay
@@ -29,7 +28,6 @@ class BeforePageDisplayTest extends TestCase {
 	private $title;
 
 	private UserOptionsLookup $userOptionsLookup;
-	private TestEnvironment $testEnvironment;
 
 	protected function setUp(): void {
 		$this->title = $this->getMockBuilder( Title::class )
@@ -65,19 +63,12 @@ class BeforePageDisplayTest extends TestCase {
 			->willReturn( $requestContext );
 
 		$this->userOptionsLookup = $this->createMock( UserOptionsLookup::class );
-		$this->testEnvironment = new TestEnvironment();
-		$this->testEnvironment->registerObject( 'UserOptionsLookup', $this->userOptionsLookup );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			BeforePageDisplay::class,
-			new BeforePageDisplay()
+			new BeforePageDisplay( $this->userOptionsLookup )
 		);
 	}
 
@@ -90,7 +81,7 @@ class BeforePageDisplayTest extends TestCase {
 		$this->outputPage->expects( $this->once() )
 			->method( 'prependHTML' );
 
-		$instance = new BeforePageDisplay();
+		$instance = new BeforePageDisplay( $this->userOptionsLookup );
 
 		$instance->setOptions(
 			[
@@ -105,7 +96,7 @@ class BeforePageDisplayTest extends TestCase {
 		$this->outputPage->expects( $this->never() )
 			->method( 'prependHTML' );
 
-		$instance = new BeforePageDisplay();
+		$instance = new BeforePageDisplay( $this->userOptionsLookup );
 
 		$instance->setOptions(
 			[
@@ -134,7 +125,7 @@ class BeforePageDisplayTest extends TestCase {
 			->method( 'getUser' )
 			->willReturn( $user );
 
-		$instance = new BeforePageDisplay();
+		$instance = new BeforePageDisplay( $this->userOptionsLookup );
 
 		$instance->process( $this->outputPage, $this->skin );
 	}
@@ -151,7 +142,7 @@ class BeforePageDisplayTest extends TestCase {
 			->method( 'getUser' )
 			->willReturn( $user );
 
-		$instance = new BeforePageDisplay();
+		$instance = new BeforePageDisplay( $this->userOptionsLookup );
 
 		$instance->setOptions(
 			[
@@ -184,7 +175,7 @@ class BeforePageDisplayTest extends TestCase {
 			->method( 'getUser' )
 			->willReturn( $user );
 
-		$instance = new BeforePageDisplay();
+		$instance = new BeforePageDisplay( $this->userOptionsLookup );
 
 		$instance->setOptions(
 			[
@@ -220,7 +211,7 @@ class BeforePageDisplayTest extends TestCase {
 		$this->outputPage->expects( $expected )
 			->method( 'addLink' );
 
-		$instance = new BeforePageDisplay();
+		$instance = new BeforePageDisplay( $this->userOptionsLookup );
 
 		$instance->setOptions(
 			[

--- a/tests/phpunit/Unit/MediaWiki/Hooks/FileUploadTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/FileUploadTest.php
@@ -9,8 +9,6 @@ use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Hooks\FileUpload;
 use SMW\MediaWiki\PageCreator;
 use SMW\NamespaceExaminer;
-use SMW\Property\SpecificationLookup;
-use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -24,8 +22,7 @@ use SMW\Tests\TestEnvironment;
  */
 class FileUploadTest extends TestCase {
 
-	private $testEnvironment;
-	private $propertySpecificationLookup;
+	private TestEnvironment $testEnvironment;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -36,27 +33,6 @@ class FileUploadTest extends TestCase {
 			'smwgMainCacheType'  => 'hash',
 			'smwgEnableUpdateJobs' => false
 		] );
-
-		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'findAssociatedRev' ] )
-			->getMock();
-
-		$store = $this->getMockBuilder( SQLStore::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
-			->getMock();
-
-		$store->expects( $this->any() )
-			->method( 'getObjectIds' )
-			->willReturn( $idTable );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
-
-		$this->propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
 	}
 
 	protected function tearDown(): void {
@@ -71,10 +47,13 @@ class FileUploadTest extends TestCase {
 		$hookContainer = $this->getMockBuilder( HookContainer::class )
 			->disableOriginalConstructor()
 			->getMock();
+		$pageCreator = $this->getMockBuilder( PageCreator::class )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->assertInstanceOf(
 			FileUpload::class,
-			new FileUpload( $namespaceExaminer, $hookContainer )
+			new FileUpload( $namespaceExaminer, $hookContainer, $pageCreator )
 		);
 	}
 
@@ -119,13 +98,12 @@ class FileUploadTest extends TestCase {
 			->with( $title )
 			->willReturn( $wikiFilePage );
 
-		$this->testEnvironment->registerObject( 'PageCreator', $pageCreator );
-
 		$instance = new FileUpload(
 			$namespaceExaminer,
 			$this->getMockBuilder( HookContainer::class )
 				->disableOriginalConstructor()
-				->getMock()
+				->getMock(),
+			$pageCreator
 		);
 
 		$reUploadStatus = true;
@@ -161,13 +139,12 @@ class FileUploadTest extends TestCase {
 		$pageCreator->expects( $this->never() ) // <-- never
 			->method( 'createFilePage' );
 
-		$this->testEnvironment->registerObject( 'PageCreator', $pageCreator );
-
 		$instance = new FileUpload(
 			$namespaceExaminer,
 			$this->getMockBuilder( HookContainer::class )
 				->disableOriginalConstructor()
-				->getMock()
+				->getMock(),
+			$pageCreator
 		);
 
 		$instance->process( $file, false );

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksIntegrationTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksIntegrationTest.php
@@ -3,7 +3,6 @@
 namespace SMW\Tests\Unit\MediaWiki\Hooks;
 
 use PHPUnit\Framework\TestCase;
-use SMW\ParserData;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Tests\Utils\UtilityFactory;
 
@@ -46,16 +45,10 @@ class InternalParseBeforeLinksIntegrationTest extends TestCase {
 		parent::tearDown();
 	}
 
+	/**
+	 * @doesNotPerformAssertions
+	 */
 	public function testNonParseForInvokedMessageParse() {
-		$parserData = $this->getMockBuilder( ParserData::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$parserData->expects( $this->never() )
-			->method( 'getSemanticData' );
-
-		$this->applicationFactory->registerObject( 'ParserData', $parserData );
-
 		wfMessage( 'properties' )->parse();
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksIntegrationTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksIntegrationTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Unit\MediaWiki\Hooks;
 
 use PHPUnit\Framework\TestCase;
+use SMW\ParserData;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Tests\Utils\UtilityFactory;
 
@@ -45,10 +46,16 @@ class InternalParseBeforeLinksIntegrationTest extends TestCase {
 		parent::tearDown();
 	}
 
-	/**
-	 * @doesNotPerformAssertions
-	 */
 	public function testNonParseForInvokedMessageParse() {
+		$parserData = $this->getMockBuilder( ParserData::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserData->expects( $this->never() )
+			->method( 'getSemanticData' );
+
+		$this->applicationFactory->registerObject( 'ParserData', $parserData );
+
 		wfMessage( 'properties' )->parse();
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
@@ -10,7 +10,6 @@ use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Hooks\InternalParseBeforeLinks;
 use SMW\Services\ServicesFactory as ApplicationFactory;
-use SMW\Store;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockTitle;
 
@@ -41,12 +40,6 @@ class InternalParseBeforeLinksTest extends TestCase {
 		$this->stripState = $this->getMockBuilder( '\StripState' )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/LinksUpdateCompleteTest.php
@@ -11,6 +11,7 @@ use SMW\MediaWiki\Hooks\LinksUpdateComplete;
 use SMW\MediaWiki\RevisionGuard;
 use SMW\NamespaceExaminer;
 use SMW\ParserData;
+use SMW\Services\ServicesFactory;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
 
@@ -47,22 +48,6 @@ class LinksUpdateCompleteTest extends TestCase {
 		$this->namespaceExaminer = $this->getMockBuilder( NamespaceExaminer::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'findAssociatedRev' ] )
-			->getMock();
-
-		$store = $this->getMockBuilder( SQLStore::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'getObjectIds' ] )
-			->getMock();
-
-		$store->expects( $this->any() )
-			->method( 'getObjectIds' )
-			->willReturn( $idTable );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
-		$this->testEnvironment->registerObject( 'RevisionGuard', $this->revisionGuard );
 	}
 
 	protected function tearDown(): void {
@@ -71,9 +56,11 @@ class LinksUpdateCompleteTest extends TestCase {
 	}
 
 	public function testCanConstruct() {
+		$servicesFactory = $this->createMock( ServicesFactory::class );
+
 		$this->assertInstanceOf(
 			LinksUpdateComplete::class,
-			new LinksUpdateComplete( $this->namespaceExaminer )
+			new LinksUpdateComplete( $this->namespaceExaminer, $servicesFactory )
 		);
 	}
 
@@ -136,7 +123,8 @@ class LinksUpdateCompleteTest extends TestCase {
 		$this->testEnvironment->registerObject( 'Store', $store );
 
 		$instance = new LinksUpdateComplete(
-			$this->namespaceExaminer
+			$this->namespaceExaminer,
+			ServicesFactory::getInstance()
 		);
 
 		$instance->setLogger( $this->spyLogger );
@@ -171,7 +159,11 @@ class LinksUpdateCompleteTest extends TestCase {
 		$parserData->expects( $this->once() )
 			->method( 'updateStore' );
 
-		$this->testEnvironment->registerObject( 'ParserData', $parserData );
+		$servicesFactory = $this->createMock( ServicesFactory::class );
+
+		$servicesFactory->expects( $this->once() )
+			->method( 'newParserData' )
+			->willReturn( $parserData );
 
 		$linksUpdate = $this->createMock( LinksUpdate::class );
 
@@ -184,7 +176,8 @@ class LinksUpdateCompleteTest extends TestCase {
 			->willReturn( $parserOutput );
 
 		$instance = new LinksUpdateComplete(
-			$this->namespaceExaminer
+			$this->namespaceExaminer,
+			$servicesFactory
 		);
 
 		$instance->setRevisionGuard(
@@ -219,7 +212,11 @@ class LinksUpdateCompleteTest extends TestCase {
 		$parserData->expects( $this->once() )
 			->method( 'updateStore' );
 
-		$this->testEnvironment->registerObject( 'ParserData', $parserData );
+		$servicesFactory = $this->createMock( ServicesFactory::class );
+
+		$servicesFactory->expects( $this->once() )
+			->method( 'newParserData' )
+			->willReturn( $parserData );
 
 		$linksUpdate = $this->createMock( LinksUpdate::class );
 
@@ -236,7 +233,8 @@ class LinksUpdateCompleteTest extends TestCase {
 			->willReturn( false );
 
 		$instance = new LinksUpdateComplete(
-			$this->namespaceExaminer
+			$this->namespaceExaminer,
+			$servicesFactory
 		);
 
 		$instance->setRevisionGuard(
@@ -256,8 +254,11 @@ class LinksUpdateCompleteTest extends TestCase {
 		$linksUpdate->expects( $this->never() )
 			->method( 'getTitle' );
 
+		$servicesFactory = $this->createMock( ServicesFactory::class );
+
 		$instance = new LinksUpdateComplete(
-			$this->namespaceExaminer
+			$this->namespaceExaminer,
+			$servicesFactory
 		);
 
 		$instance->setLogger( $this->spyLogger );

--- a/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -11,14 +11,12 @@ use PHPUnit\Framework\TestCase;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
-use SMW\EntityCache;
 use SMW\Factbox\FactboxFactory;
 use SMW\Factbox\FactboxText;
 use SMW\MediaWiki\Hooks\OutputPageParserOutput;
 use SMW\MediaWiki\Permission\PermissionExaminer;
 use SMW\NamespaceExaminer;
 use SMW\Services\ServicesFactory as ApplicationFactory;
-use SMW\Store;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockTitle;
 
@@ -41,6 +39,7 @@ class OutputPageParserOutputTest extends TestCase {
 	private $namespaceExaminer;
 	private $permissionExaminer;
 	private FactboxText $factboxText;
+	private FactboxFactory $factboxFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -72,6 +71,10 @@ class OutputPageParserOutputTest extends TestCase {
 			->getMock();
 
 		$this->factboxText = $this->applicationFactory->getFactboxText();
+
+		$this->factboxFactory = $this->getMockBuilder( FactboxFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown(): void {
@@ -82,7 +85,7 @@ class OutputPageParserOutputTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			OutputPageParserOutput::class,
-			new OutputPageParserOutput( $this->namespaceExaminer, $this->permissionExaminer, $this->factboxText )
+			new OutputPageParserOutput( $this->namespaceExaminer, $this->permissionExaminer, $this->factboxText, $this->factboxFactory )
 		);
 	}
 
@@ -94,39 +97,21 @@ class OutputPageParserOutputTest extends TestCase {
 			->method( 'isSemanticEnabled' )
 			->willReturn( $parameters['smwgNamespacesWithSemanticLinks'] );
 
-		$entityCache = new EntityCache(
-			$this->applicationFactory->newCacheFactory()->newFixedInMemoryCache()
-		);
-
-		$this->testEnvironment->registerObject( 'EntityCache', $entityCache );
-
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$this->testEnvironment->registerObject( 'Store', $store );
-
 		$outputPage   = $parameters['outputPage'];
 		$parserOutput = $parameters['parserOutput'];
+
+		$cachedFactbox = $this->applicationFactory->create( 'FactboxFactory' )->newCachedFactbox();
+
+		$this->factboxFactory->expects( $this->any() )
+			->method( 'newCachedFactbox' )
+			->willReturn( $cachedFactbox );
 
 		$instance = new OutputPageParserOutput(
 			$this->namespaceExaminer,
 			$this->permissionExaminer,
-			$this->factboxText
+			$this->factboxText,
+			$this->factboxFactory
 		);
-
-		$cachedFactbox = $this->applicationFactory->create( 'FactboxFactory' )->newCachedFactbox();
-
-		$factboxFactory = $this->getMockBuilder( FactboxFactory::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'newCachedFactbox' ] )
-			->getMock();
-
-		$factboxFactory->expects( $this->any() )
-			->method( 'newCachedFactbox' )
-			->willReturn( $cachedFactbox );
-
-		$this->testEnvironment->registerObject( 'FactboxFactory', $factboxFactory );
 
 		$this->assertEmpty(
 			$cachedFactbox->retrieveContent( $outputPage )

--- a/tests/phpunit/Unit/MediaWiki/Hooks/PageMoveCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/PageMoveCompleteTest.php
@@ -26,6 +26,7 @@ class PageMoveCompleteTest extends TestCase {
 	private $testEnvironment;
 	private $namespaceExaminer;
 	private $eventDispatcher;
+	private $store;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -50,6 +51,10 @@ class PageMoveCompleteTest extends TestCase {
 		$this->eventDispatcher = $this->getMockBuilder( EventDispatcher::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->store = $this->getMockBuilder( Store::class )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
 	}
 
 	protected function tearDown(): void {
@@ -60,7 +65,7 @@ class PageMoveCompleteTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			PageMoveComplete::class,
-			new PageMoveComplete( $this->namespaceExaminer )
+			new PageMoveComplete( $this->namespaceExaminer, $this->store )
 		);
 	}
 
@@ -77,17 +82,12 @@ class PageMoveCompleteTest extends TestCase {
 		$oldTitle = $titleFactory->newFromText( 'Old' );
 		$newTitle = $titleFactory->newFromText( 'New' );
 
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$store->expects( $this->never() )
+		$this->store->expects( $this->never() )
 			->method( 'changeTitle' );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
-
 		$instance = new PageMoveComplete(
-			$this->namespaceExaminer
+			$this->namespaceExaminer,
+			$this->store
 		);
 
 		$instance->setEventDispatcher(
@@ -112,18 +112,13 @@ class PageMoveCompleteTest extends TestCase {
 		$oldTitle = $titleFactory->newFromText( 'Old' );
 		$newTitle = $titleFactory->newFromText( 'New', NS_HELP );
 
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$store->expects( $this->once() )
+		$this->store->expects( $this->once() )
 			->method( 'deleteSubject' )
 			->with( $oldTitle );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
-
 		$instance = new PageMoveComplete(
-			$this->namespaceExaminer
+			$this->namespaceExaminer,
+			$this->store
 		);
 
 		$instance->setEventDispatcher(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -117,7 +117,7 @@ class ParserAfterTidyTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			ParserAfterTidy::class,
-			new ParserAfterTidy( $this->parser, $this->namespaceExaminer, $this->cache )
+			new ParserAfterTidy( $this->parser, $this->namespaceExaminer, $this->cache, $this->applicationFactory )
 		);
 	}
 
@@ -128,7 +128,8 @@ class ParserAfterTidyTest extends TestCase {
 		$instance = new ParserAfterTidy(
 			$this->parser,
 			$this->namespaceExaminer,
-			$this->cache
+			$this->cache,
+			$this->applicationFactory
 		);
 
 		$instance->setLogger( $this->spyLogger );
@@ -166,7 +167,8 @@ class ParserAfterTidyTest extends TestCase {
 		$instance = new ParserAfterTidy(
 			$this->parser,
 			$this->namespaceExaminer,
-			$this->cache
+			$this->cache,
+			$this->applicationFactory
 		);
 
 		$text = '';
@@ -264,7 +266,8 @@ class ParserAfterTidyTest extends TestCase {
 		$instance = new ParserAfterTidy(
 			$parser,
 			$this->namespaceExaminer,
-			$cache
+			$cache,
+			$this->applicationFactory
 		);
 
 		$instance->setHookDispatcher(
@@ -316,7 +319,8 @@ class ParserAfterTidyTest extends TestCase {
 		$instance = new ParserAfterTidy(
 			$this->parser,
 			$this->namespaceExaminer,
-			$this->cache
+			$this->cache,
+			$this->applicationFactory
 		);
 
 		$instance->setHookDispatcher(
@@ -353,7 +357,8 @@ class ParserAfterTidyTest extends TestCase {
 		$instance = new ParserAfterTidy(
 			$parser,
 			$this->namespaceExaminer,
-			$this->cache
+			$this->cache,
+			$this->applicationFactory
 		);
 
 		$instance->setHookDispatcher(
@@ -430,7 +435,8 @@ class ParserAfterTidyTest extends TestCase {
 		$innerInstance = new ParserAfterTidy(
 			$innerParser,
 			$this->namespaceExaminer,
-			$this->cache
+			$this->cache,
+			$this->applicationFactory
 		);
 		$innerInstance->setHookDispatcher( $this->hookDispatcher );
 
@@ -456,7 +462,8 @@ class ParserAfterTidyTest extends TestCase {
 		$outerInstance = new ParserAfterTidy(
 			$outerParser,
 			$this->namespaceExaminer,
-			$this->cache
+			$this->cache,
+			$this->applicationFactory
 		);
 		$outerInstance->setHookDispatcher( $this->hookDispatcher );
 
@@ -524,11 +531,11 @@ class ParserAfterTidyTest extends TestCase {
 
 		$text = '';
 
-		$instanceA = new ParserAfterTidy( $parserA, $this->namespaceExaminer, $this->cache );
+		$instanceA = new ParserAfterTidy( $parserA, $this->namespaceExaminer, $this->cache, $this->applicationFactory );
 		$instanceA->setHookDispatcher( $this->hookDispatcher );
 		$instanceA->process( $text );
 
-		$instanceB = new ParserAfterTidy( $parserB, $this->namespaceExaminer, $this->cache );
+		$instanceB = new ParserAfterTidy( $parserB, $this->namespaceExaminer, $this->cache, $this->applicationFactory );
 		$instanceB->setHookDispatcher( $this->hookDispatcher );
 		$instanceB->process( $text );
 
@@ -588,7 +595,7 @@ class ParserAfterTidyTest extends TestCase {
 		$realParser->getOutput()->setExtensionData( 'smw-semanticdata-status', true );
 
 		$text = '';
-		$realInstance = new ParserAfterTidy( $realParser, $this->namespaceExaminer, $this->cache );
+		$realInstance = new ParserAfterTidy( $realParser, $this->namespaceExaminer, $this->cache, $this->applicationFactory );
 		$realInstance->setHookDispatcher( $this->hookDispatcher );
 		$realInstance->process( $text );
 
@@ -666,7 +673,7 @@ class ParserAfterTidyTest extends TestCase {
 		$parser->getOutput()->addCategory( 'Foo', 'Foo' );
 		$parser->getOutput()->setExtensionData( 'smw-semanticdata-status', true );
 
-		$instance = new ParserAfterTidy( $parser, $this->namespaceExaminer, $cache );
+		$instance = new ParserAfterTidy( $parser, $this->namespaceExaminer, $cache, $this->applicationFactory );
 		$instance->setHookDispatcher( $this->hookDispatcher );
 
 		$text = '';
@@ -693,7 +700,8 @@ class ParserAfterTidyTest extends TestCase {
 		$secondInstance = new ParserAfterTidy(
 			$secondParser,
 			$this->namespaceExaminer,
-			$cache
+			$cache,
+			$this->applicationFactory
 		);
 		$secondInstance->setHookDispatcher( $this->hookDispatcher );
 		$secondInstance->process( $text );

--- a/tests/phpunit/Unit/MediaWiki/Hooks/RevisionFromEditCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/RevisionFromEditCompleteTest.php
@@ -36,6 +36,7 @@ class RevisionFromEditCompleteTest extends TestCase {
 	private $editInfo;
 	private $propertyAnnotatorFactory;
 	private $schemaFactory;
+	private $store;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -44,11 +45,9 @@ class RevisionFromEditCompleteTest extends TestCase {
 
 		$this->semanticDataValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
 
-		$store = $this->getMockBuilder( Store::class )
+		$this->store = $this->getMockBuilder( Store::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
-
-		$this->testEnvironment->registerObject( 'Store', $store );
 
 		$this->eventDispatcher = $this->getMockBuilder( EventDispatcher::class )
 			->disableOriginalConstructor()
@@ -103,7 +102,7 @@ class RevisionFromEditCompleteTest extends TestCase {
 
 		$this->assertInstanceOf(
 			RevisionFromEditComplete::class,
-			new RevisionFromEditComplete( $this->editInfo, $pageInfoProvider, $this->propertyAnnotatorFactory, $this->schemaFactory )
+			new RevisionFromEditComplete( $this->editInfo, $pageInfoProvider, $this->propertyAnnotatorFactory, $this->schemaFactory, $this->store )
 		);
 	}
 
@@ -130,7 +129,8 @@ class RevisionFromEditCompleteTest extends TestCase {
 			$this->editInfo,
 			$pageInfoProvider,
 			$this->propertyAnnotatorFactory,
-			$this->schemaFactory
+			$this->schemaFactory,
+			$this->store
 		);
 
 		$instance->setEventDispatcher(
@@ -178,7 +178,8 @@ class RevisionFromEditCompleteTest extends TestCase {
 			$this->editInfo,
 			$pageInfoProvider,
 			$this->propertyAnnotatorFactory,
-			$this->schemaFactory
+			$this->schemaFactory,
+			$this->store
 		);
 
 		$instance->setEventDispatcher(
@@ -227,7 +228,8 @@ class RevisionFromEditCompleteTest extends TestCase {
 			$this->editInfo,
 			$pageInfoProvider,
 			$this->propertyAnnotatorFactory,
-			$this->schemaFactory
+			$this->schemaFactory,
+			$this->store
 		);
 
 		$instance->setEventDispatcher(
@@ -244,8 +246,6 @@ class RevisionFromEditCompleteTest extends TestCase {
 
 		$store->expects( $this->once() )
 			->method( 'deleteConceptCache' );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
 
 		$parserOutput = $this->getMockBuilder( ParserOutput::class )
 			->disableOriginalConstructor()
@@ -284,7 +284,8 @@ class RevisionFromEditCompleteTest extends TestCase {
 			$this->editInfo,
 			$pageInfoProvider,
 			$this->propertyAnnotatorFactory,
-			$this->schemaFactory
+			$this->schemaFactory,
+			$store
 		);
 
 		$instance->setEventDispatcher(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
@@ -80,13 +80,8 @@ class SkinAfterContentTest extends TestCase {
 
 		$this->factboxText->setText( $parameters['text'] );
 
-		$instance = new SkinAfterContent( $parameters['skin'] );
-
-		$instance->setOption( 'SMW_EXTENSION_LOADED', true );
-
 		// Replace CachedFactbox instance
 		if ( isset( $parameters['title'] ) ) {
-
 			$cachedFactbox = $this->applicationFactory->create( 'FactboxFactory' )->newCachedFactbox();
 
 			$cachedFactbox->addContentToCache(
@@ -101,9 +96,13 @@ class SkinAfterContentTest extends TestCase {
 			$factboxFactory->expects( $this->once() )
 				->method( 'newCachedFactbox' )
 				->willReturn( $cachedFactbox );
-
-			$this->applicationFactory->registerObject( 'FactboxFactory', $factboxFactory );
+		} else {
+			$factboxFactory = $this->applicationFactory->getFactboxFactory();
 		}
+
+		$instance = new SkinAfterContent( $parameters['skin'], $factboxFactory );
+
+		$instance->setOption( 'SMW_EXTENSION_LOADED', true );
 
 		$this->assertTrue(
 			$instance->performUpdate( $data )

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
@@ -55,15 +55,24 @@ class SkinAfterContentTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$factboxFactory = $this->getMockBuilder( FactboxFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->assertInstanceOf(
 			SkinAfterContent::class,
-			new SkinAfterContent( $skin )
+			new SkinAfterContent( $skin, $factboxFactory )
 		);
 	}
 
 	public function testTryToPerformUpdateOnNullSkin() {
 		$data = '';
-		$instance = new SkinAfterContent( null );
+
+		$factboxFactory = $this->getMockBuilder( FactboxFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new SkinAfterContent( null, $factboxFactory );
 
 		$instance->setOption( 'SMW_EXTENSION_LOADED', true );
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/UserChangeTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/UserChangeTest.php
@@ -8,7 +8,6 @@ use SMW\MediaWiki\Hooks\UserChange;
 use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\Jobs\UpdateJob;
 use SMW\NamespaceExaminer;
-use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\MediaWiki\Hooks\UserChange
@@ -22,13 +21,10 @@ use SMW\Tests\TestEnvironment;
 class UserChangeTest extends TestCase {
 
 	private $namespaceExaminer;
-	private $testEnvironment;
 	private $jobFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
-
-		$this->testEnvironment = new TestEnvironment();
 
 		$this->namespaceExaminer = $this->getMockBuilder( NamespaceExaminer::class )
 			->disableOriginalConstructor()
@@ -37,19 +33,12 @@ class UserChangeTest extends TestCase {
 		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'JobFactory', $this->jobFactory );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			UserChange::class,
-			new UserChange( $this->namespaceExaminer )
+			new UserChange( $this->namespaceExaminer, $this->jobFactory )
 		);
 	}
 
@@ -68,7 +57,8 @@ class UserChangeTest extends TestCase {
 			->willReturn( true );
 
 		$instance = new UserChange(
-			$this->namespaceExaminer
+			$this->namespaceExaminer,
+			$this->jobFactory
 		);
 
 		$instance->setOrigin( 'Foo' );
@@ -101,7 +91,8 @@ class UserChangeTest extends TestCase {
 			->willReturn( true );
 
 		$instance = new UserChange(
-			$this->namespaceExaminer
+			$this->namespaceExaminer,
+			$this->jobFactory
 		);
 
 		$instance->setOrigin( 'Foo' );
@@ -121,7 +112,8 @@ class UserChangeTest extends TestCase {
 			->willReturn( false );
 
 		$instance = new UserChange(
-			$this->namespaceExaminer
+			$this->namespaceExaminer,
+			$this->jobFactory
 		);
 
 		$this->assertFalse(


### PR DESCRIPTION
## Summary

Fourth slice of the follow-up to #6827: moving SMW classes off global service-locator dependency access toward constructor injection, so unit tests inject mocks directly rather than mutating a shared container through `TestEnvironment::registerObject()`.

This slice covers the `MediaWiki/Hooks` cluster (16 unit/integration test files). SMW hook-handler classes are plain classes constructed by `src/MediaWiki/Hooks.php`, so the plain-class playbook applies.

## Changes

**Real conversions** (production code changed; the in-body locator call is removed, the dependency becomes a constructor parameter, `Hooks.php` and all call sites updated, behaviour preserved):

- `ArticleDelete` ← `JobFactory`
- `ArticlePurge` ← `Cache`
- `BeforePageDisplay` ← `UserOptionsLookup`
- `FileUpload` ← `PageCreator`
- `OutputPageParserOutput` ← `FactboxFactory`
- `PageMoveComplete` ← `Store`
- `RevisionFromEditComplete` ← `Store`
- `SkinAfterContent` ← `FactboxFactory`
- `UserChange` ← `JobFactory`
- `LinksUpdateComplete`, `ParserAfterTidy` ← `ServicesFactory` (these create objects via runtime-argument factory methods such as `newParserData( $title, $output )`, so the factory itself is injected rather than a fixed instance).

The injected objects are the same instances the locator previously returned, so behaviour is unchanged.

**Dead-scaffolding removals** (test-only): the remaining `registerObject` calls referenced services the hook handler never fetched from the global locator, so they had no effect and were removed.

A few test files deliberately retain a `registerObject` call for a genuine transitive dependency reached through a collaborator (`ParserData` / `DataUpdater`) that is beyond the converted class's own interface; those clear when the collaborator classes are converted in a later slice.

## Testing

- The unit suite (7092 tests) passes; PHPCS is clean on all changed files.
- Test method counts are unchanged in every file; no assertions or test methods were removed.
- phan and the integration / `@group Database` suite are expected to be covered by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)