### PR TITLE
Remove deprecated `Property::setPropertyTypeId()` and `Property::findPropertyTypeId()`

### DIFF
--- a/docs/examples/phpunit.test.property.md
+++ b/docs/examples/phpunit.test.property.md
@@ -2,7 +2,7 @@
 
 ```php
 $property = new \SMW\DataItems\Property( 'Foo' );
-$property->setPropertyTypeId( '_txt' );
+$property->setPropertyValueType( '_txt' );
 
 // Using a dedicated property to created a DV
 $dataValue = DataValueFactory::getInstance()->newDataValueByProperty(
@@ -42,7 +42,7 @@ $store->expects( $this->at( 1 ) )
 	->will( $this->returnValue( array(
 		\SMW\DataItems\Uri::doUnserialize( 'http://semantic-mediawiki.org/swivt/1.0#_txt' ) ) ) );
 
-// Inject the store as a mock object due to Property::findPropertyTypeID finding the
+// Inject the store as a mock object due to Property::findPropertyValueType finding the
 // type dynamically when called without explicit declaration
 ApplicationFactory::getInstance()->registerObject( 'Store', $store );
 

--- a/docs/examples/query.someproperty.of.type.number.md
+++ b/docs/examples/query.someproperty.of.type.number.md
@@ -9,7 +9,7 @@
 ```php
 // Create property instance
 $property = new DIProperty( 'NumericProperty' );
-$property->setPropertyTypeId( '_num' );
+$property->setPropertyValueType( '_num' );
 
 $dataItem = new DINumber( 1111 );
 

--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -240,6 +240,8 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
   * `ParserData::pushSemanticDataToParserOutput()` — use `copyToParserOutput()` (deprecated since 3.0)
   * `DataValue::isEnabledFeature()` — use `hasFeature()` (deprecated since 3.0)
   * `TaskHandler::isEnabledFeature()` — use `hasFeature()` (deprecated since 3.1)
+  * `Property::setPropertyTypeId()` — use `setPropertyValueType()` (deprecated since 3.0)
+  * `Property::findPropertyTypeId()` — use `findPropertyValueType()` (deprecated since 3.0)
 
 ### Deprecations
 

