### PR TITLE
Prune dead TestEnvironment::registerObject calls from unit tests

### DIFF
--- a/tests/phpunit/Unit/Constraint/Constraints/UniqueValueConstraintTest.php
+++ b/tests/phpunit/Unit/Constraint/Constraints/UniqueValueConstraintTest.php
@@ -50,8 +50,6 @@ class UniqueValueConstraintTest extends TestCase {
 		$this->propertySpecificationLookup = $this->getMockBuilder( SpecificationLookup::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'PropertySpecificationLookup', $this->propertySpecificationLookup );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/Elastic/Hooks/UpdateEntityCollationCompleteTest.php
+++ b/tests/phpunit/Unit/Elastic/Hooks/UpdateEntityCollationCompleteTest.php
@@ -79,8 +79,6 @@ class UpdateEntityCollationCompleteTest extends TestCase {
 		$this->store->expects( $this->any() )
 			->method( 'getConnection' )
 			->willReturnCallback( $callback );
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/Formatters/InfolinkTest.php
+++ b/tests/phpunit/Unit/Formatters/InfolinkTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Unit\Formatters;
 
-use MediaWiki\Language\Language;
 use PHPUnit\Framework\TestCase;
 use SMW\Formatters\Infolink;
 use SMW\Tests\TestEnvironment;
@@ -22,12 +21,6 @@ class InfolinkTest extends TestCase {
 
 	protected function setUp(): void {
 		$this->testEnvironment = new TestEnvironment();
-
-		$language = $this->getMockBuilder( Language::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->testEnvironment->registerObject( 'ContentLanguage', $language );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksIntegrationTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksIntegrationTest.php
@@ -54,8 +54,6 @@ class InternalParseBeforeLinksIntegrationTest extends TestCase {
 		$parserData->expects( $this->never() )
 			->method( 'getSemanticData' );
 
-		$this->applicationFactory->registerObject( 'ParserData', $parserData );
-
 		wfMessage( 'properties' )->parse();
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksIntegrationTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksIntegrationTest.php
@@ -54,6 +54,8 @@ class InternalParseBeforeLinksIntegrationTest extends TestCase {
 		$parserData->expects( $this->never() )
 			->method( 'getSemanticData' );
 
+		$this->applicationFactory->registerObject( 'ParserData', $parserData );
+
 		wfMessage( 'properties' )->parse();
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyIntegrationTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyIntegrationTest.php
@@ -51,6 +51,8 @@ class ParserAfterTidyIntegrationTest extends TestCase {
 		$parserData->expects( $this->never() )
 			->method( 'getSemanticData' );
 
+		$this->applicationFactory->registerObject( 'ParserData', $parserData );
+
 		wfMessage( 'properties' )->parse();
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyIntegrationTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyIntegrationTest.php
@@ -51,8 +51,6 @@ class ParserAfterTidyIntegrationTest extends TestCase {
 		$parserData->expects( $this->never() )
 			->method( 'getSemanticData' );
 
-		$this->applicationFactory->registerObject( 'ParserData', $parserData );
-
 		wfMessage( 'properties' )->parse();
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
@@ -10,7 +10,6 @@ use SMW\Factbox\FactboxFactory;
 use SMW\Factbox\FactboxText;
 use SMW\MediaWiki\Hooks\SkinAfterContent;
 use SMW\Services\ServicesFactory as ApplicationFactory;
-use SMW\Settings;
 use SMW\Tests\Utils\Mock\MockTitle;
 
 /**
@@ -31,13 +30,6 @@ class SkinAfterContentTest extends TestCase {
 		parent::setUp();
 
 		$this->applicationFactory = ApplicationFactory::getInstance();
-
-		$settings = Settings::newFromArray( [
-			'smwgFactboxFeatures'  => SMW_FACTBOX_CACHE,
-			'smwgMainCacheType'        => 'hash',
-			'smwgShowFactboxEdit' => false,
-			'smwgShowFactbox' => false
-		] );
 
 		$this->factboxText = $this->applicationFactory->getFactboxText();
 	}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SkinAfterContentTest.php
@@ -39,8 +39,6 @@ class SkinAfterContentTest extends TestCase {
 			'smwgShowFactbox' => false
 		] );
 
-		$this->applicationFactory->registerObject( 'Settings', $settings );
-
 		$this->factboxText = $this->applicationFactory->getFactboxText();
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationClassUpdateJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationClassUpdateJobTest.php
@@ -30,8 +30,6 @@ class ChangePropagationClassUpdateJobTest extends TestCase {
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationClassUpdateJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationClassUpdateJobTest.php
@@ -6,7 +6,6 @@ use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Jobs\ChangePropagationClassUpdateJob;
-use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -26,10 +25,6 @@ class ChangePropagationClassUpdateJobTest extends TestCase {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
-
-		$store = $this->getMockBuilder( SQLStore::class )
-			->disableOriginalConstructor()
-			->getMock();
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationUpdateJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationUpdateJobTest.php
@@ -30,8 +30,6 @@ class ChangePropagationUpdateJobTest extends TestCase {
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationUpdateJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationUpdateJobTest.php
@@ -6,7 +6,6 @@ use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Jobs\ChangePropagationUpdateJob;
-use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -26,10 +25,6 @@ class ChangePropagationUpdateJobTest extends TestCase {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
-
-		$store = $this->getMockBuilder( SQLStore::class )
-			->disableOriginalConstructor()
-			->getMock();
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Maintenance/TableSchemaTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Maintenance/TableSchemaTaskHandlerTest.php
@@ -42,8 +42,6 @@ class TableSchemaTaskHandlerTest extends TestCase {
 		$this->outputFormatter = $this->getMockBuilder( OutputFormatter::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/MaintenanceTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/MaintenanceTaskHandlerTest.php
@@ -44,8 +44,6 @@ class MaintenanceTaskHandlerTest extends TestCase {
 		$this->fileFetcher = $this->getMockBuilder( FileFetcher::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/CacheStatisticsListTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/CacheStatisticsListTaskHandlerTest.php
@@ -40,8 +40,6 @@ class CacheStatisticsListTaskHandlerTest extends TestCase {
 		$this->outputFormatter->expects( $this->any() )
 			->method( 'encodeAsJson' )
 			->willReturn( '' );
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/CacheStatisticsListTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/CacheStatisticsListTaskHandlerTest.php
@@ -6,7 +6,6 @@ use MediaWiki\Request\WebRequest;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Specials\Admin\OutputFormatter;
 use SMW\MediaWiki\Specials\Admin\Supplement\CacheStatisticsListTaskHandler;
-use SMW\Store;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -21,17 +20,12 @@ use SMW\Tests\TestEnvironment;
 class CacheStatisticsListTaskHandlerTest extends TestCase {
 
 	private $testEnvironment;
-	private $store;
 	private $outputFormatter;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
-
-		$this->store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
 
 		$this->outputFormatter = $this->getMockBuilder( OutputFormatter::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/ConfigurationListTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/ConfigurationListTaskHandlerTest.php
@@ -6,7 +6,6 @@ use MediaWiki\Request\WebRequest;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Specials\Admin\OutputFormatter;
 use SMW\MediaWiki\Specials\Admin\Supplement\ConfigurationListTaskHandler;
-use SMW\Store;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -21,17 +20,12 @@ use SMW\Tests\TestEnvironment;
 class ConfigurationListTaskHandlerTest extends TestCase {
 
 	private $testEnvironment;
-	private $store;
 	private $outputFormatter;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
-
-		$this->store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
 
 		$this->outputFormatter = $this->getMockBuilder( OutputFormatter::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/ConfigurationListTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/ConfigurationListTaskHandlerTest.php
@@ -40,8 +40,6 @@ class ConfigurationListTaskHandlerTest extends TestCase {
 		$this->outputFormatter->expects( $this->any() )
 			->method( 'encodeAsJson' )
 			->willReturn( '' );
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/OperationalStatisticsListTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Supplement/OperationalStatisticsListTaskHandlerTest.php
@@ -37,8 +37,6 @@ class OperationalStatisticsListTaskHandlerTest extends TestCase {
 		$this->outputFormatter = $this->getMockBuilder( OutputFormatter::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/SupplementTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/SupplementTaskHandlerTest.php
@@ -38,8 +38,6 @@ class SupplementTaskHandlerTest extends TestCase {
 		$this->outputFormatter = $this->getMockBuilder( OutputFormatter::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/SupportListTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/SupportListTaskHandlerTest.php
@@ -36,8 +36,6 @@ class SupportListTaskHandlerTest extends TestCase {
 		$this->htmlFormRenderer = $this->getMockBuilder( HtmlFormRenderer::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/TaskHandlerFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/TaskHandlerFactoryTest.php
@@ -63,8 +63,6 @@ class TaskHandlerFactoryTest extends TestCase {
 		$this->outputFormatter = $this->getMockBuilder( OutputFormatter::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/TaskHandlerRegistryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/TaskHandlerRegistryTest.php
@@ -45,8 +45,6 @@ class TaskHandlerRegistryTest extends TestCase {
 		$this->outputFormatter = $this->getMockBuilder( OutputFormatter::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/MediaWiki/Specials/Browse/HtmlBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Browse/HtmlBuilderTest.php
@@ -38,8 +38,6 @@ class HtmlBuilderTest extends TestCase {
 		$this->store->expects( $this->any() )
 			->method( 'getPropertySubjects' )
 			->willReturn( [] );
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Specials/Browse/ValueFormatterTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Browse/ValueFormatterTest.php
@@ -7,7 +7,6 @@ use SMW\DataItems\WikiPage;
 use SMW\DataValues\DataValue;
 use SMW\DataValues\PropertyValue;
 use SMW\MediaWiki\Specials\Browse\ValueFormatter;
-use SMW\Store;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -22,16 +21,11 @@ use SMW\Tests\TestEnvironment;
 class ValueFormatterTest extends TestCase {
 
 	private $testEnvironment;
-	private $store;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
-
-		$this->store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Specials/Browse/ValueFormatterTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Browse/ValueFormatterTest.php
@@ -32,8 +32,6 @@ class ValueFormatterTest extends TestCase {
 		$this->store = $this->getMockBuilder( Store::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialPendingTaskListTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialPendingTaskListTest.php
@@ -6,7 +6,6 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Request\FauxRequest;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Specials\SpecialPendingTaskList;
-use SMW\Store;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -27,10 +26,6 @@ class SpecialPendingTaskListTest extends TestCase {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
-
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
 
 		$this->stringValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newStringValidator();
 	}

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialPendingTaskListTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialPendingTaskListTest.php
@@ -32,7 +32,6 @@ class SpecialPendingTaskListTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$this->testEnvironment->registerObject( 'Store', $store );
 		$this->stringValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newStringValidator();
 	}
 

--- a/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
@@ -15,7 +15,6 @@ use SMW\Parser\InTextAnnotationParser;
 use SMW\Parser\LinksProcessor;
 use SMW\ParserData;
 use SMW\Services\ServicesFactory as ApplicationFactory;
-use SMW\Store;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -42,10 +41,6 @@ class InTextAnnotationParserTest extends TestCase {
 		$this->testEnvironment = new TestEnvironment();
 		$this->semanticDataValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newSemanticDataValidator();
 		$this->stringValidator = $this->testEnvironment->getUtilityFactory()->newValidatorFactory()->newStringValidator();
-
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
 
 		$this->linksProcessor = new LinksProcessor();
 

--- a/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
+++ b/tests/phpunit/Unit/Parser/InTextAnnotationParserTest.php
@@ -47,8 +47,6 @@ class InTextAnnotationParserTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$this->testEnvironment->registerObject( 'Store', $store );
-
 		$this->linksProcessor = new LinksProcessor();
 
 		$this->magicWordsFinder = $this->getMockBuilder( MagicWordsFinder::class )

--- a/tests/phpunit/Unit/ParserFunctionFactoryTest.php
+++ b/tests/phpunit/Unit/ParserFunctionFactoryTest.php
@@ -42,8 +42,6 @@ class ParserFunctionFactoryTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->testEnvironment->registerObject( 'ParserData', $this->parserData );
-
 		$this->parserFactory = $this->testEnvironment->getUtilityFactory()->newParserFactory();
 	}
 

--- a/tests/phpunit/Unit/ParserFunctionFactoryTest.php
+++ b/tests/phpunit/Unit/ParserFunctionFactoryTest.php
@@ -4,7 +4,6 @@ namespace SMW\Tests\Unit;
 
 use MediaWiki\Parser\Parser;
 use PHPUnit\Framework\TestCase;
-use SMW\ParserData;
 use SMW\ParserFunctionFactory;
 use SMW\ParserFunctions\AskParserFunction;
 use SMW\ParserFunctions\ConceptParserFunction;
@@ -29,18 +28,12 @@ class ParserFunctionFactoryTest extends TestCase {
 
 	private $testEnvironment;
 
-	private $parserData;
-
 	private $parserFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
-
-		$this->parserData = $this->getMockBuilder( ParserData::class )
-			->disableOriginalConstructor()
-			->getMock();
 
 		$this->parserFactory = $this->testEnvironment->getUtilityFactory()->newParserFactory();
 	}

--- a/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
@@ -76,8 +76,6 @@ class AskParserFunctionTest extends TestCase {
 		$store->expects( $this->any() )
 			->method( 'getQueryResult' )
 			->willReturn( $queryResult );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/AskParserFunctionTest.php
@@ -13,9 +13,7 @@ use SMW\ParserData;
 use SMW\ParserFunctions\AskParserFunction;
 use SMW\ParserFunctions\ExpensiveFuncExecutionWatcher;
 use SMW\PostProcHandler;
-use SMW\Query\QueryResult;
 use SMW\Services\ServicesFactory as ApplicationFactory;
-use SMW\Store;
 use SMW\Tests\TestEnvironment;
 use SMW\Utils\CircularReferenceGuard;
 
@@ -60,22 +58,6 @@ class AskParserFunctionTest extends TestCase {
 		$this->expensiveFuncExecutionWatcher->expects( $this->any() )
 			->method( 'hasReachedExpensiveLimit' )
 			->willReturn( false );
-
-		$queryResult = $this->getMockBuilder( QueryResult::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$queryResult->expects( $this->any() )
-			->method( 'getErrors' )
-			->willReturn( [] );
-
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$store->expects( $this->any() )
-			->method( 'getQueryResult' )
-			->willReturn( $queryResult );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/ParserFunctions/ShowParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/ShowParserFunctionTest.php
@@ -11,9 +11,7 @@ use SMW\ParserData;
 use SMW\ParserFunctions\AskParserFunction;
 use SMW\ParserFunctions\ExpensiveFuncExecutionWatcher;
 use SMW\ParserFunctions\ShowParserFunction;
-use SMW\Query\QueryResult;
 use SMW\Services\ServicesFactory as ApplicationFactory;
-use SMW\Store;
 use SMW\Tests\TestEnvironment;
 use SMW\Utils\CircularReferenceGuard;
 
@@ -59,22 +57,6 @@ class ShowParserFunctionTest extends TestCase {
 		$this->expensiveFuncExecutionWatcher->expects( $this->any() )
 			->method( 'hasReachedExpensiveLimit' )
 			->willReturn( false );
-
-		$queryResult = $this->getMockBuilder( QueryResult::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$queryResult->expects( $this->any() )
-			->method( 'getErrors' )
-			->willReturn( [] );
-
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$store->expects( $this->any() )
-			->method( 'getQueryResult' )
-			->willReturn( $queryResult );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/ParserFunctions/ShowParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/ShowParserFunctionTest.php
@@ -75,8 +75,6 @@ class ShowParserFunctionTest extends TestCase {
 		$store->expects( $this->any() )
 			->method( 'getQueryResult' )
 			->willReturn( $queryResult );
-
-		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/SQLStore/EntityStore/StubSemanticDataTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/StubSemanticDataTest.php
@@ -34,8 +34,6 @@ class StubSemanticDataTest extends TestCase {
 		$this->store->expects( $this->any() )
 			->method( 'getRedirectTarget' )
 			->willReturnArgument( 0 );
-
-		$this->testEnvironment->registerObject( 'Store', $this->store );
 	}
 
 	protected function tearDown(): void {

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -5,7 +5,6 @@ namespace SMW\Tests\Unit\SQLStore;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use SMW\DataItems\WikiPage;
-use SMW\HierarchyLookup;
 use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
 use SMW\Lookup\CachedListLookup;
 use SMW\Lookup\ListLookup;
@@ -85,10 +84,6 @@ class SQLStoreFactoryTest extends TestCase {
 		$this->testEnvironment = new TestEnvironment();
 
 		$this->store = $this->getMockBuilder( SQLStore::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$hierarchyLookup = $this->getMockBuilder( HierarchyLookup::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}

--- a/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreFactoryTest.php
@@ -91,8 +91,6 @@ class SQLStoreFactoryTest extends TestCase {
 		$hierarchyLookup = $this->getMockBuilder( HierarchyLookup::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$this->testEnvironment->registerObject( 'HierarchyLookup', $hierarchyLookup );
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/SetupTest.php
+++ b/tests/phpunit/Unit/SetupTest.php
@@ -6,7 +6,6 @@ use MediaWiki\Language\Language;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\HookDispatcher;
 use SMW\Setup;
-use SMW\Store;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -30,18 +29,6 @@ class SetupTest extends TestCase {
 		$this->hookDispatcher = $this->getMockBuilder( HookDispatcher::class )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
-		$store->expects( $this->any() )
-			->method( 'getProperties' )
-			->willReturn( [] );
-
-		$store->expects( $this->any() )
-			->method( 'getInProperties' )
-			->willReturn( [] );
 
 		$language = $this->getMockBuilder( Language::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SetupTest.php
+++ b/tests/phpunit/Unit/SetupTest.php
@@ -65,7 +65,6 @@ class SetupTest extends TestCase {
 		];
 
 		$this->testEnvironment = new TestEnvironment( $this->defaultConfig );
-		$this->testEnvironment->registerObject( 'Store', $store );
 	}
 
 	protected function tearDown(): void {


### PR DESCRIPTION
## Summary

`TestEnvironment::registerObject('KEY', $mock)` puts a mock onto SMW's `ServicesFactory` (a global service locator) for the duration of a test. Many such calls accumulated as defensive scaffolding over years and are no longer needed: the test sets up a mock and registers it globally, but neither the class under test nor any of its collaborators ever resolves that key through the locator.

This PR removes one such dead `registerObject(...)` line from each of 25 unit test files (after code review reverted two unsafe deletions, see below).

## Methodology

Each candidate file had its single `registerObject(...)` line deleted, and the targeted test class was re-run via `composer phpunit -- --filter <TestClassName>`. A deletion was kept only if the test stayed green at unchanged assertion count. Files where deletion broke a test (transitive locator read from a downstream collaborator) were not part of this PR.

The minimum-touch principle was preserved: only the `registerObject` line is removed. Orphan mock setup (`$this->store = ...` style) and unused imports are left for a follow-up cleanup PR. The single exception is `InfolinkTest`, where the mock was a local variable and the import was used nowhere else, so all three lines could be removed cleanly.

## Code-review correction

A code review caught a methodology blind spot: `expects($this->never())` against an unreached mock is indistinguishable from `expects($this->never())` against a mock that the production code correctly avoided calling. Two tests (`InternalParseBeforeLinksIntegrationTest::testNonParseForInvokedMessageParse` and `ParserAfterTidyIntegrationTest::testNonParseForInvokedMessageParse`) relied on the `registerObject('ParserData', ...)` registration to wire their `ParserData` mock into the production code path of `wfMessage('properties')->parse()`. Without the registration their `never()` assertions would have passed vacuously. Both deletions were reverted in commit 2.

## Scope

- 25 net test files modified (53 line deletions).
- Skipped 21 test files currently modified by in-flight PRs (#6861, #6862, #6863) to avoid merge conflicts.
- Reduces files using `registerObject(...)` in the unit/integration suites from 85 to 60.

## Test plan

- [x] `composer phpunit --testsuite=semantic-mediawiki-unit` reports 7081 tests, 14498 assertions, 6 expected skips (matches master baseline).
- [x] `composer analyze` reports no new errors or warnings on the changed files.