### PR TITLE
Remove deprecated `Options::getOptions()`

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -224,6 +224,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
   * `DataTypeRegistry::getDataItemId()` — use `getDataItemByType()`
   * `DataTypeRegistry::getDefaultDataItemTypeId()` — use `getDefaultDataItemByType()`
   * `QueryResult::getLink()` — use `getQueryLink()`
+  * `Options::getOptions()` — use `toArray()` (deprecated since 3.0)
   * `PropertyRegistry::isKnownPropertyId()` — use `isRegistered()` (deprecated since 3.0)
   * `PropertyRegistry::getPropertyTypeId()` — use `getPropertyValueTypeById()` (deprecated since 3.0)
   * `PropertyRegistry::registerPropertyDescriptionMsgKeyById()` — use `registerPropertyDescriptionByMsgKey()` (deprecated since 3.0)

--- a/src/DataValues/DataValue.php
+++ b/src/DataValues/DataValue.php
@@ -823,7 +823,7 @@ abstract class DataValue {
 			return;
 		}
 
-		foreach ( $options->getOptions() as $key => $value ) {
+		foreach ( $options->toArray() as $key => $value ) {
 			$this->setOption( $key, $value );
 		}
 	}

--- a/src/Options.php
+++ b/src/Options.php
@@ -128,16 +128,6 @@ class Options implements JsonDeserializable {
 	}
 
 	/**
-	 * @deprecated since 3.0, use Options::toArray
-	 * @since 2.4
-	 *
-	 * @return array
-	 */
-	public function getOptions(): array {
-		return $this->toArray();
-	}
-
-	/**
 	 * @since 3.0
 	 *
 	 * @param array $keys

--- a/tests/phpunit/Utils/Mock/MockObjectBuilder.php
+++ b/tests/phpunit/Utils/Mock/MockObjectBuilder.php
@@ -97,7 +97,7 @@ class MockObjectBuilder extends TestCase {
 	 * @return array
 	 */
 	public function getInvokedMethods() {
-		return array_keys( $this->configuration->getOptions() );
+		return array_keys( $this->configuration->toArray() );
 	}
 
 	/**
@@ -182,7 +182,7 @@ class MockObjectBuilder extends TestCase {
 
 		if ( $this->configuration instanceof Options ) {
 			$this->configuration = new Options(
-				array_merge( $this->configuration->getOptions(), $configuration->getOptions() )
+				array_merge( $this->configuration->toArray(), $configuration->toArray() )
 			);
 			return $this->configuration;
 		}


### PR DESCRIPTION
## What

Removes `SMW\Options::getOptions(): array`, deprecated since SMW 3.0 in favour of `toArray()`. The deprecated method was a one-line delegator to its replacement.

## Why a careful sweep was needed

The method name collides with several unrelated same-named methods: `Parser::getOptions()`, `DataValue::getOptions()` (returns an `Options` instance), `ParamDefinition::getOptions()`, `ImportContents::getOptions()`, `HtmlBuilder::getOptions()`. Most `->getOptions()` callsites in the codebase invoke one of those unrelated methods, not the deprecated one, and must be left untouched.

The four callsites that actually invoke the deprecated `Options::getOptions()` are:

- One internal caller in `DataValue::copyOptions()`, reached from `PropertyValue` and `PropertyChainValue` during property-value and property-chain rendering
- Three calls on `Options` instances in `tests/phpunit/Utils/Mock/MockObjectBuilder.php` (where `$this->configuration = new Options(...)`)

All four are repointed to `->toArray()`.

| Change | File |
|---|---|
| Delete `Options::getOptions()` | `src/Options.php` |
| Repoint internal call to `->toArray()` | `src/DataValues/DataValue.php` |
| Repoint 3 calls to `->toArray()` | `tests/phpunit/Utils/Mock/MockObjectBuilder.php` |
| Removed-code list entry | `RELEASE-NOTES-7.0.0.md` |

**4 files, +4/−13.**

## Testing

- `parallel-lint`, PHPCS: pass
- PHPUnit: `OptionsTest`, `SettingsTest` (covers `Settings extends Options`), `PropertyValueTest`, `PropertyChainValueTest`, `DataValueFactoryTest` — all pass
- Browser smoke test on a 1.43 dev wiki: `Special:Properties`/`WantedProperties`/`UnusedProperties`/`Types`/`Ask` render HTTP 200 with no error strings; inline parse of `{{#ask: [[Has author.Has name::Frank]] |?Has author}}` exercises `PropertyChainValue` construction through `DataValue::copyOptions()` and returns a clean parse with no PHP errors in the container log