### PR TITLE
Inject MediaWiki services into ElasticFactory products

### DIFF
--- a/src/Elastic/ElasticFactory.php
+++ b/src/Elastic/ElasticFactory.php
@@ -162,10 +162,13 @@ class ElasticFactory {
 		}
 
 		$connection = $store->getConnection( 'elastic' );
+		$mwServices = MediaWikiServices::getInstance();
 
 		$indexer = new Indexer(
 			$store,
-			$this->newBulk( $connection )
+			$this->newBulk( $connection ),
+			$mwServices->getTitleFactory(),
+			$mwServices->getRevisionLookup()
 		);
 
 		if ( $messageReporter === null ) {
@@ -344,6 +347,7 @@ class ElasticFactory {
 		$queryEngine = new QueryEngine(
 			$store,
 			$conditionBuilder,
+			$applicationFactory->getQueryFactory(),
 			$config
 		);
 

--- a/src/Elastic/Indexer/Indexer.php
+++ b/src/Elastic/Indexer/Indexer.php
@@ -2,10 +2,11 @@
 
 namespace SMW\Elastic\Indexer;
 
-use MediaWiki\MediaWikiServices;
+use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Revision\SlotRecord;
 use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleFactory;
 use Onoi\MessageReporter\MessageReporterAwareTrait;
 use Psr\Log\LoggerAwareTrait;
 use RuntimeException;
@@ -48,6 +49,8 @@ class Indexer {
 	public function __construct(
 		private Store $store,
 		private Bulk $bulk,
+		private readonly TitleFactory $titleFactory,
+		private readonly RevisionLookup $revisionLookup,
 	) {
 	}
 
@@ -118,7 +121,7 @@ class Indexer {
 			return;
 		}
 
-		$title = MediaWikiServices::getInstance()->getTitleFactory()->newFromText(
+		$title = $this->titleFactory->newFromText(
 			$this->origin . ':' . md5( json_encode( $idList ) )
 		);
 
@@ -224,7 +227,7 @@ class Indexer {
 			return '';
 		}
 
-		$revision = MediaWikiServices::getInstance()->getRevisionLookup()->getRevisionById( $id );
+		$revision = $this->revisionLookup->getRevisionById( $id );
 
 		if ( $revision == null ) {
 			return '';

--- a/src/Elastic/QueryEngine/QueryEngine.php
+++ b/src/Elastic/QueryEngine/QueryEngine.php
@@ -13,7 +13,6 @@ use SMW\Query\Query;
 use SMW\Query\ScoreSet;
 use SMW\QueryEngine as IQueryEngine;
 use SMW\QueryFactory;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
 
 /**
@@ -25,8 +24,6 @@ use SMW\Store;
 class QueryEngine implements IQueryEngine {
 
 	use LoggerAwareTrait;
-
-	private QueryFactory $queryFactory;
 
 	private FieldMapper $fieldMapper;
 
@@ -42,13 +39,13 @@ class QueryEngine implements IQueryEngine {
 	public function __construct(
 		private Store $store,
 		private ConditionBuilder $conditionBuilder,
+		private readonly QueryFactory $queryFactory,
 		private ?Options $options = null,
 	) {
 		if ( $this->options === null ) {
 			$this->options = new Options();
 		}
 
-		$this->queryFactory = ApplicationFactory::getInstance()->getQueryFactory();
 		$this->fieldMapper = new FieldMapper();
 		$this->sortBuilder = new SortBuilder( $this->store );
 

--- a/tests/phpunit/Unit/Elastic/Indexer/IndexerTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/IndexerTest.php
@@ -2,6 +2,9 @@
 
 namespace SMW\Tests\Unit\Elastic\Indexer;
 
+use MediaWiki\Revision\RevisionLookup;
+use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleFactory;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use SMW\DataItems\WikiPage;
@@ -30,6 +33,8 @@ class IndexerTest extends TestCase {
 	private $logger;
 	private $jobQueue;
 	private $testEnvironment;
+	private TitleFactory $titleFactory;
+	private RevisionLookup $revisionLookup;
 
 	protected function setUp(): void {
 		$this->testEnvironment = new TestEnvironment();
@@ -67,6 +72,14 @@ class IndexerTest extends TestCase {
 			->getMock();
 
 		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
+
+		$this->titleFactory = $this->getMockBuilder( TitleFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->revisionLookup = $this->getMockBuilder( RevisionLookup::class )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown(): void {
@@ -77,7 +90,7 @@ class IndexerTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			Indexer::class,
-			new Indexer( $this->store, $this->bulk )
+			new Indexer( $this->store, $this->bulk, $this->titleFactory, $this->revisionLookup )
 		);
 	}
 
@@ -113,7 +126,9 @@ class IndexerTest extends TestCase {
 
 		$instance = new Indexer(
 			$this->store,
-			$this->bulk
+			$this->bulk,
+			$this->titleFactory,
+			$this->revisionLookup
 		);
 
 		$instance->setLogger( $this->logger );
@@ -132,7 +147,9 @@ class IndexerTest extends TestCase {
 
 		$instance = new Indexer(
 			$this->store,
-			$this->bulk
+			$this->bulk,
+			$this->titleFactory,
+			$this->revisionLookup
 		);
 
 		$instance->setLogger( $this->logger );
@@ -158,7 +175,9 @@ class IndexerTest extends TestCase {
 
 		$instance = new Indexer(
 			$this->store,
-			$this->bulk
+			$this->bulk,
+			$this->titleFactory,
+			$this->revisionLookup
 		);
 
 		$instance->setLogger( $this->logger );
@@ -175,9 +194,17 @@ class IndexerTest extends TestCase {
 			->method( 'ping' )
 			->willReturn( false );
 
+		$title = $this->getMockBuilder( Title::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->titleFactory->method( 'newFromText' )->willReturn( $title );
+
 		$instance = new Indexer(
 			$this->store,
-			$this->bulk
+			$this->bulk,
+			$this->titleFactory,
+			$this->revisionLookup
 		);
 
 		$instance->setLogger( $this->logger );
@@ -210,7 +237,9 @@ class IndexerTest extends TestCase {
 
 		$instance = new Indexer(
 			$this->store,
-			$this->bulk
+			$this->bulk,
+			$this->titleFactory,
+			$this->revisionLookup
 		);
 
 		$instance->setLogger( $this->logger );
@@ -237,7 +266,9 @@ class IndexerTest extends TestCase {
 
 		$instance = new Indexer(
 			$this->store,
-			$this->bulk
+			$this->bulk,
+			$this->titleFactory,
+			$this->revisionLookup
 		);
 
 		$instance->setLogger( $this->logger );

--- a/tests/phpunit/Unit/Elastic/QueryEngine/QueryEngineTest.php
+++ b/tests/phpunit/Unit/Elastic/QueryEngine/QueryEngineTest.php
@@ -11,6 +11,7 @@ use SMW\MediaWiki\Connection\Database;
 use SMW\Query\Language\Description;
 use SMW\Query\Query;
 use SMW\Query\QueryResult;
+use SMW\QueryFactory;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\SQLStore;
 
@@ -29,6 +30,7 @@ class QueryEngineTest extends TestCase {
 	private $conditionBuilder;
 	private $elasticClient;
 	private $idTable;
+	private QueryFactory $queryFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -68,12 +70,14 @@ class QueryEngineTest extends TestCase {
 		$this->conditionBuilder = $this->getMockBuilder( ConditionBuilder::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->queryFactory = new QueryFactory();
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			QueryEngine::class,
-			new QueryEngine( $this->store, $this->conditionBuilder )
+			new QueryEngine( $this->store, $this->conditionBuilder, $this->queryFactory )
 		);
 	}
 
@@ -98,7 +102,8 @@ class QueryEngineTest extends TestCase {
 
 		$instance = new QueryEngine(
 			$this->store,
-			$this->conditionBuilder
+			$this->conditionBuilder,
+			$this->queryFactory
 		);
 
 		$this->assertInstanceOf(
@@ -167,7 +172,8 @@ class QueryEngineTest extends TestCase {
 
 		$instance = new QueryEngine(
 			$this->store,
-			$this->conditionBuilder
+			$this->conditionBuilder,
+			$this->queryFactory
 		);
 
 		$this->assertInstanceOf(


### PR DESCRIPTION
## Summary

Continues the DI follow-up to #6827 and mirrors #6862 (which did the equivalent SQLStoreFactory lift). The `Indexer` and `QueryEngine` classes under `src/Elastic/` previously fetched their MediaWiki / SMW service dependencies from global service locators inside method bodies (or in the constructor body for `QueryEngine`). The `ElasticFactory` already has those services on hand, so this PR moves them to constructor parameters and updates the factory to wire them in.

With this change every product reachable through `SQLStoreFactory` or `ElasticFactory` is free of `MediaWikiServices::getInstance()` / `ApplicationFactory::getInstance()` calls.

## Service-locator calls removed

| File | Locator call | Lifted to constructor |
| --- | --- | --- |
| `src/Elastic/Indexer/Indexer.php` | `MediaWikiServices::getInstance()->getTitleFactory()` in `delete()` | `MediaWiki\Title\TitleFactory` |
| `src/Elastic/Indexer/Indexer.php` | `MediaWikiServices::getInstance()->getRevisionLookup()` in the revision-content fetch path | `MediaWiki\Revision\RevisionLookup` |
| `src/Elastic/QueryEngine/QueryEngine.php` | `ApplicationFactory::getInstance()->getQueryFactory()` in the constructor body | `SMW\QueryFactory` |

`ElasticFactory::newIndexer()` and `newQueryEngine()` now wire the new dependencies in.

## Tests

Both `IndexerTest` and `QueryEngineTest` updated to pass plain `getMockBuilder()`-built service mocks instead of relying on global singletons. `IndexerTest::testDelete_FailedConnection_PushJob` now mocks `titleFactory->newFromText` to return a non-null `Title` (matching the original behaviour where the real `TitleFactory` produced a Title that `IndexerRecoveryJob::pushFromParams()` then accepted). `QueryEngineTest` constructs a real `new QueryFactory()` (it has no dependencies of its own) rather than mocking.

## Test plan

- [x] `composer phpunit --testsuite=semantic-mediawiki-unit` reports 7081 tests, 14498 assertions, 6 expected skips.
- [x] `composer analyze` reports no new errors or warnings on the changed files.