### PR TITLE
Inject MediaWiki services into SQLStoreFactory products

### DIFF
--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -14,7 +14,7 @@ use SMW\MediaWiki\Collator;
 use SMW\MediaWiki\Connection\Sequence;
 use SMW\PropertyRegistry;
 use SMW\RequestOptions;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Settings;
 use SMW\SQLStore\Lookup\RedirectTargetLookup;
 use SMW\SQLStore\PropertyTable\PropertyTableHashes;
 use SMW\SQLStore\PropertyTableInfoFetcher;
@@ -127,6 +127,7 @@ class EntityIdManager {
 	public function __construct(
 		SQLStore $store,
 		private readonly SQLStoreFactory $factory,
+		private readonly Settings $settings,
 	) {
 		$this->store = $store;
 		$this->initCache();
@@ -1116,7 +1117,7 @@ class EntityIdManager {
 	}
 
 	private function resolveCacheSizes(): array {
-		$configured = ApplicationFactory::getInstance()->getSettings()->safeGet( 'smwgEntityCacheSizes', [] );
+		$configured = $this->settings->safeGet( 'smwgEntityCacheSizes', [] );
 
 		if ( !is_array( $configured ) || $configured === [] ) {
 			return self::DEFAULT_CACHE_SIZES;

--- a/src/SQLStore/Installer.php
+++ b/src/SQLStore/Installer.php
@@ -2,7 +2,8 @@
 
 namespace SMW\SQLStore;
 
-use MediaWiki\MediaWikiServices;
+use MediaWiki\JobQueue\JobFactory;
+use MediaWiki\Title\TitleFactory;
 use Onoi\MessageReporter\MessageReporter;
 use Onoi\MessageReporter\MessageReporterAwareTrait;
 use Onoi\MessageReporter\MessageReporterFactory;
@@ -68,6 +69,8 @@ class Installer implements MessageReporter {
 		private TableBuildExaminer $tableBuildExaminer,
 		private VersionExaminer $versionExaminer,
 		private TableOptimizer $tableOptimizer,
+		private readonly TitleFactory $titleFactory,
+		private readonly JobFactory $jobFactory,
 	) {
 		$this->options = new Options();
 		$this->setupFile = new SetupFile();
@@ -362,7 +365,7 @@ class Installer implements MessageReporter {
 			$this->cliMsgFormatter->firstCol( "... Property statistics rebuild job ...", 3 )
 		);
 
-		$title = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( 'SMW\SQLStore\Installer' );
+		$title = $this->titleFactory->newFromText( 'SMW\SQLStore\Installer' );
 
 		if ( $title === null ) {
 			throw new RuntimeException(
@@ -370,10 +373,8 @@ class Installer implements MessageReporter {
 			);
 		}
 
-		$mwJobFactory = MediaWikiServices::getInstance()->getJobFactory();
-
 		/** @var Job $propertyStatisticsRebuildJob */
-		$propertyStatisticsRebuildJob = $mwJobFactory->newJob(
+		$propertyStatisticsRebuildJob = $this->jobFactory->newJob(
 			'smw.propertyStatisticsRebuild',
 			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ]
 				+ Job::newRootJobParams( 'smw.propertyStatisticsRebuild', $title )
@@ -391,7 +392,7 @@ class Installer implements MessageReporter {
 		);
 
 		/** @var Job $entityIdDisposerJob */
-		$entityIdDisposerJob = $mwJobFactory->newJob(
+		$entityIdDisposerJob = $this->jobFactory->newJob(
 			'smw.entityIdDisposer',
 			[ 'namespace' => $title->getNamespace(), 'title' => $title->getDBkey() ]
 				+ Job::newRootJobParams( 'smw.entityIdDisposer', $title )

--- a/src/SQLStore/Rebuilder/Rebuilder.php
+++ b/src/SQLStore/Rebuilder/Rebuilder.php
@@ -3,14 +3,12 @@
 namespace SMW\SQLStore\Rebuilder;
 
 use MediaWiki\HookContainer\HookContainer;
-use MediaWiki\MediaWikiServices;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\TitleFactory;
 use SMW\NamespaceExaminer;
 use SMW\PropertyRegistry;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\SQLStore\SQLStore;
 use SMW\Utils\Lru;
@@ -29,14 +27,10 @@ use stdClass;
  */
 class Rebuilder {
 
-	private JobFactory $jobFactory;
-
 	/**
 	 * @var NamespaceExaminer
 	 */
 	private $namespaceExaminer;
-
-	private HookContainer $hookContainer;
 
 	private ?array $options = null;
 
@@ -63,9 +57,9 @@ class Rebuilder {
 		private readonly TitleFactory $titleFactory,
 		private readonly EntityValidator $entityValidator,
 		private readonly PropertyTableIdReferenceDisposer $propertyTableIdReferenceDisposer,
+		private readonly JobFactory $jobFactory,
+		private readonly HookContainer $hookContainer,
 	) {
-		$this->jobFactory = ApplicationFactory::getInstance()->newJobFactory();
-		$this->hookContainer = MediaWikiServices::getInstance()->getHookContainer();
 		$this->lru = new Lru( 10000 );
 	}
 

--- a/src/SQLStore/RedirectStore.php
+++ b/src/SQLStore/RedirectStore.php
@@ -2,7 +2,8 @@
 
 namespace SMW\SQLStore;
 
-use MediaWiki\MediaWikiServices;
+use MediaWiki\JobQueue\JobFactory;
+use MediaWiki\Title\TitleFactory;
 use Onoi\Cache\Cache;
 use SMW\InMemoryPoolCache;
 use SMW\Listener\ChangeListener\ChangeRecord;
@@ -30,6 +31,8 @@ class RedirectStore {
 	 */
 	public function __construct(
 		private readonly Store $store,
+		private readonly TitleFactory $titleFactory,
+		private readonly JobFactory $jobFactory,
 		private ?Cache $cache = null,
 	) {
 		if ( $this->cache === null ) {
@@ -303,14 +306,11 @@ class RedirectStore {
 
 		$res = $queryBuilder->fetchResultSet();
 
-		$services = MediaWikiServices::getInstance();
-		$titleFactory = $services->getTitleFactory();
-		$jobFactory = $services->getJobFactory();
 		foreach ( $res as $row ) {
-			$title = $titleFactory->makeTitleSafe( $row->ns, $row->t );
+			$title = $this->titleFactory->makeTitleSafe( $row->ns, $row->t );
 
 			if ( $title !== null ) {
-				$jobs[] = $jobFactory->newJob(
+				$jobs[] = $this->jobFactory->newJob(
 					'smw.update',
 					[
 						'namespace' => $title->getNamespace(),

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -127,7 +127,8 @@ class SQLStoreFactory {
 
 		$entityIdManager = new EntityIdManager(
 			$this->store,
-			$this
+			$this,
+			$settings
 		);
 
 		$entityIdManager->setEqualitySupport(
@@ -348,7 +349,9 @@ class SQLStoreFactory {
 			$this->store,
 			$applicationFactory->newTitleFactory(),
 			$entityValidator,
-			$this->newPropertyTableIdReferenceDisposer()
+			$this->newPropertyTableIdReferenceDisposer(),
+			$applicationFactory->newJobFactory(),
+			MediaWikiServices::getInstance()->getHookContainer()
 		);
 
 		return $rebuilder;
@@ -476,12 +479,16 @@ class SQLStoreFactory {
 			$setupFile
 		);
 
+		$mwServices = MediaWikiServices::getInstance();
+
 		$installer = new Installer(
 			$tableSchemaManager,
 			$tableBuilder,
 			$tableBuildExaminer,
 			$versionExaminer,
-			$tableOptimizer
+			$tableOptimizer,
+			$mwServices->getTitleFactory(),
+			$mwServices->getJobFactory()
 		);
 
 		$installer->setHookDispatcher(
@@ -851,9 +858,12 @@ class SQLStoreFactory {
 	 */
 	public function newRedirectStore(): RedirectStore {
 		$settings = ApplicationFactory::getInstance()->getSettings();
+		$mwServices = MediaWikiServices::getInstance();
 
 		$redirectStore = new RedirectStore(
-			$this->store
+			$this->store,
+			$mwServices->getTitleFactory(),
+			$mwServices->getJobFactory()
 		);
 
 		$redirectStore->setCommandLineMode(

--- a/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
@@ -2,12 +2,15 @@
 
 namespace SMW\Tests\Unit\SQLStore;
 
+use MediaWiki\JobQueue\JobFactory;
+use MediaWiki\Title\TitleFactory;
 use Onoi\Cache\Cache;
 use Onoi\Cache\FixedInMemoryLruCache;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Connection\Database;
+use SMW\Settings;
 use SMW\SQLStore\EntityStore\AuxiliaryFields;
 use SMW\SQLStore\EntityStore\CacheWarmer;
 use SMW\SQLStore\EntityStore\DuplicateFinder;
@@ -52,6 +55,7 @@ class EntityIdManagerTest extends TestCase {
 	private $tableFieldUpdater;
 	private $auxiliaryFields;
 	private $factory;
+	private Settings $settings;
 	private Database $connection;
 
 	protected function setUp(): void {
@@ -119,7 +123,19 @@ class EntityIdManagerTest extends TestCase {
 			->method( 'getConnection' )
 			->willReturn( $this->connection );
 
-		$redirectStore = new RedirectStore( $this->store );
+		$titleFactory = $this->getMockBuilder( TitleFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$jobFactory = $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$redirectStore = new RedirectStore( $this->store, $titleFactory, $jobFactory );
+
+		$this->settings = $this->getMockBuilder( Settings::class )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->factory = $this->getMockBuilder( SQLStoreFactory::class )
 			->disableOriginalConstructor()
@@ -178,7 +194,7 @@ class EntityIdManagerTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			EntityIdManager::class,
-			new EntityIdManager( $this->store, $this->factory )
+			new EntityIdManager( $this->store, $this->factory, $this->settings )
 		);
 	}
 
@@ -199,7 +215,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$this->store,
-			$this->factory
+			$this->factory,
+			$this->settings
 		);
 
 		$this->assertFalse(
@@ -251,7 +268,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$store,
-			$this->factory
+			$this->factory,
+			$this->settings
 		);
 
 		$result = $instance->getSMWPropertyID( new Property( 'Foo' ) );
@@ -285,7 +303,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$store,
-			$this->factory
+			$this->factory,
+			$this->settings
 		);
 
 		$sortkey = $parameters['sortkey'];
@@ -340,7 +359,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$store,
-			$this->factory
+			$this->factory,
+			$this->settings
 		);
 
 		$instance->setEqualitySupport( SMW_EQ_SOME );
@@ -378,7 +398,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$this->store,
-			$this->factory
+			$this->factory,
+			$this->settings
 		);
 
 		$this->assertInstanceOf(
@@ -397,7 +418,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$this->store,
-			$this->factory
+			$this->factory,
+			$this->settings
 		);
 
 		$instance->updateInterwikiField(
@@ -428,7 +450,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$this->store,
-			$this->factory
+			$this->factory,
+			$this->settings
 		);
 
 		$this->assertEquals(
@@ -464,7 +487,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$store,
-			$this->factory
+			$this->factory,
+			$this->settings
 		);
 
 		$this->assertEquals(
@@ -513,7 +537,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$store,
-			$factory
+			$factory,
+			$this->settings
 		);
 
 		$instance->warmUpCache( $list );
@@ -571,7 +596,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$store,
-			$factory
+			$factory,
+			$this->settings
 		);
 
 		$this->assertEquals(
@@ -610,7 +636,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$this->store,
-			$this->factory
+			$this->factory,
+			$this->settings
 		);
 
 		$instance->preload( $subjects );
@@ -625,7 +652,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$this->store,
-			$this->factory
+			$this->factory,
+			$this->settings
 		);
 
 		$instance->updateFieldMaps( 42, [ 'Foo' ], [ 'F' => 1 ] );
@@ -638,7 +666,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$this->store,
-			$this->factory
+			$this->factory,
+			$this->settings
 		);
 
 		$instance->getSequenceMap( 1001 );
@@ -651,7 +680,8 @@ class EntityIdManagerTest extends TestCase {
 
 		$instance = new EntityIdManager(
 			$this->store,
-			$this->factory
+			$this->factory,
+			$this->settings
 		);
 
 		$instance->loadSequenceMap( [ 42, 1001 ] );

--- a/tests/phpunit/Unit/SQLStore/InstallerTest.php
+++ b/tests/phpunit/Unit/SQLStore/InstallerTest.php
@@ -2,10 +2,13 @@
 
 namespace SMW\Tests\Unit\SQLStore;
 
+use MediaWiki\JobQueue\JobFactory;
+use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleFactory;
 use Onoi\MessageReporter\MessageReporterFactory;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\HookDispatcher;
-use SMW\MediaWiki\JobQueue;
+use SMW\MediaWiki\Job;
 use SMW\SetupFile;
 use SMW\SQLStore\Installer;
 use SMW\SQLStore\Installer\TableOptimizer;
@@ -34,7 +37,8 @@ class InstallerTest extends TestCase {
 	private $tableBuildExaminer;
 	private $versionExaminer;
 	private $tableOptimizer;
-	private JobQueue $jobQueue;
+	private TitleFactory $titleFactory;
+	private JobFactory $jobFactory;
 	private $hookDispatcher;
 	private $setupFile;
 
@@ -63,7 +67,11 @@ class InstallerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+		$this->titleFactory = $this->getMockBuilder( TitleFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -74,8 +82,6 @@ class InstallerTest extends TestCase {
 		$this->setupFile = $this->getMockBuilder( SetupFile::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
 	}
 
 	public function testCanConstruct() {
@@ -84,7 +90,9 @@ class InstallerTest extends TestCase {
 			$this->tableBuilder,
 			$this->tableBuildExaminer,
 			$this->versionExaminer,
-			$this->tableOptimizer
+			$this->tableOptimizer,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$this->assertInstanceOf(
@@ -122,7 +130,9 @@ class InstallerTest extends TestCase {
 			$tableBuilder,
 			$this->tableBuildExaminer,
 			$this->versionExaminer,
-			$this->tableOptimizer
+			$this->tableOptimizer,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$instance->setHookDispatcher( $this->hookDispatcher );
@@ -144,7 +154,9 @@ class InstallerTest extends TestCase {
 			$this->tableBuilder,
 			$this->tableBuildExaminer,
 			$this->versionExaminer,
-			$this->tableOptimizer
+			$this->tableOptimizer,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$instance->setHookDispatcher( $this->hookDispatcher );
@@ -155,8 +167,20 @@ class InstallerTest extends TestCase {
 	}
 
 	public function testInstallWithSupplementJobs() {
-		$this->jobQueue->expects( $this->exactly( 2 ) )
-			->method( 'push' );
+		$title = $this->getMockBuilder( Title::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->titleFactory->method( 'newFromText' )->willReturn( $title );
+
+		$job = $this->getMockBuilder( Job::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$job->expects( $this->exactly( 2 ) )
+			->method( 'insert' );
+
+		$this->jobFactory->method( 'newJob' )->willReturn( $job );
 
 		$table = $this->getMockBuilder( Table::class )
 			->disableOriginalConstructor()
@@ -186,7 +210,9 @@ class InstallerTest extends TestCase {
 			$tableBuilder,
 			$this->tableBuildExaminer,
 			$this->versionExaminer,
-			$this->tableOptimizer
+			$this->tableOptimizer,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$instance->setHookDispatcher( $this->hookDispatcher );
@@ -225,7 +251,9 @@ class InstallerTest extends TestCase {
 			$tableBuilder,
 			$this->tableBuildExaminer,
 			$this->versionExaminer,
-			$this->tableOptimizer
+			$this->tableOptimizer,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$instance->setHookDispatcher( $this->hookDispatcher );
@@ -259,7 +287,9 @@ class InstallerTest extends TestCase {
 			$tableBuilder,
 			$this->tableBuildExaminer,
 			$this->versionExaminer,
-			$this->tableOptimizer
+			$this->tableOptimizer,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$instance->setHookDispatcher( $this->hookDispatcher );
@@ -277,7 +307,9 @@ class InstallerTest extends TestCase {
 			$this->tableBuilder,
 			$this->tableBuildExaminer,
 			$this->versionExaminer,
-			$this->tableOptimizer
+			$this->tableOptimizer,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$callback = static function () use( $instance ) {

--- a/tests/phpunit/Unit/SQLStore/Rebuilder/RebuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/Rebuilder/RebuilderTest.php
@@ -2,9 +2,11 @@
 
 namespace SMW\Tests\Unit\SQLStore\Rebuilder;
 
+use MediaWiki\HookContainer\HookContainer;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Connection\Database;
+use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\TitleFactory;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
@@ -31,6 +33,8 @@ class RebuilderTest extends TestCase {
 	private $titleFactory;
 	private $entityValidator;
 	private $propertyTableIdReferenceDisposer;
+	private $jobFactory;
+	private $hookContainer;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -54,6 +58,14 @@ class RebuilderTest extends TestCase {
 		$this->propertyTableIdReferenceDisposer = $this->getMockBuilder( PropertyTableIdReferenceDisposer::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->hookContainer = $this->getMockBuilder( HookContainer::class )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown(): void {
@@ -68,7 +80,7 @@ class RebuilderTest extends TestCase {
 
 		$this->assertInstanceOf(
 			Rebuilder::class,
-			new Rebuilder( $store, $this->titleFactory, $this->entityValidator, $this->propertyTableIdReferenceDisposer )
+			new Rebuilder( $store, $this->titleFactory, $this->entityValidator, $this->propertyTableIdReferenceDisposer, $this->jobFactory, $this->hookContainer )
 		);
 	}
 
@@ -110,7 +122,9 @@ class RebuilderTest extends TestCase {
 			$store,
 			$this->titleFactory,
 			$this->entityValidator,
-			$this->propertyTableIdReferenceDisposer
+			$this->propertyTableIdReferenceDisposer,
+			$this->jobFactory,
+			$this->hookContainer
 		);
 
 		$instance->setDispatchRangeLimit( 1 );
@@ -202,7 +216,9 @@ class RebuilderTest extends TestCase {
 			$store,
 			$this->titleFactory,
 			$this->entityValidator,
-			$this->propertyTableIdReferenceDisposer
+			$this->propertyTableIdReferenceDisposer,
+			$this->jobFactory,
+			$this->hookContainer
 		);
 
 		$instance->setDispatchRangeLimit( 1 );

--- a/tests/phpunit/Unit/SQLStore/RedirectStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/RedirectStoreTest.php
@@ -2,12 +2,15 @@
 
 namespace SMW\Tests\Unit\SQLStore;
 
+use MediaWiki\JobQueue\JobFactory;
+use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleFactory;
 use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\Connection\ConnectionManager;
 use SMW\InMemoryPoolCache;
 use SMW\MediaWiki\Connection\Database;
-use SMW\MediaWiki\JobQueue;
+use SMW\MediaWiki\Job;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\RedirectStore;
 use SMW\SQLStore\SQLStore;
@@ -38,7 +41,8 @@ class RedirectStoreTest extends TestCase {
 	private $cache;
 	private $testEnvironment;
 	private $connectionManager;
-	private JobQueue $jobQueue;
+	private TitleFactory $titleFactory;
+	private JobFactory $jobFactory;
 
 	protected function setUp(): void {
 		$this->testEnvironment = new TestEnvironment();
@@ -66,11 +70,13 @@ class RedirectStoreTest extends TestCase {
 
 		$this->store->setConnectionManager( $this->connectionManager );
 
-		$this->jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+		$this->titleFactory = $this->getMockBuilder( TitleFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
+		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
 
 		InMemoryPoolCache::getInstance()->clear();
 	}
@@ -83,7 +89,7 @@ class RedirectStoreTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			RedirectStore::class,
-			new RedirectStore( $this->store )
+			new RedirectStore( $this->store, $this->titleFactory, $this->jobFactory )
 		);
 	}
 
@@ -99,7 +105,9 @@ class RedirectStoreTest extends TestCase {
 			->willReturn( $selectBuilder );
 
 		$instance = new RedirectStore(
-			$this->store
+			$this->store,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$this->assertEquals(
@@ -138,7 +146,9 @@ class RedirectStoreTest extends TestCase {
 			->willReturn( $selectBuilder );
 
 		$instance = new RedirectStore(
-			$this->store
+			$this->store,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$this->assertSame(
@@ -184,7 +194,9 @@ class RedirectStoreTest extends TestCase {
 			->willReturn( $insertBuilder );
 
 		$instance = new RedirectStore(
-			$this->store
+			$this->store,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$instance->addRedirect( 42, 'Foo', 0 );
@@ -234,7 +246,9 @@ class RedirectStoreTest extends TestCase {
 			->willReturn( $selectBuilder );
 
 		$instance = new RedirectStore(
-			$this->store
+			$this->store,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$instance->deleteRedirect( 'Foo', 9001 );
@@ -306,11 +320,26 @@ class RedirectStoreTest extends TestCase {
 			true
 		);
 
-		$this->jobQueue->expects( $this->once() )
+		$title = $this->getMockBuilder( Title::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$title->method( 'getNamespace' )->willReturn( NS_MAIN );
+		$title->method( 'getDBkey' )->willReturn( 'Bar' );
+
+		$this->titleFactory->method( 'makeTitleSafe' )->willReturn( $title );
+
+		$job = $this->getMockBuilder( Job::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$job->expects( $this->once() )
 			->method( 'lazyPush' );
 
+		$this->jobFactory->method( 'newJob' )->willReturn( $job );
+
 		$instance = new RedirectStore(
-			$store
+			$store,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$instance->setCommandLineMode( false );
@@ -325,8 +354,21 @@ class RedirectStoreTest extends TestCase {
 			->with( SQLStore::UPDATE_TRANSACTION )
 			->willReturn( true );
 
-		$this->jobQueue->expects( $this->once() )
+		$title = $this->getMockBuilder( Title::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$title->method( 'getNamespace' )->willReturn( NS_MAIN );
+		$title->method( 'getDBkey' )->willReturn( 'Bar' );
+
+		$this->titleFactory->method( 'makeTitleSafe' )->willReturn( $title );
+
+		$job = $this->getMockBuilder( Job::class )
+			->disableOriginalConstructor()
+			->getMock();
+		$job->expects( $this->once() )
 			->method( 'lazyPush' );
+
+		$this->jobFactory->method( 'newJob' )->willReturn( $job );
 
 		$row = new stdClass;
 		$row->ns = NS_MAIN;
@@ -378,7 +420,9 @@ class RedirectStoreTest extends TestCase {
 		);
 
 		$instance = new RedirectStore(
-			$store
+			$store,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$instance->setCommandLineMode( true );
@@ -402,7 +446,9 @@ class RedirectStoreTest extends TestCase {
 		);
 
 		$instance = new RedirectStore(
-			$store
+			$store,
+			$this->titleFactory,
+			$this->jobFactory
 		);
 
 		$instance->setEqualitySupport( SMW_EQ_NONE );


### PR DESCRIPTION
## Summary

Continues the DI follow-up to #6827. Four `SQLStoreFactory` product classes (`RedirectStore`, `EntityIdManager`, `Installer`, `SQLStore\Rebuilder\Rebuilder`) previously fetched their MediaWiki / SMW service dependencies from global service locators inside method bodies (or in the constructor body for `Rebuilder`). The factory already has those services on hand, so this PR moves them to constructor parameters and updates `SQLStoreFactory` to wire them in. With this change every product reachable through `SQLStoreFactory` is free of `MediaWikiServices::getInstance()` / `ApplicationFactory::getInstance()` calls.

## Service-locator calls removed

| File | Locator call | Lifted to constructor |
| --- | --- | --- |
| `src/SQLStore/RedirectStore.php` | `MediaWikiServices::getInstance()` in `findUpdateJobs()` | `TitleFactory`, `JobFactory` (MW core) |
| `src/SQLStore/EntityStore/EntityIdManager.php` | `ApplicationFactory::getInstance()->getSettings()` in `resolveCacheSizes()` | `SMW\Settings` |
| `src/SQLStore/Installer.php` | two `MediaWikiServices::getInstance()` calls in `addSupplementJobs()` | `TitleFactory`, `JobFactory` (MW core) |
| `src/SQLStore/Rebuilder/Rebuilder.php` | `ApplicationFactory::getInstance()->newJobFactory()` + `MediaWikiServices::getInstance()->getHookContainer()` in the constructor body | `SMW\MediaWiki\JobFactory`, `HookContainer` |

`SQLStoreFactory::newRedirectStore()`, `newEntityIdManager()`, `newInstaller()`, and `newRebuilder()` now wire the new dependencies in.

## Tests

The product tests no longer need a live `MediaWikiServices` / `ApplicationFactory` singleton to instantiate these classes; they pass plain `getMockBuilder()`-built service mocks. Two tests (`RedirectStoreTest::testUpdateRedirect*`, `InstallerTest::testInstallWithSupplementJobs`) previously asserted on a `TestEnvironment::registerObject( 'JobQueue', ... )` mock's `lazyPush` / `push` method to verify job dispatch. They now mock the `JobFactory` to return a mock SMW `Job` and assert on the mock job's `lazyPush()` / `insert()` directly. Same coverage of the dispatch surface, less coupling to the SMW JobQueue singleton.

## Test plan

- [x] `composer phpunit --testsuite=semantic-mediawiki-unit` reports 7081 tests, 14498 assertions, 6 expected skips.
- [x] `composer analyze` reports no new errors or warnings on the changed files.
- [x] `php maintenance/run.php update --quick` (which exercises the new `Installer` + `Rebuilder` constructors via the real factory) completes without error.