### PR TITLE
Remove 3 pre-7.0 deprecated methods (Tier 3) and update callers

### DIFF
--- a/docs/examples/hook.pagecontentsavecomplete.md
+++ b/docs/examples/hook.pagecontentsavecomplete.md
@@ -92,7 +92,7 @@ MediaWikiServices::getInstance()->getHookContainer()->register( 'PageContentSave
                 new Container( $containerSemanticData )
         );
 
-        $parserData->pushSemanticDataToParserOutput();
+        $parserData->copyToParserOutput();
 
         return true;
 

--- a/docs/examples/semanticdata.access.md
+++ b/docs/examples/semanticdata.access.md
@@ -44,7 +44,7 @@ foreach ( $values as $value ) {
 }
 
 // Ensures that objects are pushed to the ParserOutput
-$parserData->pushSemanticDataToParserOutput();
+$parserData->copyToParserOutput();
 ```
 
 ## Access semantic data currently stored in-memory

--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -234,6 +234,9 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
   * `LocalLanguage::fetchByLanguageCode()` — use `fetch()` (deprecated since 3.0)
   * `LocalLanguage::getPropertyId()`, `findMonth()`, `getMonthLabel()` — use `getPropertyIdByLabel()`, `findMonthNumberByLabel()`, `getMonthLabelByNumber()`
   * `LoadBalancerConnectionProvider::asConnectionRef()` (deprecated since 5.0)
+  * `ParserData::pushSemanticDataToParserOutput()` — use `copyToParserOutput()` (deprecated since 3.0)
+  * `DataValue::isEnabledFeature()` — use `hasFeature()` (deprecated since 3.0)
+  * `TaskHandler::isEnabledFeature()` — use `hasFeature()` (deprecated since 3.1)
 
 ### Deprecations
 

--- a/src/DataValues/DataValue.php
+++ b/src/DataValues/DataValue.php
@@ -875,14 +875,6 @@ abstract class DataValue {
 	}
 
 	/**
-	 * @deprecated since 3.0, use DataValue::hasFeature
-	 * @since 2.4
-	 */
-	public function isEnabledFeature( $feature ) {
-		return $this->hasFeature( $feature );
-	}
-
-	/**
 	 * @since 2.5
 	 */
 	protected function getOptions(): ?Options {

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -107,7 +107,7 @@ class MonolingualTextValue extends AbstractMultiValue {
 
 		if (
 			( $languageCode !== '' && $languageCodeValue->getErrors() !== [] ) ||
-			( $languageCode === '' && $this->isEnabledFeature( SMW_DV_MLTV_LCODE ) ) ) {
+			( $languageCode === '' && $this->hasFeature( SMW_DV_MLTV_LCODE ) ) ) {
 			$this->addError( $languageCodeValue->getErrors() );
 			return;
 		}

--- a/src/DataValues/NumberValue.php
+++ b/src/DataValues/NumberValue.php
@@ -139,7 +139,7 @@ class NumberValue extends DataValue {
 				')\s*(?:[eE][-+]?\d+)?)/u';
 
 		// #1718 Whether to preserve spaces in unit labels or not (e.g. sq mi, sqmi)
-		$space = $this->isEnabledFeature( SMW_DV_NUMV_USPACE ) ? ' ' : '';
+		$space = $this->hasFeature( SMW_DV_NUMV_USPACE ) ? ' ' : '';
 
 		$parts = preg_split(
 			$regex,

--- a/src/DataValues/PropertyValue.php
+++ b/src/DataValues/PropertyValue.php
@@ -180,7 +180,7 @@ class PropertyValue extends DataValue {
 		}
 
 		// @see the SMW_DV_PROV_DTITLE explanation
-		if ( $this->isEnabledFeature( SMW_DV_PROV_DTITLE ) ) {
+		if ( $this->hasFeature( SMW_DV_PROV_DTITLE ) ) {
 			$dataItem = $this->dataValueServiceFactory->getPropertySpecificationLookup()->getPropertyFromDisplayTitle(
 				$value
 			);
@@ -191,7 +191,7 @@ class PropertyValue extends DataValue {
 		// Copy the original DI to ensure we can compare it against a possible redirect
 		$this->inceptiveProperty = $this->m_dataitem;
 
-		if ( $this->isEnabledFeature( SMW_DV_PROV_REDI ) ) {
+		if ( $this->hasFeature( SMW_DV_PROV_REDI ) ) {
 			$this->m_dataitem = $this->m_dataitem->getRedirectTarget();
 		}
 

--- a/src/DataValues/UniquenessConstraintValue.php
+++ b/src/DataValues/UniquenessConstraintValue.php
@@ -25,7 +25,7 @@ class UniquenessConstraintValue extends BooleanValue {
 	 * @param string $userValue
 	 */
 	protected function parseUserValue( $userValue ): void {
-		if ( !$this->isEnabledFeature( SMW_DV_PVUC ) ) {
+		if ( !$this->hasFeature( SMW_DV_PVUC ) ) {
 			$this->addErrorMsg(
 				[
 					'smw-datavalue-feature-not-supported',

--- a/src/DataValues/ValueFormatters/PropertyValueFormatter.php
+++ b/src/DataValues/ValueFormatters/PropertyValueFormatter.php
@@ -291,7 +291,7 @@ class PropertyValueFormatter extends DataValueFormatter {
 	}
 
 	private function hintPreferredLabelUse(): string {
-		if ( !$this->dataValue->isEnabledFeature( SMW_DV_PROV_LHNT ) ||
+		if ( !$this->dataValue->hasFeature( SMW_DV_PROV_LHNT ) ||
 			$this->dataValue->getOption( PropertyValue::OPT_NO_PREF_LHNT ) ) {
 			return '';
 		}

--- a/src/DataValues/ValueFormatters/TimeValueFormatter.php
+++ b/src/DataValues/ValueFormatters/TimeValueFormatter.php
@@ -420,7 +420,7 @@ class TimeValueFormatter extends DataValueFormatter {
 	}
 
 	private function hintCalendarModel( Time $dataItem ): string {
-		if ( $this->dataValue->isEnabledFeature( SMW_DV_TIMEV_CM ) && $dataItem->getCalendarModel() !== Time::CM_GREGORIAN ) {
+		if ( $this->dataValue->hasFeature( SMW_DV_TIMEV_CM ) && $dataItem->getCalendarModel() !== Time::CM_GREGORIAN ) {
 			return ' ' . Html::rawElement( 'sup', [], $dataItem->getCalendarModelLiteral() );
 		}
 

--- a/src/DataValues/ValueValidators/PatternConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/PatternConstraintValueValidator.php
@@ -48,7 +48,7 @@ class PatternConstraintValueValidator implements ConstraintValueValidator {
 		if (
 			!$dataValue instanceof DataValue ||
 			$dataValue->getProperty() === null ||
-			!$dataValue->isEnabledFeature( SMW_DV_PVAP ) ) {
+			!$dataValue->hasFeature( SMW_DV_PVAP ) ) {
 			return $this->hasConstraintViolation;
 		}
 

--- a/src/DataValues/ValueValidators/PropertySpecificationConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/PropertySpecificationConstraintValueValidator.php
@@ -50,7 +50,7 @@ class PropertySpecificationConstraintValueValidator implements ConstraintValueVa
 
 	private function doValidateCodifiedPreferredPropertyLabelConstraints( DataValue $dataValue ): void {
 		// Annotated but not enabled
-		if ( !$dataValue->isEnabledFeature( SMW_DV_PPLB ) ) {
+		if ( !$dataValue->hasFeature( SMW_DV_PPLB ) ) {
 			$dataValue->addErrorMsg(
 				[
 					'smw-datavalue-feature-not-supported',

--- a/src/DataValues/ValueValidators/UniquenessConstraintValueValidator.php
+++ b/src/DataValues/ValueValidators/UniquenessConstraintValueValidator.php
@@ -66,7 +66,7 @@ class UniquenessConstraintValueValidator implements ConstraintValueValidator {
 	}
 
 	private function canValidate( $dataValue ): bool {
-		if ( !$dataValue->isEnabledFeature( SMW_DV_PVUC ) || !$dataValue instanceof DataValue ) {
+		if ( !$dataValue->hasFeature( SMW_DV_PVUC ) || !$dataValue instanceof DataValue ) {
 			return false;
 		}
 

--- a/src/Factbox/Factbox.php
+++ b/src/Factbox/Factbox.php
@@ -82,7 +82,7 @@ class Factbox {
 		if ( $this->content !== '' || $this->attachments !== [] ) {
 			$this->parserData->getOutput()->addModuleStyles( self::getModuleStyles() );
 			$this->parserData->getOutput()->addModules( self::getModules() );
-			$this->parserData->pushSemanticDataToParserOutput();
+			$this->parserData->copyToParserOutput();
 			$this->isVisible = true;
 		}
 

--- a/src/MediaWiki/Hooks/FileUpload.php
+++ b/src/MediaWiki/Hooks/FileUpload.php
@@ -90,7 +90,7 @@ class FileUpload implements HookListener {
 
 		$parserData->setOrigin( 'FileUpload' );
 
-		$parserData->pushSemanticDataToParserOutput();
+		$parserData->copyToParserOutput();
 		$parserData->updateStore( true );
 
 		return true;

--- a/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Supplement/EntityLookupTaskHandler.php
@@ -116,7 +116,7 @@ class EntityLookupTaskHandler extends TaskHandler implements ActionableTask {
 
 		$id = $webRequest->getText( 'id' );
 
-		if ( $this->isEnabledFeature( SMW_ADM_DISPOSAL ) && $id > 0 && $webRequest->getText( 'dispose' ) === 'yes' ) {
+		if ( $this->hasFeature( SMW_ADM_DISPOSAL ) && $id > 0 && $webRequest->getText( 'dispose' ) === 'yes' ) {
 			$this->doDispose( $id );
 		}
 
@@ -168,7 +168,7 @@ class EntityLookupTaskHandler extends TaskHandler implements ActionableTask {
 			$id = '';
 		}
 
-		if ( !$this->isEnabledFeature( SMW_ADM_DISPOSAL ) ) {
+		if ( !$this->hasFeature( SMW_ADM_DISPOSAL ) ) {
 			return $html;
 		}
 

--- a/src/MediaWiki/Specials/Admin/TaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/TaskHandler.php
@@ -33,14 +33,6 @@ abstract class TaskHandler {
 	protected bool $isApiTask = false;
 
 	/**
-	 * @deprecated since 3.1, use TaskHandler::hasFeature
-	 * @since 2.5
-	 */
-	public function isEnabledFeature( int $feature ): bool {
-		return $this->hasFeature( $feature );
-	}
-
-	/**
 	 * @since 3.1
 	 */
 	public function hasFeature( int $feature ): bool {

--- a/src/MediaWiki/Specials/SpecialAdmin.php
+++ b/src/MediaWiki/Specials/SpecialAdmin.php
@@ -156,7 +156,7 @@ class SpecialAdmin extends SpecialPage {
 		$supportTaskList = $taskHandlerRegistry->get( TaskHandler::SECTION_SUPPORT );
 		$supportTask = end( $supportTaskList );
 
-		$default = $alertsSection === '' ? ( $supportTask->isEnabledFeature( SMW_ADM_SHOW_OVERVIEW ) ? 'general' : 'maintenance' ) : 'alerts';
+		$default = $alertsSection === '' ? ( $supportTask->hasFeature( SMW_ADM_SHOW_OVERVIEW ) ? 'general' : 'maintenance' ) : 'alerts';
 
 		// If we want to remain on a specific tab on a GET request, use the `tab`
 		// parameter since we are unable to fetch any #href hash from a request
@@ -174,7 +174,7 @@ class SpecialAdmin extends SpecialPage {
 		);
 
 		$supportSection = '';
-		if ( $supportTask->isEnabledFeature( SMW_ADM_SHOW_OVERVIEW ) ) {
+		if ( $supportTask->hasFeature( SMW_ADM_SHOW_OVERVIEW ) ) {
 			$supportSection = $supportTask->getHtml();
 			$htmlTabs->tab( 'general', $this->msg_text( 'smw-admin-tab-general' ) );
 		}
@@ -182,7 +182,7 @@ class SpecialAdmin extends SpecialPage {
 		$htmlTabs->tab( 'maintenance', $this->msg_text( 'smw-admin-tab-maintenance' ) );
 		$htmlTabs->tab( 'supplement', $this->msg_text( 'smw-admin-tab-supplement' ) );
 
-		if ( $supportTask->isEnabledFeature( SMW_ADM_SHOW_OVERVIEW ) ) {
+		if ( $supportTask->hasFeature( SMW_ADM_SHOW_OVERVIEW ) ) {
 			$htmlTabs->content( 'general', $supportSection );
 		}
 

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -311,13 +311,6 @@ class ParserData {
 	}
 
 	/**
-	 * @deprecated since 3.0, use copyToParserOutput
-	 */
-	public function pushSemanticDataToParserOutput(): void {
-		$this->copyToParserOutput();
-	}
-
-	/**
 	 * @since 3.0
 	 */
 	public function markParserOutput(): void {

--- a/src/ParserFunctions/ConceptParserFunction.php
+++ b/src/ParserFunctions/ConceptParserFunction.php
@@ -108,7 +108,7 @@ class ConceptParserFunction {
 
 		$this->addQueryProfile( $query );
 
-		$this->parserData->pushSemanticDataToParserOutput();
+		$this->parserData->copyToParserOutput();
 
 		if ( $this->messageFormatter->exists() ) {
 			return $this->messageFormatter->getHtml();

--- a/src/ParserFunctions/DeclareParserFunction.php
+++ b/src/ParserFunctions/DeclareParserFunction.php
@@ -69,7 +69,7 @@ class DeclareParserFunction {
 			}
 		}
 
-		$this->parserData->pushSemanticDataToParserOutput();
+		$this->parserData->copyToParserOutput();
 
 		return '';
 	}

--- a/src/ParserFunctions/RecurringEventsParserFunction.php
+++ b/src/ParserFunctions/RecurringEventsParserFunction.php
@@ -77,7 +77,7 @@ class RecurringEventsParserFunction extends SubobjectParserFunction {
 		}
 
 		// Update ParserOutput
-		$this->parserData->pushSemanticDataToParserOutput();
+		$this->parserData->copyToParserOutput();
 
 		$this->messageFormatter->addFromArray(
 			$this->parserData->getErrors()

--- a/tests/phpunit/Unit/ParserDataTest.php
+++ b/tests/phpunit/Unit/ParserDataTest.php
@@ -143,7 +143,7 @@ class ParserDataTest extends TestCase {
 		);
 	}
 
-	public function testAddDataValueAndPushSemanticDataToParserOutput() {
+	public function testAddDataValueAndCopyToParserOutput() {
 		$titleFactory = MediaWikiServices::getInstance()->getTitleFactory();
 
 		$title = $titleFactory->newFromText( __METHOD__ );
@@ -156,7 +156,7 @@ class ParserDataTest extends TestCase {
 		);
 
 		$this->assertFalse( $instance->getSemanticData()->isEmpty() );
-		$instance->pushSemanticDataToParserOutput();
+		$instance->copyToParserOutput();
 
 		$title = $titleFactory->newFromText( __METHOD__ . '-1' );
 
@@ -349,7 +349,7 @@ class ParserDataTest extends TestCase {
 			)
 		);
 
-		$import->pushSemanticDataToParserOutput();
+		$import->copyToParserOutput();
 
 		$instance = new ParserData(
 			$titleFactory->newFromText( __METHOD__ ),

--- a/tests/phpunit/Unit/Property/Annotators/CategoryPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/CategoryPropertyAnnotatorTest.php
@@ -136,7 +136,7 @@ class CategoryPropertyAnnotatorTest extends TestCase {
 		);
 
 		$instance->addAnnotation();
-		$parserData->pushSemanticDataToParserOutput();
+		$parserData->copyToParserOutput();
 
 		$parserDataAfterAnnotation = new ParserData( $title, $parserOutput );
 


### PR DESCRIPTION
## What

Tier 3 of the pre-SMW-7.0 deprecation cleanup. Removes three deprecated thin-delegator methods and repoints their callers to the documented replacement:

| Removed | Replacement | Deprecated since |
|---|---|---|
| `ParserData::pushSemanticDataToParserOutput()` | `copyToParserOutput()` | 3.0 |
| `DataValue::isEnabledFeature()` | `hasFeature()` | 3.0 |
| `TaskHandler::isEnabledFeature()` | `hasFeature()` | 3.1 |

23 call sites repointed (8 `pushSemanticDataToParserOutput`, 15 `isEnabledFeature`). Each removed method delegated directly to its replacement, so there is no behaviour change.

`ResultPrinter::isEnabledFeature()` is a **separate, non-deprecated** method (same name, different class) and is intentionally left unchanged, along with its test.

Also updated: `RELEASE-NOTES-7.0.0.md` and two `docs/examples/*.md` snippets that referenced the removed `pushSemanticDataToParserOutput()`.

## Why

Dead-code cleanup for the 7.0 major release; these methods have carried `@deprecated` annotations since 3.0-3.1. Follows on from #6841 (Tier 1+2).

## Testing

- `parallel-lint`: pass
- PHPCS: pass on all 21 changed PHP files
- PHPUnit unit suite: pass (7093 tests, 0 failures)
- Independent code review: pass
- PHPUnit integration/structure suites: not verified locally (local dev container hang). Relying on CI, which runs the full suite on a clean environment; kept in draft until CI is green.