### PR TITLE
Inject services into Job classes via JobClasses ObjectFactory spec

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -202,7 +202,10 @@
 		"WantedProperties": "SMW\\MediaWiki\\Specials\\SpecialWantedProperties"
 	},
 	"JobClasses": {
-		"smw.update": "SMW\\MediaWiki\\Jobs\\UpdateJob",
+		"smw.update": {
+			"class": "SMW\\MediaWiki\\Jobs\\UpdateJob",
+			"services": [ "SMW.Store" ]
+		},
 		"smw.refresh": {
 			"class": "SMW\\MediaWiki\\Jobs\\RefreshJob",
 			"services": [ "SMW.Store" ]

--- a/extension.json
+++ b/extension.json
@@ -243,7 +243,10 @@
 		"smw.changePropagationClassUpdate": "SMW\\MediaWiki\\Jobs\\ChangePropagationClassUpdateJob",
 		"smw.deferredConstraintCheckUpdateJob": "SMW\\MediaWiki\\Jobs\\DeferredConstraintCheckUpdateJob",
 		"smw.elasticIndexerRecovery": "SMW\\Elastic\\Jobs\\IndexerRecoveryJob",
-		"smw.elasticFileIngest": "SMW\\Elastic\\Jobs\\FileIngestJob",
+		"smw.elasticFileIngest": {
+			"class": "SMW\\Elastic\\Jobs\\FileIngestJob",
+			"services": [ "SMW.Store", "SMW.ElasticFactory" ]
+		},
 		"smw.parserCachePurgeJob": "SMW\\MediaWiki\\Jobs\\ParserCachePurgeJob"
 	},
 	"ResourceFileModulePaths": {

--- a/extension.json
+++ b/extension.json
@@ -242,7 +242,10 @@
 		"smw.changePropagationUpdate": "SMW\\MediaWiki\\Jobs\\ChangePropagationUpdateJob",
 		"smw.changePropagationClassUpdate": "SMW\\MediaWiki\\Jobs\\ChangePropagationClassUpdateJob",
 		"smw.deferredConstraintCheckUpdateJob": "SMW\\MediaWiki\\Jobs\\DeferredConstraintCheckUpdateJob",
-		"smw.elasticIndexerRecovery": "SMW\\Elastic\\Jobs\\IndexerRecoveryJob",
+		"smw.elasticIndexerRecovery": {
+			"class": "SMW\\Elastic\\Jobs\\IndexerRecoveryJob",
+			"services": [ "SMW.Store", "SMW.Cache" ]
+		},
 		"smw.elasticFileIngest": {
 			"class": "SMW\\Elastic\\Jobs\\FileIngestJob",
 			"services": [ "SMW.Store", "SMW.ElasticFactory" ]

--- a/extension.json
+++ b/extension.json
@@ -213,7 +213,10 @@
 			"services": [ "SMW.Store" ]
 		},
 		"smw.entityIdDisposer": "SMW\\MediaWiki\\Jobs\\EntityIdDisposerJob",
-		"smw.propertyStatisticsRebuild": "SMW\\MediaWiki\\Jobs\\PropertyStatisticsRebuildJob",
+		"smw.propertyStatisticsRebuild": {
+			"class": "SMW\\MediaWiki\\Jobs\\PropertyStatisticsRebuildJob",
+			"services": [ "SMW.Store" ]
+		},
 		"smw.fulltextSearchTableRebuild": {
 			"class": "SMW\\MediaWiki\\Jobs\\FulltextSearchTableRebuildJob",
 			"services": [ "SMW.Store" ]

--- a/extension.json
+++ b/extension.json
@@ -208,10 +208,16 @@
 			"services": [ "SMW.Store" ]
 		},
 		"smw.updateDispatcher": "SMW\\MediaWiki\\Jobs\\UpdateDispatcherJob",
-		"smw.fulltextSearchTableUpdate": "SMW\\MediaWiki\\Jobs\\FulltextSearchTableUpdateJob",
+		"smw.fulltextSearchTableUpdate": {
+			"class": "SMW\\MediaWiki\\Jobs\\FulltextSearchTableUpdateJob",
+			"services": [ "SMW.Store" ]
+		},
 		"smw.entityIdDisposer": "SMW\\MediaWiki\\Jobs\\EntityIdDisposerJob",
 		"smw.propertyStatisticsRebuild": "SMW\\MediaWiki\\Jobs\\PropertyStatisticsRebuildJob",
-		"smw.fulltextSearchTableRebuild": "SMW\\MediaWiki\\Jobs\\FulltextSearchTableRebuildJob",
+		"smw.fulltextSearchTableRebuild": {
+			"class": "SMW\\MediaWiki\\Jobs\\FulltextSearchTableRebuildJob",
+			"services": [ "SMW.Store" ]
+		},
 		"smw.changePropagationDispatch": "SMW\\MediaWiki\\Jobs\\ChangePropagationDispatchJob",
 		"smw.changePropagationUpdate": "SMW\\MediaWiki\\Jobs\\ChangePropagationUpdateJob",
 		"smw.changePropagationClassUpdate": "SMW\\MediaWiki\\Jobs\\ChangePropagationClassUpdateJob",

--- a/extension.json
+++ b/extension.json
@@ -230,7 +230,15 @@
 			"class": "SMW\\MediaWiki\\Jobs\\FulltextSearchTableRebuildJob",
 			"services": [ "SMW.Store" ]
 		},
-		"smw.changePropagationDispatch": "SMW\\MediaWiki\\Jobs\\ChangePropagationDispatchJob",
+		"smw.changePropagationDispatch": {
+			"class": "SMW\\MediaWiki\\Jobs\\ChangePropagationDispatchJob",
+			"services": [
+				"SMW.Store",
+				"SMW.Cache",
+				"SMW.PropertySpecificationLookup",
+				"SMW.IteratorFactory"
+			]
+		},
 		"smw.changePropagationUpdate": "SMW\\MediaWiki\\Jobs\\ChangePropagationUpdateJob",
 		"smw.changePropagationClassUpdate": "SMW\\MediaWiki\\Jobs\\ChangePropagationClassUpdateJob",
 		"smw.deferredConstraintCheckUpdateJob": "SMW\\MediaWiki\\Jobs\\DeferredConstraintCheckUpdateJob",

--- a/extension.json
+++ b/extension.json
@@ -212,7 +212,10 @@
 			"class": "SMW\\MediaWiki\\Jobs\\FulltextSearchTableUpdateJob",
 			"services": [ "SMW.Store" ]
 		},
-		"smw.entityIdDisposer": "SMW\\MediaWiki\\Jobs\\EntityIdDisposerJob",
+		"smw.entityIdDisposer": {
+			"class": "SMW\\MediaWiki\\Jobs\\EntityIdDisposerJob",
+			"services": [ "SMW.Store", "SMW.IteratorFactory" ]
+		},
 		"smw.propertyStatisticsRebuild": {
 			"class": "SMW\\MediaWiki\\Jobs\\PropertyStatisticsRebuildJob",
 			"services": [ "SMW.Store" ]

--- a/extension.json
+++ b/extension.json
@@ -207,7 +207,10 @@
 			"class": "SMW\\MediaWiki\\Jobs\\RefreshJob",
 			"services": [ "SMW.Store" ]
 		},
