### PR TITLE
Make Codecov project/patch status checks informational

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,2 +1,12 @@
 fixes:
   - "/var/www/html/extensions/SemanticMediaWiki/::"
+
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+        removed_code_behavior: adjust_base
+    patch:
+      default:
+        informational: true


### PR DESCRIPTION
## Problem

Codecov runs with its default status checks because `codecov.yml` only contained a `fixes` path mapping and no `coverage.status` block. The defaults are strict:

- `project`: `target: auto`, `threshold: 0%` so any coverage drop, even -0.01%, fails the check.
- `patch`: `target: auto` so the diff must match the project's overall coverage level; a low diff-coverage patch (e.g. 55.55%) fails automatically.

Coverage is not used to gate merges, so a red CI from these checks is pure noise.

## Change

Add a `coverage.status` block setting both `project` and `patch` to `informational: true`. Codecov still posts the PR comment with coverage deltas, but the checks always report success instead of failing CI.

Also sets `removed_code_behavior: adjust_base` so PRs that delete untested code are not scored as coverage regressions.

## Note

If `codecov/project` or `codecov/patch` are configured as required status checks in branch protection, an informational check still reports success and will not block. No CI behaviour other than the Codecov check status is affected.