### PR TITLE
Globalise stateless SMW services on MediaWikiServices

### DIFF
--- a/src/DependencyValidator.php
+++ b/src/DependencyValidator.php
@@ -17,43 +17,18 @@ class DependencyValidator {
 
 	use EventDispatcherAwareTrait;
 
-	private NamespaceExaminer $namespaceExaminer;
-
-	private DependencyLinksValidator $dependencyLinksValidator;
-
-	private EntityCache $entityCache;
-
-	private int $cacheTTL = 3600;
-
-	private ?string $eTag = null;
-
 	private static array $titles = [];
 
 	/**
 	 * @since 3.1
 	 */
 	public function __construct(
-		NamespaceExaminer $namespaceExaminer,
-		DependencyLinksValidator $dependencyLinksValidator,
-		EntityCache $entityCache
+		private readonly NamespaceExaminer $namespaceExaminer,
+		private readonly DependencyLinksValidator $dependencyLinksValidator,
+		private readonly EntityCache $entityCache,
+		private readonly string $eTag,
+		private readonly int $cacheTTL
 	) {
-		$this->namespaceExaminer = $namespaceExaminer;
-		$this->dependencyLinksValidator = $dependencyLinksValidator;
-		$this->entityCache = $entityCache;
-	}
-
-	/**
-	 * @since 3.1
-	 */
-	public function setCacheTTL( int $cacheTTL ): void {
-		$this->cacheTTL = $cacheTTL;
-	}
-
-	/**
-	 * @since 3.1
-	 */
-	public function setETag( string $eTag ): void {
-		$this->eTag = $eTag;
 	}
 
 	/**

--- a/src/MediaWiki/Hooks.php
+++ b/src/MediaWiki/Hooks.php
@@ -654,16 +654,11 @@ class Hooks {
 		// parser cache
 		$parserCache = $applicationFactory->create( 'ParserCache' );
 
-		$dependencyValidator = $applicationFactory->create( 'DependencyValidator' );
-
 		// #4741
 		$wikiPage = $page->getPage();
 
-		$dependencyValidator->setETag(
-			$this->getETag( $parserCache, $wikiPage, $wikiPage->makeParserOptions( 'canonical' ) )
-		);
-
-		$dependencyValidator->setCacheTTL(
+		$dependencyValidator = $applicationFactory->newDependencyValidator(
+			$this->getETag( $parserCache, $wikiPage, $wikiPage->makeParserOptions( 'canonical' ) ),
 			Site::getCacheExpireTime( 'parser' )
 		);
 
@@ -706,10 +701,8 @@ class Hooks {
 		// parser cache
 		$parserCache = $applicationFactory->create( 'ParserCache' );
 
-		$dependencyValidator = $applicationFactory->create( 'DependencyValidator' );
-		$dependencyValidator->setETag( $this->getETag( $parserCache, $page, $popts ) );
-
-		$dependencyValidator->setCacheTTL(
+		$dependencyValidator = $applicationFactory->newDependencyValidator(
+			$this->getETag( $parserCache, $page, $popts ),
 			Site::getCacheExpireTime( 'parser' )
 		);
 

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -42,6 +42,8 @@ use SMW\Query\QuerySourceFactory;
 use SMW\QueryFactory;
 use SMW\Schema\SchemaFactory;
 use SMW\SerializerFactory;
+use SMW\Services\DataValueServiceFactory;
+use SMW\Services\ImporterServiceFactory;
 use SMW\Services\ServicesFactory;
 use SMW\Settings;
 use SMW\SetupFile;
@@ -662,6 +664,34 @@ return [
 		);
 
 		return $namespaceExaminer;
+	},
+
+	'SMW.DataValueServiceFactory' => static function ( MediaWikiServices $services ): DataValueServiceFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'DataValueServiceFactory' ) ) {
+			return $servicesFactory->getDataValueServiceFactory();
+		}
+
+		$servicesContainer = DataValueServiceFactory::newServicesContainer(
+			$servicesFactory->getSettings()->get( 'smwgServicesFileDir' )
+		);
+
+		return new DataValueServiceFactory( $servicesContainer );
+	},
+
+	'SMW.ImporterServiceFactory' => static function ( MediaWikiServices $services ): ImporterServiceFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'ImporterServiceFactory' ) ) {
+			return $servicesFactory->getImporterServiceFactory();
+		}
+
+		$servicesContainer = ImporterServiceFactory::newServicesContainer(
+			$servicesFactory->getSettings()->get( 'smwgServicesFileDir' )
+		);
+
+		return new ImporterServiceFactory( $servicesContainer );
 	},
 
 ];

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -17,6 +17,7 @@ use SMW\Listener\EventListener\EventListeners\InvalidateEntityCacheEventListener
 use SMW\Listener\EventListener\EventListeners\InvalidatePropertySpecificationLookupCacheEventListener;
 use SMW\Listener\EventListener\EventListeners\InvalidateResultCacheEventListener;
 use SMW\Localizer\Localizer;
+use SMW\Maintenance\MaintenanceFactory;
 use SMW\MediaWiki\Connection\ConnectionProvider;
 use SMW\MediaWiki\HookDispatcher;
 use SMW\MediaWiki\JobFactory;
@@ -26,6 +27,7 @@ use SMW\MediaWiki\MediaWikiNsContentReader;
 use SMW\MediaWiki\Permission\TitlePermissions;
 use SMW\MediaWiki\PermissionManager;
 use SMW\MediaWiki\RevisionGuard;
+use SMW\ParserFunctionFactory;
 use SMW\Property\AnnotatorFactory;
 use SMW\Property\SpecificationLookup;
 use SMW\PropertyLabelFinder;
@@ -574,6 +576,26 @@ return [
 		}
 
 		return new SerializerFactory();
+	},
+
+	'SMW.ParserFunctionFactory' => static function ( MediaWikiServices $services ): ParserFunctionFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'ParserFunctionFactory' ) ) {
+			return $servicesFactory->getParserFunctionFactory();
+		}
+
+		return new ParserFunctionFactory();
+	},
+
+	'SMW.MaintenanceFactory' => static function ( MediaWikiServices $services ): MaintenanceFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'MaintenanceFactory' ) ) {
+			return $servicesFactory->getMaintenanceFactory();
+		}
+
+		return new MaintenanceFactory();
 	},
 
 ];

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -35,6 +35,7 @@ use SMW\Query\Processor\QueryCreator;
 use SMW\Query\QuerySourceFactory;
 use SMW\QueryFactory;
 use SMW\Schema\SchemaFactory;
+use SMW\SerializerFactory;
 use SMW\Services\ServicesFactory;
 use SMW\Settings;
 use SMW\SetupFile;
@@ -563,6 +564,16 @@ return [
 		return new InvalidatePropertySpecificationLookupCacheEventListener(
 			$servicesFactory->getPropertySpecificationLookup()
 		);
+	},
+
+	'SMW.SerializerFactory' => static function ( MediaWikiServices $services ): SerializerFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'SerializerFactory' ) ) {
+			return $servicesFactory->getSerializerFactory();
+		}
+
+		return new SerializerFactory();
 	},
 
 ];

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -7,7 +7,6 @@ use SMW\CacheFactory;
 use SMW\Connection\ConnectionManager;
 use SMW\ConstraintFactory;
 use SMW\DataItemFactory;
-use SMW\DependencyValidator;
 use SMW\DisplayTitleFinder;
 use SMW\Elastic\ElasticFactory;
 use SMW\EntityCache;
@@ -745,22 +744,6 @@ return [
 		);
 
 		return $hierarchyLookup;
-	},
-
-	'SMW.DependencyValidator' => static function ( MediaWikiServices $services ): DependencyValidator {
-		$servicesFactory = ServicesFactory::getInstance();
-
-		if ( $servicesFactory->hasTestOverride( 'DependencyValidator' ) ) {
-			return $servicesFactory->getDependencyValidator();
-		}
-
-		$queryDependencyLinksStoreFactory = $servicesFactory->getQueryDependencyLinksStoreFactory();
-
-		return new DependencyValidator(
-			$servicesFactory->getNamespaceExaminer(),
-			$queryDependencyLinksStoreFactory->newDependencyLinksValidator(),
-			$servicesFactory->getEntityCache()
-		);
 	},
 
 ];

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -598,4 +598,16 @@ return [
 		return new MaintenanceFactory();
 	},
 
+	'SMW.CacheFactory' => static function ( MediaWikiServices $services ): CacheFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'CacheFactory' ) ) {
+			return $servicesFactory->getCacheFactory();
+		}
+
+		return new CacheFactory(
+			$servicesFactory->getSettings()->get( 'smwgMainCacheType' )
+		);
+	},
+
 ];

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -7,6 +7,7 @@ use SMW\CacheFactory;
 use SMW\Connection\ConnectionManager;
 use SMW\ConstraintFactory;
 use SMW\DataItemFactory;
+use SMW\DisplayTitleFinder;
 use SMW\Elastic\ElasticFactory;
 use SMW\EntityCache;
 use SMW\Factbox\FactboxFactory;
@@ -693,6 +694,27 @@ return [
 		);
 
 		return new ImporterServiceFactory( $servicesContainer );
+	},
+
+	'SMW.DisplayTitleFinder' => static function ( MediaWikiServices $services ): DisplayTitleFinder {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'DisplayTitleFinder' ) ) {
+			return $servicesFactory->getDisplayTitleFinder();
+		}
+
+		$settings = $servicesFactory->getSettings();
+
+		$displayTitleFinder = new DisplayTitleFinder(
+			$servicesFactory->getStore(),
+			$servicesFactory->getEntityCache()
+		);
+
+		$displayTitleFinder->setCanUse(
+			$settings->isFlagSet( 'smwgDVFeatures', SMW_DV_WPV_DTITLE )
+		);
+
+		return $displayTitleFinder;
 	},
 
 	'SMW.HierarchyLookup' => static function ( MediaWikiServices $services ): HierarchyLookup {

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -7,6 +7,7 @@ use SMW\CacheFactory;
 use SMW\Connection\ConnectionManager;
 use SMW\ConstraintFactory;
 use SMW\DataItemFactory;
+use SMW\DependencyValidator;
 use SMW\DisplayTitleFinder;
 use SMW\Elastic\ElasticFactory;
 use SMW\EntityCache;
@@ -744,6 +745,22 @@ return [
 		);
 
 		return $hierarchyLookup;
+	},
+
+	'SMW.DependencyValidator' => static function ( MediaWikiServices $services ): DependencyValidator {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'DependencyValidator' ) ) {
+			return $servicesFactory->getDependencyValidator();
+		}
+
+		$queryDependencyLinksStoreFactory = $servicesFactory->getQueryDependencyLinksStoreFactory();
+
+		return new DependencyValidator(
+			$servicesFactory->getNamespaceExaminer(),
+			$queryDependencyLinksStoreFactory->newDependencyLinksValidator(),
+			$servicesFactory->getEntityCache()
+		);
 	},
 
 ];

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -11,6 +11,7 @@ use SMW\Elastic\ElasticFactory;
 use SMW\EntityCache;
 use SMW\Factbox\FactboxFactory;
 use SMW\Factbox\FactboxText;
+use SMW\HierarchyLookup;
 use SMW\InMemoryPoolCache;
 use SMW\IteratorFactory;
 use SMW\Listener\EventListener\EventListeners\InvalidateEntityCacheEventListener;
@@ -692,6 +693,35 @@ return [
 		);
 
 		return new ImporterServiceFactory( $servicesContainer );
+	},
+
+	'SMW.HierarchyLookup' => static function ( MediaWikiServices $services ): HierarchyLookup {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'HierarchyLookup' ) ) {
+			return $servicesFactory->getHierarchyLookup();
+		}
+
+		$settings = $servicesFactory->getSettings();
+
+		$hierarchyLookup = new HierarchyLookup(
+			$servicesFactory->getStore(),
+			$servicesFactory->getCache()
+		);
+
+		$hierarchyLookup->setLogger(
+			$servicesFactory->getMediaWikiLogger()
+		);
+
+		$hierarchyLookup->setSubcategoryDepth(
+			$settings->get( 'smwgQSubcategoryDepth' )
+		);
+
+		$hierarchyLookup->setSubpropertyDepth(
+			$settings->get( 'smwgQSubpropertyDepth' )
+		);
+
+		return $hierarchyLookup;
 	},
 
 ];

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -24,6 +24,7 @@ use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\JobQueue;
 use SMW\MediaWiki\ManualEntryLogger;
 use SMW\MediaWiki\MediaWikiNsContentReader;
+use SMW\MediaWiki\MwCollaboratorFactory;
 use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\Permission\TitlePermissions;
 use SMW\MediaWiki\PermissionManager;
@@ -630,6 +631,16 @@ return [
 		}
 
 		return new PageCreator();
+	},
+
+	'SMW.MwCollaboratorFactory' => static function ( MediaWikiServices $services ): MwCollaboratorFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'MwCollaboratorFactory' ) ) {
+			return $servicesFactory->getMwCollaboratorFactory();
+		}
+
+		return new MwCollaboratorFactory( $servicesFactory );
 	},
 
 ];

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -30,6 +30,7 @@ use SMW\MediaWiki\Permission\TitlePermissions;
 use SMW\MediaWiki\PermissionManager;
 use SMW\MediaWiki\RevisionGuard;
 use SMW\MediaWiki\TitleFactory;
+use SMW\NamespaceExaminer;
 use SMW\ParserFunctionFactory;
 use SMW\Property\AnnotatorFactory;
 use SMW\Property\SpecificationLookup;
@@ -641,6 +642,26 @@ return [
 		}
 
 		return new MwCollaboratorFactory( $servicesFactory );
+	},
+
+	'SMW.NamespaceExaminer' => static function ( MediaWikiServices $services ): NamespaceExaminer {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'NamespaceExaminer' ) ) {
+			return $servicesFactory->getNamespaceExaminer();
+		}
+
+		$settings = $servicesFactory->getSettings();
+
+		$namespaceExaminer = new NamespaceExaminer(
+			$settings->get( 'smwgNamespacesWithSemanticLinks' )
+		);
+
+		$namespaceExaminer->setValidNamespaces(
+			$services->getNamespaceInfo()->getValidNamespaces()
+		);
+
+		return $namespaceExaminer;
 	},
 
 ];

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -24,9 +24,11 @@ use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\JobQueue;
 use SMW\MediaWiki\ManualEntryLogger;
 use SMW\MediaWiki\MediaWikiNsContentReader;
+use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\Permission\TitlePermissions;
 use SMW\MediaWiki\PermissionManager;
 use SMW\MediaWiki\RevisionGuard;
+use SMW\MediaWiki\TitleFactory;
 use SMW\ParserFunctionFactory;
 use SMW\Property\AnnotatorFactory;
 use SMW\Property\SpecificationLookup;
@@ -608,6 +610,26 @@ return [
 		return new CacheFactory(
 			$servicesFactory->getSettings()->get( 'smwgMainCacheType' )
 		);
+	},
+
+	'SMW.TitleFactory' => static function ( MediaWikiServices $services ): TitleFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'TitleFactory' ) ) {
+			return $servicesFactory->getTitleFactory();
+		}
+
+		return new TitleFactory();
+	},
+
+	'SMW.PageCreator' => static function ( MediaWikiServices $services ): PageCreator {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'PageCreator' ) ) {
+			return $servicesFactory->getPageCreator();
+		}
+
+		return new PageCreator();
 	},
 
 ];

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -346,6 +346,7 @@ class ServicesFactory {
 			'NamespaceExaminer' => fn () => $this->getNamespaceExaminer(),
 			'DataValueServiceFactory' => fn () => $this->getDataValueServiceFactory(),
 			'ImporterServiceFactory' => fn () => $this->getImporterServiceFactory(),
+			'HierarchyLookup' => fn () => $this->newHierarchyLookup( ...$args ),
 
 			// Bucket-B/C SMW services constructed fresh per call.
 			'IndicatorRegistry' => fn () => $this->newIndicatorRegistry( ...$args ),
@@ -370,7 +371,6 @@ class ServicesFactory {
 			// @phan-suppress-next-line PhanParamTooFewUnpack
 			'EditProtectionUpdater' => fn () => $this->newEditProtectionUpdater( ...$args ),
 			'PropertyRestrictionExaminer' => fn () => $this->newPropertyRestrictionExaminer(),
-			'HierarchyLookup' => fn () => $this->newHierarchyLookup( ...$args ),
 			'DisplayTitleFinder' => fn () => $this->newDisplayTitleFinder( ...$args ),
 			'MagicWordsFinder' => fn () => $this->newMagicWordsFinder( ...$args ),
 			'DependencyValidator' => fn () => $this->newDependencyValidator( ...$args ),
@@ -950,6 +950,13 @@ class ServicesFactory {
 			return $this->testOverrides['HierarchyLookup'];
 		}
 
+		// SMW.HierarchyLookup on the global container uses the default store
+		// and cache; when the caller asks for a non-default combination, build
+		// the instance inline so the override-only entry-points keep working.
+		if ( $store === null && $cacheType === null ) {
+			return $this->getHierarchyLookup();
+		}
+
 		$hierarchyLookup = new HierarchyLookup(
 			$store ?? $this->getStore(),
 			$this->getCache( $cacheType )
@@ -968,6 +975,17 @@ class ServicesFactory {
 		);
 
 		return $hierarchyLookup;
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getHierarchyLookup(): HierarchyLookup {
+		if ( array_key_exists( 'HierarchyLookup', $this->testOverrides ) ) {
+			return $this->testOverrides['HierarchyLookup'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.HierarchyLookup' );
 	}
 
 	/**

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -347,6 +347,7 @@ class ServicesFactory {
 			'DataValueServiceFactory' => fn () => $this->getDataValueServiceFactory(),
 			'ImporterServiceFactory' => fn () => $this->getImporterServiceFactory(),
 			'HierarchyLookup' => fn () => $this->newHierarchyLookup( ...$args ),
+			'DisplayTitleFinder' => fn () => $this->newDisplayTitleFinder( ...$args ),
 
 			// Bucket-B/C SMW services constructed fresh per call.
 			'IndicatorRegistry' => fn () => $this->newIndicatorRegistry( ...$args ),
@@ -371,7 +372,6 @@ class ServicesFactory {
 			// @phan-suppress-next-line PhanParamTooFewUnpack
 			'EditProtectionUpdater' => fn () => $this->newEditProtectionUpdater( ...$args ),
 			'PropertyRestrictionExaminer' => fn () => $this->newPropertyRestrictionExaminer(),
-			'DisplayTitleFinder' => fn () => $this->newDisplayTitleFinder( ...$args ),
 			'MagicWordsFinder' => fn () => $this->newMagicWordsFinder( ...$args ),
 			'DependencyValidator' => fn () => $this->newDependencyValidator( ...$args ),
 			'Parser' => fn () => $this->newParser(),
@@ -996,10 +996,17 @@ class ServicesFactory {
 			return $this->testOverrides['DisplayTitleFinder'];
 		}
 
+		// SMW.DisplayTitleFinder on the global container uses the default
+		// store; when the caller passes a custom store, build the instance
+		// inline so the override-only entry-points keep working.
+		if ( $store === null ) {
+			return $this->getDisplayTitleFinder();
+		}
+
 		$settings = $this->getSettings();
 
 		$displayTitleFinder = new DisplayTitleFinder(
-			$store ?? $this->getStore(),
+			$store,
 			$this->getEntityCache()
 		);
 
@@ -1008,6 +1015,17 @@ class ServicesFactory {
 		);
 
 		return $displayTitleFinder;
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getDisplayTitleFinder(): DisplayTitleFinder {
+		if ( array_key_exists( 'DisplayTitleFinder', $this->testOverrides ) ) {
+			return $this->testOverrides['DisplayTitleFinder'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.DisplayTitleFinder' );
 	}
 
 	/**

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -342,6 +342,7 @@ class ServicesFactory {
 			'CacheFactory' => fn () => $this->getCacheFactory( ...$args ),
 			'TitleFactory' => fn () => $this->getTitleFactory(),
 			'PageCreator' => fn () => $this->getPageCreator(),
+			'MwCollaboratorFactory' => fn () => $this->getMwCollaboratorFactory(),
 
 			// Bucket-B/C SMW services constructed fresh per call.
 			'IndicatorRegistry' => fn () => $this->newIndicatorRegistry( ...$args ),
@@ -898,7 +899,18 @@ class ServicesFactory {
 	 * @return MwCollaboratorFactory
 	 */
 	public function newMwCollaboratorFactory(): MwCollaboratorFactory {
-		return new MwCollaboratorFactory( $this );
+		return $this->getMwCollaboratorFactory();
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getMwCollaboratorFactory(): MwCollaboratorFactory {
+		if ( array_key_exists( 'MwCollaboratorFactory', $this->testOverrides ) ) {
+			return $this->testOverrides['MwCollaboratorFactory'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.MwCollaboratorFactory' );
 	}
 
 	/**

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -344,6 +344,8 @@ class ServicesFactory {
 			'PageCreator' => fn () => $this->getPageCreator(),
 			'MwCollaboratorFactory' => fn () => $this->getMwCollaboratorFactory(),
 			'NamespaceExaminer' => fn () => $this->getNamespaceExaminer(),
+			'DataValueServiceFactory' => fn () => $this->getDataValueServiceFactory(),
+			'ImporterServiceFactory' => fn () => $this->getImporterServiceFactory(),
 
 			// Bucket-B/C SMW services constructed fresh per call.
 			'IndicatorRegistry' => fn () => $this->newIndicatorRegistry( ...$args ),
@@ -360,8 +362,6 @@ class ServicesFactory {
 			'TempFile' => fn () => $this->newTempFile(),
 			// @phan-suppress-next-line PhanParamTooFewUnpack
 			'PostProcHandler' => fn () => $this->newPostProcHandler( ...$args ),
-			'DataValueServiceFactory' => fn () => $this->getDataValueServiceFactory(),
-			'ImporterServiceFactory' => fn () => $this->getImporterServiceFactory(),
 			// @phan-suppress-next-line PhanParamTooFewUnpack
 			'BlobStore' => fn () => $this->newBlobStore( ...$args ),
 			'ResultCache' => fn () => $this->getResultCache( ...$args ),
@@ -1181,11 +1181,7 @@ class ServicesFactory {
 			return $this->testOverrides['DataValueServiceFactory'];
 		}
 
-		$servicesContainer = DataValueServiceFactory::newServicesContainer(
-			$this->getSettings()->get( 'smwgServicesFileDir' )
-		);
-
-		return new DataValueServiceFactory( $servicesContainer );
+		return MediaWikiServices::getInstance()->getService( 'SMW.DataValueServiceFactory' );
 	}
 
 	/**
@@ -1196,11 +1192,7 @@ class ServicesFactory {
 			return $this->testOverrides['ImporterServiceFactory'];
 		}
 
-		$servicesContainer = ImporterServiceFactory::newServicesContainer(
-			$this->getSettings()->get( 'smwgServicesFileDir' )
-		);
-
-		return new ImporterServiceFactory( $servicesContainer );
+		return MediaWikiServices::getInstance()->getService( 'SMW.ImporterServiceFactory' );
 	}
 
 	/**

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -348,6 +348,7 @@ class ServicesFactory {
 			'ImporterServiceFactory' => fn () => $this->getImporterServiceFactory(),
 			'HierarchyLookup' => fn () => $this->newHierarchyLookup( ...$args ),
 			'DisplayTitleFinder' => fn () => $this->newDisplayTitleFinder( ...$args ),
+			'DependencyValidator' => fn () => $this->newDependencyValidator( ...$args ),
 
 			// Bucket-B/C SMW services constructed fresh per call.
 			'IndicatorRegistry' => fn () => $this->newIndicatorRegistry( ...$args ),
@@ -373,7 +374,6 @@ class ServicesFactory {
 			'EditProtectionUpdater' => fn () => $this->newEditProtectionUpdater( ...$args ),
 			'PropertyRestrictionExaminer' => fn () => $this->newPropertyRestrictionExaminer(),
 			'MagicWordsFinder' => fn () => $this->newMagicWordsFinder( ...$args ),
-			'DependencyValidator' => fn () => $this->newDependencyValidator( ...$args ),
 			'Parser' => fn () => $this->newParser(),
 			'RevisionLookup' => fn () => $this->newRevisionLookup(),
 			// @phan-suppress-next-line PhanParamTooFewUnpack
@@ -1050,13 +1050,31 @@ class ServicesFactory {
 			return $this->testOverrides['DependencyValidator'];
 		}
 
+		// `$store` is accepted for backwards compatibility with the historical
+		// signature but the underlying class never receives it. When the caller
+		// passes nothing, return the globalised instance.
+		if ( $store === null ) {
+			return $this->getDependencyValidator();
+		}
+
 		$queryDependencyLinksStoreFactory = $this->getQueryDependencyLinksStoreFactory();
 
 		return new DependencyValidator(
-			$this->newNamespaceExaminer(),
+			$this->getNamespaceExaminer(),
 			$queryDependencyLinksStoreFactory->newDependencyLinksValidator(),
 			$this->getEntityCache()
 		);
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getDependencyValidator(): DependencyValidator {
+		if ( array_key_exists( 'DependencyValidator', $this->testOverrides ) ) {
+			return $this->testOverrides['DependencyValidator'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.DependencyValidator' );
 	}
 
 	/**

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -336,6 +336,8 @@ class ServicesFactory {
 			'InvalidateEntityCacheEventListener' => fn () => $this->getInvalidateEntityCacheEventListener(),
 			'InvalidatePropertySpecificationLookupCacheEventListener' => fn () => $this->getInvalidatePropertySpecificationLookupCacheEventListener(),
 			'SerializerFactory' => fn () => $this->getSerializerFactory(),
+			'ParserFunctionFactory' => fn () => $this->getParserFunctionFactory(),
+			'MaintenanceFactory' => fn () => $this->getMaintenanceFactory(),
 
 			// Bucket-B/C SMW services constructed fresh per call.
 			'IndicatorRegistry' => fn () => $this->newIndicatorRegistry( ...$args ),
@@ -444,14 +446,36 @@ class ServicesFactory {
 	 * @since 2.1
 	 */
 	public function newParserFunctionFactory(): ParserFunctionFactory {
-		return new ParserFunctionFactory();
+		return $this->getParserFunctionFactory();
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getParserFunctionFactory(): ParserFunctionFactory {
+		if ( array_key_exists( 'ParserFunctionFactory', $this->testOverrides ) ) {
+			return $this->testOverrides['ParserFunctionFactory'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.ParserFunctionFactory' );
 	}
 
 	/**
 	 * @since 2.2
 	 */
 	public function newMaintenanceFactory(): MaintenanceFactory {
-		return new MaintenanceFactory();
+		return $this->getMaintenanceFactory();
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getMaintenanceFactory(): MaintenanceFactory {
+		if ( array_key_exists( 'MaintenanceFactory', $this->testOverrides ) ) {
+			return $this->testOverrides['MaintenanceFactory'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.MaintenanceFactory' );
 	}
 
 	/**

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -338,8 +338,7 @@ class ServicesFactory {
 			'SerializerFactory' => fn () => $this->getSerializerFactory(),
 			'ParserFunctionFactory' => fn () => $this->getParserFunctionFactory(),
 			'MaintenanceFactory' => fn () => $this->getMaintenanceFactory(),
-			// @phan-suppress-next-line PhanParamTooManyUnpack
-			'CacheFactory' => fn () => $this->getCacheFactory( ...$args ),
+			'CacheFactory' => fn () => $this->getCacheFactory(),
 			'TitleFactory' => fn () => $this->getTitleFactory(),
 			'PageCreator' => fn () => $this->getPageCreator(),
 			'MwCollaboratorFactory' => fn () => $this->getMwCollaboratorFactory(),
@@ -348,7 +347,6 @@ class ServicesFactory {
 			'ImporterServiceFactory' => fn () => $this->getImporterServiceFactory(),
 			'HierarchyLookup' => fn () => $this->newHierarchyLookup( ...$args ),
 			'DisplayTitleFinder' => fn () => $this->newDisplayTitleFinder( ...$args ),
-			'DependencyValidator' => fn () => $this->newDependencyValidator( ...$args ),
 
 			// Bucket-B/C SMW services constructed fresh per call.
 			'IndicatorRegistry' => fn () => $this->newIndicatorRegistry( ...$args ),
@@ -1045,16 +1043,9 @@ class ServicesFactory {
 	/**
 	 * @since 7.0.0
 	 */
-	public function newDependencyValidator( $store = null ): DependencyValidator {
+	public function newDependencyValidator( string $eTag, int $cacheTTL ): DependencyValidator {
 		if ( array_key_exists( 'DependencyValidator', $this->testOverrides ) ) {
 			return $this->testOverrides['DependencyValidator'];
-		}
-
-		// `$store` is accepted for backwards compatibility with the historical
-		// signature but the underlying class never receives it. When the caller
-		// passes nothing, return the globalised instance.
-		if ( $store === null ) {
-			return $this->getDependencyValidator();
 		}
 
 		$queryDependencyLinksStoreFactory = $this->getQueryDependencyLinksStoreFactory();
@@ -1062,19 +1053,10 @@ class ServicesFactory {
 		return new DependencyValidator(
 			$this->getNamespaceExaminer(),
 			$queryDependencyLinksStoreFactory->newDependencyLinksValidator(),
-			$this->getEntityCache()
+			$this->getEntityCache(),
+			$eTag,
+			$cacheTTL
 		);
-	}
-
-	/**
-	 * @since 7.0.0
-	 */
-	public function getDependencyValidator(): DependencyValidator {
-		if ( array_key_exists( 'DependencyValidator', $this->testOverrides ) ) {
-			return $this->testOverrides['DependencyValidator'];
-		}
-
-		return MediaWikiServices::getInstance()->getService( 'SMW.DependencyValidator' );
 	}
 
 	/**

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -340,6 +340,8 @@ class ServicesFactory {
 			'MaintenanceFactory' => fn () => $this->getMaintenanceFactory(),
 			// @phan-suppress-next-line PhanParamTooManyUnpack
 			'CacheFactory' => fn () => $this->getCacheFactory( ...$args ),
+			'TitleFactory' => fn () => $this->getTitleFactory(),
+			'PageCreator' => fn () => $this->getPageCreator(),
 
 			// Bucket-B/C SMW services constructed fresh per call.
 			'IndicatorRegistry' => fn () => $this->newIndicatorRegistry( ...$args ),
@@ -349,9 +351,7 @@ class ServicesFactory {
 			'LinksProcessor' => fn () => $this->newLinksProcessor(),
 			// @phan-suppress-next-line PhanParamTooFewUnpack
 			'MessageFormatter' => fn () => $this->newMessageFormatter( ...$args ),
-			'PageCreator' => fn () => $this->newPageCreator(),
 			'PageUpdater' => fn () => $this->newPageUpdater( ...$args ),
-			'TitleFactory' => fn () => $this->newTitleFactory(),
 			// @phan-suppress-next-line PhanParamTooFewUnpack
 			'ContentParser' => fn () => $this->newContentParser( ...$args ),
 			'DeferredCallableUpdate' => fn () => $this->newDeferredCallableUpdate( ...$args ),
@@ -630,11 +630,18 @@ class ServicesFactory {
 	 * @since 2.0
 	 */
 	public function newTitleFactory(): TitleFactory {
+		return $this->getTitleFactory();
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getTitleFactory(): TitleFactory {
 		if ( array_key_exists( 'TitleFactory', $this->testOverrides ) ) {
 			return $this->testOverrides['TitleFactory'];
 		}
 
-		return new TitleFactory();
+		return MediaWikiServices::getInstance()->getService( 'SMW.TitleFactory' );
 	}
 
 	/**
@@ -643,11 +650,18 @@ class ServicesFactory {
 	 * @return PageCreator
 	 */
 	public function newPageCreator() {
+		return $this->getPageCreator();
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getPageCreator(): PageCreator {
 		if ( array_key_exists( 'PageCreator', $this->testOverrides ) ) {
 			return $this->testOverrides['PageCreator'];
 		}
 
-		return new PageCreator();
+		return MediaWikiServices::getInstance()->getService( 'SMW.PageCreator' );
 	}
 
 	/**

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -343,10 +343,10 @@ class ServicesFactory {
 			'TitleFactory' => fn () => $this->getTitleFactory(),
 			'PageCreator' => fn () => $this->getPageCreator(),
 			'MwCollaboratorFactory' => fn () => $this->getMwCollaboratorFactory(),
+			'NamespaceExaminer' => fn () => $this->getNamespaceExaminer(),
 
 			// Bucket-B/C SMW services constructed fresh per call.
 			'IndicatorRegistry' => fn () => $this->newIndicatorRegistry( ...$args ),
-			'NamespaceExaminer' => fn () => $this->newNamespaceExaminer(),
 			// @phan-suppress-next-line PhanParamTooFewUnpack
 			'ParserData' => fn () => $this->newParserData( ...$args ),
 			'LinksProcessor' => fn () => $this->newLinksProcessor(),
@@ -917,29 +917,18 @@ class ServicesFactory {
 	 * @since 2.1
 	 */
 	public function getNamespaceExaminer(): NamespaceExaminer {
-		return $this->newNamespaceExaminer();
+		if ( array_key_exists( 'NamespaceExaminer', $this->testOverrides ) ) {
+			return $this->testOverrides['NamespaceExaminer'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.NamespaceExaminer' );
 	}
 
 	/**
 	 * @since 7.0.0
 	 */
 	public function newNamespaceExaminer(): NamespaceExaminer {
-		if ( array_key_exists( 'NamespaceExaminer', $this->testOverrides ) ) {
-			return $this->testOverrides['NamespaceExaminer'];
-		}
-
-		$settings = $this->getSettings();
-		$namespaceInfo = MediaWikiServices::getInstance()->getNamespaceInfo();
-
-		$namespaceExaminer = new NamespaceExaminer(
-			$settings->get( 'smwgNamespacesWithSemanticLinks' )
-		);
-
-		$namespaceExaminer->setValidNamespaces(
-			$namespaceInfo->getValidNamespaces()
-		);
-
-		return $namespaceExaminer;
+		return $this->getNamespaceExaminer();
 	}
 
 	/**

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -338,11 +338,11 @@ class ServicesFactory {
 			'SerializerFactory' => fn () => $this->getSerializerFactory(),
 			'ParserFunctionFactory' => fn () => $this->getParserFunctionFactory(),
 			'MaintenanceFactory' => fn () => $this->getMaintenanceFactory(),
+			// @phan-suppress-next-line PhanParamTooManyUnpack
+			'CacheFactory' => fn () => $this->getCacheFactory( ...$args ),
 
 			// Bucket-B/C SMW services constructed fresh per call.
 			'IndicatorRegistry' => fn () => $this->newIndicatorRegistry( ...$args ),
-			// @phan-suppress-next-line PhanParamTooManyUnpack
-			'CacheFactory' => fn () => $this->getCacheFactory( ...$args ),
 			'NamespaceExaminer' => fn () => $this->newNamespaceExaminer(),
 			// @phan-suppress-next-line PhanParamTooFewUnpack
 			'ParserData' => fn () => $this->newParserData( ...$args ),
@@ -482,14 +482,18 @@ class ServicesFactory {
 	 * @since 2.2
 	 */
 	public function newCacheFactory(): CacheFactory {
-		return new CacheFactory( $this->getSettings()->get( 'smwgMainCacheType' ) );
+		return $this->getCacheFactory();
 	}
 
 	/**
 	 * @since 2.2
 	 */
 	public function getCacheFactory(): CacheFactory {
-		return $this->newCacheFactory();
+		if ( array_key_exists( 'CacheFactory', $this->testOverrides ) ) {
+			return $this->testOverrides['CacheFactory'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.CacheFactory' );
 	}
 
 	/**

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -335,6 +335,7 @@ class ServicesFactory {
 			'InvalidateResultCacheEventListener' => fn () => $this->getInvalidateResultCacheEventListener(),
 			'InvalidateEntityCacheEventListener' => fn () => $this->getInvalidateEntityCacheEventListener(),
 			'InvalidatePropertySpecificationLookupCacheEventListener' => fn () => $this->getInvalidatePropertySpecificationLookupCacheEventListener(),
+			'SerializerFactory' => fn () => $this->getSerializerFactory(),
 
 			// Bucket-B/C SMW services constructed fresh per call.
 			'IndicatorRegistry' => fn () => $this->newIndicatorRegistry( ...$args ),
@@ -403,7 +404,18 @@ class ServicesFactory {
 	 * @since 2.0
 	 */
 	public function newSerializerFactory(): SerializerFactory {
-		return new SerializerFactory();
+		return $this->getSerializerFactory();
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getSerializerFactory(): SerializerFactory {
+		if ( array_key_exists( 'SerializerFactory', $this->testOverrides ) ) {
+			return $this->testOverrides['SerializerFactory'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.SerializerFactory' );
 	}
 
 	/**

--- a/tests/phpunit/Integration/Services/BehaviourSensitiveServiceCharacterizationTest.php
+++ b/tests/phpunit/Integration/Services/BehaviourSensitiveServiceCharacterizationTest.php
@@ -180,16 +180,16 @@ class BehaviourSensitiveServiceCharacterizationTest extends MediaWikiIntegration
 	// -------------------------------------------------------------------------
 
 	/**
-	 * ImporterServiceFactory is reached via create('ImporterServiceFactory').
-	 * The callback constructs a new ImporterServiceFactory each time, so two create() calls
-	 * return distinct instances.
+	 * ImporterServiceFactory is globalised as `SMW.ImporterServiceFactory` on
+	 * the MediaWiki ServiceContainer; two create() retrievals return the same
+	 * shared instance.
 	 */
 	public function testImporterServiceFactoryTypeAndIdentity(): void {
 		$first = $this->factory->create( 'ImporterServiceFactory' );
 		$second = $this->factory->create( 'ImporterServiceFactory' );
 
 		$this->assertInstanceOf( ImporterServiceFactory::class, $first );
-		$this->assertNotSame( $first, $second, 'ImporterServiceFactory: create() constructs a new instance each time' );
+		$this->assertSame( $first, $second, 'ImporterServiceFactory: globalised as SMW.ImporterServiceFactory; both retrievals must return the same instance' );
 	}
 
 	/**

--- a/tests/phpunit/Integration/Services/BehaviourSensitiveServiceCharacterizationTest.php
+++ b/tests/phpunit/Integration/Services/BehaviourSensitiveServiceCharacterizationTest.php
@@ -124,29 +124,29 @@ class BehaviourSensitiveServiceCharacterizationTest extends MediaWikiIntegration
 	}
 
 	/**
-	 * PageCreator is reached via ServicesFactory::newPageCreator() which calls create('PageCreator').
-	 * The callback constructs a new PageCreator each time, so two calls return distinct instances.
+	 * PageCreator is globalised as `SMW.PageCreator` on the MediaWiki
+	 * ServiceContainer; ServicesFactory::newPageCreator() returns the same
+	 * shared instance on repeated calls.
 	 */
 	public function testPageCreatorTypeAndIdentity(): void {
 		$first = $this->factory->newPageCreator();
 		$second = $this->factory->newPageCreator();
 
 		$this->assertInstanceOf( PageCreator::class, $first );
-		$this->assertNotSame( $first, $second, 'PageCreator: newPageCreator() calls create() which constructs a new instance each time' );
+		$this->assertSame( $first, $second, 'PageCreator: globalised as SMW.PageCreator; both retrievals must return the same instance' );
 	}
 
 	/**
-	 * TitleFactory is reached via ServicesFactory::newTitleFactory() which calls
-	 * create('TitleFactory', ...). The callback constructs a new TitleFactory each time,
-	 * so two calls return distinct instances. The PageCreator argument passed by the caller
-	 * is ignored by the registered callback.
+	 * TitleFactory is globalised as `SMW.TitleFactory` on the MediaWiki
+	 * ServiceContainer; ServicesFactory::newTitleFactory() returns the same
+	 * shared instance on repeated calls.
 	 */
 	public function testTitleFactoryTypeAndIdentity(): void {
 		$first = $this->factory->newTitleFactory();
 		$second = $this->factory->newTitleFactory();
 
 		$this->assertInstanceOf( TitleFactory::class, $first );
-		$this->assertNotSame( $first, $second, 'TitleFactory: newTitleFactory() calls create() which constructs a new instance each time' );
+		$this->assertSame( $first, $second, 'TitleFactory: globalised as SMW.TitleFactory; both retrievals must return the same instance' );
 	}
 
 	/**

--- a/tests/phpunit/Integration/Services/BehaviourSensitiveServiceCharacterizationTest.php
+++ b/tests/phpunit/Integration/Services/BehaviourSensitiveServiceCharacterizationTest.php
@@ -98,16 +98,16 @@ class BehaviourSensitiveServiceCharacterizationTest extends MediaWikiIntegration
 	}
 
 	/**
-	 * NamespaceExaminer is reached via ServicesFactory::getNamespaceExaminer() which calls
-	 * create('NamespaceExaminer'). The callback constructs a new NamespaceExaminer each time,
-	 * so two calls return distinct instances.
+	 * NamespaceExaminer is globalised as `SMW.NamespaceExaminer` on the
+	 * MediaWiki ServiceContainer; two retrievals via ServicesFactory return
+	 * the same shared instance.
 	 */
 	public function testNamespaceExaminerTypeAndIdentity(): void {
 		$first = $this->factory->getNamespaceExaminer();
 		$second = $this->factory->getNamespaceExaminer();
 
 		$this->assertInstanceOf( NamespaceExaminer::class, $first );
-		$this->assertNotSame( $first, $second, 'NamespaceExaminer: getNamespaceExaminer() calls create() which constructs a new instance each time' );
+		$this->assertSame( $first, $second, 'NamespaceExaminer: globalised as SMW.NamespaceExaminer; both retrievals must return the same instance' );
 	}
 
 	/**

--- a/tests/phpunit/Integration/Services/ServiceWiringTest.php
+++ b/tests/phpunit/Integration/Services/ServiceWiringTest.php
@@ -10,7 +10,6 @@ use SMW\CacheFactory;
 use SMW\Connection\ConnectionManager;
 use SMW\ConstraintFactory;
 use SMW\DataItemFactory;
-use SMW\DependencyValidator;
 use SMW\DisplayTitleFinder;
 use SMW\Elastic\ElasticFactory;
 use SMW\Elastic\Jobs\FileIngestJob;
@@ -140,7 +139,6 @@ class ServiceWiringTest extends MediaWikiIntegrationTestCase {
 			[ 'SMW.ImporterServiceFactory', ImporterServiceFactory::class ],
 			[ 'SMW.HierarchyLookup', HierarchyLookup::class ],
 			[ 'SMW.DisplayTitleFinder', DisplayTitleFinder::class ],
-			[ 'SMW.DependencyValidator', DependencyValidator::class ],
 		];
 	}
 

--- a/tests/phpunit/Integration/Services/ServiceWiringTest.php
+++ b/tests/phpunit/Integration/Services/ServiceWiringTest.php
@@ -6,20 +6,25 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
 use Onoi\Cache\Cache;
+use SMW\CacheFactory;
 use SMW\Connection\ConnectionManager;
 use SMW\ConstraintFactory;
 use SMW\DataItemFactory;
+use SMW\DependencyValidator;
+use SMW\DisplayTitleFinder;
 use SMW\Elastic\ElasticFactory;
 use SMW\Elastic\Jobs\FileIngestJob;
 use SMW\Elastic\Jobs\IndexerRecoveryJob;
 use SMW\EntityCache;
 use SMW\Factbox\FactboxFactory;
 use SMW\Factbox\FactboxText;
+use SMW\HierarchyLookup;
 use SMW\InMemoryPoolCache;
 use SMW\IteratorFactory;
 use SMW\Listener\EventListener\EventListeners\InvalidateEntityCacheEventListener;
 use SMW\Listener\EventListener\EventListeners\InvalidatePropertySpecificationLookupCacheEventListener;
 use SMW\Listener\EventListener\EventListeners\InvalidateResultCacheEventListener;
+use SMW\Maintenance\MaintenanceFactory;
 use SMW\MediaWiki\Connection\ConnectionProvider;
 use SMW\MediaWiki\HookDispatcher;
 use SMW\MediaWiki\Job;
@@ -39,9 +44,14 @@ use SMW\MediaWiki\Jobs\UpdateDispatcherJob;
 use SMW\MediaWiki\Jobs\UpdateJob;
 use SMW\MediaWiki\ManualEntryLogger;
 use SMW\MediaWiki\MediaWikiNsContentReader;
+use SMW\MediaWiki\MwCollaboratorFactory;
+use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\Permission\TitlePermissions;
 use SMW\MediaWiki\PermissionManager;
 use SMW\MediaWiki\RevisionGuard;
+use SMW\MediaWiki\TitleFactory;
+use SMW\NamespaceExaminer;
+use SMW\ParserFunctionFactory;
 use SMW\Property\AnnotatorFactory;
 use SMW\Property\SpecificationLookup;
 use SMW\PropertyLabelFinder;
@@ -51,6 +61,9 @@ use SMW\Query\Processor\QueryCreator;
 use SMW\Query\QuerySourceFactory;
 use SMW\QueryFactory;
 use SMW\Schema\SchemaFactory;
+use SMW\SerializerFactory;
+use SMW\Services\DataValueServiceFactory;
+use SMW\Services\ImporterServiceFactory;
 use SMW\Settings;
 use SMW\SetupFile;
 use SMW\SQLStore\QueryDependencyLinksStoreFactory;
@@ -115,6 +128,19 @@ class ServiceWiringTest extends MediaWikiIntegrationTestCase {
 			[ 'SMW.InvalidateResultCacheEventListener', InvalidateResultCacheEventListener::class ],
 			[ 'SMW.InvalidateEntityCacheEventListener', InvalidateEntityCacheEventListener::class ],
 			[ 'SMW.InvalidatePropertySpecificationLookupCacheEventListener', InvalidatePropertySpecificationLookupCacheEventListener::class ],
+			[ 'SMW.SerializerFactory', SerializerFactory::class ],
+			[ 'SMW.ParserFunctionFactory', ParserFunctionFactory::class ],
+			[ 'SMW.MaintenanceFactory', MaintenanceFactory::class ],
+			[ 'SMW.CacheFactory', CacheFactory::class ],
+			[ 'SMW.TitleFactory', TitleFactory::class ],
+			[ 'SMW.PageCreator', PageCreator::class ],
+			[ 'SMW.MwCollaboratorFactory', MwCollaboratorFactory::class ],
+			[ 'SMW.NamespaceExaminer', NamespaceExaminer::class ],
+			[ 'SMW.DataValueServiceFactory', DataValueServiceFactory::class ],
+			[ 'SMW.ImporterServiceFactory', ImporterServiceFactory::class ],
+			[ 'SMW.HierarchyLookup', HierarchyLookup::class ],
+			[ 'SMW.DisplayTitleFinder', DisplayTitleFinder::class ],
+			[ 'SMW.DependencyValidator', DependencyValidator::class ],
 		];
 	}
 

--- a/tests/phpunit/Unit/DependencyValidatorTest.php
+++ b/tests/phpunit/Unit/DependencyValidatorTest.php
@@ -56,10 +56,20 @@ class DependencyValidatorTest extends TestCase {
 		parent::tearDown();
 	}
 
+	private function newInstance( string $eTag = '', int $cacheTTL = 3600 ): DependencyValidator {
+		return new DependencyValidator(
+			$this->namespaceExaminer,
+			$this->dependencyLinksValidator,
+			$this->entityCache,
+			$eTag,
+			$cacheTTL
+		);
+	}
+
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			DependencyValidator::class,
-			new DependencyValidator( $this->namespaceExaminer, $this->dependencyLinksValidator, $this->entityCache )
+			$this->newInstance()
 		);
 	}
 
@@ -97,13 +107,7 @@ class DependencyValidatorTest extends TestCase {
 			->method( 'getCheckedDependencies' )
 			->willReturn( [] );
 
-		$instance = new DependencyValidator(
-			$this->namespaceExaminer,
-			$this->dependencyLinksValidator,
-			$this->entityCache
-		);
-
-		$instance->setETag( 'foo-etag' );
+		$instance = $this->newInstance( 'foo-etag' );
 
 		$instance->setEventDispatcher(
 			$eventDispatcher
@@ -133,13 +137,7 @@ class DependencyValidatorTest extends TestCase {
 			->with( $subject )
 			->willReturn( false );
 
-		$instance = new DependencyValidator(
-			$this->namespaceExaminer,
-			$this->dependencyLinksValidator,
-			$this->entityCache
-		);
-
-		$instance->setETag( 'foo-etag' );
+		$instance = $this->newInstance( 'foo-etag' );
 
 		$this->assertFalse(
 			$instance->hasArchaicDependencies( $subject )
@@ -156,13 +154,7 @@ class DependencyValidatorTest extends TestCase {
 
 		$subject = WikiPage::newFromText( 'Foo' );
 
-		$instance = new DependencyValidator(
-			$this->namespaceExaminer,
-			$this->dependencyLinksValidator,
-			$this->entityCache
-		);
-
-		$instance->setETag( 'foo-etag' );
+		$instance = $this->newInstance( 'foo-etag' );
 
 		$this->assertFalse(
 			$instance->hasArchaicDependencies( $subject )
@@ -173,11 +165,7 @@ class DependencyValidatorTest extends TestCase {
 		$subject = WikiPage::newFromText( 'Foo' );
 		$title = $subject->getTitle();
 
-		$instance = new DependencyValidator(
-			$this->namespaceExaminer,
-			$this->dependencyLinksValidator,
-			$this->entityCache
-		);
+		$instance = $this->newInstance();
 
 		$instance->markTitle( $title );
 
@@ -196,11 +184,7 @@ class DependencyValidatorTest extends TestCase {
 
 		$subject = WikiPage::newFromText( 'Foo' );
 
-		$instance = new DependencyValidator(
-			$this->namespaceExaminer,
-			$this->dependencyLinksValidator,
-			$this->entityCache
-		);
+		$instance = $this->newInstance();
 
 		$this->assertTrue(
 			$instance->canKeepParserCache( $subject )
@@ -219,13 +203,7 @@ class DependencyValidatorTest extends TestCase {
 
 		$subject = WikiPage::newFromText( 'Foo' );
 
-		$instance = new DependencyValidator(
-			$this->namespaceExaminer,
-			$this->dependencyLinksValidator,
-			$this->entityCache
-		);
-
-		$instance->setETag( 'foo-etag' );
+		$instance = $this->newInstance( 'foo-etag' );
 
 		$this->assertTrue(
 			$instance->canKeepParserCache( $subject )
@@ -249,13 +227,7 @@ class DependencyValidatorTest extends TestCase {
 
 		$subject = WikiPage::newFromText( 'Foo' );
 
-		$instance = new DependencyValidator(
-			$this->namespaceExaminer,
-			$this->dependencyLinksValidator,
-			$this->entityCache
-		);
-
-		$instance->setETag( 'foo-etag' );
+		$instance = $this->newInstance( 'foo-etag' );
 
 		$this->assertFalse(
 			$instance->canKeepParserCache( $subject )

--- a/tests/phpunit/Unit/PostProcHandlerTest.php
+++ b/tests/phpunit/Unit/PostProcHandlerTest.php
@@ -256,7 +256,9 @@ class PostProcHandlerTest extends TestCase {
 		$dependencyValidator = new DependencyValidator(
 			$namespaceExaminer,
 			$dependencyLinksValidator,
-			$entityCache
+			$entityCache,
+			'',
+			3600
 		);
 		$dependencyValidator->markTitle( $title );
 


### PR DESCRIPTION
## Summary

Broaden the catalog of SMW services registered on MediaWiki's `ServiceContainer`. PR #6855 globalised the initial 35 services; PR #6856 demonstrated that ObjectFactory-injected services via `JobClasses` specs work end-to-end. This PR brings 12 more stateless SMW services onto `MediaWikiServices` as `SMW.X` entries so upcoming framework-constrained migrations (`HookHandlers`, `APIModules`, `SpecialPages`) can inject them through the same ObjectFactory mechanism without partial-DI fallbacks.

Together with the `DependencyValidator` hardening below, this completes the architectural split: every stateless SMW service lives on `MediaWikiServices`; every per-request or per-call factory stays on `ServicesFactory`.

## Services globalised

```
SMW.SerializerFactory          SMW.MwCollaboratorFactory
SMW.ParserFunctionFactory      SMW.NamespaceExaminer
SMW.MaintenanceFactory         SMW.DataValueServiceFactory
SMW.CacheFactory               SMW.ImporterServiceFactory
SMW.TitleFactory               SMW.HierarchyLookup
SMW.PageCreator                SMW.DisplayTitleFinder
```

Each new wiring callback follows the testOverride-aware pattern established by PR #6855: the callback first consults `ServicesFactory::hasTestOverride( 'Foo' )` and, when an override is registered, delegates to the matching `ServicesFactory::getX()` accessor. Otherwise normal construction runs. The corresponding `newX()` / `getX()` accessor on `ServicesFactory` proxies through `MediaWikiServices` after the same `testOverrides` check.

Two services (`HierarchyLookup`, `DisplayTitleFinder`) accept an optional explicit-store argument; the accessor preserves the inline-build branch for callers passing one, and the default no-args path goes through the global container.

## DependencyValidator hardened (not globalised)

`DependencyValidator` previously exposed `setETag()` / `setCacheTTL()` setters that both production callers (`Hooks::onArticleViewHeader` and `Hooks::onRejectParserCacheValue`) invoked with per-request values before use. Sharing the instance as a global singleton would have leaked the last writer's eTag across callers (the eTag participates in the EntityCache sub-key, so a stale value silently corrupts cache lookups).

This PR converts `$eTag` and `$cacheTTL` to required `readonly` constructor arguments and removes the setters. Both call sites now obtain an instance via `ApplicationFactory::newDependencyValidator( $eTag, $cacheTTL )` which constructs inline with the per-request values. The previously implicit "set 3 fields before use" contract is enforced at the type level. `DependencyValidator` is correctly classified as a per-request collaborator and stays off `MediaWikiServices`.

`PropertyRestrictionExaminer` stays off the catalog for the same reason (mutable `setUser()` plus a growing `$exists` cache; the freshness contract is already locked by an existing characterisation test).

## Drive-by

`routeToFactoryMethod()` had a `// @phan-suppress-next-line PhanParamTooManyUnpack` annotation around `'CacheFactory' => fn () => $this->getCacheFactory( ...$args )`. `getCacheFactory()` is no-arg and no live caller threads args through the deprecated `singleton('CacheFactory', ...)` shim, so the suppression was hiding a non-issue. Dropped both the spread and the suppression.

## Behavioural test flips

`BehaviourSensitiveServiceCharacterizationTest` had four assertions characterising `NamespaceExaminer`, `PageCreator`, `TitleFactory`, and `ImporterServiceFactory` as fresh-per-call. Now that these services are globalised, two retrievals return the same shared instance. The assertions flip from `assertNotSame` to `assertSame` with revised docstrings.

## Test plan

- Unit suite (`semantic-mediawiki-unit`): 7081 tests / 14495 assertions / 0 failures / 6 pre-existing skips. Matches master baseline.
- `ServiceWiringTest` resolves all 47 globalised `SMW.X` services and all 14 `JobClasses` commands through MediaWiki's containers.
- `BehaviourSensitiveServiceCharacterizationTest`: 15 tests / 29 assertions.
- `DependencyValidatorTest` and `PostProcHandlerTest` updated for the new constructor signature.
- PHPCS clean on all changed files.
- phan clean (locally with `--allow-polyfill-parser`; CI handles `php-ast`).