### PR TITLE
Remove 4 legacy compatibility hook names

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -180,6 +180,16 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 **Hooks:**
 
 * **`SMW::GroupPermissions::BeforeInitializationComplete` hook removed.** Permission rights and group assignments are now declared in `extension.json`. Extensions that modified SMW permissions via this hook should use MediaWiki's standard `$wgGroupPermissions` override in `LocalSettings.php` instead.
+* **Four legacy hook names removed.** SMW previously fired these old hook names alongside their modern replacements; they have been deprecated since 2.3-3.1. Extensions that registered handlers under the old names must move them to the modern hook:
+
+  | Removed | Use instead | Deprecated since |
+  |---|---|---|
+  | `smwRefreshDataJobs` | `SMW::SQLStore::BeforeDataRebuildJobInsert` | 2.3 |
+  | `SMWSQLStore3::updateDataAfter` | `SMW::SQLStore::AfterDataUpdateComplete` | 2.3 |
+  | `SMWStore::updateDataBefore` | `SMW::Store::BeforeDataUpdateComplete` | 3.1 |
+  | `SMWStore::updateDataAfter` | `SMW::Store::AfterDataUpdateComplete` | 3.1 |
+
+  The two `SMW::Store::*` modern hooks accept the same arguments as their predecessors; renaming the registration is sufficient. The two `SMW::SQLStore::*` modern hooks pass different arguments, so handler callback signatures must also be updated: `SMW::SQLStore::BeforeDataRebuildJobInsert` prepends a `Store $store` parameter, and `SMW::SQLStore::AfterDataUpdateComplete` appends a `ChangeOp $changeOp` parameter.
 
 **Removed APIs:**
 

--- a/docs/technical/hooks.md
+++ b/docs/technical/hooks.md
@@ -72,13 +72,9 @@ Implementing a hook should be made in consideration of the expected performance 
 - `smwInitDatatypes` (since 1.9)
 - `smwInitProperties` (since 2.1)
 - `smwShowFactbox` (since 2.1)
-- `smwRefreshDataJobs` (since 2.3)
 - `smwUpdatePropertySubjects` (since 1.9)
 - `smwAddToRDFExport` (since 3.0)
 - `SMWSQLStore3::updateDataBefore` (since 3.1)
-- `SMWSQLStore3::updateDataAfter` (since 2.3)
-- `SMWStore::updateDataBefore` (since 3.1)
-- `SMWStore::updateDataAfter` (since 3.1)
 - `SMWResultFormat` (since 3.1)
 
 [hooks]: https://www.mediawiki.org/wiki/Hooks "Manual:Hooks"

--- a/docs/technical/hooks/hook.sqlstore.afterdataupdatecomplete.md
+++ b/docs/technical/hooks/hook.sqlstore.afterdataupdatecomplete.md
@@ -1,5 +1,5 @@
 * Since: 2.3
-* Description: Hook to process information after an update has been completed. Further provides `ChangeOp` to identify entities that have been added/removed during the update. (`SMWSQLStore3::updateDataAfter` was deprecated with 2.3)
+* Description: Hook to process information after an update has been completed. Further provides `ChangeOp` to identify entities that have been added/removed during the update.
 * Reference class: [`SQLStoreUpdater.php`][SQLStoreUpdater.php]
 
 ### Signature

--- a/docs/technical/hooks/hook.sqlstore.beforedatarebuildjobinserts.md
+++ b/docs/technical/hooks/hook.sqlstore.beforedatarebuildjobinserts.md
@@ -1,5 +1,5 @@
 * Since: 2.3
-* Description: Hook to add update jobs while running the rebuild process. (`smwRefreshDataJobs` was deprecated with 2.3)
+* Description: Hook to add update jobs while running the rebuild process.
 * Reference class: [`Rebuilder.php`][Rebuilder.php]
 
 ### Signature

--- a/docs/technical/hooks/hook.store.afterdataupdatecomplete.md
+++ b/docs/technical/hooks/hook.store.afterdataupdatecomplete.md
@@ -1,5 +1,5 @@
 * Since: 3.1
-* Description: Hook to process information after an update has been completed. (`SMWStore::updateDataAfter` was deprecated with 3.1)
+* Description: Hook to process information after an update has been completed.
 * Reference class: [`Store.php`][Store.php]
 
 ### Signature

--- a/docs/technical/hooks/hook.store.beforedataupdatecomplete.md
+++ b/docs/technical/hooks/hook.store.beforedataupdatecomplete.md
@@ -1,5 +1,5 @@
 * Since: 3.1
-* Description: Hook to extend the `SemanticData` object before the update is completed. (`SMWStore::updateDataBefore` was deprecated with 3.1)
+* Description: Hook to extend the `SemanticData` object before the update is completed.
 * Reference class: [`Store.php`][Store.php]
 
 ### Signature

