### PR TITLE
Remove dead MediaWiki pre-1.43 compatibility branches

### DIFF
--- a/src/MediaWiki/Api/BrowseByProperty.php
+++ b/src/MediaWiki/Api/BrowseByProperty.php
@@ -79,12 +79,10 @@ class BrowseByProperty extends ApiBase {
 		// any other data field can
 		// https://www.mediawiki.org/wiki/API:JSON_version_2
 		// " ... can indicate that a property beginning with an underscore is not metadata using"
-		if ( method_exists( $this->getResult(), 'setPreserveKeysList' ) ) {
-			$this->getResult()->setPreserveKeysList(
-				$data,
-				array_keys( $data )
-			);
-		}
+		$this->getResult()->setPreserveKeysList(
+			$data,
+			array_keys( $data )
+		);
 
 		$this->getResult()->addValue(
 			null,

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -1484,16 +1484,9 @@ class Hooks {
 			$contentIterator
 		);
 
-		if ( defined( 'User::MAINTENANCE_SCRIPT_USER' ) ) {
-			$maintenanceUser = User::MAINTENANCE_SCRIPT_USER;
-		} else {
-			// MW < 1.37
-			$maintenanceUser = 'Maintenance script';
-		}
-
 		$importer->isEnabled( $options->safeGet( Installer::RUN_IMPORT, false ) );
 		$importer->setMessageReporter( $messageReporter );
-		$importer->setImporter( $maintenanceUser );
+		$importer->setImporter( User::MAINTENANCE_SCRIPT_USER );
 		$importer->runImport();
 
 		return true;

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -219,14 +219,8 @@ class ParserAfterTidy implements HookListener {
 		$parserDefaultSort = $parserOutput->getPageProperty( 'defaultsort' );
 
 		$parserCategories = [];
-		// MW >= 1.40
-		if ( method_exists( $parserOutput, 'getCategorySortKey' ) ) {
-			$names = $parserOutput->getCategoryNames();
-			foreach ( $names as $name ) {
-				$parserCategories[$name] = $parserOutput->getCategorySortKey( $name );
-			}
-		} else {
-			$parserCategories = $parserOutput->getCategories();
+		foreach ( $parserOutput->getCategoryNames() as $name ) {
+			$parserCategories[$name] = $parserOutput->getCategorySortKey( $name );
 		}
 
 		if ( $displayTitle ||


### PR DESCRIPTION
## What

Removes three MediaWiki version-compatibility fallback branches that are now unreachable. The extension requires MediaWiki >= 1.43, so each guarded API is always present:

- `src/MediaWiki/Hooks.php` - `User::MAINTENANCE_SCRIPT_USER` (MW 1.37+); the `defined()` check and `'Maintenance script'` string fallback are dead.
- `src/MediaWiki/Hooks/ParserAfterTidy.php` - `ParserOutput::getCategorySortKey()` / `getCategoryNames()` (MW 1.40+); the `method_exists()` check and the `getCategories()` fallback are dead.
- `src/MediaWiki/Api/BrowseByProperty.php` - `ApiResult::setPreserveKeysList()` (MW 1.25+); the `method_exists()` check is dead.

## Why

Dead-code cleanup following the 1.43 minimum requirement. No behaviour change on any supported MediaWiki version.

## Testing

- `parallel-lint`: pass
- PHPCS: pass on changed files
- PHPUnit: `HooksTest`, `ParserAfterTidyTest`, `ParserAfterTidyIntegrationTest`, `BrowseByPropertyTest` all pass
- Manual smoke test on a 1.43 dev wiki: the `browsebyproperty` API returns correctly keyed results, and reparsing/`forcelinkupdate` on category-bearing pages runs `ParserAfterTidy` cleanly with no errors