### PR TITLE
Remove 21 pre-7.0 deprecated methods and update callers

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -219,6 +219,21 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
   * `DataTypeRegistry::getDataItemId()` — use `getDataItemByType()`
   * `DataTypeRegistry::getDefaultDataItemTypeId()` — use `getDefaultDataItemByType()`
   * `QueryResult::getLink()` — use `getQueryLink()`
+  * `PropertyRegistry::isKnownPropertyId()` — use `isRegistered()` (deprecated since 3.0)
+  * `PropertyRegistry::getPropertyTypeId()` — use `getPropertyValueTypeById()` (deprecated since 3.0)
+  * `PropertyRegistry::registerPropertyDescriptionMsgKeyById()` — use `registerPropertyDescriptionByMsgKey()` (deprecated since 3.0)
+  * `ParserData::setSemanticDataStateToParserOutputProperty()` — use `copyToParserOutput()` (deprecated since 3.0)
+  * `ChangeOp::getCombinedIdListOfChangedEntities()` — use `getChangedEntityIdSummaryList()` (deprecated since 3.0)
+  * `TableChangeOp::getFixedPropertyValueBy()` — use `getFixedPropertyValByField()` (deprecated since 3.0)
+  * `DataTypeRegistry::findTypeId()` — use `findTypeByLabel()` (deprecated since 3.0)
+  * `DataValue::checkAllowedValues()` — use `checkConstraints()` (deprecated since 3.1)
+  * `EntityIdManager::getDataItemPoolHashListFor()` — use `getDataItemsFromList()` (deprecated since 3.0)
+  * `CallableUpdate::enabledDeferredUpdate()` — use `isDeferrableUpdate()` (deprecated since 3.0)
+  * `TaskHandler::setEnabledFeatures()` — use `setFeatureSet()` (deprecated since 3.1)
+  * `MwCollaboratorFactory::newEditInfoProvider()` — use `newEditInfo()` (deprecated since 3.1)
+  * `LocalLanguage::fetchByLanguageCode()` — use `fetch()` (deprecated since 3.0)
+  * `LocalLanguage::getPropertyId()`, `findMonth()`, `getMonthLabel()` — use `getPropertyIdByLabel()`, `findMonthNumberByLabel()`, `getMonthLabelByNumber()`
+  * `LoadBalancerConnectionProvider::asConnectionRef()` (deprecated since 5.0)
 
 ### Deprecations
 