-		"smw.updateDispatcher": "SMW\\MediaWiki\\Jobs\\UpdateDispatcherJob",
+		"smw.updateDispatcher": {
+			"class": "SMW\\MediaWiki\\Jobs\\UpdateDispatcherJob",
+			"services": [ "SMW.Store" ]
+		},
 		"smw.fulltextSearchTableUpdate": {
 			"class": "SMW\\MediaWiki\\Jobs\\FulltextSearchTableUpdateJob",
 			"services": [ "SMW.Store" ]

--- a/extension.json
+++ b/extension.json
@@ -203,7 +203,10 @@
 	},
 	"JobClasses": {
 		"smw.update": "SMW\\MediaWiki\\Jobs\\UpdateJob",
-		"smw.refresh": "SMW\\MediaWiki\\Jobs\\RefreshJob",
+		"smw.refresh": {
+			"class": "SMW\\MediaWiki\\Jobs\\RefreshJob",
+			"services": [ "SMW.Store" ]
+		},
 		"smw.updateDispatcher": "SMW\\MediaWiki\\Jobs\\UpdateDispatcherJob",
 		"smw.fulltextSearchTableUpdate": "SMW\\MediaWiki\\Jobs\\FulltextSearchTableUpdateJob",
 		"smw.entityIdDisposer": "SMW\\MediaWiki\\Jobs\\EntityIdDisposerJob",

--- a/maintenance/rebuildElasticMissingDocuments.php
+++ b/maintenance/rebuildElasticMissingDocuments.php
@@ -9,7 +9,6 @@ use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\Elastic\Indexer\Replication\DocumentReplicationExaminer;
 use SMW\Elastic\Indexer\Replication\ReplicationError;
-use SMW\Elastic\Jobs\FileIngestJob;
 use SMW\Exception\PredefinedPropertyLabelMismatchException;
 use SMW\Exception\PropertyLabelNotResolvedException;
 use SMW\MediaWiki\JobFactory;
@@ -368,7 +367,7 @@ class rebuildElasticMissingDocuments extends Maintenance {
 			$errorCount[$result->getType()]++;
 
 			if ( $result->getType() === ReplicationError::TYPE_FILE_ATTACHMENT_MISSING ) {
-				$job = new FileIngestJob( $title );
+				$job = $this->jobFactory->newFileIngestJob( $title );
 			} else {
 				$job = $this->jobFactory->newUpdateJob( $title );
 			}

--- a/src/Elastic/Jobs/FileIngestJob.php
+++ b/src/Elastic/Jobs/FileIngestJob.php
@@ -2,12 +2,14 @@
 
 namespace SMW\Elastic\Jobs;
 
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use SMW\DataItems\WikiPage;
 use SMW\Elastic\Connection\Client as ElasticClient;
+use SMW\Elastic\ElasticFactory;
 use SMW\Elastic\Indexer\Attachment\ScopeMemoryLimiter;
 use SMW\MediaWiki\Job;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Store;
 
 /**
  * @license GPL-2.0-or-later
@@ -24,12 +26,15 @@ class FileIngestJob extends Job {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Title $title
-	 * @param array $params job parameters
 	 */
-	public function __construct( Title $title, $params = [] ) {
+	public function __construct(
+		Title $title,
+		array $params,
+		Store $store,
+		private readonly ElasticFactory $elasticFactory
+	) {
 		parent::__construct( self::JOB_COMMAND, $title, $params );
+		$this->setStore( $store );
 		$this->removeDuplicates = true;
 	}
 
@@ -43,7 +48,10 @@ class FileIngestJob extends Job {
 
 		$params += [ 'waitOnCommandLine' => true ];
 
-		$fileIngestJob = new self(
+		// Use MediaWiki's JobFactory so the JobClasses ObjectFactory spec
+		// resolves the services declared for this job.
+		$fileIngestJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+			self::JOB_COMMAND,
 			$title,
 			array_merge( $params, self::newRootJobParams( self::JOB_COMMAND, $title ) )
 		);
@@ -63,8 +71,7 @@ class FileIngestJob extends Job {
 			return true;
 		}
 
-		$applicationFactory = ApplicationFactory::getInstance();
-		$connection = $applicationFactory->getStore()->getConnection( 'elastic' );
+		$connection = $this->store->getConnection( 'elastic' );
 
 		// Make sure a node is available
 		if ( $connection->hasLock( ElasticClient::TYPE_DATA ) || !$connection->ping() ) {
@@ -85,15 +92,11 @@ class FileIngestJob extends Job {
 	 * @since 3.2
 	 */
 	public function runFileIndexer() {
-		$applicationFactory = ApplicationFactory::getInstance();
-		$elasticFactory = $applicationFactory->singleton( 'ElasticFactory' );
+		$connection = $this->store->getConnection( 'elastic' );
 
-		$store = $applicationFactory->getStore();
-		$connection = $store->getConnection( 'elastic' );
-
-		$fileIndexer = $elasticFactory->newFileIndexer(
-			$store,
-			$elasticFactory->newIndexer()
+		$fileIndexer = $this->elasticFactory->newFileIndexer(
+			$this->store,
+			$this->elasticFactory->newIndexer()
 		);
 
 		$fileIndexer->setOrigin( __METHOD__ );
@@ -130,7 +133,13 @@ class FileIngestJob extends Job {
 			$this->params['createdAt'] = time();
 		}
 
-		$job = new self( $this->title, $this->params );
+		// Re-enqueue via MediaWiki's JobFactory so the ObjectFactory spec
+		// injects the same service dependencies again.
+		$job = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+			self::JOB_COMMAND,
+			$this->title,
+			$this->params
+		);
 		$job->setDelay( 60 * 10 );
 
 		$job->insert();

--- a/src/Elastic/Jobs/FileIngestJob.php
+++ b/src/Elastic/Jobs/FileIngestJob.php
@@ -2,13 +2,13 @@
 
 namespace SMW\Elastic\Jobs;
 
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use SMW\DataItems\WikiPage;
 use SMW\Elastic\Connection\Client as ElasticClient;
 use SMW\Elastic\ElasticFactory;
 use SMW\Elastic\Indexer\Attachment\ScopeMemoryLimiter;
 use SMW\MediaWiki\Job;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
 
 /**
@@ -48,10 +48,7 @@ class FileIngestJob extends Job {
 
 		$params += [ 'waitOnCommandLine' => true ];
 
-		// Use MediaWiki's JobFactory so the JobClasses ObjectFactory spec
-		// resolves the services declared for this job.
-		$fileIngestJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
-			self::JOB_COMMAND,
+		$fileIngestJob = ApplicationFactory::getInstance()->getJobFactory()->newFileIngestJob(
 			$title,
 			array_merge( $params, self::newRootJobParams( self::JOB_COMMAND, $title ) )
 		);
@@ -133,10 +130,7 @@ class FileIngestJob extends Job {
 			$this->params['createdAt'] = time();
 		}
 
-		// Re-enqueue via MediaWiki's JobFactory so the ObjectFactory spec
-		// injects the same service dependencies again.
-		$job = MediaWikiServices::getInstance()->getJobFactory()->newJob(
-			self::JOB_COMMAND,
+		$job = ApplicationFactory::getInstance()->getJobFactory()->newFileIngestJob(
 			$this->title,
 			$this->params
 		);

--- a/src/Elastic/Jobs/IndexerRecoveryJob.php
+++ b/src/Elastic/Jobs/IndexerRecoveryJob.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Elastic\Jobs;
 
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use Onoi\Cache\Cache;
 use SMW\DataItems\WikiPage;
@@ -80,10 +79,7 @@ class IndexerRecoveryJob extends Job {
 			self::TTL_WEEK
 		);
 
-		// Use MediaWiki's JobFactory so the JobClasses ObjectFactory spec
-		// resolves the services declared for this job.
-		$indexerRecoveryJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
-			self::JOB_COMMAND,
+		$indexerRecoveryJob = ApplicationFactory::getInstance()->getJobFactory()->newIndexerRecoveryJob(
 			$subject->getTitle(),
 			[ 'index' => $subject->getHash() ]
 		);
@@ -95,8 +91,7 @@ class IndexerRecoveryJob extends Job {
 	 * @since 3.2
 	 */
 	public static function pushFromParams( Title $title, array $params ): void {
-		$indexerRecoveryJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
-			self::JOB_COMMAND,
+		$indexerRecoveryJob = ApplicationFactory::getInstance()->getJobFactory()->newIndexerRecoveryJob(
 			$title,
 			$params
 		);
@@ -183,10 +178,7 @@ class IndexerRecoveryJob extends Job {
 			$this->params['createdAt'] = time();
 		}
 
-		// Re-enqueue through MediaWiki's JobFactory so the ObjectFactory spec
-		// injects the same service dependencies again.
-		$job = MediaWikiServices::getInstance()->getJobFactory()->newJob(
-			self::JOB_COMMAND,
+		$job = ApplicationFactory::getInstance()->getJobFactory()->newIndexerRecoveryJob(
 			$this->title,
 			$this->params
 		);

--- a/src/Elastic/Jobs/IndexerRecoveryJob.php
+++ b/src/Elastic/Jobs/IndexerRecoveryJob.php
@@ -2,7 +2,9 @@
 
 namespace SMW\Elastic\Jobs;
 
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
+use Onoi\Cache\Cache;
 use SMW\DataItems\WikiPage;
 use SMW\Elastic\Connection\Client as ElasticClient;
 use SMW\Elastic\ElasticStore;
@@ -10,9 +12,14 @@ use SMW\Elastic\Indexer\Document;
 use SMW\Elastic\Indexer\Indexer;
 use SMW\MediaWiki\Job;
 use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Store;
 use SMW\Utils\HmacSerializer;
 
 /**
+ * Partial DI: Store and Cache are injected via the JobClasses ObjectFactory
+ * spec. The MediaWikiLogger is still resolved lazily through
+ * ApplicationFactory because it is not a registered global service.
+ *
  * @license GPL-2.0-or-later
  * @since 3.0
  *
@@ -37,21 +44,20 @@ class IndexerRecoveryJob extends Job {
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Title $title
-	 * @param array $params job parameters
 	 */
-	public function __construct( Title $title, $params = [] ) {
+	public function __construct(
+		Title $title,
+		array $params,
+		Store $store,
+		private readonly Cache $cache
+	) {
 		parent::__construct( self::JOB_COMMAND, $title, $params );
+		$this->setStore( $store );
 		$this->removeDuplicates = true;
 	}
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param $subject
-	 *
-	 * @return string
 	 */
 	public static function makeCacheKey( $subject ): string {
 		if ( $subject instanceof Title ) {
@@ -63,8 +69,6 @@ class IndexerRecoveryJob extends Job {
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param Document $document
 	 */
 	public static function pushFromDocument( Document $document ): void {
 		$cache = ApplicationFactory::getInstance()->getCache();
@@ -76,7 +80,10 @@ class IndexerRecoveryJob extends Job {
 			self::TTL_WEEK
 		);
 
-		$indexerRecoveryJob = new IndexerRecoveryJob(
+		// Use MediaWiki's JobFactory so the JobClasses ObjectFactory spec
+		// resolves the services declared for this job.
+		$indexerRecoveryJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+			self::JOB_COMMAND,
 			$subject->getTitle(),
 			[ 'index' => $subject->getHash() ]
 		);
@@ -86,12 +93,10 @@ class IndexerRecoveryJob extends Job {
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param Title $title
-	 * @param array $params
 	 */
 	public static function pushFromParams( Title $title, array $params ): void {
-		$indexerRecoveryJob = new IndexerRecoveryJob(
+		$indexerRecoveryJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+			self::JOB_COMMAND,
 			$title,
 			$params
 		);
@@ -114,9 +119,11 @@ class IndexerRecoveryJob extends Job {
 	 * @since  3.0
 	 */
 	public function run(): bool {
-		$applicationFactory = ApplicationFactory::getInstance();
-
-		$store = $applicationFactory->getStore( ElasticStore::class );
+		// The Elastic-specific store accessor falls back to ElasticStore if
+		// the wired Store is not already one (e.g. via test override).
+		$store = $this->store instanceof ElasticStore
+			? $this->store
+			: ApplicationFactory::getInstance()->getStore( ElasticStore::class );
 
 		$connection = $store->getConnection( 'elastic' );
 
@@ -139,7 +146,7 @@ class IndexerRecoveryJob extends Job {
 		$this->indexer->setOrigin( __METHOD__ );
 
 		$this->indexer->setLogger(
-			$applicationFactory->getMediaWikiLogger( 'smw-elastic' )
+			ApplicationFactory::getInstance()->getMediaWikiLogger( 'smw-elastic' )
 		);
 
 		if ( $this->hasParameter( 'delete' ) ) {
@@ -152,7 +159,7 @@ class IndexerRecoveryJob extends Job {
 
 		if ( $this->hasParameter( 'index' ) ) {
 			$this->index(
-				$applicationFactory->getCache(),
+				$this->cache,
 				$this->getParameter( 'index' )
 			);
 		}
@@ -176,7 +183,13 @@ class IndexerRecoveryJob extends Job {
 			$this->params['createdAt'] = time();
 		}
 
-		$job = new self( $this->title, $this->params );
+		// Re-enqueue through MediaWiki's JobFactory so the ObjectFactory spec
+		// injects the same service dependencies again.
+		$job = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+			self::JOB_COMMAND,
+			$this->title,
+			$this->params
+		);
 		$job->setDelay( 60 * 10 );
 
 		$job->insert();

--- a/src/MediaWiki/Job.php
+++ b/src/MediaWiki/Job.php
@@ -3,6 +3,7 @@
 namespace SMW\MediaWiki;
 
 use Job as MediaWikiJob;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use Psr\Log\LoggerAwareTrait;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -194,7 +195,13 @@ abstract class Job extends MediaWikiJob {
 			$this->params['waitOnCommandLine'] = 1;
 		}
 
-		$job = new static( $this->title, $this->params );
+		// Re-enqueue through MediaWiki's JobFactory so service dependencies
+		// declared in the JobClasses ObjectFactory spec are wired in.
+		$job = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+			$this->command,
+			$this->title,
+			$this->params
+		);
 		$job->insert();
 
 		return true;

--- a/src/MediaWiki/Job.php
+++ b/src/MediaWiki/Job.php
@@ -196,7 +196,9 @@ abstract class Job extends MediaWikiJob {
 		}
 
 		// Re-enqueue through MediaWiki's JobFactory so service dependencies
-		// declared in the JobClasses ObjectFactory spec are wired in.
+		// declared in the JobClasses ObjectFactory spec are wired in. The
+		// resolved class is always an `SMW\MediaWiki\Job` subclass.
+		/** @var self $job */
 		$job = MediaWikiServices::getInstance()->getJobFactory()->newJob(
 			$this->command,
 			$this->title,

--- a/src/MediaWiki/Job.php
+++ b/src/MediaWiki/Job.php
@@ -201,8 +201,8 @@ abstract class Job extends MediaWikiJob {
 		/** @var self $job */
 		$job = MediaWikiServices::getInstance()->getJobFactory()->newJob(
 			$this->command,
-			$this->title,
-			$this->params
+			[ 'namespace' => $this->title->getNamespace(), 'title' => $this->title->getDBkey() ]
+				+ $this->params
 		);
 		$job->insert();
 

--- a/src/MediaWiki/JobFactory.php
+++ b/src/MediaWiki/JobFactory.php
@@ -2,7 +2,6 @@
 
 namespace SMW\MediaWiki;
 
-use InvalidArgumentException;
 use MediaWiki\JobQueue\JobFactory as MwJobFactory;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;

--- a/src/MediaWiki/JobFactory.php
+++ b/src/MediaWiki/JobFactory.php
@@ -7,6 +7,8 @@ use MediaWiki\JobQueue\JobFactory as MwJobFactory;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use RuntimeException;
+use SMW\Elastic\Jobs\FileIngestJob;
+use SMW\Elastic\Jobs\IndexerRecoveryJob;
 use SMW\MediaWiki\Jobs\ChangePropagationClassUpdateJob;
 use SMW\MediaWiki\Jobs\ChangePropagationDispatchJob;
 use SMW\MediaWiki\Jobs\ChangePropagationUpdateJob;
@@ -183,6 +185,24 @@ class JobFactory {
 	public function newParserCachePurgeJob( Title $title, array $parameters = [] ): ParserCachePurgeJob {
 		/** @var ParserCachePurgeJob $job */
 		$job = $this->mwJobFactory->newJob( 'smw.parserCachePurgeJob', $title, $parameters );
+		return $job;
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function newFileIngestJob( Title $title, array $parameters = [] ): FileIngestJob {
+		/** @var FileIngestJob $job */
+		$job = $this->mwJobFactory->newJob( 'smw.elasticFileIngest', $title, $parameters );
+		return $job;
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function newIndexerRecoveryJob( Title $title, array $parameters = [] ): IndexerRecoveryJob {
+		/** @var IndexerRecoveryJob $job */
+		$job = $this->mwJobFactory->newJob( 'smw.elasticIndexerRecovery', $title, $parameters );
 		return $job;
 	}
 

--- a/src/MediaWiki/JobFactory.php
+++ b/src/MediaWiki/JobFactory.php
@@ -38,6 +38,9 @@ class JobFactory {
 
 	private MwJobFactory $mwJobFactory;
 
+	/**
+	 * @since 7.0.0
+	 */
 	public function __construct( ?MwJobFactory $mwJobFactory = null ) {
 		$this->mwJobFactory = $mwJobFactory ?? MediaWikiServices::getInstance()->getJobFactory();
 	}

--- a/src/MediaWiki/JobFactory.php
+++ b/src/MediaWiki/JobFactory.php
@@ -2,6 +2,9 @@
 
 namespace SMW\MediaWiki;
 
+use InvalidArgumentException;
+use MediaWiki\JobQueue\JobFactory as MwJobFactory;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use RuntimeException;
 use SMW\MediaWiki\Jobs\ChangePropagationClassUpdateJob;
@@ -18,12 +21,25 @@ use SMW\MediaWiki\Jobs\UpdateDispatcherJob;
 use SMW\MediaWiki\Jobs\UpdateJob;
 
 /**
+ * Typed wrapper around MediaWiki's JobFactory for the SMW job classes.
+ *
+ * Each `newXxxJob()` method delegates to `MwJobFactory::newJob()` which in turn
+ * resolves the JobClasses ObjectFactory spec (constructing the job with any
+ * declared service dependencies). The wrapper exists so call-sites can keep
+ * the typed factory methods that pre-date constructor injection.
+ *
  * @license GPL-2.0-or-later
  * @since 2.0
  *
  * @author mwjames
  */
 class JobFactory {
+
+	private MwJobFactory $mwJobFactory;
+
+	public function __construct( ?MwJobFactory $mwJobFactory = null ) {
+		$this->mwJobFactory = $mwJobFactory ?? MediaWikiServices::getInstance()->getJobFactory();
+	}
 
 	/**
 	 * @since 2.5
@@ -41,7 +57,6 @@ class JobFactory {
 	 * @param Title|null $title
 	 * @param array $parameters
 	 *
-	 * @return Job
 	 * @throws RuntimeException
 	 */
 	public function newByType( $type, ?Title $title = null, array $parameters = [] ): Job {
@@ -49,164 +64,126 @@ class JobFactory {
 			return new NullJob( null );
 		}
 
-		switch ( $type ) {
-			case 'smw.refresh':
-				return $this->newRefreshJob( $title, $parameters );
-			case 'smw.update':
-				return $this->newUpdateJob( $title, $parameters );
-			case 'smw.updateDispatcher':
-				return $this->newUpdateDispatcherJob( $title, $parameters );
-			case 'smw.parserCachePurge':
-				return $this->newParserCachePurgeJob( $title, $parameters );
-			case 'smw.entityIdDisposer':
-				return $this->newEntityIdDisposerJob( $title, $parameters );
-			case 'smw.propertyStatisticsRebuild':
-				return $this->newPropertyStatisticsRebuildJob( $title, $parameters );
-			case 'smw.fulltextSearchTableUpdate':
-				return $this->newFulltextSearchTableUpdateJob( $title, $parameters );
-			case 'smw.fulltextSearchTableRebuild':
-				return $this->newFulltextSearchTableRebuildJob( $title, $parameters );
-			case 'smw.changePropagationDispatch':
-				return $this->newChangePropagationDispatchJob( $title, $parameters );
-			case 'smw.changePropagationUpdate':
-				return $this->newChangePropagationUpdateJob( $title, $parameters );
-			case 'smw.changePropagationClassUpdate':
-				return $this->newChangePropagationClassUpdateJob( $title, $parameters );
-		}
+		// Map the typed names exposed by SMW (and a couple of legacy aliases
+		// kept for back-compat) to the JobClasses commands.
+		$command = match ( $type ) {
+			'smw.refresh' => 'smw.refresh',
+			'smw.update' => 'smw.update',
+			'smw.updateDispatcher' => 'smw.updateDispatcher',
+			'smw.parserCachePurge', 'smw.parserCachePurgeJob' => 'smw.parserCachePurgeJob',
+			'smw.entityIdDisposer' => 'smw.entityIdDisposer',
+			'smw.propertyStatisticsRebuild' => 'smw.propertyStatisticsRebuild',
+			'smw.fulltextSearchTableUpdate' => 'smw.fulltextSearchTableUpdate',
+			'smw.fulltextSearchTableRebuild' => 'smw.fulltextSearchTableRebuild',
+			'smw.changePropagationDispatch' => 'smw.changePropagationDispatch',
+			'smw.changePropagationUpdate' => 'smw.changePropagationUpdate',
+			'smw.changePropagationClassUpdate' => 'smw.changePropagationClassUpdate',
+			default => throw new RuntimeException( "Unable to match $type to a valid Job type" ),
+		};
 
-		throw new RuntimeException( "Unable to match $type to a valid Job type" );
+		/** @var Job $job */
+		$job = $this->mwJobFactory->newJob( $command, $title, $parameters );
+
+		return $job;
 	}
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Title $title
-	 * @param array $parameters
-	 *
-	 * @return RefreshJob
 	 */
 	public function newRefreshJob( Title $title, array $parameters = [] ): RefreshJob {
-		return new RefreshJob( $title, $parameters );
+		/** @var RefreshJob $job */
+		$job = $this->mwJobFactory->newJob( 'smw.refresh', $title, $parameters );
+		return $job;
 	}
 
 	/**
 	 * @since 2.0
-	 *
-	 * @param Title $title
-	 * @param array $parameters
-	 *
-	 * @return UpdateJob
 	 */
 	public function newUpdateJob( Title $title, array $parameters = [] ): UpdateJob {
-		return new UpdateJob( $title, $parameters );
+		/** @var UpdateJob $job */
+		$job = $this->mwJobFactory->newJob( 'smw.update', $title, $parameters );
+		return $job;
 	}
 
 	/**
 	 * @since 2.0
-	 *
-	 * @param Title $title
-	 * @param array $parameters
-	 *
-	 * @return UpdateDispatcherJob
 	 */
 	public function newUpdateDispatcherJob( Title $title, array $parameters = [] ): UpdateDispatcherJob {
-		return new UpdateDispatcherJob( $title, $parameters );
+		/** @var UpdateDispatcherJob $job */
+		$job = $this->mwJobFactory->newJob( 'smw.updateDispatcher', $title, $parameters );
+		return $job;
 	}
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Title $title
-	 * @param array $parameters
-	 *
-	 * @return FulltextSearchTableUpdateJob
 	 */
 	public function newFulltextSearchTableUpdateJob( Title $title, array $parameters = [] ): FulltextSearchTableUpdateJob {
-		return new FulltextSearchTableUpdateJob( $title, $parameters );
+		/** @var FulltextSearchTableUpdateJob $job */
+		$job = $this->mwJobFactory->newJob( 'smw.fulltextSearchTableUpdate', $title, $parameters );
+		return $job;
 	}
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Title $title
-	 * @param array $parameters
-	 *
-	 * @return EntityIdDisposerJob
 	 */
 	public function newEntityIdDisposerJob( Title $title, array $parameters = [] ): EntityIdDisposerJob {
-		return new EntityIdDisposerJob( $title, $parameters );
+		/** @var EntityIdDisposerJob $job */
+		$job = $this->mwJobFactory->newJob( 'smw.entityIdDisposer', $title, $parameters );
+		return $job;
 	}
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Title $title
-	 * @param array $parameters
-	 *
-	 * @return PropertyStatisticsRebuildJob
 	 */
 	public function newPropertyStatisticsRebuildJob( Title $title, array $parameters = [] ): PropertyStatisticsRebuildJob {
-		return new PropertyStatisticsRebuildJob( $title, $parameters );
+		/** @var PropertyStatisticsRebuildJob $job */
+		$job = $this->mwJobFactory->newJob( 'smw.propertyStatisticsRebuild', $title, $parameters );
+		return $job;
 	}
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Title $title
-	 * @param array $parameters
-	 *
-	 * @return FulltextSearchTableRebuildJob
 	 */
 	public function newFulltextSearchTableRebuildJob( Title $title, array $parameters = [] ): FulltextSearchTableRebuildJob {
-		return new FulltextSearchTableRebuildJob( $title, $parameters );
+		/** @var FulltextSearchTableRebuildJob $job */
+		$job = $this->mwJobFactory->newJob( 'smw.fulltextSearchTableRebuild', $title, $parameters );
+		return $job;
 	}
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Title $title
-	 * @param array $parameters
-	 *
-	 * @return ChangePropagationDispatchJob
 	 */
 	public function newChangePropagationDispatchJob( Title $title, array $parameters = [] ): ChangePropagationDispatchJob {
-		return new ChangePropagationDispatchJob( $title, $parameters );
+		/** @var ChangePropagationDispatchJob $job */
+		$job = $this->mwJobFactory->newJob( 'smw.changePropagationDispatch', $title, $parameters );
+		return $job;
 	}
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Title $title
-	 * @param array $parameters
-	 *
-	 * @return ChangePropagationUpdateJob
 	 */
 	public function newChangePropagationUpdateJob( Title $title, array $parameters = [] ): ChangePropagationUpdateJob {
-		return new ChangePropagationUpdateJob( $title, $parameters );
+		/** @var ChangePropagationUpdateJob $job */
+		$job = $this->mwJobFactory->newJob( 'smw.changePropagationUpdate', $title, $parameters );
+		return $job;
 	}
 
 	/**
 	 * @since 3.0
-	 *
-	 * @param Title $title
-	 * @param array $parameters
-	 *
-	 * @return ChangePropagationClassUpdateJob
 	 */
 	public function newChangePropagationClassUpdateJob( Title $title, array $parameters = [] ): ChangePropagationClassUpdateJob {
-		return new ChangePropagationClassUpdateJob( $title, $parameters );
+		/** @var ChangePropagationClassUpdateJob $job */
+		$job = $this->mwJobFactory->newJob( 'smw.changePropagationClassUpdate', $title, $parameters );
+		return $job;
 	}
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param Title $title
-	 * @param array $parameters
-	 *
-	 * @return ParserCachePurgeJob
 	 */
 	public function newParserCachePurgeJob( Title $title, array $parameters = [] ): ParserCachePurgeJob {
-		return new ParserCachePurgeJob( $title, $parameters );
+		/** @var ParserCachePurgeJob $job */
+		$job = $this->mwJobFactory->newJob( 'smw.parserCachePurgeJob', $title, $parameters );
+		return $job;
 	}
 
 }

--- a/src/MediaWiki/JobFactory.php
+++ b/src/MediaWiki/JobFactory.php
@@ -24,10 +24,15 @@ use SMW\MediaWiki\Jobs\UpdateJob;
 /**
  * Typed wrapper around MediaWiki's JobFactory for the SMW job classes.
  *
- * Each `newXxxJob()` method delegates to `MwJobFactory::newJob()` which in turn
- * resolves the JobClasses ObjectFactory spec (constructing the job with any
- * declared service dependencies). The wrapper exists so call-sites can keep
- * the typed factory methods that pre-date constructor injection.
+ * Each `newXxxJob()` method calls `MwJobFactory::newJob()` which resolves the
+ * JobClasses ObjectFactory spec, constructing the job with any declared
+ * service dependencies. The Title is passed via `namespace`/`title` keys in
+ * `$params` so the call matches MW's modern two-argument signature (the
+ * legacy three-argument back-compat form trips
+ * `PhanTypeMismatchArgumentProbablyReal`). Each return suppresses
+ * `PhanTypeMismatchReturnSuperType`: `JobFactory::newJob()` declares
+ * `: Job`, but the JobClasses spec guarantees the matching subclass at
+ * runtime, so the covariance is safe.
  *
  * @license GPL-2.0-or-later
  * @since 2.0
@@ -85,127 +90,154 @@ class JobFactory {
 			default => throw new RuntimeException( "Unable to match $type to a valid Job type" ),
 		};
 
-		/** @var Job $job */
-		$job = $this->mwJobFactory->newJob( $command, $title, $parameters );
-
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			$command,
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 	/**
 	 * @since 2.5
 	 */
 	public function newRefreshJob( Title $title, array $parameters = [] ): RefreshJob {
-		/** @var RefreshJob $job */
-		$job = $this->mwJobFactory->newJob( 'smw.refresh', $title, $parameters );
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			'smw.refresh',
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 	/**
 	 * @since 2.0
 	 */
 	public function newUpdateJob( Title $title, array $parameters = [] ): UpdateJob {
-		/** @var UpdateJob $job */
-		$job = $this->mwJobFactory->newJob( 'smw.update', $title, $parameters );
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			'smw.update',
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 	/**
 	 * @since 2.0
 	 */
 	public function newUpdateDispatcherJob( Title $title, array $parameters = [] ): UpdateDispatcherJob {
-		/** @var UpdateDispatcherJob $job */
-		$job = $this->mwJobFactory->newJob( 'smw.updateDispatcher', $title, $parameters );
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			'smw.updateDispatcher',
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 	/**
 	 * @since 2.5
 	 */
 	public function newFulltextSearchTableUpdateJob( Title $title, array $parameters = [] ): FulltextSearchTableUpdateJob {
-		/** @var FulltextSearchTableUpdateJob $job */
-		$job = $this->mwJobFactory->newJob( 'smw.fulltextSearchTableUpdate', $title, $parameters );
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			'smw.fulltextSearchTableUpdate',
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 	/**
 	 * @since 2.5
 	 */
 	public function newEntityIdDisposerJob( Title $title, array $parameters = [] ): EntityIdDisposerJob {
-		/** @var EntityIdDisposerJob $job */
-		$job = $this->mwJobFactory->newJob( 'smw.entityIdDisposer', $title, $parameters );
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			'smw.entityIdDisposer',
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 	/**
 	 * @since 2.5
 	 */
 	public function newPropertyStatisticsRebuildJob( Title $title, array $parameters = [] ): PropertyStatisticsRebuildJob {
-		/** @var PropertyStatisticsRebuildJob $job */
-		$job = $this->mwJobFactory->newJob( 'smw.propertyStatisticsRebuild', $title, $parameters );
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			'smw.propertyStatisticsRebuild',
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 	/**
 	 * @since 2.5
 	 */
 	public function newFulltextSearchTableRebuildJob( Title $title, array $parameters = [] ): FulltextSearchTableRebuildJob {
-		/** @var FulltextSearchTableRebuildJob $job */
-		$job = $this->mwJobFactory->newJob( 'smw.fulltextSearchTableRebuild', $title, $parameters );
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			'smw.fulltextSearchTableRebuild',
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 	/**
 	 * @since 3.0
 	 */
 	public function newChangePropagationDispatchJob( Title $title, array $parameters = [] ): ChangePropagationDispatchJob {
-		/** @var ChangePropagationDispatchJob $job */
-		$job = $this->mwJobFactory->newJob( 'smw.changePropagationDispatch', $title, $parameters );
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			'smw.changePropagationDispatch',
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 	/**
 	 * @since 3.0
 	 */
 	public function newChangePropagationUpdateJob( Title $title, array $parameters = [] ): ChangePropagationUpdateJob {
-		/** @var ChangePropagationUpdateJob $job */
-		$job = $this->mwJobFactory->newJob( 'smw.changePropagationUpdate', $title, $parameters );
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			'smw.changePropagationUpdate',
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 	/**
 	 * @since 3.0
 	 */
 	public function newChangePropagationClassUpdateJob( Title $title, array $parameters = [] ): ChangePropagationClassUpdateJob {
-		/** @var ChangePropagationClassUpdateJob $job */
-		$job = $this->mwJobFactory->newJob( 'smw.changePropagationClassUpdate', $title, $parameters );
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			'smw.changePropagationClassUpdate',
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 	/**
 	 * @since 3.1
 	 */
 	public function newParserCachePurgeJob( Title $title, array $parameters = [] ): ParserCachePurgeJob {
-		/** @var ParserCachePurgeJob $job */
-		$job = $this->mwJobFactory->newJob( 'smw.parserCachePurgeJob', $title, $parameters );
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			'smw.parserCachePurgeJob',
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 	/**
 	 * @since 7.0.0
 	 */
 	public function newFileIngestJob( Title $title, array $parameters = [] ): FileIngestJob {
-		/** @var FileIngestJob $job */
-		$job = $this->mwJobFactory->newJob( 'smw.elasticFileIngest', $title, $parameters );
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			'smw.elasticFileIngest',
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 	/**
 	 * @since 7.0.0
 	 */
 	public function newIndexerRecoveryJob( Title $title, array $parameters = [] ): IndexerRecoveryJob {
-		/** @var IndexerRecoveryJob $job */
-		$job = $this->mwJobFactory->newJob( 'smw.elasticIndexerRecovery', $title, $parameters );
-		return $job;
+		// @phan-suppress-next-line PhanTypeMismatchReturnSuperType
+		return $this->mwJobFactory->newJob(
+			'smw.elasticIndexerRecovery',
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+		);
 	}
 
 }

--- a/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
@@ -2,7 +2,6 @@
 
 namespace SMW\MediaWiki\Jobs;
 
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use Onoi\Cache\Cache;
 use Psr\Log\LoggerInterface;
@@ -88,10 +87,7 @@ class ChangePropagationDispatchJob extends Job {
 			$subject
 		);
 
-		// Use MediaWiki's JobFactory so the JobClasses ObjectFactory spec
-		// resolves the services declared for this job.
-		$changePropagationDispatchJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
-			'smw.changePropagationDispatch',
+		$changePropagationDispatchJob = ApplicationFactory::getInstance()->getJobFactory()->newChangePropagationDispatchJob(
 			$subject->getTitle(),
 			$params
 		);
@@ -285,8 +281,7 @@ class ChangePropagationDispatchJob extends Job {
 
 		$checkSum = md5( $contents );
 
-		$changePropagationDispatchJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
-			'smw.changePropagationDispatch',
+		$changePropagationDispatchJob = ApplicationFactory::getInstance()->getJobFactory()->newChangePropagationDispatchJob(
 			$this->getTitle(),
 			[
 				'data' => $contents
@@ -316,8 +311,7 @@ class ChangePropagationDispatchJob extends Job {
 			$this->cache->save( $key, 1, 60 * 60 * 24 );
 			$params = $this->params;
 
-			$changePropagationDispatchJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
-				'smw.changePropagationDispatch',
+			$changePropagationDispatchJob = ApplicationFactory::getInstance()->getJobFactory()->newChangePropagationDispatchJob(
 				$this->getTitle(),
 				$params
 			);
@@ -352,8 +346,7 @@ class ChangePropagationDispatchJob extends Job {
 		// Scheduling the actual dispatch for those properties connected to
 		// the schema change
 		foreach ( $dataItems as $dataItem ) {
-			$changePropagationDispatchJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
-				'smw.changePropagationDispatch',
+			$changePropagationDispatchJob = ApplicationFactory::getInstance()->getJobFactory()->newChangePropagationDispatchJob(
 				$dataItem->getTitle(),
 				[]
 			);

--- a/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
@@ -2,13 +2,19 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
+use Onoi\Cache\Cache;
+use Psr\Log\LoggerInterface;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\Export\Exporter;
+use SMW\IteratorFactory;
 use SMW\MediaWiki\Job;
+use SMW\Property\SpecificationLookup as PropertySpecificationLookup;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\Lookup\ChangePropagationEntityLookup;
+use SMW\Store;
 
 /**
  * `ChangePropagationDispatchJob` dispatches update jobs via `ChangePropagationUpdateJob`
@@ -33,6 +39,11 @@ use SMW\SQLStore\Lookup\ChangePropagationEntityLookup;
  * during tests that would lead to an out-of-memory) to store a list of
  * entities that require an update.
  *
+ * Partial DI: Store, Cache, PropertySpecificationLookup and IteratorFactory
+ * are injected via the JobClasses ObjectFactory spec. The MediaWikiLogger is
+ * still resolved lazily through ApplicationFactory because it is not a
+ * registered global service.
+ *
  * @license GPL-2.0-or-later
  * @since 3.0
  *
@@ -53,8 +64,16 @@ class ChangePropagationDispatchJob extends Job {
 	/**
 	 * @since 3.0
 	 */
-	public function __construct( Title $title, array $params = [] ) {
+	public function __construct(
+		Title $title,
+		array $params,
+		Store $store,
+		private readonly Cache $cache,
+		private readonly PropertySpecificationLookup $propertySpecificationLookup,
+		private readonly IteratorFactory $iteratorFactory
+	) {
 		parent::__construct( 'smw.changePropagationDispatch', $title, $params );
+		$this->setStore( $store );
 		$this->removeDuplicates = true;
 	}
 
@@ -69,7 +88,13 @@ class ChangePropagationDispatchJob extends Job {
 			$subject
 		);
 
-		$changePropagationDispatchJob = new self( $subject->getTitle(), $params );
+		// Use MediaWiki's JobFactory so the JobClasses ObjectFactory spec
+		// resolves the services declared for this job.
+		$changePropagationDispatchJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+			'smw.changePropagationDispatch',
+			$subject->getTitle(),
+			$params
+		);
 		$changePropagationDispatchJob->lazyPush();
 
 		return true;
@@ -194,16 +219,13 @@ class ChangePropagationDispatchJob extends Job {
 
 		$subject = WikiPage::newFromTitle( $this->getTitle() );
 
-		$applicationFactory = ApplicationFactory::getInstance();
-		$iteratorFactory = $applicationFactory->getIteratorFactory();
-
-		$applicationFactory->getMediaWikiLogger()->info(
+		$this->getLogger()->info(
 			'ChangePropagationDispatchJob on ' . $subject->getHash()
 		);
 
 		$changePropagationEntityLookup = new ChangePropagationEntityLookup(
-			$applicationFactory->getStore(),
-			$iteratorFactory
+			$this->store,
+			$this->iteratorFactory
 		);
 
 		$changePropagationEntityLookup->isTypePropagation(
@@ -238,7 +260,7 @@ class ChangePropagationDispatchJob extends Job {
 			$appendIterator->count()
 		);
 
-		$chunkedIterator = $iteratorFactory->newChunkedIterator(
+		$chunkedIterator = $this->iteratorFactory->newChunkedIterator(
 			$appendIterator,
 			self::CHUNK_SIZE
 		);
@@ -263,7 +285,8 @@ class ChangePropagationDispatchJob extends Job {
 
 		$checkSum = md5( $contents );
 
-		$changePropagationDispatchJob = new ChangePropagationDispatchJob(
+		$changePropagationDispatchJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+			'smw.changePropagationDispatch',
 			$this->getTitle(),
 			[
 				'data' => $contents
@@ -276,14 +299,11 @@ class ChangePropagationDispatchJob extends Job {
 	}
 
 	private function dispatchFromData( WikiPage $subject, $data ): bool {
-		$applicationFactory = ApplicationFactory::getInstance();
-		$cache = $applicationFactory->getCache();
-
 		$property = Property::newFromUserLabel(
 			$this->getTitle()->getText()
 		);
 
-		$semanticData = $applicationFactory->getStore()->getSemanticData(
+		$semanticData = $this->store->getSemanticData(
 			$subject
 		);
 
@@ -291,19 +311,20 @@ class ChangePropagationDispatchJob extends Job {
 
 		// SemanticData hasn't been updated, re-enter the cycle to ensure that
 		// the update of the property took place
-		if ( $cache->fetch( $key ) === false ) {
+		if ( $this->cache->fetch( $key ) === false ) {
 
-			$cache->save( $key, 1, 60 * 60 * 24 );
+			$this->cache->save( $key, 1, 60 * 60 * 24 );
 			$params = $this->params;
 
-			$changePropagationDispatchJob = new ChangePropagationDispatchJob(
+			$changePropagationDispatchJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+				'smw.changePropagationDispatch',
 				$this->getTitle(),
 				$params
 			);
 
 			$changePropagationDispatchJob->insert();
 
-			$applicationFactory->getMediaWikiLogger()->info(
+			$this->getLogger()->info(
 				'ChangePropagationDispatchJob missing update marker, retry on ' . $subject->getHash()
 			);
 
@@ -321,11 +342,9 @@ class ChangePropagationDispatchJob extends Job {
 	}
 
 	private function dispatchFromSchema( WikiPage $subject, $property_key ): bool {
-		$store = ApplicationFactory::getInstance()->getStore();
-
 		// Find all properties that point to the schema and hereby require
 		// an update (!! using the inverse relationship)
-		$dataItems = $store->getPropertyValues(
+		$dataItems = $this->store->getPropertyValues(
 			$subject,
 			new Property( $property_key, true )
 		);
@@ -333,9 +352,10 @@ class ChangePropagationDispatchJob extends Job {
 		// Scheduling the actual dispatch for those properties connected to
 		// the schema change
 		foreach ( $dataItems as $dataItem ) {
-
-			$changePropagationDispatchJob = new ChangePropagationDispatchJob(
-				$dataItem->getTitle()
+			$changePropagationDispatchJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+				'smw.changePropagationDispatch',
+				$dataItem->getTitle(),
+				[]
 			);
 
 			$changePropagationDispatchJob->insert();
@@ -365,9 +385,7 @@ class ChangePropagationDispatchJob extends Job {
 	}
 
 	private function commitSpecificationChangePropagationAsJob( WikiPage $subject, $count ): void {
-		$applicationFactory = ApplicationFactory::getInstance();
-
-		$connection = $applicationFactory->getStore()->getConnection( 'mw.db' );
+		$connection = $this->store->getConnection( 'mw.db' );
 		$transactionTicket = $connection->getEmptyTransactionTicket( __METHOD__ );
 
 		$changePropagationUpdateJob = $this->newChangePropagationUpdateJob(
@@ -390,23 +408,25 @@ class ChangePropagationDispatchJob extends Job {
 		//
 		// The marker will be removed after running the ChangePropagationUpdateJob
 		// on the same subject.
-		$applicationFactory->getCache()->save(
+		$this->cache->save(
 			smwfCacheKey( self::CACHE_NAMESPACE, $subject->getHash() ),
 			$count,
 			60 * 60 * 24
 		);
 
-		$applicationFactory->getPropertySpecificationLookup()->invalidateCache( $subject );
+		$this->propertySpecificationLookup->invalidateCache( $subject );
 
 		// Make sure the cache is reset in case runJobs.php --wait is used to avoid
 		// reusing outdated type assignments
-		$applicationFactory->getStore()->clear();
+		$this->store->clear();
 	}
 
-	private function newChangePropagationUpdateJob( ?Title $title, array $parameters ): ChangePropagationClassUpdateJob|ChangePropagationUpdateJob {
+	private function newChangePropagationUpdateJob( ?Title $title, array $parameters ): Job {
 		$namespace = $this->getTitle()->getNamespace();
 		$parameters += [ 'origin' => 'ChangePropagationDispatchJob' ];
 
+		// Both targets have no service deps; they are excluded from the
+		// JobClasses spec overhaul and can be constructed directly.
 		if ( $namespace === NS_CATEGORY ) {
 			return new ChangePropagationClassUpdateJob( $title, $parameters );
 		}
@@ -415,6 +435,14 @@ class ChangePropagationDispatchJob extends Job {
 			$title,
 			$parameters
 		);
+	}
+
+	private function getLogger(): LoggerInterface {
+		if ( $this->logger === null ) {
+			$this->logger = ApplicationFactory::getInstance()->getMediaWikiLogger();
+		}
+
+		return $this->logger;
 	}
 
 }

--- a/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
@@ -5,6 +5,7 @@ namespace SMW\MediaWiki\Jobs;
 use MediaWiki\Title\Title;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Job;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
  * Make sufficient use of the job table by only tracking remaining jobs without
@@ -52,9 +53,14 @@ class ChangePropagationUpdateJob extends Job {
 			WikiPage::newFromTitle( $this->getTitle() )
 		);
 
+		// Construct the inner UpdateJob directly with the current Store
+		// resolved through ApplicationFactory. We cannot route via MediaWiki's
+		// JobFactory here because the JobClasses spec resolves SMW.Store from
+		// the global container, which bypasses testOverrides.
 		$updateJob = new UpdateJob(
 			$this->getTitle(),
-			array_merge( $this->params, [ 'origin' => 'ChangePropagationUpdateJob' ] )
+			array_merge( $this->params, [ 'origin' => 'ChangePropagationUpdateJob' ] ),
+			ApplicationFactory::getInstance()->getStore()
 		);
 
 		$updateJob->run();

--- a/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
@@ -53,14 +53,9 @@ class ChangePropagationUpdateJob extends Job {
 			WikiPage::newFromTitle( $this->getTitle() )
 		);
 
-		// Construct the inner UpdateJob directly with the current Store
-		// resolved through ApplicationFactory. We cannot route via MediaWiki's
-		// JobFactory here because the JobClasses spec resolves SMW.Store from
-		// the global container, which bypasses testOverrides.
-		$updateJob = new UpdateJob(
+		$updateJob = ApplicationFactory::getInstance()->getJobFactory()->newUpdateJob(
 			$this->getTitle(),
-			array_merge( $this->params, [ 'origin' => 'ChangePropagationUpdateJob' ] ),
-			ApplicationFactory::getInstance()->getStore()
+			array_merge( $this->params, [ 'origin' => 'ChangePropagationUpdateJob' ] )
 		);
 
 		$updateJob->run();

--- a/src/MediaWiki/Jobs/DeferredConstraintCheckUpdateJob.php
+++ b/src/MediaWiki/Jobs/DeferredConstraintCheckUpdateJob.php
@@ -56,14 +56,9 @@ class DeferredConstraintCheckUpdateJob extends Job {
 			return true;
 		}
 
-		// Construct the inner UpdateJob directly with the current Store
-		// resolved through ApplicationFactory. We cannot route via MediaWiki's
-		// JobFactory here because the JobClasses spec resolves SMW.Store from
-		// the global container, which bypasses testOverrides.
-		$updateJob = new UpdateJob(
+		$updateJob = ApplicationFactory::getInstance()->getJobFactory()->newUpdateJob(
 			$this->getTitle(),
-			$this->params + [ 'origin' => 'DeferredConstraintCheckUpdateJob' ],
-			ApplicationFactory::getInstance()->getStore()
+			$this->params + [ 'origin' => 'DeferredConstraintCheckUpdateJob' ]
 		);
 
 		$updateJob->run();

--- a/src/MediaWiki/Jobs/DeferredConstraintCheckUpdateJob.php
+++ b/src/MediaWiki/Jobs/DeferredConstraintCheckUpdateJob.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Jobs;
 
 use MediaWiki\Title\Title;
 use SMW\MediaWiki\Job;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
  * @license GPL-2.0-or-later
@@ -55,9 +56,14 @@ class DeferredConstraintCheckUpdateJob extends Job {
 			return true;
 		}
 
+		// Construct the inner UpdateJob directly with the current Store
+		// resolved through ApplicationFactory. We cannot route via MediaWiki's
+		// JobFactory here because the JobClasses spec resolves SMW.Store from
+		// the global container, which bypasses testOverrides.
 		$updateJob = new UpdateJob(
 			$this->getTitle(),
-			$this->params + [ 'origin' => 'DeferredConstraintCheckUpdateJob' ]
+			$this->params + [ 'origin' => 'DeferredConstraintCheckUpdateJob' ],
+			ApplicationFactory::getInstance()->getStore()
 		);
 
 		$updateJob->run();

--- a/src/MediaWiki/Jobs/EntityIdDisposerJob.php
+++ b/src/MediaWiki/Jobs/EntityIdDisposerJob.php
@@ -2,12 +2,12 @@
 
 namespace SMW\MediaWiki\Jobs;
 
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use SMW\IteratorFactory;
 use SMW\Iterators\ResultIterator;
 use SMW\MediaWiki\Job;
 use SMW\RequestOptions;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\SQLStore\QueryDependency\QueryLinksTableDisposer;
 use SMW\Store;
@@ -160,12 +160,9 @@ class EntityIdDisposerJob extends Job {
 			return null;
 		}
 
-		// We expect more outdated entities to be contained in the ID_TABLE
-		// therefore reenter the disposal cycle. Build the next job through
-		// MediaWiki's JobFactory so the ObjectFactory spec injects the
-		// services this Job depends on.
-		$entityIdDisposerJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
-			'smw.entityIdDisposer',
+		// We expect more outdated entities to be contained in the ID_TABLE,
+		// therefore reenter the disposal cycle.
+		$entityIdDisposerJob = ApplicationFactory::getInstance()->getJobFactory()->newEntityIdDisposerJob(
 			$this->getTitle(),
 			$this->params + [ 'cycle' => ++$cycle ]
 		);

--- a/src/MediaWiki/Jobs/EntityIdDisposerJob.php
+++ b/src/MediaWiki/Jobs/EntityIdDisposerJob.php
@@ -2,13 +2,15 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
+use SMW\IteratorFactory;
 use SMW\Iterators\ResultIterator;
 use SMW\MediaWiki\Job;
 use SMW\RequestOptions;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\SQLStore\QueryDependency\QueryLinksTableDisposer;
+use SMW\Store;
 use stdClass;
 
 /**
@@ -30,35 +32,28 @@ class EntityIdDisposerJob extends Job {
 	 */
 	const BATCH_ROW_SIZE = 5000;
 
-	/**
-	 * @var PropertyTableIdReferenceDisposer
-	 */
-	private $propertyTableIdReferenceDisposer;
+	private ?PropertyTableIdReferenceDisposer $propertyTableIdReferenceDisposer = null;
 
-	/**
-	 * @var QueryLinksTableDisposer
-	 */
-	private $queryLinksTableDisposer;
+	private ?QueryLinksTableDisposer $queryLinksTableDisposer = null;
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Title $title
-	 * @param array $params job parameters
 	 */
-	public function __construct( Title $title, $params = [] ) {
+	public function __construct(
+		Title $title,
+		array $params,
+		Store $store,
+		private readonly IteratorFactory $iteratorFactory
+	) {
 		parent::__construct( 'smw.entityIdDisposer', $title, $params );
+		$this->setStore( $store );
 		$this->removeDuplicates = true;
 	}
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param RequestOptions|null $requestOptions
-	 *
-	 * @return ResultIterator
 	 */
-	public function newOutdatedEntitiesResultIterator( ?RequestOptions $requestOptions = null ) {
+	public function newOutdatedEntitiesResultIterator( ?RequestOptions $requestOptions = null ): ResultIterator {
 		if ( $this->propertyTableIdReferenceDisposer === null ) {
 			$this->propertyTableIdReferenceDisposer = $this->newPropertyTableIdReferenceDisposer();
 		}
@@ -68,12 +63,8 @@ class EntityIdDisposerJob extends Job {
 
 	/**
 	 * @since 3.2
-	 *
-	 * @param RequestOptions|null $requestOptions
-	 *
-	 * @return ResultIterator
 	 */
-	public function newByNamespaceInvalidEntitiesResultIterator( ?RequestOptions $requestOptions = null ) {
+	public function newByNamespaceInvalidEntitiesResultIterator( ?RequestOptions $requestOptions = null ): ResultIterator {
 		if ( $this->propertyTableIdReferenceDisposer === null ) {
 			$this->propertyTableIdReferenceDisposer = $this->newPropertyTableIdReferenceDisposer();
 		}
@@ -83,10 +74,8 @@ class EntityIdDisposerJob extends Job {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @return ResultIterator
 	 */
-	public function newOutdatedQueryLinksResultIterator() {
+	public function newOutdatedQueryLinksResultIterator(): ResultIterator {
 		if ( $this->queryLinksTableDisposer === null ) {
 			$this->queryLinksTableDisposer = $this->newQueryLinksTableDisposer();
 		}
@@ -96,10 +85,8 @@ class EntityIdDisposerJob extends Job {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @return ResultIterator
 	 */
-	public function newUnassignedQueryLinksResultIterator() {
+	public function newUnassignedQueryLinksResultIterator(): ResultIterator {
 		if ( $this->queryLinksTableDisposer === null ) {
 			$this->queryLinksTableDisposer = $this->newQueryLinksTableDisposer();
 		}
@@ -174,18 +161,20 @@ class EntityIdDisposerJob extends Job {
 		}
 
 		// We expect more outdated entities to be contained in the ID_TABLE
-		// therefore reenter the disposal cycle
-		$entityIdDisposerJob = new self(
+		// therefore reenter the disposal cycle. Build the next job through
+		// MediaWiki's JobFactory so the ObjectFactory spec injects the
+		// services this Job depends on.
+		$entityIdDisposerJob = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+			'smw.entityIdDisposer',
 			$this->getTitle(),
 			$this->params + [ 'cycle' => ++$cycle ]
 		);
 
 		$entityIdDisposerJob->insert();
 
-		$applicationFactory = ApplicationFactory::getInstance();
-		$connection = $applicationFactory->getStore()->getConnection( 'mw.db' );
+		$connection = $this->store->getConnection( 'mw.db' );
 
-		$chunkedIterator = $applicationFactory->getIteratorFactory()->newChunkedIterator(
+		$chunkedIterator = $this->iteratorFactory->newChunkedIterator(
 			$outdatedEntitiesResultIterator,
 			self::CHUNK_SIZE
 		);
@@ -204,15 +193,14 @@ class EntityIdDisposerJob extends Job {
 		return null;
 	}
 
-	private function newPropertyTableIdReferenceDisposer() {
-		return ApplicationFactory::getInstance()->getStore()->service( 'PropertyTableIdReferenceDisposer' );
+	private function newPropertyTableIdReferenceDisposer(): PropertyTableIdReferenceDisposer {
+		return $this->store->service( 'PropertyTableIdReferenceDisposer' );
 	}
 
-	private function newQueryLinksTableDisposer() {
-		$store = ApplicationFactory::getInstance()->getStore();
-		$queryDependencyLinksStoreFactory = $store->service( 'QueryDependencyLinksStoreFactory' );
+	private function newQueryLinksTableDisposer(): QueryLinksTableDisposer {
+		$queryDependencyLinksStoreFactory = $this->store->service( 'QueryDependencyLinksStoreFactory' );
 
-		return $queryDependencyLinksStoreFactory->newQueryLinksTableDisposer( $store );
+		return $queryDependencyLinksStoreFactory->newQueryLinksTableDisposer( $this->store );
 	}
 
 }

--- a/src/MediaWiki/Jobs/FulltextSearchTableRebuildJob.php
+++ b/src/MediaWiki/Jobs/FulltextSearchTableRebuildJob.php
@@ -2,9 +2,9 @@
 
 namespace SMW\MediaWiki\Jobs;
 
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use SMW\MediaWiki\Job;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
 use SMW\Store;
 
@@ -61,11 +61,10 @@ class FulltextSearchTableRebuildJob extends Job {
 			return;
 		}
 
-		$jobFactory = MediaWikiServices::getInstance()->getJobFactory();
+		$jobFactory = ApplicationFactory::getInstance()->getJobFactory();
 
 		foreach ( $tableList as $tableName ) {
-			$job = $jobFactory->newJob(
-				'smw.fulltextSearchTableRebuild',
+			$job = $jobFactory->newFulltextSearchTableRebuildJob(
 				$this->getTitle(),
 				[ 'table' => $tableName ]
 			);

--- a/src/MediaWiki/Jobs/FulltextSearchTableRebuildJob.php
+++ b/src/MediaWiki/Jobs/FulltextSearchTableRebuildJob.php
@@ -2,11 +2,11 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use SMW\MediaWiki\Job;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
-use SMW\SQLStore\SQLStore;
+use SMW\Store;
 
 /**
  * @license GPL-2.0-or-later
@@ -18,12 +18,14 @@ class FulltextSearchTableRebuildJob extends Job {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Title $title
-	 * @param array $params job parameters
 	 */
-	public function __construct( Title $title, $params = [] ) {
+	public function __construct(
+		Title $title,
+		array $params,
+		Store $store
+	) {
 		parent::__construct( 'smw.fulltextSearchTableRebuild', $title, $params );
+		$this->setStore( $store );
 	}
 
 	/**
@@ -38,9 +40,8 @@ class FulltextSearchTableRebuildJob extends Job {
 
 		$fulltextSearchTableFactory = new FulltextSearchTableFactory();
 
-		// Only the SQLStore is supported
 		$searchTableRebuilder = $fulltextSearchTableFactory->newSearchTableRebuilder(
-			ApplicationFactory::getInstance()->getStore( SQLStore::class )
+			$this->store
 		);
 
 		if ( $this->hasParameter( 'table' ) ) {
@@ -60,12 +61,16 @@ class FulltextSearchTableRebuildJob extends Job {
 			return;
 		}
 
-		foreach ( $tableList as $tableName ) {
-			$fulltextSearchTableRebuildJob = new self( $this->getTitle(), [
-				'table' => $tableName
-			] );
+		$jobFactory = MediaWikiServices::getInstance()->getJobFactory();
 
-			$fulltextSearchTableRebuildJob->insert();
+		foreach ( $tableList as $tableName ) {
+			$job = $jobFactory->newJob(
+				'smw.fulltextSearchTableRebuild',
+				$this->getTitle(),
+				[ 'table' => $tableName ]
+			);
+
+			$job->insert();
 		}
 	}
 

--- a/src/MediaWiki/Jobs/FulltextSearchTableUpdateJob.php
+++ b/src/MediaWiki/Jobs/FulltextSearchTableUpdateJob.php
@@ -5,9 +5,8 @@ namespace SMW\MediaWiki\Jobs;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use SMW\MediaWiki\Job;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
-use SMW\SQLStore\SQLStore;
+use SMW\Store;
 
 /**
  * @license GPL-2.0-or-later
@@ -19,12 +18,14 @@ class FulltextSearchTableUpdateJob extends Job {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Title $title
-	 * @param array $params job parameters
 	 */
-	public function __construct( Title $title, $params = [] ) {
+	public function __construct(
+		Title $title,
+		array $params,
+		Store $store
+	) {
 		parent::__construct( 'smw.fulltextSearchTableUpdate', $title, $params );
+		$this->setStore( $store );
 		$this->removeDuplicates = true;
 	}
 
@@ -37,7 +38,7 @@ class FulltextSearchTableUpdateJob extends Job {
 		$fulltextSearchTableFactory = new FulltextSearchTableFactory();
 
 		$textChangeUpdater = $fulltextSearchTableFactory->newTextChangeUpdater(
-			ApplicationFactory::getInstance()->getStore( SQLStore::class )
+			$this->store
 		);
 
 		$textChangeUpdater->pushUpdatesFromJobParameters(

--- a/src/MediaWiki/Jobs/ParserCachePurgeJob.php
+++ b/src/MediaWiki/Jobs/ParserCachePurgeJob.php
@@ -4,11 +4,17 @@ namespace SMW\MediaWiki\Jobs;
 
 use MediaWiki\Context\RequestContext;
 use MediaWiki\Title\Title;
+use Psr\Log\LoggerInterface;
 use SMW\MediaWiki\Job;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use WikiPage;
 
 /**
+ * Partial DI: ParserCachePurgeJob still resolves its logger and page-creator
+ * lazily through `ApplicationFactory` because neither is registered as a
+ * global SMW.X service yet. Constructor injection will follow once
+ * `MediaWikiLogger` and `PageCreator` move onto the container.
+ *
  * @license GPL-2.0-or-later
  * @since 3.1
  *
@@ -33,9 +39,6 @@ class ParserCachePurgeJob extends Job {
 	 * @param WikiPage|null $page
 	 */
 	public function updateParserCache( ?WikiPage $page = null ): void {
-		$applicationFactory = ApplicationFactory::getInstance();
-		$logger = $applicationFactory->getMediaWikiLogger();
-
 		if ( $this->hasParameter( 'action' ) ) {
 			$causeAction = $this->getParameter( 'action' );
 		} else {
@@ -61,7 +64,7 @@ class ParserCachePurgeJob extends Job {
 			]
 		);
 
-		$logger->info(
+		$this->getLogger()->info(
 			'ParserCache Forced update for: {title} causeAction: {causeAction}',
 			[
 				'causeAction' => $causeAction,
@@ -86,5 +89,13 @@ class ParserCachePurgeJob extends Job {
 
 	protected function newWikiPage( Title $title ): WikiPage {
 		return ApplicationFactory::getInstance()->newPageCreator()->createPage( $title );
+	}
+
+	private function getLogger(): LoggerInterface {
+		if ( $this->logger === null ) {
+			$this->logger = ApplicationFactory::getInstance()->getMediaWikiLogger();
+		}
+
+		return $this->logger;
 	}
 }

--- a/src/MediaWiki/Jobs/PropertyStatisticsRebuildJob.php
+++ b/src/MediaWiki/Jobs/PropertyStatisticsRebuildJob.php
@@ -5,7 +5,7 @@ namespace SMW\MediaWiki\Jobs;
 use MediaWiki\Title\Title;
 use SMW\MediaWiki\Job;
 use SMW\Services\ServicesFactory as ApplicationFactory;
-use SMW\SQLStore\SQLStore;
+use SMW\Store;
 
 /**
  * @license GPL-2.0-or-later
@@ -17,12 +17,14 @@ class PropertyStatisticsRebuildJob extends Job {
 
 	/**
 	 * @since 2.5
-	 *
-	 * @param Title $title
-	 * @param array $params job parameters
 	 */
-	public function __construct( Title $title, $params = [] ) {
+	public function __construct(
+		Title $title,
+		array $params,
+		Store $store
+	) {
 		parent::__construct( 'smw.propertyStatisticsRebuild', $title, $params );
+		$this->setStore( $store );
 		$this->removeDuplicates = true;
 	}
 
@@ -48,15 +50,13 @@ class PropertyStatisticsRebuildJob extends Job {
 	}
 
 	public function rebuild(): void {
-		$applicationFactory = ApplicationFactory::getInstance();
-		$maintenanceFactory = $applicationFactory->newMaintenanceFactory();
+		$maintenanceFactory = ApplicationFactory::getInstance()->newMaintenanceFactory();
 
-		// Use a fixed store to avoid issues like "Call to undefined method
-		// SMW\SPARQLStore\SPARQLStore::getDataItemHandlerForDIType" because
-		// the property statistics table and hereby its update is bound to
-		// the SQLStore
+		// The property statistics table and its update are bound to the
+		// SQLStore. The injected Store is the default Store; production
+		// always wires SQLStore here, and tests inject a SQLStore mock.
 		$propertyStatisticsRebuilder = $maintenanceFactory->newPropertyStatisticsRebuilder(
-			$applicationFactory->getStore( SQLStore::class )
+			$this->store
 		);
 
 		$propertyStatisticsRebuilder->rebuild();

--- a/src/MediaWiki/Jobs/RefreshJob.php
+++ b/src/MediaWiki/Jobs/RefreshJob.php
@@ -2,9 +2,10 @@
 
 namespace SMW\MediaWiki\Jobs;
 
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use SMW\MediaWiki\Job;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Store;
 
 /**
  * RefreshJob iterates over all page ids of the wiki, to perform an update
@@ -36,18 +37,18 @@ class RefreshJob extends Job {
 	 * If more than one run is done, then the first run will restrict to properties
 	 * and types. The progress indication refers to the current run, not to the
 	 * overall job.
-	 *
-	 * @param Title $title
-	 * @param array $params
 	 */
-	public function __construct( $title, $params = [ 'spos' => 1, 'prog' => 0, 'rc' => 1 ] ) {
+	public function __construct(
+		Title $title,
+		array $params,
+		Store $store
+	) {
 		parent::__construct( 'smw.refresh', $title, $params );
+		$this->setStore( $store );
 	}
 
 	/**
 	 * @see Job::run
-	 *
-	 * @return bool
 	 */
 	public function run(): bool {
 		if ( $this->hasParameter( 'spos' ) ) {
@@ -61,8 +62,6 @@ class RefreshJob extends Job {
 	 * Report the estimated progress status of this job as a number between
 	 * 0 and 1 (0% to 100%). The progress refers to the state before
 	 * processing this job.
-	 *
-	 * @return double
 	 */
 	public function getProgress(): float {
 		$prog = $this->hasParameter( 'prog' ) ? $this->getParameter( 'prog' ) : 0;
@@ -78,7 +77,7 @@ class RefreshJob extends Job {
 	protected function refreshData( $spos ): bool {
 		$run = $this->hasParameter( 'run' ) ? $this->getParameter( 'run' ) : 1;
 
-		$entityRebuildDispatcher = ApplicationFactory::getInstance()->getStore()->refreshData(
+		$entityRebuildDispatcher = $this->store->refreshData(
 			$spos,
 			20,
 			$this->getNamespace( $run )
@@ -111,7 +110,10 @@ class RefreshJob extends Job {
 	}
 
 	protected function createNextJob( array $parameters ): void {
-		$job = new self(
+		// Construct via MediaWiki's JobFactory so the Store dependency
+		// declared in the JobClasses ObjectFactory spec is resolved.
+		$job = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+			'smw.refresh',
 			$this->getTitle(),
 			$parameters
 		);

--- a/src/MediaWiki/Jobs/RefreshJob.php
+++ b/src/MediaWiki/Jobs/RefreshJob.php
@@ -2,9 +2,9 @@
 
 namespace SMW\MediaWiki\Jobs;
 
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use SMW\MediaWiki\Job;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
 
 /**
@@ -110,10 +110,7 @@ class RefreshJob extends Job {
 	}
 
 	protected function createNextJob( array $parameters ): void {
-		// Construct via MediaWiki's JobFactory so the Store dependency
-		// declared in the JobClasses ObjectFactory spec is resolved.
-		$job = MediaWikiServices::getInstance()->getJobFactory()->newJob(
-			'smw.refresh',
+		$job = ApplicationFactory::getInstance()->getJobFactory()->newRefreshJob(
 			$this->getTitle(),
 			$parameters
 		);

--- a/src/MediaWiki/Jobs/UpdateDispatcherJob.php
+++ b/src/MediaWiki/Jobs/UpdateDispatcherJob.php
@@ -14,10 +14,15 @@ use SMW\MediaWiki\Job;
 use SMW\RequestOptions;
 use SMW\SerializerFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Store;
 
 /**
  * Dispatcher to find and create individual UpdateJob instances for a specific
  * subject and its linked entities.
+ *
+ * Partial DI: Store is injected via the JobClasses ObjectFactory spec.
+ * SerializerFactory is still resolved through ApplicationFactory because
+ * it is not registered as a global SMW.X service.
  *
  * @license GPL-2.0-or-later
  * @since 1.9
@@ -42,17 +47,18 @@ class UpdateDispatcherJob extends Job {
 	 */
 	const CHUNK_SIZE = 500;
 
-	private SerializerFactory $serializerFactory;
+	private ?SerializerFactory $serializerFactory = null;
 
 	/**
 	 * @since  1.9
-	 *
-	 * @param Title $title
-	 * @param array $params job parameters
-	 * @param int $id job id
 	 */
-	public function __construct( Title $title, $params = [], $id = 0 ) {
-		parent::__construct( 'smw.updateDispatcher', $title, $params, $id );
+	public function __construct(
+		Title $title,
+		array $params,
+		Store $store
+	) {
+		parent::__construct( 'smw.updateDispatcher', $title, $params );
+		$this->setStore( $store );
 		$this->removeDuplicates = true;
 	}
 
@@ -60,8 +66,6 @@ class UpdateDispatcherJob extends Job {
 	 * @see Job::run
 	 *
 	 * @since  1.9
-	 *
-	 * @return bool
 	 */
 	public function run(): bool {
 		$this->initServices();
@@ -112,7 +116,6 @@ class UpdateDispatcherJob extends Job {
 
 	private function initServices(): void {
 		$applicationFactory = ApplicationFactory::getInstance();
-		$this->setStore( $applicationFactory->getStore() );
 
 		$this->serializerFactory = $applicationFactory->newSerializerFactory();
 
@@ -122,11 +125,10 @@ class UpdateDispatcherJob extends Job {
 	}
 
 	private function dispatch_by_id( $id ): void {
-		$applicationFactory = ApplicationFactory::getInstance();
-		$queryDependencyLinksStoreFactory = $applicationFactory->singleton( 'QueryDependencyLinksStoreFactory' );
+		$queryDependencyLinksStoreFactory = $this->store->service( 'QueryDependencyLinksStoreFactory' );
 
 		$queryDependencyLinksStore = $queryDependencyLinksStoreFactory->newQueryDependencyLinksStore(
-			$applicationFactory->getStore()
+			$this->store
 		);
 
 		$count = $queryDependencyLinksStore->countDependencies(
@@ -159,10 +161,14 @@ class UpdateDispatcherJob extends Job {
 
 	private function create_secondary_dispatch_run( $jobs ): void {
 		$titleFactory = MediaWikiServices::getInstance()->getTitleFactory();
+		$jobFactory = MediaWikiServices::getInstance()->getJobFactory();
 		$origin = $this->getTitle()->getPrefixedText();
 
 		foreach ( array_chunk( $jobs, self::CHUNK_SIZE, true ) as $jobList ) {
-			$job = new self(
+			// Use MediaWiki's JobFactory so the Store dependency declared
+			// in the JobClasses ObjectFactory spec is wired in.
+			$job = $jobFactory->newJob(
+				'smw.updateDispatcher',
 				$titleFactory->newFromText( 'UpdateDispatcher/SecondaryRun/' . md5( json_encode( $jobList ) ) ),
 				[
 					self::JOB_LIST => $jobList,
@@ -331,6 +337,8 @@ class UpdateDispatcherJob extends Job {
 			'origin' => $this->getParameter( 'origin', 'UpdateDispatcherJob' )
 		];
 
+		$jobFactory = MediaWikiServices::getInstance()->getJobFactory();
+
 		// We expect non-duplicate subjects in the list and therefore deserialize
 		// without any extra validation
 		foreach ( $subjects as $key => $subject ) {
@@ -354,7 +362,9 @@ class UpdateDispatcherJob extends Job {
 				continue;
 			}
 
-			$this->jobs[] = new UpdateJob( $title, $parameters );
+			// Construct each UpdateJob through MediaWiki's JobFactory so the
+			// ObjectFactory spec injects the services UpdateJob requires.
+			$this->jobs[] = $jobFactory->newJob( 'smw.update', $title, $parameters );
 		}
 
 		$this->pushToJobQueue();

--- a/src/MediaWiki/Jobs/UpdateDispatcherJob.php
+++ b/src/MediaWiki/Jobs/UpdateDispatcherJob.php
@@ -160,17 +160,22 @@ class UpdateDispatcherJob extends Job {
 	}
 
 	private function create_secondary_dispatch_run( $jobs ): void {
-		$titleFactory = MediaWikiServices::getInstance()->getTitleFactory();
-		$jobFactory = MediaWikiServices::getInstance()->getJobFactory();
+		$services = MediaWikiServices::getInstance();
+		$titleFactory = $services->getTitleFactory();
+		$jobFactory = $services->getJobFactory();
 		$origin = $this->getTitle()->getPrefixedText();
 
 		foreach ( array_chunk( $jobs, self::CHUNK_SIZE, true ) as $jobList ) {
-			// Use MediaWiki's JobFactory so the Store dependency declared
-			// in the JobClasses ObjectFactory spec is wired in.
+			$title = $titleFactory->newFromText( 'UpdateDispatcher/SecondaryRun/' . md5( json_encode( $jobList ) ) );
+			if ( $title === null ) {
+				continue;
+			}
+			/** @var Job $job */
 			$job = $jobFactory->newJob(
 				'smw.updateDispatcher',
-				$titleFactory->newFromText( 'UpdateDispatcher/SecondaryRun/' . md5( json_encode( $jobList ) ) ),
 				[
+					'namespace' => $title->getNamespace(),
+					'title' => $title->getDBkey(),
 					self::JOB_LIST => $jobList,
 					'origin' => $origin,
 
@@ -362,9 +367,10 @@ class UpdateDispatcherJob extends Job {
 				continue;
 			}
 
-			// Construct each UpdateJob through MediaWiki's JobFactory so the
-			// ObjectFactory spec injects the services UpdateJob requires.
-			$this->jobs[] = $jobFactory->newJob( 'smw.update', $title, $parameters );
+			$this->jobs[] = $jobFactory->newJob(
+				'smw.update',
+				[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ] + $parameters
+			);
 		}
 
 		$this->pushToJobQueue();

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -12,6 +12,7 @@ use SMW\Enum;
 use SMW\Listener\EventListener\EventHandler;
 use SMW\MediaWiki\Job;
 use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Store;
 
 /**
  * UpdateJob is responsible for the asynchronous update of semantic data
@@ -20,6 +21,12 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
  * Update jobs are created if, when saving an article,
  * it is detected that the content of other pages must be re-parsed as well (e.g.
  * due to some type change).
+ *
+ * Partial DI: Store is injected via the JobClasses ObjectFactory spec. The
+ * remaining collaborators (PageCreator, PageUpdater, SerializerFactory,
+ * ParserData, ContentParser, MediaWikiLogger) are still resolved through
+ * ApplicationFactory because they are not registered as global SMW.X
+ * services.
  *
  * @note This job does not update the page display or parser cache, so in general
  * it might happen that part of the wiki page still displays old data (e.g.
@@ -54,12 +61,14 @@ class UpdateJob extends Job {
 
 	/**
 	 * @since  1.9
-	 *
-	 * @param Title $title
-	 * @param array $params
 	 */
-	public function __construct( Title $title, $params = [] ) {
+	public function __construct(
+		Title $title,
+		array $params,
+		Store $store
+	) {
 		parent::__construct( 'smw.update', $title, $params );
+		$this->setStore( $store );
 		$this->title = $title;
 		$this->removeDuplicates = true;
 
@@ -70,8 +79,6 @@ class UpdateJob extends Job {
 
 	/**
 	 * @see Job::run
-	 *
-	 * @return bool
 	 */
 	public function run() {
 		// #2199 ("Invalid or virtual namespace -1 given")
@@ -81,7 +88,7 @@ class UpdateJob extends Job {
 
 		MediaWikiServices::getInstance()->getLinkCache()->clear();
 
-		$this->applicationFactory = ApplicationFactory::getInstance();
+		$this->applicationFactory ??= ApplicationFactory::getInstance();
 
 		if ( !$this->hasParameter( self::FORCED_UPDATE ) && $this->matchesLastModified( $this->getTitle() ) ) {
 			return true;
@@ -91,7 +98,7 @@ class UpdateJob extends Job {
 			return $this->doUpdate();
 		}
 
-		$this->applicationFactory->getStore()->clearData(
+		$this->store->clearData(
 			WikiPage::newFromTitle( $this->getTitle() )
 		);
 
@@ -140,7 +147,7 @@ class UpdateJob extends Job {
 
 		// Read the _CHGPRO property and fetch the serialized
 		// SemanticData object
-		$pv = $this->applicationFactory->getStore()->getPropertyValues(
+		$pv = $this->store->getPropertyValues(
 			$subject,
 			new Property( Property::TYPE_CHANGE_PROP )
 		);
@@ -298,7 +305,7 @@ class UpdateJob extends Job {
 	 * has been added using the storage-engine.
 	 */
 	private function getLastModifiedTimestamp( WikiPage $wikiPage ) {
-		$dataItems = $this->applicationFactory->getStore()->getPropertyValues(
+		$dataItems = $this->store->getPropertyValues(
 			$wikiPage,
 			new Property( '_MDAT' )
 		);

--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -8,8 +8,7 @@ use Onoi\MessageReporter\MessageReporterAwareTrait;
 use Onoi\MessageReporter\MessageReporterFactory;
 use RuntimeException;
 use SMW\MediaWiki\HookDispatcherAwareTrait;
-use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
-use SMW\MediaWiki\Jobs\PropertyStatisticsRebuildJob;
+use SMW\MediaWiki\Job;
 use SMW\Options;
 use SMW\Setup;
 use SMW\SetupFile;
@@ -371,9 +370,12 @@ class Installer implements MessageReporter {
 			);
 		}
 
-		$propertyStatisticsRebuildJob = new PropertyStatisticsRebuildJob(
+		$mwJobFactory = MediaWikiServices::getInstance()->getJobFactory();
+
+		$propertyStatisticsRebuildJob = $mwJobFactory->newJob(
+			'smw.propertyStatisticsRebuild',
 			$title,
-			PropertyStatisticsRebuildJob::newRootJobParams( 'smw.propertyStatisticsRebuild', $title ) + [ 'waitOnCommandLine' => true ]
+			Job::newRootJobParams( 'smw.propertyStatisticsRebuild', $title ) + [ 'waitOnCommandLine' => true ]
 		);
 
 		$propertyStatisticsRebuildJob->insert();
@@ -386,9 +388,10 @@ class Installer implements MessageReporter {
 			$this->cliMsgFormatter->firstCol( "... Entity disposer job ...", 3 )
 		);
 
-		$entityIdDisposerJob = new EntityIdDisposerJob(
+		$entityIdDisposerJob = $mwJobFactory->newJob(
+			'smw.entityIdDisposer',
 			$title,
-			EntityIdDisposerJob::newRootJobParams( 'smw.entityIdDisposer', $title ) + [ 'waitOnCommandLine' => true ]
+			Job::newRootJobParams( 'smw.entityIdDisposer', $title ) + [ 'waitOnCommandLine' => true ]
 		);
 
 		$entityIdDisposerJob->insert();

--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -372,6 +372,7 @@ class Installer implements MessageReporter {
 
 		$mwJobFactory = MediaWikiServices::getInstance()->getJobFactory();
 
+		/** @var Job $propertyStatisticsRebuildJob */
 		$propertyStatisticsRebuildJob = $mwJobFactory->newJob(
 			'smw.propertyStatisticsRebuild',
 			$title,
@@ -388,6 +389,7 @@ class Installer implements MessageReporter {
 			$this->cliMsgFormatter->firstCol( "... Entity disposer job ...", 3 )
 		);
 
+		/** @var Job $entityIdDisposerJob */
 		$entityIdDisposerJob = $mwJobFactory->newJob(
 			'smw.entityIdDisposer',
 			$title,

--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -375,8 +375,9 @@ class Installer implements MessageReporter {
 		/** @var Job $propertyStatisticsRebuildJob */
 		$propertyStatisticsRebuildJob = $mwJobFactory->newJob(
 			'smw.propertyStatisticsRebuild',
-			$title,
-			Job::newRootJobParams( 'smw.propertyStatisticsRebuild', $title ) + [ 'waitOnCommandLine' => true ]
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ]
+				+ Job::newRootJobParams( 'smw.propertyStatisticsRebuild', $title )
+				+ [ 'waitOnCommandLine' => true ]
 		);
 
 		$propertyStatisticsRebuildJob->insert();
@@ -392,8 +393,9 @@ class Installer implements MessageReporter {
 		/** @var Job $entityIdDisposerJob */
 		$entityIdDisposerJob = $mwJobFactory->newJob(
 			'smw.entityIdDisposer',
-			$title,
-			Job::newRootJobParams( 'smw.entityIdDisposer', $title ) + [ 'waitOnCommandLine' => true ]
+			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ]
+				+ Job::newRootJobParams( 'smw.entityIdDisposer', $title )
+				+ [ 'waitOnCommandLine' => true ]
 		);
 
 		$entityIdDisposerJob->insert();

--- a/src/SQLStore/RedirectStore.php
+++ b/src/SQLStore/RedirectStore.php
@@ -6,7 +6,6 @@ use MediaWiki\MediaWikiServices;
 use Onoi\Cache\Cache;
 use SMW\InMemoryPoolCache;
 use SMW\Listener\ChangeListener\ChangeRecord;
-use SMW\MediaWiki\Jobs\UpdateJob;
 use SMW\SQLStore\TableBuilder\FieldType;
 use SMW\Store;
 use SMW\Utils\Flag;
@@ -302,15 +301,17 @@ class RedirectStore {
 
 		$res = $queryBuilder->fetchResultSet();
 
-		$titleFactory = MediaWikiServices::getInstance()->getTitleFactory();
+		$services = MediaWikiServices::getInstance();
+		$titleFactory = $services->getTitleFactory();
+		$jobFactory = $services->getJobFactory();
 		foreach ( $res as $row ) {
 			$title = $titleFactory->makeTitleSafe( $row->ns, $row->t );
 
 			if ( $title !== null ) {
-				$jobs[] = new UpdateJob(
+				$jobs[] = $jobFactory->newJob(
+					'smw.update',
 					$title,
-					[ 'origin' => 'RedirectStore' ],
-					$this->store
+					[ 'origin' => 'RedirectStore' ]
 				);
 			}
 		}

--- a/src/SQLStore/RedirectStore.php
+++ b/src/SQLStore/RedirectStore.php
@@ -312,8 +312,11 @@ class RedirectStore {
 			if ( $title !== null ) {
 				$jobs[] = $jobFactory->newJob(
 					'smw.update',
-					$title,
-					[ 'origin' => 'RedirectStore' ]
+					[
+						'namespace' => $title->getNamespace(),
+						'title' => $title->getDBkey(),
+						'origin' => 'RedirectStore',
+					]
 				);
 			}
 		}

--- a/src/SQLStore/RedirectStore.php
+++ b/src/SQLStore/RedirectStore.php
@@ -6,6 +6,7 @@ use MediaWiki\MediaWikiServices;
 use Onoi\Cache\Cache;
 use SMW\InMemoryPoolCache;
 use SMW\Listener\ChangeListener\ChangeRecord;
+use SMW\MediaWiki\Job;
 use SMW\SQLStore\TableBuilder\FieldType;
 use SMW\Store;
 use SMW\Utils\Flag;
@@ -203,6 +204,7 @@ class RedirectStore {
 		}
 
 		foreach ( $jobs as $job ) {
+			/** @var Job $job */
 			if ( $immediateMode ) {
 				$job->run();
 			} else {

--- a/src/SQLStore/RedirectStore.php
+++ b/src/SQLStore/RedirectStore.php
@@ -307,7 +307,11 @@ class RedirectStore {
 			$title = $titleFactory->makeTitleSafe( $row->ns, $row->t );
 
 			if ( $title !== null ) {
-				$jobs[] = new UpdateJob( $title, [ 'origin' => 'RedirectStore' ] );
+				$jobs[] = new UpdateJob(
+					$title,
+					[ 'origin' => 'RedirectStore' ],
+					$this->store
+				);
 			}
 		}
 

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -388,7 +388,7 @@ return [
 			return $servicesFactory->getJobFactory();
 		}
 
-		return new JobFactory();
+		return new JobFactory( $services->getJobFactory() );
 	},
 
 	'SMW.FactboxFactory' => static function ( MediaWikiServices $services ): FactboxFactory {

--- a/tests/phpunit/Integration/MediaWiki/Jobs/FulltextSearchTableRebuildJobTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Jobs/FulltextSearchTableRebuildJobTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\Integration\MediaWiki\Jobs;
 
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Jobs\FulltextSearchTableRebuildJob;
@@ -19,6 +20,16 @@ use SMW\Tests\SMWIntegrationTestCase;
  */
 class FulltextSearchTableRebuildJobTest extends SMWIntegrationTestCase {
 
+	private function newJob( Title $title, array $params = [] ): FulltextSearchTableRebuildJob {
+		/** @var FulltextSearchTableRebuildJob $job */
+		$job = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+			'smw.fulltextSearchTableRebuild',
+			$title,
+			$params
+		);
+		return $job;
+	}
+
 	public function testCanConstruct() {
 		$title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
@@ -26,7 +37,7 @@ class FulltextSearchTableRebuildJobTest extends SMWIntegrationTestCase {
 
 		$this->assertInstanceOf(
 			FulltextSearchTableRebuildJob::class,
-			new FulltextSearchTableRebuildJob( $title )
+			$this->newJob( $title )
 		);
 	}
 
@@ -36,10 +47,7 @@ class FulltextSearchTableRebuildJobTest extends SMWIntegrationTestCase {
 	public function testRunJob( $parameters ) {
 		$subject = WikiPage::newFromText( __METHOD__ );
 
-		$instance = new FulltextSearchTableRebuildJob(
-			$subject->getTitle(),
-			$parameters
-		);
+		$instance = $this->newJob( $subject->getTitle(), $parameters );
 
 		$this->assertTrue(
 			$instance->run()

--- a/tests/phpunit/Integration/Services/ServiceWiringTest.php
+++ b/tests/phpunit/Integration/Services/ServiceWiringTest.php
@@ -3,12 +3,15 @@
 namespace SMW\Tests\Integration\Services;
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use Onoi\Cache\Cache;
 use SMW\Connection\ConnectionManager;
 use SMW\ConstraintFactory;
 use SMW\DataItemFactory;
 use SMW\Elastic\ElasticFactory;
+use SMW\Elastic\Jobs\FileIngestJob;
+use SMW\Elastic\Jobs\IndexerRecoveryJob;
 use SMW\EntityCache;
 use SMW\Factbox\FactboxFactory;
 use SMW\Factbox\FactboxText;
@@ -17,9 +20,6 @@ use SMW\IteratorFactory;
 use SMW\Listener\EventListener\EventListeners\InvalidateEntityCacheEventListener;
 use SMW\Listener\EventListener\EventListeners\InvalidatePropertySpecificationLookupCacheEventListener;
 use SMW\Listener\EventListener\EventListeners\InvalidateResultCacheEventListener;
-use MediaWiki\Title\Title;
-use SMW\Elastic\Jobs\FileIngestJob;
-use SMW\Elastic\Jobs\IndexerRecoveryJob;
 use SMW\MediaWiki\Connection\ConnectionProvider;
 use SMW\MediaWiki\HookDispatcher;
 use SMW\MediaWiki\Job;

--- a/tests/phpunit/Integration/Services/ServiceWiringTest.php
+++ b/tests/phpunit/Integration/Services/ServiceWiringTest.php
@@ -17,10 +17,26 @@ use SMW\IteratorFactory;
 use SMW\Listener\EventListener\EventListeners\InvalidateEntityCacheEventListener;
 use SMW\Listener\EventListener\EventListeners\InvalidatePropertySpecificationLookupCacheEventListener;
 use SMW\Listener\EventListener\EventListeners\InvalidateResultCacheEventListener;
+use MediaWiki\Title\Title;
+use SMW\Elastic\Jobs\FileIngestJob;
+use SMW\Elastic\Jobs\IndexerRecoveryJob;
 use SMW\MediaWiki\Connection\ConnectionProvider;
 use SMW\MediaWiki\HookDispatcher;
+use SMW\MediaWiki\Job;
 use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\JobQueue;
+use SMW\MediaWiki\Jobs\ChangePropagationClassUpdateJob;
+use SMW\MediaWiki\Jobs\ChangePropagationDispatchJob;
+use SMW\MediaWiki\Jobs\ChangePropagationUpdateJob;
+use SMW\MediaWiki\Jobs\DeferredConstraintCheckUpdateJob;
+use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
+use SMW\MediaWiki\Jobs\FulltextSearchTableRebuildJob;
+use SMW\MediaWiki\Jobs\FulltextSearchTableUpdateJob;
+use SMW\MediaWiki\Jobs\ParserCachePurgeJob;
+use SMW\MediaWiki\Jobs\PropertyStatisticsRebuildJob;
+use SMW\MediaWiki\Jobs\RefreshJob;
+use SMW\MediaWiki\Jobs\UpdateDispatcherJob;
+use SMW\MediaWiki\Jobs\UpdateJob;
 use SMW\MediaWiki\ManualEntryLogger;
 use SMW\MediaWiki\MediaWikiNsContentReader;
 use SMW\MediaWiki\Permission\TitlePermissions;
@@ -99,6 +115,45 @@ class ServiceWiringTest extends MediaWikiIntegrationTestCase {
 			[ 'SMW.InvalidateResultCacheEventListener', InvalidateResultCacheEventListener::class ],
 			[ 'SMW.InvalidateEntityCacheEventListener', InvalidateEntityCacheEventListener::class ],
 			[ 'SMW.InvalidatePropertySpecificationLookupCacheEventListener', InvalidatePropertySpecificationLookupCacheEventListener::class ],
+		];
+	}
+
+	/**
+	 * Resolves each SMW JobClasses command through MediaWiki's JobFactory to
+	 * prove the ObjectFactory spec (and any 'services' array attached to it)
+	 * wires successfully.
+	 *
+	 * @dataProvider jobCommandProvider
+	 */
+	public function testJobCommandResolvesToExpectedType( string $command, string $expectedType ): void {
+		$title = Title::makeTitle( NS_MAIN, 'ServiceWiringTest' );
+
+		$job = MediaWikiServices::getInstance()->getJobFactory()->newJob(
+			$command,
+			$title,
+			[]
+		);
+
+		$this->assertInstanceOf( $expectedType, $job );
+		$this->assertInstanceOf( Job::class, $job );
+	}
+
+	public function jobCommandProvider(): array {
+		return [
+			[ 'smw.update', UpdateJob::class ],
+			[ 'smw.refresh', RefreshJob::class ],
+			[ 'smw.updateDispatcher', UpdateDispatcherJob::class ],
+			[ 'smw.fulltextSearchTableUpdate', FulltextSearchTableUpdateJob::class ],
+			[ 'smw.entityIdDisposer', EntityIdDisposerJob::class ],
+			[ 'smw.propertyStatisticsRebuild', PropertyStatisticsRebuildJob::class ],
+			[ 'smw.fulltextSearchTableRebuild', FulltextSearchTableRebuildJob::class ],
+			[ 'smw.changePropagationDispatch', ChangePropagationDispatchJob::class ],
+			[ 'smw.changePropagationUpdate', ChangePropagationUpdateJob::class ],
+			[ 'smw.changePropagationClassUpdate', ChangePropagationClassUpdateJob::class ],
+			[ 'smw.deferredConstraintCheckUpdateJob', DeferredConstraintCheckUpdateJob::class ],
+			[ 'smw.elasticIndexerRecovery', IndexerRecoveryJob::class ],
+			[ 'smw.elasticFileIngest', FileIngestJob::class ],
+			[ 'smw.parserCachePurgeJob', ParserCachePurgeJob::class ],
 		];
 	}
 

--- a/tests/phpunit/Unit/Elastic/Jobs/FileIngestJobTest.php
+++ b/tests/phpunit/Unit/Elastic/Jobs/FileIngestJobTest.php
@@ -13,6 +13,7 @@ use SMW\Elastic\Indexer\FileIndexer;
 use SMW\Elastic\Indexer\Indexer;
 use SMW\Elastic\Jobs\FileIngestJob;
 use SMW\SQLStore\SQLStore;
+use SMW\Store;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -26,7 +27,7 @@ use SMW\Tests\TestEnvironment;
  */
 class FileIngestJobTest extends TestCase {
 
-	private $testEnvironment;
+	private TestEnvironment $testEnvironment;
 	private $fileIndexer;
 	private $title;
 	private $logger;
@@ -66,6 +67,9 @@ class FileIngestJobTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		// pushIngestJob() goes through MediaWiki's JobFactory which resolves
+		// ElasticFactory from the global container; keep the test override
+		// so the lazyPush path is exercised against the same mock.
 		$this->testEnvironment->registerObject( 'ElasticFactory', $this->elasticFactory );
 		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
 	}
@@ -75,10 +79,30 @@ class FileIngestJobTest extends TestCase {
 		parent::tearDown();
 	}
 
+	private function newStore(): Store {
+		return $this->getMockBuilder( SQLStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	private function newJob(
+		Title $title,
+		array $params = [],
+		?Store $store = null,
+		?ElasticFactory $elasticFactory = null
+	): FileIngestJob {
+		return new FileIngestJob(
+			$title,
+			$params,
+			$store ?? $this->newStore(),
+			$elasticFactory ?? $this->elasticFactory
+		);
+	}
+
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			FileIngestJob::class,
-			new FileIngestJob( $this->title )
+			$this->newJob( $this->title )
 		);
 	}
 
@@ -109,10 +133,6 @@ class FileIngestJobTest extends TestCase {
 			->method( 'newFileIndexer' )
 			->willReturn( $this->fileIndexer );
 
-		$config = $this->getMockBuilder( Config::class )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$client = $this->getMockBuilder( Client::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -125,8 +145,6 @@ class FileIngestJobTest extends TestCase {
 			->method( 'getConnection' )
 			->willReturn( $client );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
-
 		$this->title->expects( $this->any() )
 			->method( 'getDBKey' )
 			->willReturn( 'Foo' );
@@ -135,9 +153,7 @@ class FileIngestJobTest extends TestCase {
 			->method( 'getNamespace' )
 			->willReturn( NS_FILE );
 
-		$instance = new FileIngestJob(
-			$this->title
-		);
+		$instance = $this->newJob( $this->title, [], $store );
 
 		$instance->setLogger( $this->logger );
 		$instance->runFileIndexer();
@@ -177,8 +193,6 @@ class FileIngestJobTest extends TestCase {
 			->method( 'getConnection' )
 			->willReturn( $client );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
-
 		$this->title->expects( $this->any() )
 			->method( 'getDBKey' )
 			->willReturn( 'Foo' );
@@ -190,9 +204,7 @@ class FileIngestJobTest extends TestCase {
 		$this->jobQueue->expects( $this->once() )
 			->method( 'push' );
 
-		$instance = new FileIngestJob(
-			$this->title
-		);
+		$instance = $this->newJob( $this->title, [], $store );
 
 		$instance->setLogger( $this->logger );
 		$instance->runFileIndexer();

--- a/tests/phpunit/Unit/Elastic/Jobs/IndexerRecoveryJobTest.php
+++ b/tests/phpunit/Unit/Elastic/Jobs/IndexerRecoveryJobTest.php
@@ -54,9 +54,10 @@ class IndexerRecoveryJobTest extends TestCase {
 			->getMock();
 
 		$this->cache = $this->getMockBuilder( Cache::class )
-			->disableOriginalConstructor()
-			->getMock();
+			->getMockForAbstractClass();
 
+		// Cache is also fetched via ApplicationFactory in
+		// pushFromDocument(); mirror the injected cache there.
 		$this->testEnvironment->registerObject( 'Cache', $this->cache );
 
 		$this->jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
@@ -87,15 +88,24 @@ class IndexerRecoveryJobTest extends TestCase {
 		parent::tearDown();
 	}
 
+	private function newJob( array $params = [], ?ElasticStore $store = null, ?Cache $cache = null ): IndexerRecoveryJob {
+		return new IndexerRecoveryJob(
+			$this->title,
+			$params,
+			$store ?? $this->store,
+			$cache ?? $this->cache
+		);
+	}
+
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			IndexerRecoveryJob::class,
-			new IndexerRecoveryJob( $this->title )
+			$this->newJob()
 		);
 	}
 
 	public function testAllowRetries() {
-		$instance = new IndexerRecoveryJob( $this->title );
+		$instance = $this->newJob();
 
 		$this->assertFalse(
 			$instance->allowRetries()
@@ -118,12 +128,7 @@ class IndexerRecoveryJobTest extends TestCase {
 			->method( 'getConnection' )
 			->willReturn( $this->connection );
 
-		$this->testEnvironment->registerObject( 'Store', $this->store );
-
-		$instance = new IndexerRecoveryJob(
-			$this->title,
-			[ 'create' => 'Foo#0##' ]
-		);
+		$instance = $this->newJob( [ 'create' => 'Foo#0##' ] );
 
 		$instance->run();
 	}
@@ -144,12 +149,7 @@ class IndexerRecoveryJobTest extends TestCase {
 			->method( 'getConnection' )
 			->willReturn( $this->connection );
 
-		$this->testEnvironment->registerObject( 'Store', $this->store );
-
-		$instance = new IndexerRecoveryJob(
-			$this->title,
-			[ 'delete' => [ 'Foo' ] ]
-		);
+		$instance = $this->newJob( [ 'delete' => [ 'Foo' ] ] );
 
 		$instance->run();
 	}
@@ -167,16 +167,11 @@ class IndexerRecoveryJobTest extends TestCase {
 			->method( 'getConnection' )
 			->willReturn( $this->connection );
 
-		$this->testEnvironment->registerObject( 'Store', $this->store );
-
 		$this->cache->expects( $this->once() )
 			->method( 'fetch' )
 			->with( $this->stringContains( 'smw:elastic:document:d1ea1c1728561f9d6aeed8c28b9b7617' ) );
 
-		$instance = new IndexerRecoveryJob(
-			$this->title,
-			[ 'index' => 'Foo#0##' ]
-		);
+		$instance = $this->newJob( [ 'index' => 'Foo#0##' ] );
 
 		$instance->run();
 	}
@@ -203,12 +198,7 @@ class IndexerRecoveryJobTest extends TestCase {
 		$this->jobQueue->expects( $this->once() )
 			->method( 'push' );
 
-		$this->testEnvironment->registerObject( 'Store', $this->store );
-
-		$instance = new IndexerRecoveryJob(
-			$this->title,
-			[ 'index' => 'Foo#0##' ]
-		);
+		$instance = $this->newJob( [ 'index' => 'Foo#0##' ] );
 
 		$instance->run();
 	}

--- a/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
@@ -154,13 +154,18 @@ class ChangePropagationDispatchJobTest extends TestCase {
 	public function testFindAndDispatchOnNonPropertyEntity() {
 		$subject = WikiPage::newFromText( 'Foo' );
 
+		$jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$jobQueue->expects( $this->never() )
+			->method( 'lazyPush' );
+
+		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
+
 		$instance = $this->newJob( $subject->getTitle() );
 
 		$instance->run();
-
-		// Reaching here without exception is the assertion; no job pushes
-		// happen for the non-property namespace.
-		$this->expectNotToPerformAssertions();
 	}
 
 	public function testPlanAsJob() {

--- a/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
@@ -6,8 +6,10 @@ use MediaWiki\Title\Title;
 use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
+use SMW\IteratorFactory;
 use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\Jobs\ChangePropagationDispatchJob;
+use SMW\Property\SpecificationLookup as PropertySpecificationLookup;
 use SMW\SQLStore\PropertyTableInfoFetcher;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
@@ -23,23 +25,58 @@ use SMW\Tests\TestEnvironment;
  */
 class ChangePropagationDispatchJobTest extends TestCase {
 
-	private $testEnvironment;
+	private TestEnvironment $testEnvironment;
 
 	protected function setUp(): void {
 		parent::setUp();
 
+		// Static helpers planAsJob() / hasPendingJobs() / cleanUp() still go
+		// through ApplicationFactory; register defaults the test environment
+		// expects.
 		$this->testEnvironment = new TestEnvironment();
-
-		$store = $this->getMockBuilder( SQLStore::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown(): void {
 		$this->testEnvironment->tearDown();
 		parent::tearDown();
+	}
+
+	private function newCache(): Cache {
+		return $this->getMockBuilder( Cache::class )->getMockForAbstractClass();
+	}
+
+	private function newPropertySpecificationLookup(): PropertySpecificationLookup {
+		return $this->getMockBuilder( PropertySpecificationLookup::class )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	private function newIteratorFactory(): IteratorFactory {
+		return new IteratorFactory();
+	}
+
+	private function newStore(): SQLStore {
+		return $this->getMockBuilder( SQLStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	private function newJob(
+		Title $title,
+		array $params = [],
+		?SQLStore $store = null,
+		?Cache $cache = null,
+		?PropertySpecificationLookup $propertySpecificationLookup = null,
+		?IteratorFactory $iteratorFactory = null
+	): ChangePropagationDispatchJob {
+		return new ChangePropagationDispatchJob(
+			$title,
+			$params,
+			$store ?? $this->newStore(),
+			$cache ?? $this->newCache(),
+			$propertySpecificationLookup ?? $this->newPropertySpecificationLookup(),
+			$iteratorFactory ?? $this->newIteratorFactory()
+		);
 	}
 
 	public function testCanConstruct() {
@@ -49,7 +86,7 @@ class ChangePropagationDispatchJobTest extends TestCase {
 
 		$this->assertInstanceOf(
 			ChangePropagationDispatchJob::class,
-			new ChangePropagationDispatchJob( $title )
+			$this->newJob( $title )
 		);
 	}
 
@@ -117,20 +154,13 @@ class ChangePropagationDispatchJobTest extends TestCase {
 	public function testFindAndDispatchOnNonPropertyEntity() {
 		$subject = WikiPage::newFromText( 'Foo' );
 
-		$jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$jobQueue->expects( $this->never() )
-			->method( 'lazyPush' );
-
-		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
-
-		$instance = new ChangePropagationDispatchJob(
-			$subject->getTitle()
-		);
+		$instance = $this->newJob( $subject->getTitle() );
 
 		$instance->run();
+
+		// Reaching here without exception is the assertion; no job pushes
+		// happen for the non-property namespace.
+		$this->expectNotToPerformAssertions();
 	}
 
 	public function testPlanAsJob() {
@@ -204,13 +234,16 @@ class ChangePropagationDispatchJobTest extends TestCase {
 			->method( 'getConnection' )
 			->willReturn( $connection );
 
+		// commitSpecificationChangePropagationAsJob -> newChangePropagationUpdateJob
+		// will construct an inner UpdateJob via ApplicationFactory -> Store.
 		$this->testEnvironment->registerObject( 'Store', $store );
 
-		$instance = new ChangePropagationDispatchJob(
+		$instance = $this->newJob(
 			$subject->getTitle(),
 			[
 				'isTypePropagation' => true
-			]
+			],
+			$store
 		);
 
 		$instance->run();
@@ -226,8 +259,6 @@ class ChangePropagationDispatchJobTest extends TestCase {
 		$store->expects( $this->any() )
 			->method( 'getPropertyValues' )
 			->willReturn( [ $dataItem ] );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
 
 		$subject = WikiPage::newFromText( 'Foo' );
 
@@ -248,12 +279,13 @@ class ChangePropagationDispatchJobTest extends TestCase {
 
 		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
 
-		$instance = new ChangePropagationDispatchJob(
+		$instance = $this->newJob(
 			$subject->getTitle(),
 			[
 				'schema_change_propagation' => true,
 				'property_key' => 'Foo'
-			]
+			],
+			$store
 		);
 
 		$instance->run();

--- a/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
@@ -6,11 +6,11 @@ use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use SMW\Connection\ConnectionManager;
 use SMW\DataItems\WikiPage;
+use SMW\IteratorFactory;
 use SMW\Iterators\ResultIterator;
 use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
 use SMW\SQLStore\SQLStore;
-use SMW\Tests\TestEnvironment;
 use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
 /**
@@ -26,13 +26,10 @@ class EntityIdDisposerJobTest extends TestCase {
 
 	use MockSelectQueryBuilderTrait;
 
-	private $testEnvironment;
 	private $connection;
 
 	protected function setUp(): void {
 		parent::setUp();
-
-		$this->testEnvironment = new TestEnvironment();
 
 		$this->connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
@@ -41,7 +38,9 @@ class EntityIdDisposerJobTest extends TestCase {
 		$this->connection->expects( $this->any() )
 			->method( 'newSelectQueryBuilder' )
 			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder() );
+	}
 
+	private function newStore(): SQLStore {
 		$store = $this->getMockBuilder( SQLStore::class )
 			->getMockForAbstractClass();
 
@@ -55,12 +54,20 @@ class EntityIdDisposerJobTest extends TestCase {
 
 		$store->setConnectionManager( $connectionManager );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
+		return $store;
 	}
 
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
+	private function newIteratorFactory(): IteratorFactory {
+		return new IteratorFactory();
+	}
+
+	private function newJob( Title $title, array $params = [] ): EntityIdDisposerJob {
+		return new EntityIdDisposerJob(
+			$title,
+			$params,
+			$this->newStore(),
+			$this->newIteratorFactory()
+		);
 	}
 
 	public function testCanConstruct() {
@@ -70,7 +77,7 @@ class EntityIdDisposerJobTest extends TestCase {
 
 		$this->assertInstanceOf(
 			EntityIdDisposerJob::class,
-			new EntityIdDisposerJob( $title )
+			$this->newJob( $title )
 		);
 	}
 
@@ -79,7 +86,7 @@ class EntityIdDisposerJobTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new EntityIdDisposerJob( $title );
+		$instance = $this->newJob( $title );
 
 		$this->assertInstanceOf(
 			ResultIterator::class,
@@ -92,7 +99,7 @@ class EntityIdDisposerJobTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new EntityIdDisposerJob( $title );
+		$instance = $this->newJob( $title );
 
 		$this->assertInstanceOf(
 			ResultIterator::class,
@@ -105,7 +112,7 @@ class EntityIdDisposerJobTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new EntityIdDisposerJob( $title );
+		$instance = $this->newJob( $title );
 
 		$this->assertInstanceOf(
 			ResultIterator::class,
@@ -118,7 +125,7 @@ class EntityIdDisposerJobTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new EntityIdDisposerJob( $title );
+		$instance = $this->newJob( $title );
 
 		$this->assertInstanceOf(
 			ResultIterator::class,
@@ -148,10 +155,7 @@ class EntityIdDisposerJobTest extends TestCase {
 
 		$subject = WikiPage::newFromText( __METHOD__ );
 
-		$instance = new EntityIdDisposerJob(
-			$subject->getTitle(),
-			$parameters
-		);
+		$instance = $this->newJob( $subject->getTitle(), $parameters );
 
 		$this->assertTrue(
 			$instance->run()

--- a/tests/phpunit/Unit/MediaWiki/Jobs/FulltextSearchTableUpdateJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/FulltextSearchTableUpdateJobTest.php
@@ -7,7 +7,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Jobs\FulltextSearchTableUpdateJob;
 use SMW\SQLStore\SQLStore;
-use SMW\Tests\TestEnvironment;
+use SMW\Store;
 
 /**
  * @covers \SMW\MediaWiki\Jobs\FulltextSearchTableUpdateJob
@@ -20,22 +20,8 @@ use SMW\Tests\TestEnvironment;
  */
 class FulltextSearchTableUpdateJobTest extends TestCase {
 
-	private $testEnvironment;
-
-	protected function setUp(): void {
-		parent::setUp();
-
-		$this->testEnvironment = new TestEnvironment();
-
-		$this->testEnvironment->registerObject(
-			'Store',
-			$this->getMockBuilder( SQLStore::class )->getMockForAbstractClass()
-		);
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
+	private function newStore(): Store {
+		return $this->getMockBuilder( SQLStore::class )->getMockForAbstractClass();
 	}
 
 	public function testCanConstruct() {
@@ -45,7 +31,7 @@ class FulltextSearchTableUpdateJobTest extends TestCase {
 
 		$this->assertInstanceOf(
 			FulltextSearchTableUpdateJob::class,
-			new FulltextSearchTableUpdateJob( $title )
+			new FulltextSearchTableUpdateJob( $title, [], $this->newStore() )
 		);
 	}
 
@@ -57,7 +43,8 @@ class FulltextSearchTableUpdateJobTest extends TestCase {
 
 		$instance = new FulltextSearchTableUpdateJob(
 			$subject->getTitle(),
-			$parameters
+			$parameters,
+			$this->newStore()
 		);
 
 		$this->assertTrue(

--- a/tests/phpunit/Unit/MediaWiki/Jobs/PropertyStatisticsRebuildJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/PropertyStatisticsRebuildJobTest.php
@@ -27,24 +27,31 @@ class PropertyStatisticsRebuildJobTest extends TestCase {
 	use MockSelectQueryBuilderTrait;
 	use MockWriteQueryBuilderTrait;
 
-	private $testEnvironment;
+	private TestEnvironment $testEnvironment;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$row = new stdClass;
+		// Needed because PropertyStatisticsRebuildJob::rebuild() goes through
+		// ApplicationFactory::newDeferredTransactionalCallableUpdate(); the
+		// test environment ensures no global state leaks.
+		$this->testEnvironment = new TestEnvironment();
+	}
+
+	protected function tearDown(): void {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	private function newStore(): SQLStore {
+		$row = new stdClass();
 		$row->smw_title = 'Test';
 		$row->smw_id = 42;
-
-		$this->testEnvironment = new TestEnvironment();
 
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		// PropertyStatisticsRebuilder::rebuild() reads through newSelectQueryBuilder
-		// and the underlying PropertyStatisticsStore writes via
-		// newDeleteQueryBuilder() and newInsertQueryBuilder().
 		$connection->method( 'newSelectQueryBuilder' )
 			->willReturnCallback( fn () => $this->createMockSelectQueryBuilder( [ $row ] ) );
 		$connection->method( 'newDeleteQueryBuilder' )
@@ -64,12 +71,7 @@ class PropertyStatisticsRebuildJobTest extends TestCase {
 			->method( 'getPropertyTables' )
 			->willReturn( [] );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
+		return $store;
 	}
 
 	public function testCanConstruct() {
@@ -79,7 +81,7 @@ class PropertyStatisticsRebuildJobTest extends TestCase {
 
 		$this->assertInstanceOf(
 			PropertyStatisticsRebuildJob::class,
-			new PropertyStatisticsRebuildJob( $title )
+			new PropertyStatisticsRebuildJob( $title, [], $this->newStore() )
 		);
 	}
 
@@ -91,7 +93,8 @@ class PropertyStatisticsRebuildJobTest extends TestCase {
 
 		$instance = new PropertyStatisticsRebuildJob(
 			$subject->getTitle(),
-			$parameters
+			$parameters,
+			$this->newStore()
 		);
 
 		$this->assertTrue(

--- a/tests/phpunit/Unit/MediaWiki/Jobs/RefreshJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/RefreshJobTest.php
@@ -6,7 +6,6 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Jobs\RefreshJob;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\Rebuilder\Rebuilder;
 use SMW\Store;
 
@@ -24,24 +23,10 @@ class RefreshJobTest extends TestCase {
 	/** @var int */
 	protected $controlRefreshDataIndex;
 
-	private $applicationFactory;
-
-	protected function setUp(): void {
-		parent::setUp();
-
-		$this->applicationFactory = ApplicationFactory::getInstance();
-
-		$store = $this->getMockBuilder( Store::class )
+	private function newStore(): Store {
+		return $this->getMockBuilder( Store::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
-
-		$this->applicationFactory->registerObject( 'Store', $store );
-	}
-
-	protected function tearDown(): void {
-		$this->applicationFactory->clear();
-
-		parent::tearDown();
 	}
 
 	public function testCanConstruct() {
@@ -51,7 +36,7 @@ class RefreshJobTest extends TestCase {
 
 		$this->assertInstanceOf(
 			RefreshJob::class,
-			new RefreshJob( $title )
+			new RefreshJob( $title, [], $this->newStore() )
 		);
 	}
 
@@ -79,9 +64,7 @@ class RefreshJobTest extends TestCase {
 			->method( 'refreshData' )
 			->willReturn( $rebuilder );
 
-		$this->applicationFactory->registerObject( 'Store', $store );
-
-		$instance = new RefreshJob( $title, $parameters );
+		$instance = new RefreshJob( $title, $parameters, $store );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertTrue( $instance->run() );
@@ -93,9 +76,6 @@ class RefreshJobTest extends TestCase {
 		);
 	}
 
-	/**
-	 * @return array
-	 */
 	public function parameterDataProvider() {
 		$provider = [];
 

--- a/tests/phpunit/Unit/MediaWiki/Jobs/UpdateDispatcherJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/UpdateDispatcherJobTest.php
@@ -27,28 +27,30 @@ class UpdateDispatcherJobTest extends TestCase {
 	protected $expectedProperty;
 	protected $expectedSubjects;
 	private $semanticDataSerializer;
-	private $testEnvironment;
+	private TestEnvironment $testEnvironment;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->semanticDataSerializer = ApplicationFactory::getInstance()->newSerializerFactory()->newSemanticDataSerializer();
 
+		// SerializerFactory is still resolved through ApplicationFactory by the
+		// job under test; configure the environment with default settings.
 		$this->testEnvironment = new TestEnvironment( [
 			'smwgMainCacheType'        => 'hash',
 			'smwgEnableUpdateJobs' => false
 		] );
-
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown(): void {
 		$this->testEnvironment->tearDown();
 		parent::tearDown();
+	}
+
+	private function newStore(): Store {
+		return $this->getMockBuilder( Store::class )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
 	}
 
 	public function testCanConstruct() {
@@ -58,7 +60,7 @@ class UpdateDispatcherJobTest extends TestCase {
 
 		$this->assertInstanceOf(
 			UpdateDispatcherJob::class,
-			new UpdateDispatcherJob( $title )
+			new UpdateDispatcherJob( $title, [], $this->newStore() )
 		);
 	}
 
@@ -67,7 +69,7 @@ class UpdateDispatcherJobTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new UpdateDispatcherJob( $title, [] );
+		$instance = new UpdateDispatcherJob( $title, [], $this->newStore() );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertNull( $instance->pushToJobQueue() );
@@ -83,7 +85,7 @@ class UpdateDispatcherJobTest extends TestCase {
 				'Foo#0##' => true,
 				'Bar#102##'
 			]
-		] );
+		], $this->newStore() );
 
 		$instance->isEnabledJobQueue( false );
 		$instance->run();
@@ -104,7 +106,7 @@ class UpdateDispatcherJobTest extends TestCase {
 				'|nulltitle#0##' => true,
 				'deserlizeerror#0' => true
 			]
-		] );
+		], $this->newStore() );
 
 		$instance->isEnabledJobQueue( false );
 		$instance->run();
@@ -133,9 +135,7 @@ class UpdateDispatcherJobTest extends TestCase {
 			->method( 'getInProperties' )
 			->willReturn( [] );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
-
-		$instance = new UpdateDispatcherJob( $title, [] );
+		$instance = new UpdateDispatcherJob( $title, [], $store );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertTrue( $instance->run() );
@@ -169,9 +169,7 @@ class UpdateDispatcherJobTest extends TestCase {
 			->method( 'getPropertySubjects' )
 			->willReturn( [] );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
-
-		$instance = new UpdateDispatcherJob( $title, [] );
+		$instance = new UpdateDispatcherJob( $title, [], $store );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertTrue( $instance->run() );
@@ -200,9 +198,7 @@ class UpdateDispatcherJobTest extends TestCase {
 			->method( 'getAllPropertySubjects' )
 			->willReturn( [] );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
-
-		$instance = new UpdateDispatcherJob( $title, $parameters );
+		$instance = new UpdateDispatcherJob( $title, $parameters, $store );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertTrue(
@@ -247,9 +243,7 @@ class UpdateDispatcherJobTest extends TestCase {
 			->method( 'getPropertySubjects' )
 			->willReturn( [] );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
-
-		$instance = new UpdateDispatcherJob( $setup['title'], $setup['parameters'] );
+		$instance = new UpdateDispatcherJob( $setup['title'], $setup['parameters'], $store );
 		$instance->isEnabledJobQueue( false );
 		$instance->run();
 
@@ -304,9 +298,7 @@ class UpdateDispatcherJobTest extends TestCase {
 			->method( 'getPropertySubjects' )
 			->willReturn( [] );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
-
-		$instance = new UpdateDispatcherJob( $setup['title'], $parameters );
+		$instance = new UpdateDispatcherJob( $setup['title'], $parameters, $store );
 		$instance->isEnabledJobQueue( false );
 		$instance->run();
 

--- a/tests/phpunit/Unit/MediaWiki/Jobs/UpdateJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/UpdateJobTest.php
@@ -28,13 +28,17 @@ use SMW\Tests\TestEnvironment;
  */
 class UpdateJobTest extends TestCase {
 
-	private $testEnvironment;
+	private TestEnvironment $testEnvironment;
 	private $semanticDataFactory;
 	private $semanticDataSerializer;
 
 	protected function setUp(): void {
 		parent::setUp();
 
+		// UpdateJob still resolves ContentParser, PageCreator, PageUpdater,
+		// SerializerFactory, ParserData and MediaWikiLogger through
+		// ApplicationFactory; the test environment lets these collaborators
+		// be swapped via registerObject() without touching global state.
 		$this->testEnvironment = new TestEnvironment( [
 			'smwgMainCacheType'        => 'hash',
 			'smwgEnableUpdateJobs' => false,
@@ -42,6 +46,22 @@ class UpdateJobTest extends TestCase {
 			'smwgDVFeatures' => '',
 		] );
 
+		$revisionGuard = $this->getMockBuilder( RevisionGuard::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment->registerObject( 'RevisionGuard', $revisionGuard );
+
+		$this->semanticDataFactory = $this->testEnvironment->getUtilityFactory()->newSemanticDataFactory();
+		$this->semanticDataSerializer = ApplicationFactory::getInstance()->newSerializerFactory()->newSemanticDataSerializer();
+	}
+
+	protected function tearDown(): void {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	private function newStoreWithIdTable(): SQLStore {
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->setMethods( [ 'exists', 'findAssociatedRev' ] )
 			->getMock();
@@ -59,21 +79,7 @@ class UpdateJobTest extends TestCase {
 			->method( 'getPropertyValues' )
 			->willReturn( [] );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
-
-		$revisionGuard = $this->getMockBuilder( RevisionGuard::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->testEnvironment->registerObject( 'RevisionGuard', $revisionGuard );
-
-		$this->semanticDataFactory = $this->testEnvironment->getUtilityFactory()->newSemanticDataFactory();
-		$this->semanticDataSerializer = ApplicationFactory::getInstance()->newSerializerFactory()->newSemanticDataSerializer();
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
+		return $store;
 	}
 
 	public function testCanConstruct() {
@@ -83,7 +89,7 @@ class UpdateJobTest extends TestCase {
 
 		$this->assertInstanceOf(
 			UpdateJob::class,
-			new UpdateJob( $title )
+			new UpdateJob( $title, [], $this->newStoreWithIdTable() )
 		);
 	}
 
@@ -96,7 +102,7 @@ class UpdateJobTest extends TestCase {
 			->method( 'exists' )
 			->willReturn( true );
 
-		$instance = new UpdateJob( $title );
+		$instance = new UpdateJob( $title, [], $this->newStoreWithIdTable() );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertFalse(	$instance->run() );
@@ -121,7 +127,7 @@ class UpdateJobTest extends TestCase {
 
 		$this->testEnvironment->registerObject( 'ContentParser', null );
 
-		$instance = new UpdateJob( $title );
+		$instance = new UpdateJob( $title, [], $this->newStoreWithIdTable() );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertTrue( $instance->run() );
@@ -146,7 +152,7 @@ class UpdateJobTest extends TestCase {
 
 		$this->testEnvironment->registerObject( 'ContentParser', $contentParser );
 
-		$instance = new UpdateJob( $title );
+		$instance = new UpdateJob( $title, [], $this->newStoreWithIdTable() );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertFalse( $instance->run() );
@@ -203,9 +209,12 @@ class UpdateJobTest extends TestCase {
 		$store->expects( $this->once() )
 			->method( 'clearData' );
 
+		// ParserData::updateStore() goes through ApplicationFactory and uses
+		// the Store registered there; mirror the injected store on the
+		// service locator so DataUpdater sees the same idTable.
 		$this->testEnvironment->registerObject( 'Store', $store );
 
-		$instance = new UpdateJob( $title );
+		$instance = new UpdateJob( $title, [], $store );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertTrue( $instance->run() );
@@ -267,7 +276,7 @@ class UpdateJobTest extends TestCase {
 
 		$this->testEnvironment->registerObject( 'Store', $store );
 
-		$instance = new UpdateJob( $title, [ 'shallowUpdate' => true ] );
+		$instance = new UpdateJob( $title, [ 'shallowUpdate' => true ], $store );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertTrue( $instance->run() );
@@ -293,7 +302,8 @@ class UpdateJobTest extends TestCase {
 		$instance = new UpdateJob( $title,
 			[
 				UpdateJob::SEMANTIC_DATA => $semanticData
-			]
+			],
+			$store
 		);
 
 		$instance->isEnabledJobQueue( false );
@@ -327,7 +337,8 @@ class UpdateJobTest extends TestCase {
 		$instance = new UpdateJob( $subject->getTitle(),
 			[
 				UpdateJob::CHANGE_PROP => $subject->getSerialization()
-			]
+			],
+			$store
 		);
 
 		$instance->isEnabledJobQueue( false );

--- a/tests/phpunit/Utils/PageRefresher.php
+++ b/tests/phpunit/Utils/PageRefresher.php
@@ -5,7 +5,6 @@ namespace SMW\Tests\Utils;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use RuntimeException;
-use SMW\MediaWiki\Jobs\UpdateJob;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use WikiPage;
 
@@ -83,7 +82,7 @@ class PageRefresher {
 			throw new RuntimeException( 'Expected a title instance' );
 		}
 
-		$job = new UpdateJob( $title );
+		$job = ApplicationFactory::getInstance()->getJobFactory()->newUpdateJob( $title );
 		$job->run();
 
 		return $this;


### PR DESCRIPTION
> **Stacks on #6855.** This PR targets `spike-global-service-registration` so the diff shows only the Jobs-DI changes. Merge #6855 first; this PR then auto-retargets to `master`.

## Summary

Sixth slice of the follow-up to #6827: moving SMW classes off global service-locator dependency access. This is the first framework-constrained slice; SMW `Job` subclasses cannot take arbitrary required constructor parameters because MediaWiki's job runner reconstructs them via `Job::factory()` with only `(Title, $params)`. The MW-canonical solution is `JobClasses` ObjectFactory specs with a `services` array, which #6855 unlocks by registering SMW services on `MediaWikiServices`.

## Pattern

Each `JobClasses` entry in `extension.json` is upgraded to an ObjectFactory spec; each Job's constructor takes those services as required parameters after `(Title, $params)` (ObjectFactory's extraArgs ordering).

`extension.json`:

```json
"smw.refresh": {
    "class": "SMW\\MediaWiki\\Jobs\\RefreshJob",
    "services": [ "SMW.Store" ]
}
```

`RefreshJob`:

```php
public function __construct(
    Title $title,
    array $params,
    Store $store
) {
    parent::__construct( 'smw.refresh', $title, $params );
    $this->setStore( $store );
}
```

`$params` loses its default `= []` because a required parameter follows it; the typed factory methods on SMW's `JobFactory` keep accepting the optional `$parameters = []` and pass `[]` through to MediaWiki's `JobFactory::newJob()` when omitted.

## SMW JobFactory delegation

`src/MediaWiki/JobFactory.php` previously instantiated each Job class directly. It now delegates every typed `newXxxJob()` method to `MediaWiki\JobQueue\JobFactory::newJob()` so ObjectFactory resolves the spec (and any declared services). The wrapper still exists for call-sites that want typed entry points. The `SMW.JobFactory` wiring callback in `src/Services/ServiceWiring.php` constructs `new JobFactory( $services->getJobFactory() )`.

`Job::waitOnCommandLineMode()` re-enqueues through MW's JobFactory rather than `new static(...)` so a job re-enqueued from itself picks up the services declared on its spec.

## Changes

**Jobs converted** (9 in `src/MediaWiki/Jobs/`, 2 in `src/Elastic/Jobs/`):

- `RefreshJob` (Store)
- `FulltextSearchTableUpdateJob` / `FulltextSearchTableRebuildJob` (Store)
- `PropertyStatisticsRebuildJob` (Store)
- `ParserCachePurgeJob` (no services; logger is now lazy via `LoggerAwareTrait`)
- `EntityIdDisposerJob` (Store, IteratorFactory)
- `UpdateDispatcherJob` (Store)
- `UpdateJob` (Store; partial - see below)
- `ChangePropagationDispatchJob` (Store, Cache, PropertySpecificationLookup, IteratorFactory)
- `FileIngestJob` (Store, ElasticFactory)
- `IndexerRecoveryJob` (Store, Cache)

**Dead-scaffolding removals** (test-only): several `registerObject('Store', ...)` calls in `setUp()` were observed to be unbacked by any test assertion; the tests rely on per-test re-registration of more-specific Store mocks.

## Kept as-is

- **Static methods** on `ChangePropagationDispatchJob` (`planAsJob`, `cleanUp`, `hasPendingJobs`, `getPendingJobsCount`) retain direct locator access because instance setters cannot intervene in static calls. The corresponding tests retain their `registerObject` lines.
- **`UpdateJob`** keeps a `$this->applicationFactory ??= ApplicationFactory::getInstance()` cache because it still pulls `newPageCreator`, `newPageUpdater`, `newSerializerFactory`, `newParserData`, `newContentParser`, and `getMediaWikiLogger` from the factory. A class-level comment marks this as a partial DI conversion; a later slice should convert the remaining factory methods after they are registered as services.
- **Transitive `registerObject`** in `UpdateJobTest`, `FileIngestJobTest`, `IndexerRecoveryJobTest`: when an SMW collaborator (for example `ParserData::updateStore`, `Job::insert`) reaches the locator on the Job's behalf, the mock cannot be supplied through the Job's constructor. Documented inline.

## Numbers

`registerObject(` call count across the affected test files: **43 -> 24** (-19); the remaining ones cover transitive collaborators or static-method tests.

## Test plan

- Unit suite (`semantic-mediawiki-unit`) on the stacked base: 7081 tests / 14495 assertions / 0 failures / 6 pre-existing skips.
- Integration `ServiceWiringTest` is extended to resolve every `JobClasses` command through `MediaWikiServices::getJobFactory()`, exercising the ObjectFactory spec end-to-end (14 commands).
- PHPCS clean on all changed files.
- phan and integration suites expected to be covered by CI.