--- a/src/Constraint/Constraints/ShapeConstraint.php
+++ b/src/Constraint/Constraints/ShapeConstraint.php
@@ -124,7 +124,7 @@ class ShapeConstraint implements Constraint {
 
 	private function isType( $type, Property $property ): bool {
 		$diType = DataTypeRegistry::getInstance()->getDataItemByType(
-			$property->findPropertyTypeId()
+			$property->findPropertyValueType()
 		);
 
 		switch ( $type ) {

--- a/src/DataItems/Property.php
+++ b/src/DataItems/Property.php
@@ -261,7 +261,7 @@ class Property extends DataItem {
 	public function getCanonicalDiWikiPage( string $subobjectName = '' ): ?WikiPage {
 		if ( $this->isUserDefined() ) {
 			$dbkey = $this->m_key;
-		} elseif ( $this->m_key === $this->findPropertyTypeID() ) {
+		} elseif ( $this->m_key === $this->findPropertyValueType() ) {
 			// If _dat as property [[Date::...]] refers directly to its _dat type
 			// then use the en-label as canonical representation
 			$dbkey = PropertyRegistry::getInstance()->findPropertyLabelFromIdByLanguageCode( $this->m_key, 'en' );
@@ -293,13 +293,6 @@ class Property extends DataItem {
 	}
 
 	/**
-	 * @deprecated since 3.0, use Property::setPropertyValueType
-	 */
-	public function setPropertyTypeId( string $valueType ): Property {
-		return $this->setPropertyValueType( $valueType );
-	}
-
-	/**
 	 * @since 3.0
 	 *
 	 * @throws DataTypeLookupException
@@ -321,13 +314,6 @@ class Property extends DataItem {
 		}
 
 		throw new RuntimeException( 'DataType cannot be altered for a predefined property' );
-	}
-
-	/**
-	 * @deprecated since 3.0, use Property::findPropertyValueType
-	 */
-	public function findPropertyTypeId(): string {
-		return $this->findPropertyValueType();
 	}
 
 	/**

--- a/src/DataValueFactory.php
+++ b/src/DataValueFactory.php
@@ -252,7 +252,7 @@ class DataValueFactory {
 		$contextPage = null
 	) {
 		if ( $property !== null ) {
-			$typeId = $property->findPropertyTypeID();
+			$typeId = $property->findPropertyValueType();
 		} else {
 			$typeId = $this->dataTypeRegistry->getDefaultDataItemByType( $dataItem->getDiType() );
 		}
@@ -292,7 +292,7 @@ class DataValueFactory {
 		$caption = false,
 		$contextPage = null
 	) {
-		$typeId = $property->isInverse() ? '_wpg' : $property->findPropertyTypeID();
+		$typeId = $property->isInverse() ? '_wpg' : $property->findPropertyValueType();
 
 		return $this->newDataValueByType( $typeId, $valueString, $caption, $property, $contextPage );
 	}

--- a/src/DataValues/PropertyValue.php
+++ b/src/DataValues/PropertyValue.php
@@ -456,7 +456,7 @@ class PropertyValue extends DataValue {
 
 	/**
 	 * Convenience method to find the type id of this property. Most callers
-	 * should rather use Property::findPropertyTypeId() directly. Note
+	 * should rather use Property::findPropertyValueType() directly. Note
 	 * that this is not the same as getTypeID(), which returns the id of
 	 * this property datavalue.
 	 *
@@ -467,7 +467,7 @@ class PropertyValue extends DataValue {
 			return '__err';
 		}
 
-		return $this->m_dataitem->findPropertyTypeId();
+		return $this->m_dataitem->findPropertyValueType();
 	}
 
 	private function createDataItemFrom( bool $reqCapitalizedFirstChar, $propertyName, $capitalizedName, bool $inverse ): Property {

--- a/src/Deserializers/SemanticDataDeserializer.php
+++ b/src/Deserializers/SemanticDataDeserializer.php
@@ -161,7 +161,7 @@ class SemanticDataDeserializer implements Deserializer {
 	/**
 	 * Returns DataItemId for a property
 	 *
-	 * @note findPropertyTypeID is calling the Store to find the
+	 * @note findPropertyValueType is calling the Store to find the
 	 * typeId reference this is costly but at the moment there is no other
 	 * way to determine the typeId
 	 *
@@ -175,7 +175,7 @@ class SemanticDataDeserializer implements Deserializer {
 	 */
 	private function getDataItemId( Property $property ) {
 		if ( !isset( $this->dataItemTypeIdCache[$property->getKey()] ) ) {
-			$this->dataItemTypeIdCache[$property->getKey()] = DataTypeRegistry::getInstance()->getDataItemByType( $property->findPropertyTypeID() );
+			$this->dataItemTypeIdCache[$property->getKey()] = DataTypeRegistry::getInstance()->getDataItemByType( $property->findPropertyValueType() );
 		}
 
 		return $this->dataItemTypeIdCache[$property->getKey()];

--- a/src/Elastic/Lookup/ProximityPropertyValueLookup.php
+++ b/src/Elastic/Lookup/ProximityPropertyValueLookup.php
@@ -53,7 +53,7 @@ class ProximityPropertyValueLookup {
 		);
 
 		$diType = DataTypeRegistry::getInstance()->getDataItemByType(
-			$property->findPropertyTypeID()
+			$property->findPropertyValueType()
 		);
 
 		$field = $this->fieldMapper->getField( $property );

--- a/src/Export/Exporter.php
+++ b/src/Export/Exporter.php
@@ -444,7 +444,7 @@ class Exporter {
 	 * @todo An improved mechanism for selecting property types here is needed.
 	 */
 	public function getOWLPropertyType( Property $property ): string {
-		return TypesRegistry::getOWLPropertyByType( $property->findPropertyTypeID() );
+		return TypesRegistry::getOWLPropertyByType( $property->findPropertyValueType() );
 	}
 
 	/**
@@ -670,8 +670,8 @@ class Exporter {
 	 * values in the sense of Exporter::getInstance()->newAuxiliaryExpElement().
 	 */
 	public static function hasHelperExpElement( Property $property ): bool {
-		return ( $property->findPropertyTypeID() === '_dat' ||
-			$property->findPropertyTypeID() === '_geo' ) ||
+		return ( $property->findPropertyValueType() === '_dat' ||
+			$property->findPropertyValueType() === '_geo' ) ||
 			( !$property->isUserDefined() && !self::hasSpecialPropertyResource( $property ) );
 	}
 

--- a/src/Exporter/ExpResourceMapper.php
+++ b/src/Exporter/ExpResourceMapper.php
@@ -108,7 +108,7 @@ class ExpResourceMapper {
 		}
 
 		// No need for any aux properties besides those listed here
-		if ( !$this->bcAuxiliaryUse && $property->findPropertyTypeID() !== '_dat' && $property->findPropertyTypeID() !== '_geo' ) {
+		if ( !$this->bcAuxiliaryUse && $property->findPropertyValueType() !== '_dat' && $property->findPropertyValueType() !== '_geo' ) {
 			$useAuxiliaryModifier = false;
 		}
 

--- a/src/Exporter/ResourceBuilders/AuxiliaryPropertyValueResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/AuxiliaryPropertyValueResourceBuilder.php
@@ -39,7 +39,7 @@ class AuxiliaryPropertyValueResourceBuilder extends PredefinedPropertyValueResou
 			return;
 		}
 
-		if ( $property->getKey() === $property->findPropertyTypeID() ) {
+		if ( $property->getKey() === $property->findPropertyValueType() ) {
 			// Ensures that Boolean remains Boolean and not localized canonical
 			// representation such as "Booléen" when the content languageis not
 			// English

--- a/src/Exporter/ResourceBuilders/ExternalIdentifierPropertyValueResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/ExternalIdentifierPropertyValueResourceBuilder.php
@@ -24,7 +24,7 @@ class ExternalIdentifierPropertyValueResourceBuilder extends PropertyValueResour
 	 * {@inheritDoc}
 	 */
 	public function isResourceBuilderFor( Property $property ): bool {
-		return $property->findPropertyTypeID() === '_eid';
+		return $property->findPropertyValueType() === '_eid';
 	}
 
 	/**

--- a/src/Exporter/ResourceBuilders/KeywordPropertyValueResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/KeywordPropertyValueResourceBuilder.php
@@ -25,7 +25,7 @@ class KeywordPropertyValueResourceBuilder extends PropertyValueResourceBuilder {
 	 * {@inheritDoc}
 	 */
 	public function isResourceBuilderFor( Property $property ): bool {
-		return $property->findPropertyTypeID() === '_keyw';
+		return $property->findPropertyValueType() === '_keyw';
 	}
 
 	/**

--- a/src/Exporter/ResourceBuilders/MonolingualTextPropertyValueResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/MonolingualTextPropertyValueResourceBuilder.php
@@ -24,7 +24,7 @@ class MonolingualTextPropertyValueResourceBuilder extends PropertyValueResourceB
 	 * {@inheritDoc}
 	 */
 	public function isResourceBuilderFor( Property $property ): bool {
-		return $property->findPropertyTypeID() === '_mlt_rec';
+		return $property->findPropertyValueType() === '_mlt_rec';
 	}
 
 	/**

--- a/src/MediaWiki/Jobs/UpdateDispatcherJob.php
+++ b/src/MediaWiki/Jobs/UpdateDispatcherJob.php
@@ -209,7 +209,7 @@ class UpdateDispatcherJob extends Job {
 			// Before doing some work, make sure to only use page type properties
 			// as a means to generate a resource (job) action
 			$type = DataTypeRegistry::getInstance()->getDataItemByType(
-				$property->findPropertyTypeId()
+				$property->findPropertyValueType()
 			);
 
 			if ( $type !== DataItem::TYPE_WIKIPAGE ) {

--- a/src/MediaWiki/Search/ProfileForm/Forms/CustomForm.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/CustomForm.php
@@ -126,7 +126,7 @@ class CustomForm {
 		if ( isset( $options['type'] ) ) {
 			$type = $options['type'];
 		} else {
-			$typeID = Property::newFromUserLabel( $property )->findPropertyTypeID();
+			$typeID = Property::newFromUserLabel( $property )->findPropertyValueType();
 			$type = 'text';
 
 			if ( isset( $this->html5TypeMap[$typeID] ) ) {

--- a/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/CheckboxRangeGroupValueFilter.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/CheckboxRangeGroupValueFilter.php
@@ -127,7 +127,7 @@ class CheckboxRangeGroupValueFilter {
 		$property = Property::newFromUserLabel( $property );
 
 		$diType = DataTypeRegistry::getInstance()->getDataItemByType(
-			$property->findPropertyTypeID()
+			$property->findPropertyValueType()
 		);
 
 		foreach ( $this->compartmentIterator as $compartment ) {

--- a/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/CheckboxValueFilter.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/CheckboxValueFilter.php
@@ -60,7 +60,7 @@ class CheckboxValueFilter {
 		$prop = Property::newFromUserLabel( $property );
 
 		$isRecordType = DataTypeRegistry::getInstance()->isRecordType(
-			$prop->findPropertyTypeID()
+			$prop->findPropertyValueType()
 		);
 
 		foreach ( $values as $key => $count ) {

--- a/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/ListValueFilter.php
+++ b/src/MediaWiki/Specials/FacetedSearch/Filters/ValueFilters/ListValueFilter.php
@@ -59,7 +59,7 @@ class ListValueFilter {
 		$prop = Property::newFromUserLabel( $property );
 
 		$isRecordType = DataTypeRegistry::getInstance()->isRecordType(
-			$prop->findPropertyTypeID()
+			$prop->findPropertyValueType()
 		);
 
 		foreach ( $values as $key => $count ) {

--- a/src/MediaWiki/Specials/PageProperty/PageBuilder.php
+++ b/src/MediaWiki/Specials/PageProperty/PageBuilder.php
@@ -79,7 +79,7 @@ class PageBuilder {
 		$property = $propertyValue->getDataItem();
 
 		$isBrowsableType = DataTypeRegistry::getInstance()->isBrowsableType(
-			$property->findPropertyTypeID()
+			$property->findPropertyValueType()
 		);
 
 		$list = [];

--- a/src/MediaWiki/Specials/SearchByProperty/QueryResultLookup.php
+++ b/src/MediaWiki/Specials/SearchByProperty/QueryResultLookup.php
@@ -232,7 +232,7 @@ class QueryResultLookup {
 
 		// override $DIProperty for reference datatype
 		// with the first multiValue property
-		if ( DataTypeRegistry::getInstance()->isRecordType( $DIProperty->findPropertyTypeID() ) ) {
+		if ( DataTypeRegistry::getInstance()->isRecordType( $DIProperty->findPropertyValueType() ) ) {
 			[ $DIProperty, $dataItem ] = $this->destructureDIContainer( $DIProperty, $dataItem, $pageRequestOptions );
 		}
 

--- a/src/Property/Annotators/MandatoryTypePropertyAnnotator.php
+++ b/src/Property/Annotators/MandatoryTypePropertyAnnotator.php
@@ -78,7 +78,7 @@ class MandatoryTypePropertyAnnotator extends PropertyAnnotatorDecorator {
 		$parentProperty = Property::newFromUserLabel( $dataItem->getDBKey() );
 
 		if ( $parentProperty->isUserDefined() ) {
-			$type_id = $parentProperty->findPropertyTypeID();
+			$type_id = $parentProperty->findPropertyValueType();
 		} else {
 			$type_id = $parentProperty->getKey();
 		}

--- a/src/Property/DeclarationExaminer/PredefinedPropertyExaminer.php
+++ b/src/Property/DeclarationExaminer/PredefinedPropertyExaminer.php
@@ -111,7 +111,7 @@ class PredefinedPropertyExaminer extends DeclarationExaminer {
 		if (
 			DataTypeRegistry::getInstance()->isEqualByType(
 				$type,
-				$property->findPropertyTypeID()
+				$property->findPropertyValueType()
 			)
 		) {
 			return;

--- a/src/Property/DeclarationExaminer/UserdefinedPropertyExaminer.php
+++ b/src/Property/DeclarationExaminer/UserdefinedPropertyExaminer.php
@@ -40,7 +40,7 @@ class UserdefinedPropertyExaminer extends DeclarationExaminer {
 			return;
 		}
 
-		$type = $property->findPropertyTypeID();
+		$type = $property->findPropertyValueType();
 
 		$this->checkMessages( $property );
 
@@ -68,7 +68,7 @@ class UserdefinedPropertyExaminer extends DeclarationExaminer {
 			return;
 		}
 
-		$type = $property->findPropertyTypeID();
+		$type = $property->findPropertyValueType();
 
 		if ( $type === MonolingualTextValue::TYPE_ID ) {
 			return;
@@ -202,7 +202,7 @@ class UserdefinedPropertyExaminer extends DeclarationExaminer {
 		$key = end( $pv )->getDBKey();
 		$parentProperty = new Property( $key );
 
-		if ( $type === $parentProperty->findPropertyTypeID() ) {
+		if ( $type === $parentProperty->findPropertyValueType() ) {
 			return;
 		}
 

--- a/src/Query/Parser/LegacyParser.php
+++ b/src/Query/Parser/LegacyParser.php
@@ -533,7 +533,7 @@ class LegacyParser implements Parser {
 			$property = $propertyValue->getDataItem();
 			$propertyValueList[] = $propertyValue;
 
-			$typeid = $property->findPropertyTypeID();
+			$typeid = $property->findPropertyValueType();
 			$inverse = $property->isInverse();
 		}
 

--- a/src/Query/PrintRequest.php
+++ b/src/Query/PrintRequest.php
@@ -229,9 +229,9 @@ class PrintRequest {
 		}
 
 		if ( $this->m_mode == self::PRINT_PROP ) {
-			$this->m_typeid = $this->m_data->getDataItem()->findPropertyTypeID();
+			$this->m_typeid = $this->m_data->getDataItem()->findPropertyValueType();
 		} elseif ( $this->m_mode == self::PRINT_CHAIN ) {
-			$this->m_typeid = $this->m_data->getLastPropertyChainValue()->getDataItem()->findPropertyTypeID();
+			$this->m_typeid = $this->m_data->getLastPropertyChainValue()->getDataItem()->findPropertyValueType();
 		} else {
 			$this->m_typeid = '_wpg';
 		}

--- a/src/QueryPages/UnusedPropertiesQueryPage.php
+++ b/src/QueryPages/UnusedPropertiesQueryPage.php
@@ -173,7 +173,7 @@ class UnusedPropertiesQueryPage extends QueryPage {
 			}
 
 		} else {
-			$typeDataValue = TypesValue::newFromTypeId( $property->findPropertyTypeID() );
+			$typeDataValue = TypesValue::newFromTypeId( $property->findPropertyValueType() );
 			$propertyLink  = DataValueFactory::getInstance()
 				->newDataValueByItem( $property, null )
 				->getShortHtmlText( $this->getLinker() );

--- a/src/SPARQLStore/QueryEngine/ConditionBuilder.php
+++ b/src/SPARQLStore/QueryEngine/ConditionBuilder.php
@@ -419,7 +419,7 @@ class ConditionBuilder {
 		}
 
 		if ( $diType == DataItem::TYPE_NOTYPE ) {
-			$diType = DataTypeRegistry::getInstance()->getDataItemByType( $orderByProperty->findPropertyTypeID() );
+			$diType = DataTypeRegistry::getInstance()->getDataItemByType( $orderByProperty->findPropertyValueType() );
 		}
 
 		$this->addOrderByData( $sparqlCondition, $mainVariable, $diType );

--- a/src/SQLStore/EntityStore/EntityLookup.php
+++ b/src/SQLStore/EntityStore/EntityLookup.php
@@ -296,7 +296,7 @@ class EntityLookup implements IEntityLookup {
 			);
 
 			$result = [];
-			$propertyTypeId = $property->findPropertyTypeID();
+			$propertyTypeId = $property->findPropertyValueType();
 
 			$propertyDiId = DataTypeRegistry::getInstance()->getDataItemByType(
 				$propertyTypeId
@@ -343,7 +343,7 @@ class EntityLookup implements IEntityLookup {
 		$idTable = $this->store->getObjectIds();
 
 		$type = DataTypeRegistry::getInstance()->getDataItemByType(
-			$property->findPropertyTypeID()
+			$property->findPropertyValueType()
 		);
 
 		// #1222, Filter those where types don't match (e.g property = _txt

--- a/src/SQLStore/EntityStore/PrefetchItemLookup.php
+++ b/src/SQLStore/EntityStore/PrefetchItemLookup.php
@@ -171,7 +171,7 @@ class PrefetchItemLookup {
 		);
 
 		$type = DataTypeRegistry::getInstance()->getDataItemByType(
-			$noninverse->findPropertyTypeID()
+			$noninverse->findPropertyValueType()
 		);
 
 		$tableid = $this->store->findPropertyTableID( $noninverse );

--- a/src/SQLStore/EntityStore/StubSemanticData.php
+++ b/src/SQLStore/EntityStore/StubSemanticData.php
@@ -203,7 +203,7 @@ class StubSemanticData extends SemanticData {
 		foreach ( $this->getProperties() as $property ) {
 
 			// #619 Do not resolve subobjects for redirects
-			if ( !DataTypeRegistry::getInstance()->isSubDataType( $property->findPropertyTypeID() ) ) {
+			if ( !DataTypeRegistry::getInstance()->isSubDataType( $property->findPropertyValueType() ) ) {
 				continue;
 			}
 
@@ -377,7 +377,7 @@ class StubSemanticData extends SemanticData {
 	private function unstubPropertyValues( Property $property ): void {
 		// Not catching exception here; the
 		$this->unstubProperty( $property->getKey(), $property );
-		$propertyTypeId = $property->findPropertyTypeID();
+		$propertyTypeId = $property->findPropertyValueType();
 
 		$propertyDiId = DataTypeRegistry::getInstance()->getDataItemByType( $propertyTypeId );
 		$diHandler = $this->store->getDataItemHandlerForDIType( $propertyDiId );

--- a/src/SQLStore/Lookup/ByGroupPropertyValuesLookup.php
+++ b/src/SQLStore/Lookup/ByGroupPropertyValuesLookup.php
@@ -41,7 +41,7 @@ class ByGroupPropertyValuesLookup {
 	 */
 	public function findValueGroups( Property $property, array $subjects ): array {
 		$diType = DataTypeRegistry::getInstance()->getDataItemByType(
-			$property->findPropertyTypeID()
+			$property->findPropertyValueType()
 		);
 
 		$diHandler = $this->store->getDataItemHandlerForDIType(

--- a/src/SQLStore/Lookup/PropertyLabelSimilarityLookup.php
+++ b/src/SQLStore/Lookup/PropertyLabelSimilarityLookup.php
@@ -233,7 +233,7 @@ class PropertyLabelSimilarityLookup {
 		if ( $withType ) {
 			$summary[] = [
 				'label' => $first->getLabel(),
-				'type'  => $first->findPropertyTypeID()
+				'type'  => $first->findPropertyValueType()
 			];
 		} else {
 			$summary[] = $first->getLabel();
@@ -242,7 +242,7 @@ class PropertyLabelSimilarityLookup {
 		if ( $withType ) {
 			$summary[] = [
 				'label' => $second->getLabel(),
-				'type'  => $second->findPropertyTypeID()
+				'type'  => $second->findPropertyValueType()
 			];
 		} else {
 			$summary[] = $second->getLabel();

--- a/src/SQLStore/Lookup/ProximityPropertyValueLookup.php
+++ b/src/SQLStore/Lookup/ProximityPropertyValueLookup.php
@@ -220,7 +220,7 @@ class ProximityPropertyValueLookup {
 	}
 
 	private function getField( Property $property ): array {
-		$typeId = $property->findPropertyTypeID();
+		$typeId = $property->findPropertyValueType();
 		$diType = DataTypeRegistry::getInstance()->getDataItemByType( $typeId );
 
 		$diHandler = $this->store->getDataItemHandlerForDIType(

--- a/src/SQLStore/PropertyTableInfoFetcher.php
+++ b/src/SQLStore/PropertyTableInfoFetcher.php
@@ -155,7 +155,7 @@ class PropertyTableInfoFetcher {
 			return $this->fixedPropertyTableIds[$propertyKey];
 		}
 
-		return $this->findTableIdForDataTypeTypeId( $property->findPropertyTypeID() );
+		return $this->findTableIdForDataTypeTypeId( $property->findPropertyValueType() );
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -121,7 +121,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			return;
 		}
 
-		$typeid = $property->findPropertyTypeID();
+		$typeid = $property->findPropertyValueType();
 		$diType = DataTypeRegistry::getInstance()->getDataItemByType( $typeid );
 
 		if ( $property->isInverse() && $diType !== DataItem::TYPE_WIKIPAGE ) {

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTable.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTable.php
@@ -115,7 +115,7 @@ class SearchTable {
 	 */
 	public function isExemptedProperty( Property $property ): bool {
 		$dataItemTypeId = DataTypeRegistry::getInstance()->getDataItemByType(
-			$property->findPropertyTypeID()
+			$property->findPropertyValueType()
 		);
 
 		// Property does not belong to a valid type which means to be exempted

--- a/src/Serializers/QueryResultSerializer.php
+++ b/src/Serializers/QueryResultSerializer.php
@@ -91,13 +91,13 @@ class QueryResultSerializer implements DispatchableSerializer {
 						$recordDiValues[$label] = [
 							'label'  => $label,
 							'key'    => $property->getKey(),
-							'typeid' => $property->findPropertyTypeID(),
+							'typeid' => $property->findPropertyValueType(),
 							'item'   => []
 						];
 
 						foreach ( $recordValue->getDataItem()->getSemanticData()->getPropertyValues( $property ) as $value ) {
 
-							if ( $property->findPropertyTypeID() === '_qty' ) {
+							if ( $property->findPropertyValueType() === '_qty' ) {
 								$dataValue = DataValueFactory::getInstance()->newDataValueByItem( $value, $property );
 
 								$recordDiValues[$label]['item'][] = [

--- a/tests/phpunit/Integration/DataModel/SubobjectTest.php
+++ b/tests/phpunit/Integration/DataModel/SubobjectTest.php
@@ -158,7 +158,7 @@ class SubobjectTest extends TestCase {
 			->getMock();
 
 		$property->expects( $this->atLeastOnce() )
-			->method( 'findPropertyTypeID' )
+			->method( 'findPropertyValueType' )
 			->willReturn( $parameters['property']['typeId'] );
 
 		$property->expects( $this->atLeastOnce() )

--- a/tests/phpunit/Integration/MediaWiki/Import/RecordDataTypeTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/RecordDataTypeTest.php
@@ -98,7 +98,7 @@ class RecordDataTypeTest extends SMWIntegrationTestCase {
 		$property = Property::newFromUserLabel( 'Has record type for single test' );
 		$valueString = 'ForSingleTestAsPage;ForSingleTestAsText;3333';
 
-		if ( $property->findPropertyTypeID() === '_rec' ) {
+		if ( $property->findPropertyValueType() === '_rec' ) {
 			$valueString = 'ForSingleTestAsPage; ForSingleTestAsText; 3333';
 		}
 

--- a/tests/phpunit/Integration/MediaWiki/Import/TimeDataTypeTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Import/TimeDataTypeTest.php
@@ -230,7 +230,7 @@ class TimeDataTypeTest extends SMWIntegrationTestCase {
 
 		foreach ( $semanticData->getProperties() as $property ) {
 
-			if ( $property->findPropertyTypeID() === '_dat' && $property->equals( $expected['property'] ) ) {
+			if ( $property->findPropertyValueType() === '_dat' && $property->equals( $expected['property'] ) ) {
 				$runDateValueAssert = true;
 				$this->semanticDataValidator->assertThatPropertyValuesAreSet(
 					$expected,

--- a/tests/phpunit/Integration/Query/ComparatorFilterConditionQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ComparatorFilterConditionQueryDBIntegrationTest.php
@@ -129,7 +129,7 @@ class ComparatorFilterConditionQueryDBIntegrationTest extends SMWIntegrationTest
 
 	public function numericConjunctionFilterProvider() {
 		$property = new Property( 'SomeNumericPropertyToFilter' );
-		$property->setPropertyTypeId( '_num' );
+		$property->setPropertyValueType( '_num' );
 
 		# 0 Numeric Greater Equal, Less Equal
 		$provider[] = [
@@ -216,7 +216,7 @@ class ComparatorFilterConditionQueryDBIntegrationTest extends SMWIntegrationTest
 
 	public function textConjunctionFilterProvider() {
 		$property = new Property( 'SomeBlobPropertyToFilter' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		# 4 Text, Greater Equal, Less Equal
 		$provider[] = [
@@ -284,7 +284,7 @@ class ComparatorFilterConditionQueryDBIntegrationTest extends SMWIntegrationTest
 
 	public function dateConjunctionFilterProvider() {
 		$property = new Property( 'SomeDatePropertyToFilter' );
-		$property->setPropertyTypeId( '_dat' );
+		$property->setPropertyValueType( '_dat' );
 
 		# 7 Date, Greater Equal, Less Equal
 		$provider[] = [

--- a/tests/phpunit/Integration/Query/ConjunctionQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/ConjunctionQueryDBIntegrationTest.php
@@ -78,7 +78,7 @@ class ConjunctionQueryDBIntegrationTest extends SMWIntegrationTestCase {
 			->newEmptySemanticData();
 
 		$semanticDataOfNeverland->addPropertyObjectValue(
-			Property::newFromUserLabel( 'LocatedIn' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'LocatedIn' )->setPropertyValueType( '_wpg' ),
 			new WikiPage( 'BananaWonderland', NS_MAIN )
 		);
 
@@ -92,7 +92,7 @@ class ConjunctionQueryDBIntegrationTest extends SMWIntegrationTestCase {
 			->newEmptySemanticData();
 
 		$semanticDataOfDreamland->addPropertyObjectValue(
-			Property::newFromUserLabel( 'LocatedIn' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'LocatedIn' )->setPropertyValueType( '_wpg' ),
 			new WikiPage( 'BananaWonderland', NS_MAIN )
 		);
 
@@ -111,19 +111,19 @@ class ConjunctionQueryDBIntegrationTest extends SMWIntegrationTestCase {
 			->newEmptySemanticData();
 
 		$semanticDataOfWonderland->addPropertyObjectValue(
-			Property::newFromUserLabel( 'MemberOf' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'MemberOf' )->setPropertyValueType( '_wpg' ),
 			new WikiPage( 'Wonderland', NS_MAIN )
 		);
 
 		$this->getStore()->updateData( $semanticDataOfWonderland );
 
 		$someProperty = new SomeProperty(
-			Property::newFromUserLabel( 'LocatedIn' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'LocatedIn' )->setPropertyValueType( '_wpg' ),
 			new SomeProperty(
-				Property::newFromUserLabel( 'MemberOf' )->setPropertyTypeId( '_wpg' ),
+				Property::newFromUserLabel( 'MemberOf' )->setPropertyValueType( '_wpg' ),
 				new ValueDescription(
 					new WikiPage( 'Wonderland', NS_MAIN, '' ),
-					Property::newFromUserLabel( 'MemberOf' )->setPropertyTypeId( '_wpg' ), SMW_CMP_EQ
+					Property::newFromUserLabel( 'MemberOf' )->setPropertyValueType( '_wpg' ), SMW_CMP_EQ
 				)
 			)
 		);
@@ -182,7 +182,7 @@ class ConjunctionQueryDBIntegrationTest extends SMWIntegrationTestCase {
 		 * Page annotated with [[Born in::Paris]]
 		 */
 		$property = Property::newFromUserLabel( 'Born in' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ . 'PageOughtToBeSelected' );
 

--- a/tests/phpunit/Integration/Query/DatePropertyValueQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/DatePropertyValueQueryDBIntegrationTest.php
@@ -65,7 +65,7 @@ class DatePropertyValueQueryDBIntegrationTest extends SMWIntegrationTestCase {
 
 	public function testUserDefinedDateProperty() {
 		$property = new Property( 'SomeDateProperty' );
-		$property->setPropertyTypeId( '_dat' );
+		$property->setPropertyValueType( '_dat' );
 
 		$dataValue = $this->dataValueFactory->newDataValueByProperty(
 			$property,

--- a/tests/phpunit/Integration/Query/DisjunctionQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/DisjunctionQueryDBIntegrationTest.php
@@ -83,7 +83,7 @@ class DisjunctionQueryDBIntegrationTest extends SMWIntegrationTestCase {
 			->newEmptySemanticData();
 
 		$semanticDataOfDreamland->addPropertyObjectValue(
-			Property::newFromUserLabel( 'LocatedIn' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'LocatedIn' )->setPropertyValueType( '_wpg' ),
 			new WikiPage( 'BananaWonderland', NS_MAIN )
 		);
 
@@ -98,7 +98,7 @@ class DisjunctionQueryDBIntegrationTest extends SMWIntegrationTestCase {
 			->newEmptySemanticData();
 
 		$semanticDataOfWonderland->addPropertyObjectValue(
-			Property::newFromUserLabel( 'MemberOf' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'MemberOf' )->setPropertyValueType( '_wpg' ),
 			new WikiPage( 'Wonderland', NS_MAIN )
 		);
 
@@ -109,12 +109,12 @@ class DisjunctionQueryDBIntegrationTest extends SMWIntegrationTestCase {
 		 * Query with [[Category:WickedPlaces]] OR [[LocatedIn.MemberOf::Wonderland]]
 		 */
 		$someProperty = new SomeProperty(
-			Property::newFromUserLabel( 'LocatedIn' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'LocatedIn' )->setPropertyValueType( '_wpg' ),
 			new SomeProperty(
-				Property::newFromUserLabel( 'MemberOf' )->setPropertyTypeId( '_wpg' ),
+				Property::newFromUserLabel( 'MemberOf' )->setPropertyValueType( '_wpg' ),
 				new ValueDescription(
 					new WikiPage( 'Wonderland', NS_MAIN, '' ),
-					Property::newFromUserLabel( 'MemberOf' )->setPropertyTypeId( '_wpg' ), SMW_CMP_EQ
+					Property::newFromUserLabel( 'MemberOf' )->setPropertyValueType( '_wpg' ), SMW_CMP_EQ
 				)
 			)
 		);
@@ -165,7 +165,7 @@ class DisjunctionQueryDBIntegrationTest extends SMWIntegrationTestCase {
 
 	public function testSubqueryDisjunction() {
 		$property = new Property( 'HasSomeProperty' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		/**
 		 * Page annotated with [[HasSomeProperty:Foo]]

--- a/tests/phpunit/Integration/Query/GeneralQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/GeneralQueryDBIntegrationTest.php
@@ -56,7 +56,7 @@ class GeneralQueryDBIntegrationTest extends SMWIntegrationTestCase {
 
 	public function testPropertyBeforeAfterDataRemoval() {
 		$property = new Property( 'SomePagePropertyBeforeAfter' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$this->assertEmpty(
 			$this->searchForResultsThatCompareEqualToOnlySingularPropertyOf( $property )->getResults()
@@ -92,7 +92,7 @@ class GeneralQueryDBIntegrationTest extends SMWIntegrationTestCase {
 
 	public function testUserDefinedPropertyUsedForInvalidValueAssignment() {
 		$property = new Property( 'SomePropertyWithInvalidValueAssignment' );
-		$property->setPropertyTypeId( '_tem' );
+		$property->setPropertyValueType( '_tem' );
 
 		$dataValue = $this->dataValueFactory->newDataValueByProperty( $property, '1 Jan 1970' );
 

--- a/tests/phpunit/Integration/Query/InversePropertyRelationshipDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/InversePropertyRelationshipDBIntegrationTest.php
@@ -73,10 +73,10 @@ class InversePropertyRelationshipDBIntegrationTest extends SMWIntegrationTestCas
 		$this->getStore()->updateData( $semanticData );
 
 		$description = new SomeProperty(
-			Property::newFromUserLabel( 'Has mother', true )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'Has mother', true )->setPropertyValueType( '_wpg' ),
 			new ValueDescription(
 				new WikiPage( 'Michael', NS_MAIN, '' ),
-				Property::newFromUserLabel( 'Has mother', true )->setPropertyTypeId( '_wpg' ),
+				Property::newFromUserLabel( 'Has mother', true )->setPropertyValueType( '_wpg' ),
 				SMW_CMP_EQ
 			)
 		);
@@ -117,7 +117,7 @@ class InversePropertyRelationshipDBIntegrationTest extends SMWIntegrationTestCas
 
 	private function newDataValueForPagePropertyValue( $property, $value ) {
 		$property = Property::newFromUserLabel( $property );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$dataItem = new WikiPage( $value, NS_MAIN, '' );
 

--- a/tests/phpunit/Integration/Query/SemanticDataLookupTest.php
+++ b/tests/phpunit/Integration/Query/SemanticDataLookupTest.php
@@ -59,7 +59,7 @@ class SemanticDataLookupTest extends SMWIntegrationTestCase {
 		$this->subjectsToBeCleared[] = $semanticData->getSubject();
 
 		$property = new Property( 'SomeWpgPropertyToFilter' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$semanticData->addPropertyObjectValue( $property, WikiPage::newFromText( 'Bar' ) );
 		$semanticData->addPropertyObjectValue( $property, WikiPage::newFromText( 'Foobar' ) );
@@ -93,7 +93,7 @@ class SemanticDataLookupTest extends SMWIntegrationTestCase {
 		$this->subjectsToBeCleared[] = $subject;
 
 		$property = new Property( 'SomeWpgPropertyToFilter' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$semanticData->addPropertyObjectValue( $property, WikiPage::newFromText( 'Bar' ) );
 		$semanticData->addPropertyObjectValue( $property, WikiPage::newFromText( 'Foobar' ) );
@@ -123,7 +123,7 @@ class SemanticDataLookupTest extends SMWIntegrationTestCase {
 		$this->subjectsToBeCleared[] = $semanticData->getSubject();
 
 		$property = new Property( 'SomeWpgPropertySortedFilter' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$semanticData->addPropertyObjectValue( $property, WikiPage::newFromText( 'FooBar' ) );
 		$semanticData->addPropertyObjectValue( $property, WikiPage::newFromText( 'Bar_9' ) );
@@ -169,7 +169,7 @@ class SemanticDataLookupTest extends SMWIntegrationTestCase {
 		$this->subjectsToBeCleared[] = $semanticData->getSubject();
 
 		$property = new Property( 'SomeBlobPropertyToFilter' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		$semanticData->addPropertyObjectValue( $property, new Blob( 'testfoobar' ) );
 

--- a/tests/phpunit/Integration/Query/SortableQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SortableQueryDBIntegrationTest.php
@@ -57,7 +57,7 @@ class SortableQueryDBIntegrationTest extends SMWIntegrationTestCase {
 		];
 
 		$property = new Property( 'SomePageProperty' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$query = $this->createQueryForSamplePagesThatContain( $property, $expectedSubjects );
 
@@ -83,7 +83,7 @@ class SortableQueryDBIntegrationTest extends SMWIntegrationTestCase {
 		];
 
 		$property = new Property( 'SomeAscendingPageProperty' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$query = $this->createQueryForSamplePagesThatContain( $property, $expectedSubjects );
 
@@ -105,7 +105,7 @@ class SortableQueryDBIntegrationTest extends SMWIntegrationTestCase {
 		];
 
 		$property = new Property( 'SomeDescendingPageProperty' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$query = $this->createQueryForSamplePagesThatContain( $property, $expectedSubjects );
 

--- a/tests/phpunit/Integration/Query/SpecialCharactersQueryDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SpecialCharactersQueryDBIntegrationTest.php
@@ -124,35 +124,35 @@ class SpecialCharactersQueryDBIntegrationTest extends SMWIntegrationTestCase {
 		$provider[] = [
 			'特殊文字',
 			'Nuñez',
-			Property::newFromUserLabel( '特殊文字' )->setPropertyTypeId( '_txt' ),
+			Property::newFromUserLabel( '特殊文字' )->setPropertyValueType( '_txt' ),
 			new Blob( 'Nuñez' )
 		];
 
 		$provider[] = [
 			'特殊字符',
 			'^[0-9]*$',
-			Property::newFromUserLabel( '特殊字符' )->setPropertyTypeId( '_txt' ),
+			Property::newFromUserLabel( '特殊字符' )->setPropertyValueType( '_txt' ),
 			new Blob( '^[0-9]*$' )
 		];
 
 		$provider[] = [
 			'Caractères spéciaux',
 			'Caractères_spéciaux',
-			Property::newFromUserLabel( 'Caractères spéciaux' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'Caractères spéciaux' )->setPropertyValueType( '_wpg' ),
 			new WikiPage( 'âêîôûëïçé', NS_MAIN )
 		];
 
 		$provider[] = [
 			'áéíóúñÑü¡¿',
 			'áéíóúñÑü¡¿',
-			Property::newFromUserLabel( 'áéíóúñÑü¡¿' )->setPropertyTypeId( '_num' ),
+			Property::newFromUserLabel( 'áéíóúñÑü¡¿' )->setPropertyValueType( '_num' ),
 			new Number( 8888 )
 		];
 
 		$provider[] = [
 			'Foo',
 			'{({[[&,,;-]]})}',
-			Property::newFromUserLabel( '{({[[&,,;-]]})}' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( '{({[[&,,;-]]})}' )->setPropertyValueType( '_wpg' ),
 			new WikiPage( '{({[[&,,;-]]})}', NS_MAIN )
 		];
 

--- a/tests/phpunit/Integration/Query/SubqueryQueryEquivalenceDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SubqueryQueryEquivalenceDBIntegrationTest.php
@@ -65,10 +65,10 @@ class SubqueryQueryEquivalenceDBIntegrationTest extends SMWIntegrationTestCase {
 		$this->testEnvironment->addConfiguration( 'smwgQueryResultCacheType', false );
 
 		$this->numberProperty = new Property( 'EquivalenceNumber' );
-		$this->numberProperty->setPropertyTypeId( '_num' );
+		$this->numberProperty->setPropertyValueType( '_num' );
 
 		$this->authorProperty = new Property( 'EquivalenceAuthor' );
-		$this->authorProperty->setPropertyTypeId( '_wpg' );
+		$this->authorProperty->setPropertyValueType( '_wpg' );
 
 		// Dedicated property pair for the mixed-direction cursor walk
 		// test. Kept separate from `numberProperty`/`authorProperty` so
@@ -78,10 +78,10 @@ class SubqueryQueryEquivalenceDBIntegrationTest extends SMWIntegrationTestCase {
 		// shapes, so legacy and rewrite paths can disagree on tie
 		// order without it being a real divergence).
 		$this->mixedTieNumberProperty = new Property( 'EquivalenceMixedTieNumber' );
-		$this->mixedTieNumberProperty->setPropertyTypeId( '_num' );
+		$this->mixedTieNumberProperty->setPropertyValueType( '_num' );
 
 		$this->mixedTieAuthorProperty = new Property( 'EquivalenceMixedTieAuthor' );
-		$this->mixedTieAuthorProperty->setPropertyTypeId( '_wpg' );
+		$this->mixedTieAuthorProperty->setPropertyValueType( '_wpg' );
 
 		$this->alice = new WikiPage( 'EquivalenceAlice', NS_MAIN );
 		$this->bob = new WikiPage( 'EquivalenceBob', NS_MAIN );

--- a/tests/phpunit/Integration/SPARQLStore/QueryResultLookupWithoutBaseStoreIntegrationTest.php
+++ b/tests/phpunit/Integration/SPARQLStore/QueryResultLookupWithoutBaseStoreIntegrationTest.php
@@ -79,7 +79,7 @@ class QueryResultLookupWithoutBaseStoreIntegrationTest extends TestCase {
 		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
 
 		$property = new Property( __METHOD__ );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$semanticData->addDataValue(
 			$this->dataValueFactory->newDataValueByProperty( $property, 'Bar' )
@@ -126,7 +126,7 @@ class QueryResultLookupWithoutBaseStoreIntegrationTest extends TestCase {
 			->newEmptySemanticData();
 
 		$property = new Property( 'SomePageTypePropertyForNamespaceAnnotation' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$semanticData->addDataValue(
 			$this->dataValueFactory->newDataValueByProperty( $property, 'Bar' )
@@ -164,7 +164,7 @@ class QueryResultLookupWithoutBaseStoreIntegrationTest extends TestCase {
 		$subobject->setEmptyContainerForId( 'SubobjectToTestReferenceAfterUpdate' );
 
 		$property = new Property( 'SomeNumericPropertyToCompareReference' );
-		$property->setPropertyTypeId( '_num' );
+		$property->setPropertyValueType( '_num' );
 
 		$dataItem = new Number( 99999 );
 

--- a/tests/phpunit/Integration/SemanticDataStorageDBIntegrationTest.php
+++ b/tests/phpunit/Integration/SemanticDataStorageDBIntegrationTest.php
@@ -129,7 +129,7 @@ class SemanticDataStorageDBIntegrationTest extends SMWIntegrationTestCase {
 
 	public function testAddUserDefinedBlobPropertyAsObjectToSemanticDataForStorage() {
 		$property = new Property( 'SomeBlobProperty' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		$this->subjects[] = $subject = WikiPage::newFromTitle( MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __METHOD__ ) );
 		$semanticData = new SemanticData( $subject );

--- a/tests/phpunit/Unit/DataItems/PropertyTest.php
+++ b/tests/phpunit/Unit/DataItems/PropertyTest.php
@@ -52,32 +52,32 @@ class PropertyTest extends TestCase {
 		);
 	}
 
-	public function testSetPropertyTypeIdOnUserDefinedProperty() {
+	public function testSetPropertyValueTypeOnUserDefinedProperty() {
 		$property = new Property( 'SomeBlobProperty' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
-		$this->assertEquals( '_txt', $property->findPropertyTypeID() );
+		$this->assertEquals( '_txt', $property->findPropertyValueType() );
 	}
 
-	public function testSetPropertyTypeIdOnPredefinedProperty() {
+	public function testSetPropertyValueTypeOnPredefinedProperty() {
 		$property = new Property( '_MDAT' );
-		$property->setPropertyTypeId( '_dat' );
+		$property->setPropertyValueType( '_dat' );
 
-		$this->assertEquals( '_dat', $property->findPropertyTypeID() );
+		$this->assertEquals( '_dat', $property->findPropertyValueType() );
 	}
 
-	public function testSetUnknownPropertyTypeIdThrowsException() {
+	public function testSetUnknownPropertyValueTypeThrowsException() {
 		$property = new Property( 'SomeUnknownTypeIdProperty' );
 
 		$this->expectException( DataTypeLookupException::class );
-		$property->setPropertyTypeId( '_unknownTypeId' );
+		$property->setPropertyValueType( '_unknownTypeId' );
 	}
 
-	public function testSetPropertyTypeIdOnPredefinedPropertyThrowsException() {
+	public function testSetPropertyValueTypeOnPredefinedPropertyThrowsException() {
 		$property = new Property( '_MDAT' );
 
 		$this->expectException( 'RuntimeException' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 	}
 
 	public function testCorrectInversePrefixForPredefinedProperty() {

--- a/tests/phpunit/Unit/DataValues/InfoLinksProviderTest.php
+++ b/tests/phpunit/Unit/DataValues/InfoLinksProviderTest.php
@@ -198,7 +198,7 @@ class InfoLinksProviderTest extends TestCase {
 		$timeValue->setOutputFormat( 'LOCL' );
 
 		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_dat' );
+		$property->setPropertyValueType( '_dat' );
 
 		$timeValue->setProperty(
 			$property

--- a/tests/phpunit/Unit/Exporter/ResourceBuilders/ExternalIdentifierPropertyValueResourceBuilderTest.php
+++ b/tests/phpunit/Unit/Exporter/ResourceBuilders/ExternalIdentifierPropertyValueResourceBuilderTest.php
@@ -56,7 +56,7 @@ class ExternalIdentifierPropertyValueResourceBuilderTest extends TestCase {
 
 	public function testAddResourceValueForValidProperty() {
 		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_eid' );
+		$property->setPropertyValueType( '_eid' );
 
 		$dataItem = $this->dataItemFactory->newDIBlob( 'Bar' );
 

--- a/tests/phpunit/Unit/Exporter/ResourceBuilders/KeywordPropertyValueResourceBuilderTest.php
+++ b/tests/phpunit/Unit/Exporter/ResourceBuilders/KeywordPropertyValueResourceBuilderTest.php
@@ -56,7 +56,7 @@ class KeywordPropertyValueResourceBuilderTest extends TestCase {
 
 	public function testAddResourceValueForValidProperty() {
 		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_keyw' );
+		$property->setPropertyValueType( '_keyw' );
 
 		$dataItem = $this->dataItemFactory->newDIBlob( 'Bar' );
 

--- a/tests/phpunit/Unit/Exporter/ResourceBuilders/MonolingualTextPropertyValueResourceBuilderTest.php
+++ b/tests/phpunit/Unit/Exporter/ResourceBuilders/MonolingualTextPropertyValueResourceBuilderTest.php
@@ -59,7 +59,7 @@ class MonolingualTextPropertyValueResourceBuilderTest extends TestCase {
 
 	public function testAddResourceValueForValidProperty() {
 		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_mlt_rec' );
+		$property->setPropertyValueType( '_mlt_rec' );
 
 		$monolingualTextValue = $this->dataValueFactory->newDataValueByProperty(
 			$property,

--- a/tests/phpunit/Unit/Factbox/FactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/FactboxTest.php
@@ -352,7 +352,7 @@ class FactboxTest extends TestCase {
 			->willReturn( $test['isUserDefined'] );
 
 		$property->expects( $this->any() )
-			->method( 'findPropertyTypeID' )
+			->method( 'findPropertyValueType' )
 			->willReturn( '_wpg' );
 
 		$property->expects( $this->any() )

--- a/tests/phpunit/Unit/Property/DeclarationExaminer/UserdefinedPropertyExaminerTest.php
+++ b/tests/phpunit/Unit/Property/DeclarationExaminer/UserdefinedPropertyExaminerTest.php
@@ -291,7 +291,7 @@ class UserdefinedPropertyExaminerTest extends TestCase {
 		$dataItemFactory = new DataItemFactory();
 
 		$property = $dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		$semanticData = new SemanticData(
 			$property->getDIWikiPage()
@@ -343,7 +343,7 @@ class UserdefinedPropertyExaminerTest extends TestCase {
 		$dataItemFactory = new DataItemFactory();
 
 		$property = $dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		$semanticData = new SemanticData(
 			$property->getDIWikiPage()

--- a/tests/phpunit/Unit/Property/SpecificationLookupTest.php
+++ b/tests/phpunit/Unit/Property/SpecificationLookupTest.php
@@ -203,7 +203,7 @@ class SpecificationLookupTest extends TestCase {
 
 	public function testGetPreferredPropertyLabel() {
 		$property = $this->dataItemFactory->newDIProperty( 'SomeProperty' );
-		$property->setPropertyTypeId( '_mlt_rec' );
+		$property->setPropertyValueType( '_mlt_rec' );
 
 		$this->store->expects( $this->once() )
 			->method( 'service' )

--- a/tests/phpunit/Unit/Query/Language/ValueDescriptionTest.php
+++ b/tests/phpunit/Unit/Query/Language/ValueDescriptionTest.php
@@ -128,7 +128,7 @@ class ValueDescriptionTest extends TestCase {
 			]
 		];
 
-		$property = Property::newFromUserLabel( 'Foo' )->setPropertyTypeId( '_num' );
+		$property = Property::newFromUserLabel( 'Foo' )->setPropertyValueType( '_num' );
 		$dataItem = new Number( 9001 );
 
 		$provider['num.1'] = [
@@ -145,7 +145,7 @@ class ValueDescriptionTest extends TestCase {
 			]
 		];
 
-		$property = Property::newFromUserLabel( 'Foo' )->setPropertyTypeId( '_num' );
+		$property = Property::newFromUserLabel( 'Foo' )->setPropertyValueType( '_num' );
 		$dataItem = new Number( 9001.356 );
 
 		$provider['num.2'] = [

--- a/tests/phpunit/Unit/Query/Parser/LegacyParserTest.php
+++ b/tests/phpunit/Unit/Query/Parser/LegacyParserTest.php
@@ -71,7 +71,7 @@ class LegacyParserTest extends TestCase {
 
 	public function testPropertyWildardDescription() {
 		$description = $this->descriptionFactory->newSomeProperty(
-			Property::newFromUserLabel( 'Foo' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'Foo' )->setPropertyValueType( '_wpg' ),
 			$this->descriptionFactory->newThingDescription()
 		);
 
@@ -105,10 +105,10 @@ class LegacyParserTest extends TestCase {
 
 	public function testPropertyNotEqualValueDescription() {
 		$description = $this->descriptionFactory->newSomeProperty(
-			Property::newFromUserLabel( 'Has foo' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'Has foo' )->setPropertyValueType( '_wpg' ),
 			$this->descriptionFactory->newValueDescription(
 				new WikiPage( 'Bar', NS_MAIN, '' ),
-				Property::newFromUserLabel( 'Has foo' )->setPropertyTypeId( '_wpg' ),
+				Property::newFromUserLabel( 'Has foo' )->setPropertyValueType( '_wpg' ),
 				SMW_CMP_NEQ
 			)
 		);
@@ -121,10 +121,10 @@ class LegacyParserTest extends TestCase {
 
 	public function testInversePropertyDescription() {
 		$description = $this->descriptionFactory->newSomeProperty(
-			Property::newFromUserLabel( 'Has foo', true )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'Has foo', true )->setPropertyValueType( '_wpg' ),
 			$this->descriptionFactory->newValueDescription(
 				new WikiPage( 'Bar', NS_MAIN, '' ),
-				Property::newFromUserLabel( 'Has foo', true )->setPropertyTypeId( '_wpg' ),
+				Property::newFromUserLabel( 'Has foo', true )->setPropertyValueType( '_wpg' ),
 				SMW_CMP_EQ
 			)
 		);
@@ -137,17 +137,17 @@ class LegacyParserTest extends TestCase {
 
 	public function testConjunctionForCategoryPropertyValueGreaterThanOrEqualLessThanOrEqual() {
 		$someGreaterThanOrEqualProperty = $this->descriptionFactory->newSomeProperty(
-			Property::newFromUserLabel( 'One' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'One' )->setPropertyValueType( '_wpg' ),
 			$this->descriptionFactory->newValueDescription(
 				new WikiPage( 'A', NS_MAIN, '' ),
-				Property::newFromUserLabel( 'One' )->setPropertyTypeId( '_wpg' ), SMW_CMP_GEQ )
+				Property::newFromUserLabel( 'One' )->setPropertyValueType( '_wpg' ), SMW_CMP_GEQ )
 		);
 
 		$someLessThanOrEqualProperty = $this->descriptionFactory->newSomeProperty(
-			Property::newFromUserLabel( 'Two' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'Two' )->setPropertyValueType( '_wpg' ),
 			$this->descriptionFactory->newValueDescription(
 				new WikiPage( 'D', NS_MAIN, '' ),
-				Property::newFromUserLabel( 'Two' )->setPropertyTypeId( '_wpg' ), SMW_CMP_LEQ )
+				Property::newFromUserLabel( 'Two' )->setPropertyValueType( '_wpg' ), SMW_CMP_LEQ )
 		);
 
 		$classDescription = $this->descriptionFactory->newClassDescription(
@@ -167,12 +167,12 @@ class LegacyParserTest extends TestCase {
 
 	public function testConjunctionForCategoryPropertyChainDescription() {
 		$someProperty = $this->descriptionFactory->newSomeProperty(
-			Property::newFromUserLabel( 'One' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'One' )->setPropertyValueType( '_wpg' ),
 			$this->descriptionFactory->newSomeProperty(
-				Property::newFromUserLabel( 'Two' )->setPropertyTypeId( '_wpg' ),
+				Property::newFromUserLabel( 'Two' )->setPropertyValueType( '_wpg' ),
 				$this->descriptionFactory->newValueDescription(
 					new WikiPage( 'Bar', NS_MAIN, '' ),
-					Property::newFromUserLabel( 'Two' )->setPropertyTypeId( '_wpg' ), SMW_CMP_EQ
+					Property::newFromUserLabel( 'Two' )->setPropertyValueType( '_wpg' ), SMW_CMP_EQ
 				)
 			)
 		);
@@ -198,12 +198,12 @@ class LegacyParserTest extends TestCase {
 
 	public function testDisjunctionForCategoryPropertyChainDescription() {
 		$someProperty = $this->descriptionFactory->newSomeProperty(
-			Property::newFromUserLabel( 'One' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'One' )->setPropertyValueType( '_wpg' ),
 			$this->descriptionFactory->newSomeProperty(
-				Property::newFromUserLabel( 'Two' )->setPropertyTypeId( '_wpg' ),
+				Property::newFromUserLabel( 'Two' )->setPropertyValueType( '_wpg' ),
 				$this->descriptionFactory->newValueDescription(
 					new WikiPage( 'Bar', NS_MAIN, '' ),
-					Property::newFromUserLabel( 'Two' )->setPropertyTypeId( '_wpg' ), SMW_CMP_EQ
+					Property::newFromUserLabel( 'Two' )->setPropertyValueType( '_wpg' ), SMW_CMP_EQ
 				)
 			)
 		);
@@ -253,14 +253,14 @@ class LegacyParserTest extends TestCase {
 
 	public function testCombinedSubobjectPropertyChainDescription() {
 		$description = $this->descriptionFactory->newSomeProperty(
-			Property::newFromUserLabel( 'One' )->setPropertyTypeId( '_wpg' ),
+			Property::newFromUserLabel( 'One' )->setPropertyValueType( '_wpg' ),
 			$this->descriptionFactory->newSomeProperty(
-				Property::newFromUserLabel( '_SOBJ' )->setPropertyTypeId( '__sob' ),
+				Property::newFromUserLabel( '_SOBJ' )->setPropertyValueType( '__sob' ),
 				$this->descriptionFactory->newSomeProperty(
-					Property::newFromUserLabel( 'Two' )->setPropertyTypeId( '_wpg' ),
+					Property::newFromUserLabel( 'Two' )->setPropertyValueType( '_wpg' ),
 					$this->descriptionFactory->newValueDescription(
 						new WikiPage( 'Bar', NS_MAIN, '' ),
-						Property::newFromUserLabel( 'Two' )->setPropertyTypeId( '_wpg' ), SMW_CMP_EQ
+						Property::newFromUserLabel( 'Two' )->setPropertyValueType( '_wpg' ), SMW_CMP_EQ
 					)
 				)
 			)
@@ -274,7 +274,7 @@ class LegacyParserTest extends TestCase {
 
 	public function testSubqueryDisjunction() {
 		$property = new Property( 'HasSomeProperty' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$disjunction = $this->descriptionFactory->newDisjunction( [
 			$this->descriptionFactory->newValueDescription( new WikiPage( 'Foo', NS_MAIN ), $property ),
@@ -294,15 +294,15 @@ class LegacyParserTest extends TestCase {
 
 	public function testNestedPropertyConjunction() {
 		$property = Property::newFromUserLabel( 'Born in' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$conjunction = $this->descriptionFactory->newConjunction( [
 			$this->descriptionFactory->newClassDescription( new WikiPage( 'City', NS_CATEGORY ) ),
 			$this->descriptionFactory->newSomeProperty(
-				Property::newFromUserLabel( 'Located in' )->setPropertyTypeId( '_wpg' ),
+				Property::newFromUserLabel( 'Located in' )->setPropertyValueType( '_wpg' ),
 				$this->descriptionFactory->newValueDescription(
 					new WikiPage( 'Outback', NS_MAIN ),
-					Property::newFromUserLabel( 'Located in' )->setPropertyTypeId( '_wpg' ) )
+					Property::newFromUserLabel( 'Located in' )->setPropertyValueType( '_wpg' ) )
 				)
 			]
 		);
@@ -320,7 +320,7 @@ class LegacyParserTest extends TestCase {
 
 	public function testRestrictedDefaultNamespace() {
 		$property = Property::newFromUserLabel( 'Foo' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$description = $this->descriptionFactory->newSomeProperty(
 			$property,

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/ConditionBuilderTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/ConditionBuilderTest.php
@@ -256,7 +256,7 @@ class ConditionBuilderTest extends TestCase {
 
 	public function testQueryForSinglePageTypePropertyWithValueComparator() {
 		$property = new Property( 'Foo' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$description = new SomeProperty(
 			$property,
@@ -288,7 +288,7 @@ class ConditionBuilderTest extends TestCase {
 
 	public function testQueryForSingleBlobTypePropertyWithNotLikeComparator() {
 		$property = new Property( 'Foo' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		$description = new SomeProperty(
 			$property,
@@ -510,7 +510,7 @@ class ConditionBuilderTest extends TestCase {
 
 	public function testSingleDatePropertyWithGreaterEqualConstraint() {
 		$property = new Property( 'SomeDateProperty' );
-		$property->setPropertyTypeId( '_dat' );
+		$property->setPropertyValueType( '_dat' );
 
 		$description = new SomeProperty(
 			$property,
@@ -573,7 +573,7 @@ class ConditionBuilderTest extends TestCase {
 	 */
 	public function testSubqueryDisjunction() {
 		$property = new Property( 'HasSomeProperty' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$disjunction = new Disjunction( [
 			new ValueDescription( new WikiPage( 'Foo', NS_MAIN ), $property ),
@@ -612,7 +612,7 @@ class ConditionBuilderTest extends TestCase {
 	 */
 	public function testNestedPropertyConjunction() {
 		$property = Property::newFromUserLabel( 'Born in' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$category = new WikiPage( 'City', NS_CATEGORY );
 
@@ -772,7 +772,7 @@ class ConditionBuilderTest extends TestCase {
 			->willReturn( $title );
 
 		$property = new Property( 'Foo' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$description = new SomeProperty(
 			$property,

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreterTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreterTest.php
@@ -244,7 +244,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$conditionType = WhereCondition::class;
 
 		$property = new Property( 'Foo' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		$description = new SomeProperty(
 			$property,
@@ -270,7 +270,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$conditionType = WhereCondition::class;
 
 		$property = new Property( 'Foo' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		$description = new SomeProperty(
 			$property,
@@ -297,7 +297,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$conditionType = WhereCondition::class;
 
 		$property = new Property( 'Foo' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$propertyValue = new WikiPage( 'SomePropertyPageValue', NS_HELP );
 
@@ -330,7 +330,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$conditionType = WhereCondition::class;
 
 		$property = new Property( 'Foo' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$description = new SomeProperty(
 			$property,
@@ -359,7 +359,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$conditionType = WhereCondition::class;
 
 		$property = new Property( 'Foo' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$description = new SomeProperty(
 			$property,
@@ -395,7 +395,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$conditionType = WhereCondition::class;
 
 		$property = new Property( 'Foo', true );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$description = new SomeProperty(
 			$property,
@@ -454,7 +454,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$conditionType = WhereCondition::class;
 
 		$property = new Property( 'Foo' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		$description = new SomeProperty(
 			$property,

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreterTest.php
@@ -159,7 +159,7 @@ class SomePropertyInterpreterTest extends TestCase {
 			->willReturn( true );
 
 		$property->expects( $this->once() )
-			->method( 'findPropertyTypeID' )
+			->method( 'findPropertyValueType' )
 			->willReturn( '_txt' );
 
 		$proptable = $this->getMockBuilder( '\stdClass' )
@@ -301,7 +301,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$indexField = '';
 		$sortKeys = [];
 		$property = $dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		$description = $descriptionFactory->newSomeProperty(
 			$property,
@@ -327,7 +327,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$indexField = 'wikipageIndex';
 		$sortKeys = [];
 		$property = $dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$description = $descriptionFactory->newSomeProperty(
 			$property,
@@ -355,7 +355,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$indexField = 'wikipageIndex';
 		$sortKeys = [ 'Foo' => 'DESC' ];
 		$property = $dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_wpg' );
+		$property->setPropertyValueType( '_wpg' );
 
 		$description = $descriptionFactory->newSomeProperty(
 			$property,
@@ -384,7 +384,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$indexField = 'blobIndex';
 		$sortKeys = [];
 		$property = $dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		$description = $descriptionFactory->newSomeProperty(
 			$property,
@@ -412,7 +412,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$indexField = 'blobIndex';
 		$sortKeys = [ 'Foo' => 'ASC' ];
 		$property = $dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		$description = $descriptionFactory->newSomeProperty(
 			$property,
@@ -441,7 +441,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$indexField = 'blobIndex';
 		$sortKeys = [];
 		$property = $dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		$valueDescription = $this->getMockBuilder( ValueDescription::class )
 			->disableOriginalConstructor()
@@ -483,7 +483,7 @@ class SomePropertyInterpreterTest extends TestCase {
 		$indexField = '';
 		$sortKeys = [];
 		$property = $dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_txt' );
+		$property->setPropertyValueType( '_txt' );
 
 		$description = $descriptionFactory->newSomeProperty(
 			$property,

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/SearchTableTest.php
@@ -84,7 +84,7 @@ class SearchTableTest extends TestCase {
 		);
 
 		$property = $this->dataItemFactory->newDIProperty( 'Foo' );
-		$property->setPropertyTypeId( '_uri' );
+		$property->setPropertyValueType( '_uri' );
 
 		$this->assertFalse(
 			$instance->isExemptedProperty( $property )

--- a/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
+++ b/tests/phpunit/Unit/Serializers/QueryResultSerializerTest.php
@@ -113,7 +113,7 @@ class QueryResultSerializerTest extends TestCase {
 		$this->testEnvironment->registerObject( 'Store', $store );
 
 		$property = Property::newFromUserLabel( 'Foo' );
-		$property->setPropertyTypeId( '_rec' );
+		$property->setPropertyValueType( '_rec' );
 
 		$printRequestFactory = new PrintRequestFactory();
 
@@ -145,7 +145,7 @@ class QueryResultSerializerTest extends TestCase {
 
 	public function testSerializeFormatForTimeValue() {
 		$property = Property::newFromUserLabel( 'Foo' );
-		$property->setPropertyTypeId( '_dat' );
+		$property->setPropertyValueType( '_dat' );
 
 		$printRequestFactory = new PrintRequestFactory();
 

--- a/tests/phpunit/Utils/Fixtures/Properties/AreaProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/AreaProperty.php
@@ -30,7 +30,7 @@ class AreaProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = new Property( 'Area' );
-		$this->property->setPropertyTypeId( '_qty' );
+		$this->property->setPropertyValueType( '_qty' );
 	}
 
 	/**

--- a/tests/phpunit/Utils/Fixtures/Properties/BookRecordProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/BookRecordProperty.php
@@ -21,7 +21,7 @@ class BookRecordProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = Property::newFromUserLabel( 'Book record' );
-		$this->property->setPropertyTypeId( '_rec' );
+		$this->property->setPropertyValueType( '_rec' );
 	}
 
 	/**

--- a/tests/phpunit/Utils/Fixtures/Properties/CapitalOfProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/CapitalOfProperty.php
@@ -18,7 +18,7 @@ class CapitalOfProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = Property::newFromUserLabel( 'Capital of' );
-		$this->property->setPropertyTypeId( '_wpg' );
+		$this->property->setPropertyValueType( '_wpg' );
 	}
 
 	/**

--- a/tests/phpunit/Utils/Fixtures/Properties/CoordinatesProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/CoordinatesProperty.php
@@ -17,7 +17,7 @@ class CoordinatesProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = new Property( 'Coordinates' );
-		$this->property->setPropertyTypeId( '_geo' );
+		$this->property->setPropertyValueType( '_geo' );
 	}
 
 }

--- a/tests/phpunit/Utils/Fixtures/Properties/DescriptionProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/DescriptionProperty.php
@@ -17,7 +17,7 @@ class DescriptionProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = new Property( 'Description' );
-		$this->property->setPropertyTypeId( '_txt' );
+		$this->property->setPropertyValueType( '_txt' );
 	}
 
 }

--- a/tests/phpunit/Utils/Fixtures/Properties/EmailProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/EmailProperty.php
@@ -17,7 +17,7 @@ class EmailProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = Property::newFromUserLabel( 'Email' );
-		$this->property->setPropertyTypeId( '_ema' );
+		$this->property->setPropertyValueType( '_ema' );
 	}
 
 }

--- a/tests/phpunit/Utils/Fixtures/Properties/FixtureProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/FixtureProperty.php
@@ -39,7 +39,7 @@ abstract class FixtureProperty {
 		$semanticData->addDataValue(
 			DataValueFactory::getInstance()->newDataValueByProperty(
 				new Property( '_TYPE' ),
-				$this->property->findPropertyTypeID()
+				$this->property->findPropertyValueType()
 			)
 		);
 

--- a/tests/phpunit/Utils/Fixtures/Properties/FoundedProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/FoundedProperty.php
@@ -17,7 +17,7 @@ class FoundedProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = new Property( 'Founded' );
-		$this->property->setPropertyTypeId( '_dat' );
+		$this->property->setPropertyValueType( '_dat' );
 	}
 
 }

--- a/tests/phpunit/Utils/Fixtures/Properties/LocatedInProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/LocatedInProperty.php
@@ -17,7 +17,7 @@ class LocatedInProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = Property::newFromUserLabel( 'Located in' );
-		$this->property->setPropertyTypeId( '_wpg' );
+		$this->property->setPropertyValueType( '_wpg' );
 	}
 
 }

--- a/tests/phpunit/Utils/Fixtures/Properties/PopulationDensityProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/PopulationDensityProperty.php
@@ -19,7 +19,7 @@ class PopulationDensityProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = Property::newFromUserLabel( 'Population density' );
-		$this->property->setPropertyTypeId( '_rec' );
+		$this->property->setPropertyValueType( '_rec' );
 	}
 
 	/**

--- a/tests/phpunit/Utils/Fixtures/Properties/PopulationProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/PopulationProperty.php
@@ -17,7 +17,7 @@ class PopulationProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = new Property( 'Population' );
-		$this->property->setPropertyTypeId( '_num' );
+		$this->property->setPropertyValueType( '_num' );
 	}
 
 }

--- a/tests/phpunit/Utils/Fixtures/Properties/StatusProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/StatusProperty.php
@@ -19,7 +19,7 @@ class StatusProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = Property::newFromUserLabel( 'Status' );
-		$this->property->setPropertyTypeId( '_txt' );
+		$this->property->setPropertyValueType( '_txt' );
 	}
 
 	/**

--- a/tests/phpunit/Utils/Fixtures/Properties/TelephoneNumberProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/TelephoneNumberProperty.php
@@ -17,7 +17,7 @@ class TelephoneNumberProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = Property::newFromUserLabel( 'Telephone number' );
-		$this->property->setPropertyTypeId( '_tel' );
+		$this->property->setPropertyValueType( '_tel' );
 	}
 
 }

--- a/tests/phpunit/Utils/Fixtures/Properties/TemperatureProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/TemperatureProperty.php
@@ -17,7 +17,7 @@ class TemperatureProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = new Property( 'Temperature' );
-		$this->property->setPropertyTypeId( '_tem' );
+		$this->property->setPropertyValueType( '_tem' );
 	}
 
 }

--- a/tests/phpunit/Utils/Fixtures/Properties/TitleProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/TitleProperty.php
@@ -17,7 +17,7 @@ class TitleProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = Property::newFromUserLabel( 'Title' );
-		$this->property->setPropertyTypeId( '_wpg' );
+		$this->property->setPropertyValueType( '_wpg' );
 	}
 
 }

--- a/tests/phpunit/Utils/Fixtures/Properties/UrlProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/UrlProperty.php
@@ -17,7 +17,7 @@ class UrlProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = Property::newFromUserLabel( 'Url' );
-		$this->property->setPropertyTypeId( '_uri' );
+		$this->property->setPropertyValueType( '_uri' );
 	}
 
 }

--- a/tests/phpunit/Utils/Fixtures/Properties/YearProperty.php
+++ b/tests/phpunit/Utils/Fixtures/Properties/YearProperty.php
@@ -17,7 +17,7 @@ class YearProperty extends FixtureProperty {
 	 */
 	public function __construct() {
 		$this->property = new Property( 'Year' );
-		$this->property->setPropertyTypeId( '_dat' );
+		$this->property->setPropertyValueType( '_dat' );
 	}
 
 }

--- a/tests/phpunit/Utils/Mock/CoreMockObjectRepository.php
+++ b/tests/phpunit/Utils/Mock/CoreMockObjectRepository.php
@@ -340,8 +340,8 @@ class CoreMockObjectRepository extends TestCase implements MockObjectRepository 
 			->willReturn( DataItem::TYPE_WIKIPAGE );
 
 		$diWikiPage->expects( $this->any() )
-			->method( 'findPropertyTypeID' )
-			->willReturn( $this->builder->setValue( 'findPropertyTypeID', '_wpg' ) );
+			->method( 'findPropertyValueType' )
+			->willReturn( $this->builder->setValue( 'findPropertyValueType', '_wpg' ) );
 
 		$diWikiPage->expects( $this->any() )
 			->method( 'getSubobjectName' )
@@ -361,8 +361,8 @@ class CoreMockObjectRepository extends TestCase implements MockObjectRepository 
 			->getMock();
 
 		$property->expects( $this->any() )
-			->method( 'findPropertyTypeID' )
-			->willReturn( $this->builder->setValue( 'findPropertyTypeID', '_wpg' ) );
+			->method( 'findPropertyValueType' )
+			->willReturn( $this->builder->setValue( 'findPropertyValueType', '_wpg' ) );
 
 		$property->expects( $this->any() )
 			->method( 'getKey' )

--- a/tests/phpunit/Utils/Validators/SemanticDataValidator.php
+++ b/tests/phpunit/Utils/Validators/SemanticDataValidator.php
@@ -174,7 +174,7 @@ class SemanticDataValidator extends Assert {
 		if ( isset( $expected['propertyTypeId'] ) ) {
 			$this->assertEquals(
 				$expected['propertyTypeId'],
-				$property->findPropertyTypeID(),
+				$property->findPropertyValueType(),
 				__METHOD__ . " asserts property typeId for '{$property->getKey()}'"
 			);
 


### PR DESCRIPTION
## What

Removes two sibling deprecated methods on `SMW\DataItems\Property` and repoints all ~170 call sites to their replacements.

| Removed | Replacement | Deprecated since |
|---|---|---|
| `Property::setPropertyTypeId()` | `setPropertyValueType()` | 3.0 |
| `Property::findPropertyTypeId()` | `findPropertyValueType()` | 3.0 |

Each removed method was a one-line delegator. Every caller is repointed to the corresponding replacement, so there is no behaviour change.

## Why

Dead-code cleanup for the 7.0 major release. Both methods have carried `@deprecated since 3.0` for years; the code is heavily called (PHP method-name case-insensitivity meant production callers overwhelmingly spelled it `findPropertyTypeID` while the canonical declaration was `findPropertyTypeId`).

## Scope

- Delete both methods from `src/DataItems/Property.php`
- Repoint ~170 call sites across `src/` (36 files) and `tests/` (49 files):
  - `->setPropertyTypeId(` → `->setPropertyValueType(`
  - `->findPropertyTypeId(` / `->findPropertyTypeID(` → `->findPropertyValueType(` (both casings handled)
  - `'findPropertyTypeID'` PHPUnit mock-method strings → `'findPropertyValueType'`
- Rename four stale `testSetPropertyTypeId*` methods in `PropertyTest`
- Update two narrative comments (`PropertyValue.php`, `SemanticDataDeserializer.php`) and three `docs/examples/*.md` snippets that demonstrated the removed API

Net diff: **88 files, +188/−200**.

## Breaking change

Any external extension calling `Property::setPropertyTypeId()` or `Property::findPropertyTypeId()` / `findPropertyTypeID()` must migrate to `setPropertyValueType()` / `findPropertyValueType()`. The replacement methods have identical signatures, so the migration is a pure rename. Documented under "Removed long-deprecated code" in `RELEASE-NOTES-7.0.0.md`.

## Testing

- `parallel-lint`: pass on all 85 changed PHP files
- PHPCS: pass on all 85 changed PHP files
- PHPUnit: 13 sample suites covering changed production-code consumers — `PropertyTest`, `PropertyValueTest`, `DataValueFactoryTest`, `ShapeConstraintTest`, `UpdateDispatcherJobTest`, `MandatoryTypePropertyAnnotatorTest`, `ExporterTest`, `LegacyParserTest`, `UserdefinedPropertyExaminerTest`, `SpecificationLookupTest`, `QueryResultSerializerTest`, `FactboxTest`, `SomePropertyInterpreterTest` — all pass (~187 tests)
- Independent code review: pass (two rounds; the second review's Important items — staging the second RELEASE-NOTES entry and updating three `docs/examples/` snippets — are addressed)
- Full integration suite: not verified locally (the local dev container intermittently hangs on the integration runner); kept in draft until CI confirms