--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -258,13 +258,6 @@ class DataTypeRegistry {
 	}
 
 	/**
-	 * @deprecated since 3.0, use DataTypeRegistry::findTypeByLabel
-	 */
-	public function findTypeId( $label ) {
-		return $this->findTypeByLabel( $label );
-	}
-
-	/**
 	 * Look up the ID that identifies the datatype of the given label
 	 * internally. This id is used for all internal operations. If the
 	 * label does not belong to a known type, the empty string is returned.

--- a/src/DataValues/DataValue.php
+++ b/src/DataValues/DataValue.php
@@ -927,13 +927,6 @@ abstract class DataValue {
 	}
 
 	/**
-	 * @deprecated since 3.1, use DataValue::checkConstraints
-	 */
-	protected function checkAllowedValues(): void {
-		$this->checkConstraints();
-	}
-
-	/**
 	 * @since 3.1
 	 */
 	public function checkConstraints(): void {

--- a/src/DataValues/ValueFormatters/TimeValueFormatter.php
+++ b/src/DataValues/ValueFormatters/TimeValueFormatter.php
@@ -224,7 +224,7 @@ class TimeValueFormatter extends DataValueFormatter {
 		}
 
 		if ( $dataItem->getPrecision() >= Time::PREC_YM ) {
-			$result = $lang->getMonthLabel( $dataItem->getMonth() ) . " " . $result;
+			$result = $lang->getMonthLabelByNumber( $dataItem->getMonth() ) . " " . $result;
 		}
 
 		if ( $dataItem->getPrecision() >= Time::PREC_YMD ) {

--- a/src/DataValues/WikiPageValue.php
+++ b/src/DataValues/WikiPageValue.php
@@ -364,7 +364,7 @@ class WikiPageValue extends DataValue {
 		$caption = $this->m_caption === false ? $this->getShortCaptionText() : $this->m_caption;
 		$caption = Sanitizer::removeSomeTags( $caption );
 
-		if ( $this->getNamespace() == NS_MEDIA ) { // this extra case *is* needed
+		if ( $this->m_dataitem->getNamespace() == NS_MEDIA ) { // this extra case *is* needed
 			return $linker->makeMediaLinkObj( $this->getTitle(), $caption );
 		}
 
@@ -448,7 +448,7 @@ class WikiPageValue extends DataValue {
 
 		if ( $linker === null || $linker === false || $this->m_outformat == '-' ) {
 			return call_user_func( $sanitizerCallback, $this->getWikiValue() );
-		} elseif ( $this->getNamespace() == NS_MEDIA ) { // this extra case is really needed
+		} elseif ( $this->m_dataitem->getNamespace() == NS_MEDIA ) { // this extra case is really needed
 			return $linker->makeMediaLinkObj(
 				$this->getTitle(),
 				call_user_func( $sanitizerCallback, $this->getLongCaptionText() )
@@ -567,46 +567,6 @@ class WikiPageValue extends DataValue {
 	}
 
 	/**
-	 * @deprecated since 3.1
-	 *
-	 * Get MediaWiki's ID for this value or 0 if not available.
-	 *
-	 * @return int
-	 */
-	private function getArticleID() {
-		if ( $this->m_id === -1 ) {
-			$this->m_id = $this->getTitle() !== null ? $this->m_title->getArticleID() : 0;
-		}
-
-		return $this->m_id;
-	}
-
-	/**
-	 * @deprecated since 3.1
-	 *
-	 * Get namespace constant for this value.
-	 *
-	 * @return int
-	 */
-	private function getNamespace() {
-		return $this->m_dataitem->getNamespace();
-	}
-
-	/**
-	 * @deprecated since 3.1
-	 *
-	 * Get DBKey for this value. Subclasses that allow for values that do not
-	 * correspond to wiki pages may choose a DB key that is not a legal title
-	 * DB key but rather another suitable internal ID. Thus it is not suitable
-	 * to use this method in places where only MediaWiki Title keys are allowed.
-	 *
-	 * @return string
-	 */
-	private function getDBkey() {
-		return $this->m_dataitem->getDBkey();
-	}
-
-	/**
 	 * Get text label for this value, just like Title::getText().
 	 *
 	 * @return string
@@ -644,17 +604,6 @@ class WikiPageValue extends DataValue {
 		}
 
 		return $this->m_prefixedtext;
-	}
-
-	/**
-	 * @deprecated since 3.1
-	 *
-	 * Get interwiki prefix or empty string.
-	 *
-	 * @return string
-	 */
-	private function getInterwiki() {
-		return $this->m_dataitem->getInterwiki();
 	}
 
 	/**

--- a/src/Localizer/LocalLanguage/LocalLanguage.php
+++ b/src/Localizer/LocalLanguage/LocalLanguage.php
@@ -71,14 +71,6 @@ class LocalLanguage {
 	}
 
 	/**
-	 * @deprecated since 3.0, use Lang::fetch
-	 * @since 2.4
-	 */
-	public function fetchByLanguageCode( $languageCode ): static {
-		return $this->fetch( $languageCode );
-	}
-
-	/**
 	 * @since 2.4
 	 */
 	public function fetch( string $languageCode ): static {
@@ -308,23 +300,6 @@ class LocalLanguage {
 	}
 
 	/**
-	 * @deprecated use getPropertyIdByLabel
-	 */
-	protected function getPropertyId( $propertyLabel ): array {
-		$list = (array)$this->languageContents->get(
-			'property.aliases',
-			$this->languageCode
-		);
-
-		$list += (array)$this->languageContents->get(
-			'property.aliases',
-			$this->canonicalFallbackLanguageCode
-		);
-
-		return $list;
-	}
-
-	/**
 	 * Function receives property name (for example, `Modificatino date') and
 	 * returns a property id (for example, `_MDAT'). Property name may be
 	 * localized one. If property name is not recognized, a null value returned.
@@ -400,13 +375,6 @@ class LocalLanguage {
 	}
 
 	/**
-	 * @deprecated use findMonthNumberByLabel
-	 */
-	public function findMonth( $label ): int|float|false {
-		return $this->findMonthNumberByLabel( $label );
-	}
-
-	/**
 	 * Function looks up a month and returns the corresponding number.
 	 *
 	 * @since 2.4
@@ -431,13 +399,6 @@ class LocalLanguage {
 		}
 
 		return false;
-	}
-
-	/**
-	 * @deprecated use getMonthLabelByNumber
-	 */
-	public function getMonthLabel( $number ) {
-		return $this->getMonthLabelByNumber( $number );
 	}
 
 	/**

--- a/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
+++ b/src/MediaWiki/Connection/LoadBalancerConnectionProvider.php
@@ -35,14 +35,6 @@ class LoadBalancerConnectionProvider implements IConnectionProvider {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @deprecated since 5.0
-	 */
-	public function asConnectionRef( bool $asConnectionRef ): void {
-	}
-
-	/**
-	 * @since 3.1
 	 */
 	public function setLoadBalancer( ILoadBalancer $loadBalancer ): void {
 		$this->loadBalancer = $loadBalancer;

--- a/src/MediaWiki/Deferred/CallableUpdate.php
+++ b/src/MediaWiki/Deferred/CallableUpdate.php
@@ -97,14 +97,6 @@ class CallableUpdate implements DeferrableUpdate {
 	}
 
 	/**
-	 * @deprecated since 3.0, use DeferredCallableUpdate::isDeferrableUpdate
-	 * @since 2.4
-	 */
-	public function enabledDeferredUpdate( bool $enabledDeferredUpdate = true ): void {
-		$this->isDeferrableUpdate( $enabledDeferredUpdate );
-	}
-
-	/**
 	 * @note Unit/Integration tests in MW 1.26- showed ambiguous behaviour when
 	 * run in deferred mode because not all MW operations were supporting late
 	 * execution.

--- a/src/MediaWiki/MwCollaboratorFactory.php
+++ b/src/MediaWiki/MwCollaboratorFactory.php
@@ -178,24 +178,6 @@ class MwCollaboratorFactory {
 	}
 
 	/**
-	 * @deprecated since 3.1
-	 * @since 2.5
-	 *
-	 * @param WikiPage $wikiPage
-	 * @param RevisionRecord $revision
-	 * @param ?User $user
-	 *
-	 * @return EditInfo
-	 */
-	public function newEditInfoProvider(
-		WikiPage $wikiPage,
-		RevisionRecord $revision,
-		?User $user = null
-	): EditInfo {
-		return $this->newEditInfo( $wikiPage, $revision, $user );
-	}
-
-	/**
 	 * @since 3.1
 	 *
 	 * @param WikiPage $wikiPage

--- a/src/MediaWiki/Specials/Admin/TaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/TaskHandler.php
@@ -48,14 +48,6 @@ abstract class TaskHandler {
 	}
 
 	/**
-	 * @deprecated since 3.1, use TaskHandler::setFeatureSet
-	 * @since 2.5
-	 */
-	public function setEnabledFeatures( int $enabledFeatures ): void {
-		$this->setFeatureSet( $enabledFeatures );
-	}
-
-	/**
 	 * @since 3.1
 	 */
 	public function setFeatureSet( int $featureSet ): void {

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -332,13 +332,6 @@ class ParserData {
 	}
 
 	/**
-	 * @deprecated since 3.0, use pushSemanticDataToParserOutput
-	 */
-	public function setSemanticDataStateToParserOutputProperty(): void {
-		$this->markParserOutput();
-	}
-
-	/**
 	 * @since 2.5
 	 */
 	public static function hasSemanticData( ParserOutput $parserOutput ): bool {

--- a/src/Property/Annotators/MandatoryTypePropertyAnnotator.php
+++ b/src/Property/Annotators/MandatoryTypePropertyAnnotator.php
@@ -122,7 +122,7 @@ class MandatoryTypePropertyAnnotator extends PropertyAnnotatorDecorator {
 
 		[ $ns, $type ] = explode( ':', $importValue->getTermType(), 2 );
 
-		$typeId = DataTypeRegistry::getInstance()->findTypeId( $type );
+		$typeId = DataTypeRegistry::getInstance()->findTypeByLabel( $type );
 
 		if ( $typeId === '' ) {
 			return;

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -224,13 +224,6 @@ class PropertyRegistry {
 	}
 
 	/**
-	 * @deprecated since 3.0, use PropertyRegistry::registerPropertyDescriptionByMsgKey
-	 */
-	public function registerPropertyDescriptionMsgKeyById( $id, $msgKey ): void {
-		$this->registerPropertyDescriptionByMsgKey( $id, $msgKey );
-	}
-
-	/**
 	 * @since 2.5
 	 *
 	 * @param string $id
@@ -314,13 +307,6 @@ class PropertyRegistry {
 	}
 
 	/**
-	 * @deprecated since 3.0, use PropertyRegistry::getPropertyValueTypeById instead
-	 */
-	public function getPropertyTypeId( $id ) {
-		return $this->getPropertyValueTypeById( $id );
-	}
-
-	/**
 	 * Find and return the ID for the pre-defined property of the given
 	 * local label. If the label does not belong to a pre-defined property,
 	 * return false.
@@ -395,13 +381,6 @@ class PropertyRegistry {
 		}
 
 		return $this->propertyLabelFinder->findPreferredPropertyLabelByLanguageCode( $id, $languageCode );
-	}
-
-	/**
-	 * @deprecated since 3.0 use isRegistered instead
-	 */
-	public function isKnownPropertyId( $id ): bool {
-		return $this->isRegistered( $id );
 	}
 
 	/**

--- a/src/SQLStore/ChangeOp/ChangeOp.php
+++ b/src/SQLStore/ChangeOp/ChangeOp.php
@@ -316,16 +316,6 @@ class ChangeOp implements IteratorAggregate {
 		return array_keys( $this->getChangedEntityIdListByType() );
 	}
 
-	/**
-	 * @deprecated since 3.0, use ChangeOp::getChangedEntityIdSummaryList
-	 * @since 2.3
-	 *
-	 * @return array
-	 */
-	public function getCombinedIdListOfChangedEntities(): array {
-		return $this->getChangedEntityIdSummaryList();
-	}
-
 	private function addToIdList( array &$list, $value ): void {
 		foreach ( $value as $element ) {
 

--- a/src/SQLStore/ChangeOp/TableChangeOp.php
+++ b/src/SQLStore/ChangeOp/TableChangeOp.php
@@ -56,18 +56,6 @@ class TableChangeOp {
 	}
 
 	/**
-	 * @deprecated since 3.0, use TableChangeOp::getFixedPropertyValByField
-	 * @since 2.4
-	 *
-	 * @param string $field
-	 *
-	 * @return null|string
-	 */
-	public function getFixedPropertyValueBy( $field ) {
-		return $this->getFixedPropertyValByField( $field );
-	}
-
-	/**
 	 * @since 2.4
 	 *
 	 * @param string $opType

--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -978,13 +978,6 @@ class EntityIdManager {
 	}
 
 	/**
-	 * @deprecated since 3.0, use EntityIdManager::getDataItemsFromList
-	 */
-	public function getDataItemPoolHashListFor( array $idlist, ?RequestOptions $requestOptions = null ): MappingIterator|array {
-		return $this->idEntityFinder->getDataItemsFromList( $idlist, $requestOptions );
-	}
-
-	/**
 	 * Remove any cache entry for the given data. The key consists of the
 	 * parameters $title, $namespace, $interwiki, and $subobject. The
 	 * cached data is $id and $sortkey.

--- a/src/SQLStore/Lookup/ChangePropagationEntityLookup.php
+++ b/src/SQLStore/Lookup/ChangePropagationEntityLookup.php
@@ -167,7 +167,7 @@ class ChangePropagationEntityLookup {
 			return $idList;
 		}
 
-		return $this->store->getObjectIds()->getDataItemPoolHashListFor( $idList );
+		return $this->store->getObjectIds()->getDataItemsFromList( $idList );
 	}
 
 }

--- a/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
+++ b/src/SQLStore/QueryDependency/QueryDependencyLinksStore.php
@@ -287,7 +287,7 @@ class QueryDependencyLinksStore {
 			'smw_iw !=' . $connection->addQuotes( SMW_SQL3_SMWDELETEIW )
 		);
 
-		return $this->store->getObjectIds()->getDataItemPoolHashListFor(
+		return $this->store->getObjectIds()->getDataItemsFromList(
 			$targetLinksIdList,
 			$poolRequestOptions
 		);
@@ -349,7 +349,7 @@ class QueryDependencyLinksStore {
 		$deferredTransactionalUpdate->markAsPending( $this->isCommandLineMode );
 		$deferredTransactionalUpdate->setFingerprint( $hash );
 
-		$deferredTransactionalUpdate->enabledDeferredUpdate( true );
+		$deferredTransactionalUpdate->isDeferrableUpdate( true );
 		$deferredTransactionalUpdate->waitOnTransactionIdle();
 
 		$deferredTransactionalUpdate->pushUpdate();

--- a/src/SQLStore/QueryEngine/Fulltext/TextChangeUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextChangeUpdater.php
@@ -245,7 +245,7 @@ class TextChangeUpdater {
 			// Replace s_id for subobjects etc. with the o_id
 			if ( $tableChangeOp->isFixedPropertyOp() ) {
 				$fieldChangeOp->set( 's_id', $fieldChangeOp->has( 'o_id' ) ? $fieldChangeOp->get( 'o_id' ) : $fieldChangeOp->get( 's_id' ) );
-				$fieldChangeOp->set( 'p_id', $tableChangeOp->getFixedPropertyValueBy( 'p_id' ) );
+				$fieldChangeOp->set( 'p_id', $tableChangeOp->getFixedPropertyValByField( 'p_id' ) );
 			}
 
 			if ( !$fieldChangeOp->has( 'p_id' ) ) {

--- a/tests/phpunit/Structure/LocalLanguageAccessibilityAndIntegrityTest.php
+++ b/tests/phpunit/Structure/LocalLanguageAccessibilityAndIntegrityTest.php
@@ -65,8 +65,8 @@ class LocalLanguageAccessibilityAndIntegrityTest extends TestCase {
 
 		for ( $i = 1; $i <= 12; $i++ ) {
 
-			$label = call_user_func( [ $class, 'getMonthLabel' ], $i );
-			$month = call_user_func( [ $class, 'findMonth' ], $label );
+			$label = call_user_func( [ $class, 'getMonthLabelByNumber' ], $i );
+			$month = call_user_func( [ $class, 'findMonthNumberByLabel' ], $label );
 
 			$this->assertIsString( $label );
 			$this->assertEquals( $i, $month );

--- a/tests/phpunit/Unit/MediaWiki/Deferred/CallableUpdateTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Deferred/CallableUpdateTest.php
@@ -176,7 +176,7 @@ class CallableUpdateTest extends TestCase {
 
 		$instance->setLogger( $this->spyLogger );
 
-		$instance->enabledDeferredUpdate( false );
+		$instance->isDeferrableUpdate( false );
 		$instance->pushUpdate();
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Deferred/TransactionalCallableUpdateTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Deferred/TransactionalCallableUpdateTest.php
@@ -174,7 +174,7 @@ class TransactionalCallableUpdateTest extends TestCase {
 
 		$instance->setLogger( $this->spyLogger );
 
-		$instance->enabledDeferredUpdate( false );
+		$instance->isDeferrableUpdate( false );
 		$instance->pushUpdate();
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandlerTest.php
@@ -218,7 +218,7 @@ class EntityLookupTaskHandlerTest extends TestCase {
 			$this->outputFormatter
 		);
 
-		$instance->setEnabledFeatures( SMW_ADM_DISPOSAL );
+		$instance->setFeatureSet( SMW_ADM_DISPOSAL );
 		$instance->setUser( $user );
 
 		$instance->handleRequest( $webRequest );

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -339,7 +339,7 @@ class PropertyRegistryTest extends TestCase {
 
 		$this->assertEquals(
 			'__typ',
-			$instance->getPropertyTypeId( '_TYPE' )
+			$instance->getPropertyValueTypeById( '_TYPE' )
 		);
 	}
 
@@ -379,7 +379,7 @@ class PropertyRegistryTest extends TestCase {
 
 		$this->assertSame(
 			'',
-			$instance->getPropertyTypeId( '_UnknownId' )
+			$instance->getPropertyValueTypeById( '_UnknownId' )
 		);
 
 		$this->assertFalse(
@@ -490,7 +490,7 @@ class PropertyRegistryTest extends TestCase {
 			$propertyAliases
 		);
 
-		$instance->registerPropertyDescriptionMsgKeyById( '_foo', 'bar' );
+		$instance->registerPropertyDescriptionByMsgKey( '_foo', 'bar' );
 
 		$this->assertEquals(
 			'bar',

--- a/tests/phpunit/Unit/SQLStore/ChangeOp/TableChangeOpTest.php
+++ b/tests/phpunit/Unit/SQLStore/ChangeOp/TableChangeOpTest.php
@@ -45,7 +45,7 @@ class TableChangeOpTest extends TestCase {
 		);
 
 		$this->assertNull(
-			$instance->getFixedPropertyValueBy( 'key' )
+			$instance->getFixedPropertyValByField( 'key' )
 		);
 
 		$this->assertIsArray(
@@ -101,7 +101,7 @@ class TableChangeOpTest extends TestCase {
 
 		$this->assertSame(
 			'_MDAT',
-			$instance->getFixedPropertyValueBy( 'key' )
+			$instance->getFixedPropertyValByField( 'key' )
 		);
 	}
 

--- a/tests/phpunit/Unit/SQLStore/Lookup/ChangePropagationEntityLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/ChangePropagationEntityLookupTest.php
@@ -86,7 +86,7 @@ class ChangePropagationEntityLookupTest extends TestCase {
 
 		$entityIdManager = $this->getMockBuilder( '\stdClass' )
 			->disableOriginalConstructor()
-			->setMethods( [ 'getSMWPropertyID', 'getDataItemPoolHashListFor' ] )
+			->setMethods( [ 'getSMWPropertyID', 'getDataItemsFromList' ] )
 			->getMock();
 
 		$entityIdManager->expects( $this->any() )
@@ -94,7 +94,7 @@ class ChangePropagationEntityLookupTest extends TestCase {
 			->willReturn( 42 );
 
 		$entityIdManager->expects( $this->any() )
-			->method( 'getDataItemPoolHashListFor' )
+			->method( 'getDataItemsFromList' )
 			->willReturn( [] );
 
 		$store = $this->getMockBuilder( SQLStore::class )

--- a/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryDependency/QueryDependencyLinksStoreTest.php
@@ -214,11 +214,11 @@ class QueryDependencyLinksStoreTest extends TestCase {
 		$row->s_id = 1001;
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getDataItemPoolHashListFor' ] )
+			->setMethods( [ 'getDataItemsFromList' ] )
 			->getMock();
 
 		$idTable->expects( $this->once() )
-			->method( 'getDataItemPoolHashListFor' );
+			->method( 'getDataItemsFromList' );
 
 		$capturedWheres = [];
 		$selectBuilder = $this->createMockSelectQueryBuilder( [ $row ], $capturedWheres );
@@ -286,11 +286,11 @@ class QueryDependencyLinksStoreTest extends TestCase {
 		$row->s_id = 1001;
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'getDataItemPoolHashListFor' ] )
+			->setMethods( [ 'getDataItemsFromList' ] )
 			->getMock();
 
 		$idTable->expects( $this->once() )
-			->method( 'getDataItemPoolHashListFor' );
+			->method( 'getDataItemsFromList' );
 
 		$capturedWheres = [];
 		$selectBuilder = $this->createMockSelectQueryBuilder( [ $row ], $capturedWheres );


### PR DESCRIPTION
## What

Removes 21 deprecated methods that have been superseded since SMW 3.0-5.0, ahead of the 7.0 major release. This is the first batch of a wider pre-7.0 deprecation cleanup (the low-risk, low-caller-count methods).

Each removed method was a thin delegator that simply called its replacement. Methods that had callers were removed only after repointing every caller to that replacement, so there is no behaviour change.

**Caller-repointed removals:**

| Removed | Replacement |
|---|---|
| `DataTypeRegistry::findTypeId()` | `findTypeByLabel()` |
| `PropertyRegistry::registerPropertyDescriptionMsgKeyById()` | `registerPropertyDescriptionByMsgKey()` |
| `PropertyRegistry::getPropertyTypeId()` | `getPropertyValueTypeById()` |
| `TaskHandler::setEnabledFeatures()` | `setFeatureSet()` |
| `EntityIdManager::getDataItemPoolHashListFor()` | `getDataItemsFromList()` |
| `CallableUpdate::enabledDeferredUpdate()` | `isDeferrableUpdate()` |
| `TableChangeOp::getFixedPropertyValueBy()` | `getFixedPropertyValByField()` |
| `LocalLanguage::getMonthLabel()` | `getMonthLabelByNumber()` |
| `WikiPageValue::getNamespace()` (private) | inlined to the data item accessor |

**Zero-caller removals:** `PropertyRegistry::isKnownPropertyId()`, `ParserData::setSemanticDataStateToParserOutputProperty()`, `ChangeOp::getCombinedIdListOfChangedEntities()`, `LocalLanguage::fetchByLanguageCode()` / `getPropertyId()` / `findMonth()`, `DataValue::checkAllowedValues()`, `MwCollaboratorFactory::newEditInfoProvider()`, `LoadBalancerConnectionProvider::asConnectionRef()`, `WikiPageValue::getArticleID()` / `getDBkey()` / `getInterwiki()`.

## Why

Dead-code cleanup for the 7.0 major release. These methods have carried `@deprecated` annotations since SMW 3.0-5.0.

## Notes

- `RELEASE-NOTES-7.0.0.md` is updated with the removed-method list.
- `WikiPageValue::m_id` (a `protected` property) becomes write-only once `getArticleID()` is gone. It is left in place here to keep this change a pure method removal; removing a `protected` property touches the subclassing API surface and is better handled separately.

## Testing

- `parallel-lint`: pass
- PHPCS: pass on all 26 changed files
- PHPUnit: 22 suites covering every changed class pass, including the 7 suites whose test files were updated