### PR TITLE
Upgrade param-processor version requirement to ~1.13

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 		"php": ">=8.1",
 		"ext-mbstring": "*",
 		"composer/installers": "^2.2.0|^1.0.1",
-		"param-processor/param-processor": "~1.2",
+		"param-processor/param-processor": "~1.13",
 		"serialization/serialization": "~4.0",
 		"jeroen/message-reporter": "~1.0",
 		"onoi/cache": "~1.2",


### PR DESCRIPTION
Updated the version constraint for param-processor to ~1.13.