--- a/src/SQLStore/Rebuilder/Rebuilder.php
+++ b/src/SQLStore/Rebuilder/Rebuilder.php
@@ -183,9 +183,6 @@ class Rebuilder {
 
 		$this->matchAsSubject( $id, $emptyRange );
 
-		// Deprecated since 2.3, use 'SMW::SQLStore::BeforeDataRebuildJobInsert'
-		$this->hookContainer->run( 'smwRefreshDataJobs', [ &$this->updateJobs ] );
-
 		$this->hookContainer->run( 'SMW::SQLStore::BeforeDataRebuildJobInsert', [ $this->store, &$this->updateJobs ] );
 
 		if ( $this->getOption( 'use-job' ) ) {

--- a/src/SQLStore/SQLStoreUpdater.php
+++ b/src/SQLStore/SQLStoreUpdater.php
@@ -255,9 +255,6 @@ class SQLStoreUpdater {
 			]
 		);
 
-		// Deprecated since 2.3, use SMW::SQLStore::AfterDataUpdateComplete
-		$this->hookContainer->run( 'SMWSQLStore3::updateDataAfter', [ $this->store, $semanticData ] );
-
 		$this->hookContainer->run(
 			'SMW::SQLStore::AfterDataUpdateComplete',
 			[

--- a/src/Store.php
+++ b/src/Store.php
@@ -237,15 +237,9 @@ abstract class Store implements QueryEngine {
 		$subject = $semanticData->getSubject();
 		$hash = $subject->getHash();
 
-		// Deprecated since 3.1, use SMW::Store::BeforeDataUpdateComplete
-		$hookContainer->run( 'SMWStore::updateDataBefore', [ $this, $semanticData ] );
-
 		$hookContainer->run( 'SMW::Store::BeforeDataUpdateComplete', [ $this, $semanticData ] );
 
 		$this->doDataUpdate( $semanticData );
-
-		// Deprecated since 3.1, use SMW::Store::AfterDataUpdateComplete
-		$hookContainer->run( 'SMWStore::updateDataAfter', [ $this, $semanticData ] );
 
 		$hookContainer->run( 'SMW::Store::AfterDataUpdateComplete', [ $this, $semanticData ] );
 

--- a/tests/phpunit/Utils/MwHooksHandler.php
+++ b/tests/phpunit/Utils/MwHooksHandler.php
@@ -27,9 +27,7 @@ class MwHooksHandler {
 	private $inTestRegisteredHooks = [];
 
 	private $listOfSmwHooks = [
-		'SMWStore::updateDataBefore',
 		'SMW::Store::BeforeDataUpdateComplete',
-		'SMWStore::updateDataAfter',
 		'SMW::Store::AfterDataUpdateComplete',
 
 		// Those shoudl not be disabled so that extension used


### PR DESCRIPTION
## What

Removes four legacy hook names that SMW has been firing alongside their modern replacements for backwards compatibility. They have been deprecated since SMW 2.3-3.1.

| Removed | Use instead | Deprecated since |
|---|---|---|
| `smwRefreshDataJobs` | `SMW::SQLStore::BeforeDataRebuildJobInsert` | 2.3 |
| `SMWSQLStore3::updateDataAfter` | `SMW::SQLStore::AfterDataUpdateComplete` | 2.3 |
| `SMWStore::updateDataBefore` | `SMW::Store::BeforeDataUpdateComplete` | 3.1 |
| `SMWStore::updateDataAfter` | `SMW::Store::AfterDataUpdateComplete` | 3.1 |

Each old-name `$hookContainer->run()` call is removed; the modern hook (already fired alongside the legacy one) stays and is the documented replacement.

- Source changes: `Store.php`, `SQLStore/SQLStoreUpdater.php`, `SQLStore/Rebuilder/Rebuilder.php`
- Test helper: removed the two legacy Store names from `MwHooksHandler::$listOfSmwHooks`
- Docs: cleaned the deprecated-hooks list in `docs/technical/hooks.md` and the "was deprecated" parentheticals in the four modern-hook docs
- `RELEASE-NOTES-7.0.0.md`: breaking-change entry with migration table

## Why

Dead-code cleanup for the 7.0 major release; the legacy aliases have carried `// Deprecated since` comments for years. The modern hook names remain fully supported.

## Breaking change

Any external extension that registered handlers under one of the four old names must move them to the modern hook. Two of the four are not pure renames:

- `SMW::SQLStore::BeforeDataRebuildJobInsert` **prepends** a `Store $store` argument compared to `smwRefreshDataJobs`.
- `SMW::SQLStore::AfterDataUpdateComplete` **appends** a `ChangeOp $changeOp` argument compared to `SMWSQLStore3::updateDataAfter`.

Handlers migrating to those two must update their callback signatures. The `SMW::Store::*` pair preserves the exact argument list of its predecessor, so renaming the registration alone is sufficient. This is documented in `RELEASE-NOTES-7.0.0.md`.

## Testing

- Lint: pass on all 4 changed PHP files
- PHPCS: pass on all 4 changed PHP files
- PHPUnit: `SQLStoreUpdaterTest` (7), `SQLStore/Rebuilder/RebuilderTest` (4), `Elastic/Indexer/Rebuilder/RebuilderTest` (9) — all pass
- `SemanticMediaWikiProvidedHookInterfaceIntegrationTest` inspected — contains no references to any removed hook name
- Independent code review: pass; both Minor items (migration-table column label + the SQLStore signature-mismatch note above) addressed