### PR TITLE
Inject JobFactory and JobQueue into admin TaskHandlers and Jobs

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -202,7 +202,7 @@
 		"ExportRDF": "SMW\\MediaWiki\\Specials\\SpecialOWLExport",
 		"SMWAdmin": {
 			"class": "SMW\\MediaWiki\\Specials\\SpecialAdmin",
-			"services": [ "SMW.Store", "SMW.Settings", "SMW.HookDispatcher" ]
+			"services": [ "SMW.Store", "SMW.Settings", "SMW.HookDispatcher", "SMW.JobFactory", "SMW.JobQueue" ]
 		},
 		"PendingTaskList": "SMW\\MediaWiki\\Specials\\SpecialPendingTaskList",
 		"Ask": {
@@ -270,7 +270,7 @@
 		},
 		"smw.refresh": {
 			"class": "SMW\\MediaWiki\\Jobs\\RefreshJob",
-			"services": [ "SMW.Store" ]
+			"services": [ "SMW.Store", "SMW.JobFactory" ]
 		},
 		"smw.updateDispatcher": {
 			"class": "SMW\\MediaWiki\\Jobs\\UpdateDispatcherJob",
@@ -282,7 +282,7 @@
 		},
 		"smw.entityIdDisposer": {
 			"class": "SMW\\MediaWiki\\Jobs\\EntityIdDisposerJob",
-			"services": [ "SMW.Store", "SMW.IteratorFactory" ]
+			"services": [ "SMW.Store", "SMW.IteratorFactory", "SMW.JobFactory" ]
 		},
 		"smw.propertyStatisticsRebuild": {
 			"class": "SMW\\MediaWiki\\Jobs\\PropertyStatisticsRebuildJob",
@@ -290,7 +290,7 @@
 		},
 		"smw.fulltextSearchTableRebuild": {
 			"class": "SMW\\MediaWiki\\Jobs\\FulltextSearchTableRebuildJob",
-			"services": [ "SMW.Store" ]
+			"services": [ "SMW.Store", "SMW.JobFactory" ]
 		},
 		"smw.changePropagationDispatch": {
 			"class": "SMW\\MediaWiki\\Jobs\\ChangePropagationDispatchJob",
@@ -298,19 +298,29 @@
 				"SMW.Store",
 				"SMW.Cache",
 				"SMW.PropertySpecificationLookup",
-				"SMW.IteratorFactory"
+				"SMW.IteratorFactory",
+				"SMW.JobFactory"
 			]
 		},
-		"smw.changePropagationUpdate": "SMW\\MediaWiki\\Jobs\\ChangePropagationUpdateJob",
-		"smw.changePropagationClassUpdate": "SMW\\MediaWiki\\Jobs\\ChangePropagationClassUpdateJob",
-		"smw.deferredConstraintCheckUpdateJob": "SMW\\MediaWiki\\Jobs\\DeferredConstraintCheckUpdateJob",
+		"smw.changePropagationUpdate": {
+			"class": "SMW\\MediaWiki\\Jobs\\ChangePropagationUpdateJob",
+			"services": [ "SMW.JobFactory" ]
+		},
+		"smw.changePropagationClassUpdate": {
+			"class": "SMW\\MediaWiki\\Jobs\\ChangePropagationClassUpdateJob",
+			"services": [ "SMW.JobFactory" ]
+		},
+		"smw.deferredConstraintCheckUpdateJob": {
+			"class": "SMW\\MediaWiki\\Jobs\\DeferredConstraintCheckUpdateJob",
+			"services": [ "SMW.JobFactory" ]
+		},
 		"smw.elasticIndexerRecovery": {
 			"class": "SMW\\Elastic\\Jobs\\IndexerRecoveryJob",
-			"services": [ "SMW.Store", "SMW.Cache" ]
+			"services": [ "SMW.Store", "SMW.Cache", "SMW.JobFactory" ]
 		},
 		"smw.elasticFileIngest": {
 			"class": "SMW\\Elastic\\Jobs\\FileIngestJob",
-			"services": [ "SMW.Store", "SMW.ElasticFactory" ]
+			"services": [ "SMW.Store", "SMW.ElasticFactory", "SMW.JobFactory" ]
 		},
 		"smw.parserCachePurgeJob": "SMW\\MediaWiki\\Jobs\\ParserCachePurgeJob"
 	},

--- a/src/Elastic/Jobs/FileIngestJob.php
+++ b/src/Elastic/Jobs/FileIngestJob.php
@@ -8,6 +8,7 @@ use SMW\Elastic\Connection\Client as ElasticClient;
 use SMW\Elastic\ElasticFactory;
 use SMW\Elastic\Indexer\Attachment\ScopeMemoryLimiter;
 use SMW\MediaWiki\Job;
+use SMW\MediaWiki\JobFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
 
@@ -31,7 +32,8 @@ class FileIngestJob extends Job {
 		Title $title,
 		array $params,
 		Store $store,
-		private readonly ElasticFactory $elasticFactory
+		private readonly ElasticFactory $elasticFactory,
+		private readonly JobFactory $jobFactory
 	) {
 		parent::__construct( self::JOB_COMMAND, $title, $params );
 		$this->setStore( $store );
@@ -130,7 +132,7 @@ class FileIngestJob extends Job {
 			$this->params['createdAt'] = time();
 		}
 
-		$job = ApplicationFactory::getInstance()->getJobFactory()->newFileIngestJob(
+		$job = $this->jobFactory->newFileIngestJob(
 			$this->title,
 			$this->params
 		);

--- a/src/Elastic/Jobs/IndexerRecoveryJob.php
+++ b/src/Elastic/Jobs/IndexerRecoveryJob.php
@@ -10,6 +10,7 @@ use SMW\Elastic\ElasticStore;
 use SMW\Elastic\Indexer\Document;
 use SMW\Elastic\Indexer\Indexer;
 use SMW\MediaWiki\Job;
+use SMW\MediaWiki\JobFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
 use SMW\Utils\HmacSerializer;
@@ -48,7 +49,8 @@ class IndexerRecoveryJob extends Job {
 		Title $title,
 		array $params,
 		Store $store,
-		private readonly Cache $cache
+		private readonly Cache $cache,
+		private readonly JobFactory $jobFactory
 	) {
 		parent::__construct( self::JOB_COMMAND, $title, $params );
 		$this->setStore( $store );
@@ -178,7 +180,7 @@ class IndexerRecoveryJob extends Job {
 			$this->params['createdAt'] = time();
 		}
 
-		$job = ApplicationFactory::getInstance()->getJobFactory()->newIndexerRecoveryJob(
+		$job = $this->jobFactory->newIndexerRecoveryJob(
 			$this->title,
 			$this->params
 		);

--- a/src/MediaWiki/Jobs/ChangePropagationClassUpdateJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationClassUpdateJob.php
@@ -3,6 +3,7 @@
 namespace SMW\MediaWiki\Jobs;
 
 use MediaWiki\Title\Title;
+use SMW\MediaWiki\JobFactory;
 
 /**
  * Isolate instance to count update jobs in connection with a category related
@@ -26,13 +27,17 @@ class ChangePropagationClassUpdateJob extends ChangePropagationUpdateJob {
 	 * @param Title $title
 	 * @param array $params job parameters
 	 */
-	public function __construct( Title $title, $params = [] ) {
+	public function __construct(
+		Title $title,
+		$params = [],
+		?JobFactory $jobFactory = null
+	) {
 		$params = array_merge(
 			$params,
 			[ 'origin' => 'ChangePropagationClassUpdateJob' ]
 		);
 
-		parent::__construct( $title, $params, self::JOB_COMMAND );
+		parent::__construct( $title, $params, $jobFactory, self::JOB_COMMAND );
 	}
 
 }

--- a/src/MediaWiki/Jobs/ChangePropagationClassUpdateJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationClassUpdateJob.php
@@ -37,7 +37,7 @@ class ChangePropagationClassUpdateJob extends ChangePropagationUpdateJob {
 			[ 'origin' => 'ChangePropagationClassUpdateJob' ]
 		);
 
-		parent::__construct( $title, $params, $jobFactory, self::JOB_COMMAND );
+		parent::__construct( $title, $params, $jobFactory );
 	}
 
 }

--- a/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
@@ -10,6 +10,7 @@ use SMW\DataItems\WikiPage;
 use SMW\Export\Exporter;
 use SMW\IteratorFactory;
 use SMW\MediaWiki\Job;
+use SMW\MediaWiki\JobFactory;
 use SMW\Property\SpecificationLookup as PropertySpecificationLookup;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\Lookup\ChangePropagationEntityLookup;
@@ -69,7 +70,8 @@ class ChangePropagationDispatchJob extends Job {
 		Store $store,
 		private readonly Cache $cache,
 		private readonly PropertySpecificationLookup $propertySpecificationLookup,
-		private readonly IteratorFactory $iteratorFactory
+		private readonly IteratorFactory $iteratorFactory,
+		private readonly JobFactory $jobFactory
 	) {
 		parent::__construct( 'smw.changePropagationDispatch', $title, $params );
 		$this->setStore( $store );
@@ -281,7 +283,7 @@ class ChangePropagationDispatchJob extends Job {
 
 		$checkSum = md5( $contents );
 
-		$changePropagationDispatchJob = ApplicationFactory::getInstance()->getJobFactory()->newChangePropagationDispatchJob(
+		$changePropagationDispatchJob = $this->jobFactory->newChangePropagationDispatchJob(
 			$this->getTitle(),
 			[
 				'data' => $contents
@@ -311,7 +313,7 @@ class ChangePropagationDispatchJob extends Job {
 			$this->cache->save( $key, 1, 60 * 60 * 24 );
 			$params = $this->params;
 
-			$changePropagationDispatchJob = ApplicationFactory::getInstance()->getJobFactory()->newChangePropagationDispatchJob(
+			$changePropagationDispatchJob = $this->jobFactory->newChangePropagationDispatchJob(
 				$this->getTitle(),
 				$params
 			);
@@ -346,7 +348,7 @@ class ChangePropagationDispatchJob extends Job {
 		// Scheduling the actual dispatch for those properties connected to
 		// the schema change
 		foreach ( $dataItems as $dataItem ) {
-			$changePropagationDispatchJob = ApplicationFactory::getInstance()->getJobFactory()->newChangePropagationDispatchJob(
+			$changePropagationDispatchJob = $this->jobFactory->newChangePropagationDispatchJob(
 				$dataItem->getTitle(),
 				[]
 			);
@@ -418,13 +420,11 @@ class ChangePropagationDispatchJob extends Job {
 		$namespace = $this->getTitle()->getNamespace();
 		$parameters += [ 'origin' => 'ChangePropagationDispatchJob' ];
 
-		// Both targets have no service deps; they are excluded from the
-		// JobClasses spec overhaul and can be constructed directly.
 		if ( $namespace === NS_CATEGORY ) {
-			return new ChangePropagationClassUpdateJob( $title, $parameters );
+			return $this->jobFactory->newChangePropagationClassUpdateJob( $title, $parameters );
 		}
 
-		return new ChangePropagationUpdateJob(
+		return $this->jobFactory->newChangePropagationUpdateJob(
 			$title,
 			$parameters
 		);

--- a/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
@@ -5,6 +5,7 @@ namespace SMW\MediaWiki\Jobs;
 use MediaWiki\Title\Title;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Job;
+use SMW\MediaWiki\JobFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
@@ -28,18 +29,26 @@ class ChangePropagationUpdateJob extends Job {
 	 */
 	const JOB_COMMAND = 'smw.changePropagationUpdate';
 
+	protected JobFactory $jobFactory;
+
 	/**
 	 * @since 3.0
 	 *
 	 * @param Title $title
 	 * @param array $params job parameters
 	 */
-	public function __construct( Title $title, $params = [], $jobType = null ) {
+	public function __construct(
+		Title $title,
+		$params = [],
+		?JobFactory $jobFactory = null,
+		$jobType = null
+	) {
 		if ( $jobType === null ) {
 			$jobType = self::JOB_COMMAND;
 		}
 
 		parent::__construct( $jobType, $title, $params );
+		$this->jobFactory = $jobFactory ?? ApplicationFactory::getInstance()->getJobFactory();
 		$this->removeDuplicates = true;
 	}
 
@@ -53,7 +62,7 @@ class ChangePropagationUpdateJob extends Job {
 			WikiPage::newFromTitle( $this->getTitle() )
 		);
 
-		$updateJob = ApplicationFactory::getInstance()->getJobFactory()->newUpdateJob(
+		$updateJob = $this->jobFactory->newUpdateJob(
 			$this->getTitle(),
 			array_merge( $this->params, [ 'origin' => 'ChangePropagationUpdateJob' ] )
 		);

--- a/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationUpdateJob.php
@@ -40,14 +40,11 @@ class ChangePropagationUpdateJob extends Job {
 	public function __construct(
 		Title $title,
 		$params = [],
-		?JobFactory $jobFactory = null,
-		$jobType = null
+		?JobFactory $jobFactory = null
 	) {
-		if ( $jobType === null ) {
-			$jobType = self::JOB_COMMAND;
-		}
-
-		parent::__construct( $jobType, $title, $params );
+		parent::__construct( static::JOB_COMMAND, $title, $params );
+		// Fallback for direct `new self(...)` callsites (e.g. ChangePropagationClassUpdateJob)
+		// and ad-hoc instantiation in tests that bypass the JobClasses ObjectFactory spec.
 		$this->jobFactory = $jobFactory ?? ApplicationFactory::getInstance()->getJobFactory();
 		$this->removeDuplicates = true;
 	}

--- a/src/MediaWiki/Jobs/DeferredConstraintCheckUpdateJob.php
+++ b/src/MediaWiki/Jobs/DeferredConstraintCheckUpdateJob.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Jobs;
 
 use MediaWiki\Title\Title;
 use SMW\MediaWiki\Job;
+use SMW\MediaWiki\JobFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
@@ -16,14 +17,21 @@ class DeferredConstraintCheckUpdateJob extends Job {
 
 	const JOB_COMMAND = 'smw.deferredConstraintCheckUpdateJob';
 
+	private JobFactory $jobFactory;
+
 	/**
 	 * @since 3.1
 	 *
 	 * @param Title $title
 	 * @param array $params job parameters
 	 */
-	public function __construct( Title $title, $params = [] ) {
+	public function __construct(
+		Title $title,
+		$params = [],
+		?JobFactory $jobFactory = null
+	) {
 		parent::__construct( self::JOB_COMMAND, $title, $params );
+		$this->jobFactory = $jobFactory ?? ApplicationFactory::getInstance()->getJobFactory();
 		$this->removeDuplicates = true;
 	}
 
@@ -56,7 +64,7 @@ class DeferredConstraintCheckUpdateJob extends Job {
 			return true;
 		}
 
-		$updateJob = ApplicationFactory::getInstance()->getJobFactory()->newUpdateJob(
+		$updateJob = $this->jobFactory->newUpdateJob(
 			$this->getTitle(),
 			$this->params + [ 'origin' => 'DeferredConstraintCheckUpdateJob' ]
 		);

--- a/src/MediaWiki/Jobs/DeferredConstraintCheckUpdateJob.php
+++ b/src/MediaWiki/Jobs/DeferredConstraintCheckUpdateJob.php
@@ -31,6 +31,8 @@ class DeferredConstraintCheckUpdateJob extends Job {
 		?JobFactory $jobFactory = null
 	) {
 		parent::__construct( self::JOB_COMMAND, $title, $params );
+		// Fallback for the static pushJob() helper which uses `new self(...)` and
+		// bypasses the JobClasses ObjectFactory spec where SMW.JobFactory is wired.
 		$this->jobFactory = $jobFactory ?? ApplicationFactory::getInstance()->getJobFactory();
 		$this->removeDuplicates = true;
 	}

--- a/src/MediaWiki/Jobs/EntityIdDisposerJob.php
+++ b/src/MediaWiki/Jobs/EntityIdDisposerJob.php
@@ -6,8 +6,8 @@ use MediaWiki\Title\Title;
 use SMW\IteratorFactory;
 use SMW\Iterators\ResultIterator;
 use SMW\MediaWiki\Job;
+use SMW\MediaWiki\JobFactory;
 use SMW\RequestOptions;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\SQLStore\QueryDependency\QueryLinksTableDisposer;
 use SMW\Store;
@@ -43,7 +43,8 @@ class EntityIdDisposerJob extends Job {
 		Title $title,
 		array $params,
 		Store $store,
-		private readonly IteratorFactory $iteratorFactory
+		private readonly IteratorFactory $iteratorFactory,
+		private readonly JobFactory $jobFactory
 	) {
 		parent::__construct( 'smw.entityIdDisposer', $title, $params );
 		$this->setStore( $store );
@@ -162,7 +163,7 @@ class EntityIdDisposerJob extends Job {
 
 		// We expect more outdated entities to be contained in the ID_TABLE,
 		// therefore reenter the disposal cycle.
-		$entityIdDisposerJob = ApplicationFactory::getInstance()->getJobFactory()->newEntityIdDisposerJob(
+		$entityIdDisposerJob = $this->jobFactory->newEntityIdDisposerJob(
 			$this->getTitle(),
 			$this->params + [ 'cycle' => ++$cycle ]
 		);

--- a/src/MediaWiki/Jobs/FulltextSearchTableRebuildJob.php
+++ b/src/MediaWiki/Jobs/FulltextSearchTableRebuildJob.php
@@ -4,7 +4,7 @@ namespace SMW\MediaWiki\Jobs;
 
 use MediaWiki\Title\Title;
 use SMW\MediaWiki\Job;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\MediaWiki\JobFactory;
 use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
 use SMW\Store;
 
@@ -22,7 +22,8 @@ class FulltextSearchTableRebuildJob extends Job {
 	public function __construct(
 		Title $title,
 		array $params,
-		Store $store
+		Store $store,
+		private readonly JobFactory $jobFactory
 	) {
 		parent::__construct( 'smw.fulltextSearchTableRebuild', $title, $params );
 		$this->setStore( $store );
@@ -61,10 +62,8 @@ class FulltextSearchTableRebuildJob extends Job {
 			return;
 		}
 
-		$jobFactory = ApplicationFactory::getInstance()->getJobFactory();
-
 		foreach ( $tableList as $tableName ) {
-			$job = $jobFactory->newFulltextSearchTableRebuildJob(
+			$job = $this->jobFactory->newFulltextSearchTableRebuildJob(
 				$this->getTitle(),
 				[ 'table' => $tableName ]
 			);

--- a/src/MediaWiki/Jobs/RefreshJob.php
+++ b/src/MediaWiki/Jobs/RefreshJob.php
@@ -4,7 +4,7 @@ namespace SMW\MediaWiki\Jobs;
 
 use MediaWiki\Title\Title;
 use SMW\MediaWiki\Job;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\MediaWiki\JobFactory;
 use SMW\Store;
 
 /**
@@ -41,7 +41,8 @@ class RefreshJob extends Job {
 	public function __construct(
 		Title $title,
 		array $params,
-		Store $store
+		Store $store,
+		private readonly JobFactory $jobFactory
 	) {
 		parent::__construct( 'smw.refresh', $title, $params );
 		$this->setStore( $store );
@@ -110,7 +111,7 @@ class RefreshJob extends Job {
 	}
 
 	protected function createNextJob( array $parameters ): void {
-		$job = ApplicationFactory::getInstance()->getJobFactory()->newRefreshJob(
+		$job = $this->jobFactory->newRefreshJob(
 			$this->getTitle(),
 			$parameters
 		);

--- a/src/MediaWiki/Specials/Admin/Maintenance/DataRefreshJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/DataRefreshJobTaskHandler.php
@@ -6,11 +6,12 @@ use MediaWiki\Html\Html;
 use MediaWiki\Request\WebRequest;
 use MediaWiki\SpecialPage\SpecialPage;
 use SMW\MediaWiki\Job;
+use SMW\MediaWiki\JobFactory;
+use SMW\MediaWiki\JobQueue;
 use SMW\MediaWiki\Renderer\HtmlFormRenderer;
 use SMW\MediaWiki\Specials\Admin\ActionableTask;
 use SMW\MediaWiki\Specials\Admin\OutputFormatter;
 use SMW\MediaWiki\Specials\Admin\TaskHandler;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
  * @license GPL-2.0-or-later
@@ -28,6 +29,8 @@ class DataRefreshJobTaskHandler extends TaskHandler implements ActionableTask {
 	public function __construct(
 		private readonly HtmlFormRenderer $htmlFormRenderer,
 		private readonly OutputFormatter $outputFormatter,
+		private readonly JobFactory $jobFactory,
+		private readonly JobQueue $jobQueue,
 	) {
 	}
 
@@ -115,14 +118,13 @@ class DataRefreshJobTaskHandler extends TaskHandler implements ActionableTask {
 		}
 
 		$sure = $webRequest->getText( 'rfsure' );
-		$applicationFactory = ApplicationFactory::getInstance();
 
 		if ( $sure == 'yes' ) {
 			$refreshjob = $this->getRefreshJob();
 
 			if ( $refreshjob === null ) { // careful, there might be race conditions here
 
-				$newjob = $applicationFactory->newJobFactory()->newByType(
+				$newjob = $this->jobFactory->newByType(
 					'smw.refresh',
 					SpecialPage::getTitleFor( 'SMWAdmin' ),
 					[ 'spos' => 1, 'prog' => 0, 'rc' => 2 ]
@@ -132,9 +134,8 @@ class DataRefreshJobTaskHandler extends TaskHandler implements ActionableTask {
 			}
 
 		} elseif ( $sure == 'stop' ) {
-			$jobQueue = $applicationFactory->getJobQueue();
-			$jobQueue->disableCache();
-			$jobQueue->delete( 'smw.refresh' );
+			$this->jobQueue->disableCache();
+			$this->jobQueue->delete( 'smw.refresh' );
 		}
 
 		$this->outputFormatter->redirectToRootPage( '', [ 'tab' => 'maintenance' ] );
@@ -157,19 +158,17 @@ class DataRefreshJobTaskHandler extends TaskHandler implements ActionableTask {
 			return $this->refreshjob;
 		}
 
-		$jobQueue = ApplicationFactory::getInstance()->getJobQueue();
-
-		if ( !$jobQueue->hasPendingJob( 'smw.refresh' ) ) {
+		if ( !$this->jobQueue->hasPendingJob( 'smw.refresh' ) ) {
 			return null;
 		}
 
 		// Pop and acknowledge the job to fetch progress details
 		// from itself
-		$refreshJob = $jobQueue->pop( 'smw.refresh' );
+		$refreshJob = $this->jobQueue->pop( 'smw.refresh' );
 
 		if ( $refreshJob instanceof Job ) {
 			$refreshJob->run();
-			$jobQueue->ack( $refreshJob );
+			$this->jobQueue->ack( $refreshJob );
 			$this->refreshjob = $refreshJob;
 		}
 

--- a/src/MediaWiki/Specials/Admin/Maintenance/DisposeJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/DisposeJobTaskHandler.php
@@ -7,11 +7,12 @@ use MediaWiki\Request\WebRequest;
 use MediaWiki\SpecialPage\SpecialPage;
 use SMW\DataItems\WikiPage;
 use SMW\Localizer\Message;
+use SMW\MediaWiki\JobFactory;
+use SMW\MediaWiki\JobQueue;
 use SMW\MediaWiki\Renderer\HtmlFormRenderer;
 use SMW\MediaWiki\Specials\Admin\ActionableTask;
 use SMW\MediaWiki\Specials\Admin\OutputFormatter;
 use SMW\MediaWiki\Specials\Admin\TaskHandler;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
  * @license GPL-2.0-or-later
@@ -29,6 +30,8 @@ class DisposeJobTaskHandler extends TaskHandler implements ActionableTask {
 	public function __construct(
 		private readonly HtmlFormRenderer $htmlFormRenderer,
 		private readonly OutputFormatter $outputFormatter,
+		private readonly JobFactory $jobFactory,
+		private readonly JobQueue $jobQueue,
 	) {
 	}
 
@@ -139,7 +142,7 @@ class DisposeJobTaskHandler extends TaskHandler implements ActionableTask {
 			return;
 		}
 
-		$job = ApplicationFactory::getInstance()->newJobFactory()->newByType(
+		$job = $this->jobFactory->newByType(
 			'smw.entityIdDisposer',
 			SpecialPage::getTitleFor( 'SMWAdmin' )
 		);
@@ -150,7 +153,7 @@ class DisposeJobTaskHandler extends TaskHandler implements ActionableTask {
 	}
 
 	private function hasPendingJob(): bool {
-		return ApplicationFactory::getInstance()->getJobQueue()->hasPendingJob( 'smw.entityIdDisposer' );
+		return $this->jobQueue->hasPendingJob( 'smw.entityIdDisposer' );
 	}
 
 }

--- a/src/MediaWiki/Specials/Admin/Maintenance/FulltextSearchTableRebuildJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/FulltextSearchTableRebuildJobTaskHandler.php
@@ -7,11 +7,12 @@ use MediaWiki\Request\WebRequest;
 use MediaWiki\SpecialPage\SpecialPage;
 use SMW\DataItems\WikiPage;
 use SMW\Localizer\Message;
+use SMW\MediaWiki\JobFactory;
+use SMW\MediaWiki\JobQueue;
 use SMW\MediaWiki\Renderer\HtmlFormRenderer;
 use SMW\MediaWiki\Specials\Admin\ActionableTask;
 use SMW\MediaWiki\Specials\Admin\OutputFormatter;
 use SMW\MediaWiki\Specials\Admin\TaskHandler;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
  * @license GPL-2.0-or-later
@@ -29,6 +30,8 @@ class FulltextSearchTableRebuildJobTaskHandler extends TaskHandler implements Ac
 	public function __construct(
 		private readonly HtmlFormRenderer $htmlFormRenderer,
 		private readonly OutputFormatter $outputFormatter,
+		private readonly JobFactory $jobFactory,
+		private readonly JobQueue $jobQueue,
 	) {
 	}
 
@@ -129,7 +132,7 @@ class FulltextSearchTableRebuildJobTaskHandler extends TaskHandler implements Ac
 			return;
 		}
 
-		$job = ApplicationFactory::getInstance()->newJobFactory()->newByType(
+		$job = $this->jobFactory->newByType(
 			'smw.fulltextSearchTableRebuild',
 			SpecialPage::getTitleFor( 'SMWAdmin' ),
 			[
@@ -143,7 +146,7 @@ class FulltextSearchTableRebuildJobTaskHandler extends TaskHandler implements Ac
 	}
 
 	private function hasPendingJob(): bool {
-		return ApplicationFactory::getInstance()->getJobQueue()->hasPendingJob( 'smw.fulltextSearchTableRebuild' );
+		return $this->jobQueue->hasPendingJob( 'smw.fulltextSearchTableRebuild' );
 	}
 
 }

--- a/src/MediaWiki/Specials/Admin/Maintenance/PropertyStatsRebuildJobTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/Maintenance/PropertyStatsRebuildJobTaskHandler.php
@@ -7,11 +7,12 @@ use MediaWiki\Request\WebRequest;
 use MediaWiki\SpecialPage\SpecialPage;
 use SMW\DataItems\WikiPage;
 use SMW\Localizer\Message;
+use SMW\MediaWiki\JobFactory;
+use SMW\MediaWiki\JobQueue;
 use SMW\MediaWiki\Renderer\HtmlFormRenderer;
 use SMW\MediaWiki\Specials\Admin\ActionableTask;
 use SMW\MediaWiki\Specials\Admin\OutputFormatter;
 use SMW\MediaWiki\Specials\Admin\TaskHandler;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
  * @license GPL-2.0-or-later
@@ -29,6 +30,8 @@ class PropertyStatsRebuildJobTaskHandler extends TaskHandler implements Actionab
 	public function __construct(
 		private readonly HtmlFormRenderer $htmlFormRenderer,
 		private readonly OutputFormatter $outputFormatter,
+		private readonly JobFactory $jobFactory,
+		private readonly JobQueue $jobQueue,
 	) {
 	}
 
@@ -132,7 +135,7 @@ class PropertyStatsRebuildJobTaskHandler extends TaskHandler implements Actionab
 			return;
 		}
 
-		$job = ApplicationFactory::getInstance()->newJobFactory()->newByType(
+		$job = $this->jobFactory->newByType(
 			'smw.propertyStatisticsRebuild',
 			SpecialPage::getTitleFor( 'SMWAdmin' )
 		);
@@ -143,7 +146,7 @@ class PropertyStatsRebuildJobTaskHandler extends TaskHandler implements Actionab
 	}
 
 	private function hasPendingJob(): bool {
-		return ApplicationFactory::getInstance()->getJobQueue()->hasPendingJob( 'smw.propertyStatisticsRebuild' );
+		return $this->jobQueue->hasPendingJob( 'smw.propertyStatisticsRebuild' );
 	}
 
 }

--- a/src/MediaWiki/Specials/Admin/TaskHandlerFactory.php
+++ b/src/MediaWiki/Specials/Admin/TaskHandlerFactory.php
@@ -4,6 +4,8 @@ namespace SMW\MediaWiki\Specials\Admin;
 
 use MediaWiki\User\User;
 use SMW\MediaWiki\HookDispatcherAwareTrait;
+use SMW\MediaWiki\JobFactory;
+use SMW\MediaWiki\JobQueue;
 use SMW\MediaWiki\Renderer\HtmlFormRenderer;
 use SMW\MediaWiki\Specials\Admin\Alerts\ByNamespaceInvalidEntitiesMaintenanceAlertTaskHandler;
 use SMW\MediaWiki\Specials\Admin\Alerts\DeprecationNoticeTaskHandler;
@@ -43,6 +45,8 @@ class TaskHandlerFactory {
 		private Store $store,
 		private HtmlFormRenderer $htmlFormRenderer,
 		private OutputFormatter $outputFormatter,
+		private readonly JobFactory $jobFactory,
+		private readonly JobQueue $jobQueue,
 	) {
 	}
 
@@ -210,7 +214,12 @@ class TaskHandlerFactory {
 	 * @return DataRefreshJobTaskHandler
 	 */
 	public function newDataRefreshJobTaskHandler(): DataRefreshJobTaskHandler {
-		return new DataRefreshJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter );
+		return new DataRefreshJobTaskHandler(
+			$this->htmlFormRenderer,
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
+		);
 	}
 
 	/**
@@ -219,7 +228,12 @@ class TaskHandlerFactory {
 	 * @return DisposeJobTaskHandler
 	 */
 	public function newDisposeJobTaskHandler(): DisposeJobTaskHandler {
-		return new DisposeJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter );
+		return new DisposeJobTaskHandler(
+			$this->htmlFormRenderer,
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
+		);
 	}
 
 	/**
@@ -228,7 +242,12 @@ class TaskHandlerFactory {
 	 * @return PropertyStatsRebuildJobTaskHandler
 	 */
 	public function newPropertyStatsRebuildJobTaskHandler(): PropertyStatsRebuildJobTaskHandler {
-		return new PropertyStatsRebuildJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter );
+		return new PropertyStatsRebuildJobTaskHandler(
+			$this->htmlFormRenderer,
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
+		);
 	}
 
 	/**
@@ -237,7 +256,12 @@ class TaskHandlerFactory {
 	 * @return FulltextSearchTableRebuildJobTaskHandler
 	 */
 	public function newFulltextSearchTableRebuildJobTaskHandler(): FulltextSearchTableRebuildJobTaskHandler {
-		return new FulltextSearchTableRebuildJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter );
+		return new FulltextSearchTableRebuildJobTaskHandler(
+			$this->htmlFormRenderer,
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
+		);
 	}
 
 	/**

--- a/src/MediaWiki/Specials/SpecialAdmin.php
+++ b/src/MediaWiki/Specials/SpecialAdmin.php
@@ -6,6 +6,8 @@ use MediaWiki\SpecialPage\SpecialPage;
 use PermissionsError;
 use SMW\Localizer\Message;
 use SMW\MediaWiki\HookDispatcher;
+use SMW\MediaWiki\JobFactory;
+use SMW\MediaWiki\JobQueue;
 use SMW\MediaWiki\Specials\Admin\OutputFormatter;
 use SMW\MediaWiki\Specials\Admin\TaskHandler;
 use SMW\MediaWiki\Specials\Admin\TaskHandlerFactory;
@@ -38,7 +40,9 @@ class SpecialAdmin extends SpecialPage {
 	public function __construct(
 		private readonly Store $store,
 		private readonly Settings $settings,
-		private readonly HookDispatcher $hookDispatcher
+		private readonly HookDispatcher $hookDispatcher,
+		private readonly JobFactory $jobFactory,
+		private readonly JobQueue $jobQueue
 	) {
 		parent::__construct( 'SMWAdmin', 'smw-admin' );
 	}
@@ -110,7 +114,9 @@ class SpecialAdmin extends SpecialPage {
 		$taskHandlerFactory = new TaskHandlerFactory(
 			$store,
 			$htmlFormRenderer,
-			$outputFormatter
+			$outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$taskHandlerFactory->setHookDispatcher(

--- a/tests/phpunit/Unit/Elastic/Jobs/FileIngestJobTest.php
+++ b/tests/phpunit/Unit/Elastic/Jobs/FileIngestJobTest.php
@@ -12,6 +12,7 @@ use SMW\Elastic\ElasticFactory;
 use SMW\Elastic\Indexer\FileIndexer;
 use SMW\Elastic\Indexer\Indexer;
 use SMW\Elastic\Jobs\FileIngestJob;
+use SMW\MediaWiki\JobFactory;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
@@ -33,6 +34,7 @@ class FileIngestJobTest extends TestCase {
 	private $logger;
 	private $elasticFactory;
 	private $jobQueue;
+	private $jobFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -67,6 +69,10 @@ class FileIngestJobTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
 		// pushIngestJob() goes through MediaWiki's JobFactory which resolves
 		// ElasticFactory from the global container; keep the test override
 		// so the lazyPush path is exercised against the same mock.
@@ -89,13 +95,15 @@ class FileIngestJobTest extends TestCase {
 		Title $title,
 		array $params = [],
 		?Store $store = null,
-		?ElasticFactory $elasticFactory = null
+		?ElasticFactory $elasticFactory = null,
+		?JobFactory $jobFactory = null
 	): FileIngestJob {
 		return new FileIngestJob(
 			$title,
 			$params,
 			$store ?? $this->newStore(),
-			$elasticFactory ?? $this->elasticFactory
+			$elasticFactory ?? $this->elasticFactory,
+			$jobFactory ?? $this->jobFactory
 		);
 	}
 
@@ -201,8 +209,17 @@ class FileIngestJobTest extends TestCase {
 			->method( 'getNamespace' )
 			->willReturn( NS_FILE );
 
-		$this->jobQueue->expects( $this->once() )
-			->method( 'push' );
+		// Retry job is constructed via the injected JobFactory and inserted.
+		$retryJob = $this->getMockBuilder( FileIngestJob::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$retryJob->expects( $this->once() )
+			->method( 'insert' );
+
+		$this->jobFactory->expects( $this->once() )
+			->method( 'newFileIngestJob' )
+			->willReturn( $retryJob );
 
 		$instance = $this->newJob( $this->title, [], $store );
 

--- a/tests/phpunit/Unit/Elastic/Jobs/IndexerRecoveryJobTest.php
+++ b/tests/phpunit/Unit/Elastic/Jobs/IndexerRecoveryJobTest.php
@@ -12,6 +12,7 @@ use SMW\Elastic\ElasticStore;
 use SMW\Elastic\Indexer\Document;
 use SMW\Elastic\Indexer\Indexer;
 use SMW\Elastic\Jobs\IndexerRecoveryJob;
+use SMW\MediaWiki\JobFactory;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -32,6 +33,7 @@ class IndexerRecoveryJobTest extends TestCase {
 	private ElasticStore $store;
 	private $config;
 	private $jobQueue;
+	private $jobFactory;
 	private $indexer;
 
 	protected function setUp(): void {
@@ -66,6 +68,10 @@ class IndexerRecoveryJobTest extends TestCase {
 
 		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
 
+		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->indexer = $this->getMockBuilder( Indexer::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -93,7 +99,8 @@ class IndexerRecoveryJobTest extends TestCase {
 			$this->title,
 			$params,
 			$store ?? $this->store,
-			$cache ?? $this->cache
+			$cache ?? $this->cache,
+			$this->jobFactory
 		);
 	}
 
@@ -194,9 +201,17 @@ class IndexerRecoveryJobTest extends TestCase {
 			->method( 'getConnection' )
 			->willReturn( $this->connection );
 
-		// Check insert with next retry
-		$this->jobQueue->expects( $this->once() )
-			->method( 'push' );
+		// Retry job is constructed via the injected JobFactory and inserted.
+		$retryJob = $this->getMockBuilder( IndexerRecoveryJob::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$retryJob->expects( $this->once() )
+			->method( 'insert' );
+
+		$this->jobFactory->expects( $this->once() )
+			->method( 'newIndexerRecoveryJob' )
+			->willReturn( $retryJob );
 
 		$instance = $this->newJob( [ 'index' => 'Foo#0##' ] );
 

--- a/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
@@ -8,7 +8,9 @@ use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\IteratorFactory;
 use SMW\MediaWiki\Connection\Database;
+use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\Jobs\ChangePropagationDispatchJob;
+use SMW\MediaWiki\Jobs\ChangePropagationUpdateJob;
 use SMW\Property\SpecificationLookup as PropertySpecificationLookup;
 use SMW\SQLStore\PropertyTableInfoFetcher;
 use SMW\SQLStore\SQLStore;
@@ -61,13 +63,20 @@ class ChangePropagationDispatchJobTest extends TestCase {
 			->getMock();
 	}
 
+	private function newJobFactory(): JobFactory {
+		return $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
 	private function newJob(
 		Title $title,
 		array $params = [],
 		?SQLStore $store = null,
 		?Cache $cache = null,
 		?PropertySpecificationLookup $propertySpecificationLookup = null,
-		?IteratorFactory $iteratorFactory = null
+		?IteratorFactory $iteratorFactory = null,
+		?JobFactory $jobFactory = null
 	): ChangePropagationDispatchJob {
 		return new ChangePropagationDispatchJob(
 			$title,
@@ -75,7 +84,8 @@ class ChangePropagationDispatchJobTest extends TestCase {
 			$store ?? $this->newStore(),
 			$cache ?? $this->newCache(),
 			$propertySpecificationLookup ?? $this->newPropertySpecificationLookup(),
-			$iteratorFactory ?? $this->newIteratorFactory()
+			$iteratorFactory ?? $this->newIteratorFactory(),
+			$jobFactory ?? $this->newJobFactory()
 		);
 	}
 
@@ -163,7 +173,11 @@ class ChangePropagationDispatchJobTest extends TestCase {
 
 		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
 
-		$instance = $this->newJob( $subject->getTitle() );
+		$jobFactory = $this->newJobFactory();
+		$jobFactory->expects( $this->never() )
+			->method( 'newChangePropagationDispatchJob' );
+
+		$instance = $this->newJob( $subject->getTitle(), [], null, null, null, null, $jobFactory );
 
 		$instance->run();
 	}
@@ -189,9 +203,6 @@ class ChangePropagationDispatchJobTest extends TestCase {
 		$jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
 			->disableOriginalConstructor()
 			->getMock();
-
-		$jobQueue->expects( $this->atLeastOnce() )
-			->method( 'lazyPush' );
 
 		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
 
@@ -239,16 +250,39 @@ class ChangePropagationDispatchJobTest extends TestCase {
 			->method( 'getConnection' )
 			->willReturn( $connection );
 
-		// commitSpecificationChangePropagationAsJob -> newChangePropagationUpdateJob
-		// will construct an inner UpdateJob via ApplicationFactory -> Store.
 		$this->testEnvironment->registerObject( 'Store', $store );
+
+		$updateJob = $this->getMockBuilder( ChangePropagationUpdateJob::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$dispatchJob = $this->getMockBuilder( ChangePropagationDispatchJob::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$dispatchJob->expects( $this->atLeastOnce() )
+			->method( 'lazyPush' );
+
+		$jobFactory = $this->newJobFactory();
+
+		$jobFactory->expects( $this->atLeastOnce() )
+			->method( 'newChangePropagationUpdateJob' )
+			->willReturn( $updateJob );
+
+		$jobFactory->expects( $this->atLeastOnce() )
+			->method( 'newChangePropagationDispatchJob' )
+			->willReturn( $dispatchJob );
 
 		$instance = $this->newJob(
 			$subject->getTitle(),
 			[
 				'isTypePropagation' => true
 			],
-			$store
+			$store,
+			null,
+			null,
+			null,
+			$jobFactory
 		);
 
 		$instance->run();
@@ -267,22 +301,24 @@ class ChangePropagationDispatchJobTest extends TestCase {
 
 		$subject = WikiPage::newFromText( 'Foo' );
 
-		// Check that it is the dataItem from `getPropertyValues`
-		$checkJobParameterCallback = static function ( $jobs ) use( $dataItem ) {
-			foreach ( $jobs as $job ) {
-				return WikiPage::newFromTitle( $job->getTitle() )->equals( $dataItem );
-			}
-		};
-
-		$jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+		$innerJob = $this->getMockBuilder( ChangePropagationDispatchJob::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$jobQueue->expects( $this->once() )
-			->method( 'push' )
-			->with( $this->callback( $checkJobParameterCallback ) );
+		$innerJob->expects( $this->once() )
+			->method( 'insert' );
 
-		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
+		// Verify the dataItem from `getPropertyValues` is the target Title.
+		$checkTitleCallback = static function ( ?Title $title ) use( $dataItem ) {
+			return $title !== null && WikiPage::newFromTitle( $title )->equals( $dataItem );
+		};
+
+		$jobFactory = $this->newJobFactory();
+
+		$jobFactory->expects( $this->once() )
+			->method( 'newChangePropagationDispatchJob' )
+			->with( $this->callback( $checkTitleCallback ) )
+			->willReturn( $innerJob );
 
 		$instance = $this->newJob(
 			$subject->getTitle(),
@@ -290,7 +326,11 @@ class ChangePropagationDispatchJobTest extends TestCase {
 				'schema_change_propagation' => true,
 				'property_key' => 'Foo'
 			],
-			$store
+			$store,
+			null,
+			null,
+			null,
+			$jobFactory
 		);
 
 		$instance->run();

--- a/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationUpdateJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationUpdateJobTest.php
@@ -5,7 +5,9 @@ namespace SMW\Tests\Unit\MediaWiki\Jobs;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
+use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\Jobs\ChangePropagationUpdateJob;
+use SMW\MediaWiki\Jobs\UpdateJob;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -20,11 +22,16 @@ use SMW\Tests\TestEnvironment;
 class ChangePropagationUpdateJobTest extends TestCase {
 
 	private $testEnvironment;
+	private $jobFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
+
+		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown(): void {
@@ -39,7 +46,7 @@ class ChangePropagationUpdateJobTest extends TestCase {
 
 		$this->assertInstanceOf(
 			ChangePropagationUpdateJob::class,
-			new ChangePropagationUpdateJob( $title )
+			new ChangePropagationUpdateJob( $title, [], $this->jobFactory )
 		);
 	}
 
@@ -47,9 +54,21 @@ class ChangePropagationUpdateJobTest extends TestCase {
 	 * @dataProvider jobProvider
 	 */
 	public function testRun( $subject, $parameters ) {
+		$updateJob = $this->getMockBuilder( UpdateJob::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$updateJob->expects( $this->once() )
+			->method( 'run' );
+
+		$this->jobFactory->expects( $this->once() )
+			->method( 'newUpdateJob' )
+			->willReturn( $updateJob );
+
 		$instance = new ChangePropagationUpdateJob(
 			$subject->getTitle(),
-			$parameters
+			$parameters,
+			$this->jobFactory
 		);
 
 		$this->assertTrue(

--- a/tests/phpunit/Unit/MediaWiki/Jobs/DeferredConstraintCheckUpdateJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/DeferredConstraintCheckUpdateJobTest.php
@@ -5,7 +5,9 @@ namespace SMW\Tests\Unit\MediaWiki\Jobs;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
+use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\Jobs\DeferredConstraintCheckUpdateJob;
+use SMW\MediaWiki\Jobs\UpdateJob;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
 
@@ -22,6 +24,7 @@ class DeferredConstraintCheckUpdateJobTest extends TestCase {
 
 	private $testEnvironment;
 	private $jobQueue;
+	private $jobFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -36,6 +39,12 @@ class DeferredConstraintCheckUpdateJobTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// pushJob() reaches batchInsert() -> ApplicationFactory->getJobQueue();
+		// keep the global registration so the static path stays covered.
 		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
 		$this->testEnvironment->registerObject( 'Store', $store );
 	}
@@ -52,7 +61,7 @@ class DeferredConstraintCheckUpdateJobTest extends TestCase {
 
 		$this->assertInstanceOf(
 			DeferredConstraintCheckUpdateJob::class,
-			new DeferredConstraintCheckUpdateJob( $title )
+			new DeferredConstraintCheckUpdateJob( $title, [], $this->jobFactory )
 		);
 	}
 
@@ -71,9 +80,21 @@ class DeferredConstraintCheckUpdateJobTest extends TestCase {
 	 * @dataProvider jobProvider
 	 */
 	public function testRun( $subject, $parameters ) {
+		$updateJob = $this->getMockBuilder( UpdateJob::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$updateJob->expects( $this->once() )
+			->method( 'run' );
+
+		$this->jobFactory->expects( $this->once() )
+			->method( 'newUpdateJob' )
+			->willReturn( $updateJob );
+
 		$instance = new DeferredConstraintCheckUpdateJob(
 			$subject->getTitle(),
-			$parameters
+			$parameters,
+			$this->jobFactory
 		);
 
 		$this->assertTrue(

--- a/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
@@ -9,6 +9,7 @@ use SMW\DataItems\WikiPage;
 use SMW\IteratorFactory;
 use SMW\Iterators\ResultIterator;
 use SMW\MediaWiki\Connection\Database;
+use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
@@ -61,12 +62,29 @@ class EntityIdDisposerJobTest extends TestCase {
 		return new IteratorFactory();
 	}
 
+	private function newJobFactory(): JobFactory {
+		$jobFactory = $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$nextJob = $this->getMockBuilder( EntityIdDisposerJob::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$jobFactory->expects( $this->any() )
+			->method( 'newEntityIdDisposerJob' )
+			->willReturn( $nextJob );
+
+		return $jobFactory;
+	}
+
 	private function newJob( Title $title, array $params = [] ): EntityIdDisposerJob {
 		return new EntityIdDisposerJob(
 			$title,
 			$params,
 			$this->newStore(),
-			$this->newIteratorFactory()
+			$this->newIteratorFactory(),
+			$this->newJobFactory()
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Jobs/RefreshJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/RefreshJobTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Unit\MediaWiki\Jobs;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
+use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\Jobs\RefreshJob;
 use SMW\SQLStore\Rebuilder\Rebuilder;
 use SMW\Store;
@@ -29,6 +30,12 @@ class RefreshJobTest extends TestCase {
 			->getMockForAbstractClass();
 	}
 
+	private function newJobFactory(): JobFactory {
+		return $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
 	public function testCanConstruct() {
 		$title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
@@ -36,7 +43,7 @@ class RefreshJobTest extends TestCase {
 
 		$this->assertInstanceOf(
 			RefreshJob::class,
-			new RefreshJob( $title, [], $this->newStore() )
+			new RefreshJob( $title, [], $this->newStore(), $this->newJobFactory() )
 		);
 	}
 
@@ -64,7 +71,16 @@ class RefreshJobTest extends TestCase {
 			->method( 'refreshData' )
 			->willReturn( $rebuilder );
 
-		$instance = new RefreshJob( $title, $parameters, $store );
+		$nextJob = $this->getMockBuilder( RefreshJob::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$jobFactory = $this->newJobFactory();
+		$jobFactory->expects( $this->any() )
+			->method( 'newRefreshJob' )
+			->willReturn( $nextJob );
+
+		$instance = new RefreshJob( $title, $parameters, $store, $jobFactory );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertTrue( $instance->run() );

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Maintenance/DataRefreshJobTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Maintenance/DataRefreshJobTaskHandlerTest.php
@@ -26,6 +26,7 @@ class DataRefreshJobTaskHandlerTest extends TestCase {
 	private $testEnvironment;
 	private $htmlFormRenderer;
 	private $outputFormatter;
+	private $jobFactory;
 	private $jobQueue;
 
 	protected function setUp(): void {
@@ -41,11 +42,13 @@ class DataRefreshJobTaskHandlerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->jobQueue = $this->getMockBuilder( JobQueue::class )
+		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
+		$this->jobQueue = $this->getMockBuilder( JobQueue::class )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown(): void {
@@ -56,7 +59,7 @@ class DataRefreshJobTaskHandlerTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			DataRefreshJobTaskHandler::class,
-			new DataRefreshJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter )
+			new DataRefreshJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter, $this->jobFactory, $this->jobQueue )
 		);
 	}
 
@@ -81,7 +84,9 @@ class DataRefreshJobTaskHandlerTest extends TestCase {
 
 		$instance = new DataRefreshJobTaskHandler(
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$instance->getHtml();
@@ -102,15 +107,9 @@ class DataRefreshJobTaskHandlerTest extends TestCase {
 			->with( 'smw.refresh' )
 			->willReturn( false );
 
-		$jobFactory = $this->getMockBuilder( JobFactory::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$jobFactory->expects( $this->atLeastOnce() )
+		$this->jobFactory->expects( $this->atLeastOnce() )
 			->method( 'newByType' )
 			->willReturn( $refreshJob );
-
-		$this->testEnvironment->registerObject( 'JobFactory', $jobFactory );
 
 		$webRequest = $this->getMockBuilder( WebRequest::class )
 			->disableOriginalConstructor()
@@ -122,7 +121,9 @@ class DataRefreshJobTaskHandlerTest extends TestCase {
 
 		$instance = new DataRefreshJobTaskHandler(
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$instance->setFeatureSet( SMW_ADM_REFRESH );
@@ -144,7 +145,9 @@ class DataRefreshJobTaskHandlerTest extends TestCase {
 
 		$instance = new DataRefreshJobTaskHandler(
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$instance->setFeatureSet( SMW_ADM_REFRESH );

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Maintenance/DisposeJobTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Maintenance/DisposeJobTaskHandlerTest.php
@@ -26,6 +26,7 @@ class DisposeJobTaskHandlerTest extends TestCase {
 	private $testEnvironment;
 	private $htmlFormRenderer;
 	private $outputFormatter;
+	private $jobFactory;
 	private $jobQueue;
 
 	protected function setUp(): void {
@@ -41,11 +42,13 @@ class DisposeJobTaskHandlerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->jobQueue = $this->getMockBuilder( JobQueue::class )
+		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
+		$this->jobQueue = $this->getMockBuilder( JobQueue::class )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown(): void {
@@ -56,7 +59,7 @@ class DisposeJobTaskHandlerTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			DisposeJobTaskHandler::class,
-			new DisposeJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter )
+			new DisposeJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter, $this->jobFactory, $this->jobQueue )
 		);
 	}
 
@@ -81,7 +84,9 @@ class DisposeJobTaskHandlerTest extends TestCase {
 
 		$instance = new DisposeJobTaskHandler(
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$instance->getHtml();
@@ -100,15 +105,9 @@ class DisposeJobTaskHandlerTest extends TestCase {
 		$entityIdDisposerJob->expects( $this->once() )
 			->method( 'insert' );
 
-		$jobFactory = $this->getMockBuilder( JobFactory::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$jobFactory->expects( $this->once() )
+		$this->jobFactory->expects( $this->once() )
 			->method( 'newByType' )
 			->willReturn( $entityIdDisposerJob );
-
-		$this->testEnvironment->registerObject( 'JobFactory', $jobFactory );
 
 		$webRequest = $this->getMockBuilder( WebRequest::class )
 			->disableOriginalConstructor()
@@ -116,7 +115,9 @@ class DisposeJobTaskHandlerTest extends TestCase {
 
 		$instance = new DisposeJobTaskHandler(
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$instance->isApiTask = false;
@@ -130,14 +131,8 @@ class DisposeJobTaskHandlerTest extends TestCase {
 			->with( 'smw.entityIdDisposer' )
 			->willReturn( true );
 
-		$jobFactory = $this->getMockBuilder( JobFactory::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$jobFactory->expects( $this->never() )
+		$this->jobFactory->expects( $this->never() )
 			->method( 'newByType' );
-
-		$this->testEnvironment->registerObject( 'JobFactory', $jobFactory );
 
 		$webRequest = $this->getMockBuilder( WebRequest::class )
 			->disableOriginalConstructor()
@@ -145,7 +140,9 @@ class DisposeJobTaskHandlerTest extends TestCase {
 
 		$instance = new DisposeJobTaskHandler(
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$instance->setFeatureSet( SMW_ADM_DISPOSAL );

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Maintenance/FulltextSearchTableRebuildJobTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Maintenance/FulltextSearchTableRebuildJobTaskHandlerTest.php
@@ -26,6 +26,7 @@ class FulltextSearchTableRebuildJobTaskHandlerTest extends TestCase {
 	private $testEnvironment;
 	private $htmlFormRenderer;
 	private $outputFormatter;
+	private $jobFactory;
 	private $jobQueue;
 
 	protected function setUp(): void {
@@ -41,11 +42,13 @@ class FulltextSearchTableRebuildJobTaskHandlerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->jobQueue = $this->getMockBuilder( JobQueue::class )
+		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
+		$this->jobQueue = $this->getMockBuilder( JobQueue::class )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown(): void {
@@ -56,7 +59,7 @@ class FulltextSearchTableRebuildJobTaskHandlerTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			FulltextSearchTableRebuildJobTaskHandler::class,
-			new FulltextSearchTableRebuildJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter )
+			new FulltextSearchTableRebuildJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter, $this->jobFactory, $this->jobQueue )
 		);
 	}
 
@@ -81,7 +84,9 @@ class FulltextSearchTableRebuildJobTaskHandlerTest extends TestCase {
 
 		$instance = new FulltextSearchTableRebuildJobTaskHandler(
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$instance->getHtml();
@@ -100,15 +105,9 @@ class FulltextSearchTableRebuildJobTaskHandlerTest extends TestCase {
 		$fulltextSearchTableRebuildJob->expects( $this->once() )
 			->method( 'insert' );
 
-		$jobFactory = $this->getMockBuilder( JobFactory::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$jobFactory->expects( $this->once() )
+		$this->jobFactory->expects( $this->once() )
 			->method( 'newByType' )
 			->willReturn( $fulltextSearchTableRebuildJob );
-
-		$this->testEnvironment->registerObject( 'JobFactory', $jobFactory );
 
 		$webRequest = $this->getMockBuilder( WebRequest::class )
 			->disableOriginalConstructor()
@@ -116,7 +115,9 @@ class FulltextSearchTableRebuildJobTaskHandlerTest extends TestCase {
 
 		$instance = new FulltextSearchTableRebuildJobTaskHandler(
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$instance->isApiTask = false;
@@ -130,14 +131,8 @@ class FulltextSearchTableRebuildJobTaskHandlerTest extends TestCase {
 			->with( 'smw.fulltextSearchTableRebuild' )
 			->willReturn( true );
 
-		$jobFactory = $this->getMockBuilder( JobFactory::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$jobFactory->expects( $this->never() )
+		$this->jobFactory->expects( $this->never() )
 			->method( 'newByType' );
-
-		$this->testEnvironment->registerObject( 'JobFactory', $jobFactory );
 
 		$webRequest = $this->getMockBuilder( WebRequest::class )
 			->disableOriginalConstructor()
@@ -145,7 +140,9 @@ class FulltextSearchTableRebuildJobTaskHandlerTest extends TestCase {
 
 		$instance = new FulltextSearchTableRebuildJobTaskHandler(
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$instance->setFeatureSet( SMW_ADM_FULLT );

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/Maintenance/PropertyStatsRebuildJobTaskHandlerTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/Maintenance/PropertyStatsRebuildJobTaskHandlerTest.php
@@ -26,6 +26,7 @@ class PropertyStatsRebuildJobTaskHandlerTest extends TestCase {
 	private $testEnvironment;
 	private $htmlFormRenderer;
 	private $outputFormatter;
+	private $jobFactory;
 	private $jobQueue;
 
 	protected function setUp(): void {
@@ -41,11 +42,13 @@ class PropertyStatsRebuildJobTaskHandlerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->jobQueue = $this->getMockBuilder( JobQueue::class )
+		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
+		$this->jobQueue = $this->getMockBuilder( JobQueue::class )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown(): void {
@@ -56,7 +59,7 @@ class PropertyStatsRebuildJobTaskHandlerTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			PropertyStatsRebuildJobTaskHandler::class,
-			new PropertyStatsRebuildJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter )
+			new PropertyStatsRebuildJobTaskHandler( $this->htmlFormRenderer, $this->outputFormatter, $this->jobFactory, $this->jobQueue )
 		);
 	}
 
@@ -81,7 +84,9 @@ class PropertyStatsRebuildJobTaskHandlerTest extends TestCase {
 
 		$instance = new PropertyStatsRebuildJobTaskHandler(
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$instance->getHtml();
@@ -100,15 +105,9 @@ class PropertyStatsRebuildJobTaskHandlerTest extends TestCase {
 		$propertyStatisticsRebuildJob->expects( $this->once() )
 			->method( 'insert' );
 
-		$jobFactory = $this->getMockBuilder( JobFactory::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$jobFactory->expects( $this->once() )
+		$this->jobFactory->expects( $this->once() )
 			->method( 'newByType' )
 			->willReturn( $propertyStatisticsRebuildJob );
-
-		$this->testEnvironment->registerObject( 'JobFactory', $jobFactory );
 
 		$webRequest = $this->getMockBuilder( WebRequest::class )
 			->disableOriginalConstructor()
@@ -116,7 +115,9 @@ class PropertyStatsRebuildJobTaskHandlerTest extends TestCase {
 
 		$instance = new PropertyStatsRebuildJobTaskHandler(
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$instance->isApiTask = false;
@@ -130,14 +131,8 @@ class PropertyStatsRebuildJobTaskHandlerTest extends TestCase {
 			->with( 'smw.propertyStatisticsRebuild' )
 			->willReturn( true );
 
-		$jobFactory = $this->getMockBuilder( JobFactory::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$jobFactory->expects( $this->never() )
+		$this->jobFactory->expects( $this->never() )
 			->method( 'newByType' );
-
-		$this->testEnvironment->registerObject( 'JobFactory', $jobFactory );
 
 		$webRequest = $this->getMockBuilder( WebRequest::class )
 			->disableOriginalConstructor()
@@ -145,7 +140,9 @@ class PropertyStatsRebuildJobTaskHandlerTest extends TestCase {
 
 		$instance = new PropertyStatsRebuildJobTaskHandler(
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$instance->setFeatureSet( SMW_ADM_PSTATS );

--- a/tests/phpunit/Unit/MediaWiki/Specials/Admin/TaskHandlerFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Admin/TaskHandlerFactoryTest.php
@@ -5,6 +5,8 @@ namespace SMW\Tests\Unit\MediaWiki\Specials\Admin;
 use MediaWiki\User\User;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\HookDispatcher;
+use SMW\MediaWiki\JobFactory;
+use SMW\MediaWiki\JobQueue;
 use SMW\MediaWiki\Renderer\HtmlFormRenderer;
 use SMW\MediaWiki\Specials\Admin\Alerts\DeprecationNoticeTaskHandler;
 use SMW\MediaWiki\Specials\Admin\AlertsTaskHandler;
@@ -42,6 +44,8 @@ class TaskHandlerFactoryTest extends TestCase {
 	private $store;
 	private $htmlFormRenderer;
 	private $outputFormatter;
+	private $jobFactory;
+	private $jobQueue;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -63,12 +67,20 @@ class TaskHandlerFactoryTest extends TestCase {
 		$this->outputFormatter = $this->getMockBuilder( OutputFormatter::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->jobFactory = $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->jobQueue = $this->getMockBuilder( JobQueue::class )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			TaskHandlerFactory::class,
-			new TaskHandlerFactory( $this->store, $this->htmlFormRenderer, $this->outputFormatter )
+			new TaskHandlerFactory( $this->store, $this->htmlFormRenderer, $this->outputFormatter, $this->jobFactory, $this->jobQueue )
 		);
 	}
 
@@ -82,7 +94,9 @@ class TaskHandlerFactoryTest extends TestCase {
 		$instance = new TaskHandlerFactory(
 			$this->store,
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$instance->setHookDispatcher(
@@ -102,7 +116,9 @@ class TaskHandlerFactoryTest extends TestCase {
 		$instance = new TaskHandlerFactory(
 			$this->store,
 			$this->htmlFormRenderer,
-			$this->outputFormatter
+			$this->outputFormatter,
+			$this->jobFactory,
+			$this->jobQueue
 		);
 
 		$this->assertInstanceOf(

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialAdminTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialAdminTest.php
@@ -7,6 +7,8 @@ use MediaWiki\Output\OutputPage;
 use MediaWiki\User\User;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\HookDispatcher;
+use SMW\MediaWiki\JobFactory;
+use SMW\MediaWiki\JobQueue;
 use SMW\MediaWiki\Specials\SpecialAdmin;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Settings;
@@ -29,6 +31,8 @@ class SpecialAdminTest extends TestCase {
 	private $store;
 	private $settings;
 	private $hookDispatcher;
+	private $jobFactory;
+	private $jobQueue;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -43,6 +47,8 @@ class SpecialAdminTest extends TestCase {
 		$this->store = $applicationFactory->getStore();
 		$this->settings = $applicationFactory->getSettings();
 		$this->hookDispatcher = $applicationFactory->getHookDispatcher();
+		$this->jobFactory = $applicationFactory->getJobFactory();
+		$this->jobQueue = $applicationFactory->getJobQueue();
 	}
 
 	protected function tearDown(): void {
@@ -56,10 +62,12 @@ class SpecialAdminTest extends TestCase {
 			->getMockForAbstractClass();
 		$settings = $this->createMock( Settings::class );
 		$hookDispatcher = $this->createMock( HookDispatcher::class );
+		$jobFactory = $this->createMock( JobFactory::class );
+		$jobQueue = $this->createMock( JobQueue::class );
 
 		$this->assertInstanceOf(
 			SpecialAdmin::class,
-			new SpecialAdmin( $store, $settings, $hookDispatcher )
+			new SpecialAdmin( $store, $settings, $hookDispatcher, $jobFactory, $jobQueue )
 		);
 	}
 
@@ -75,7 +83,7 @@ class SpecialAdminTest extends TestCase {
 			->method( 'addHtml' );
 
 		$query = '';
-		$instance = new SpecialAdmin( $this->store, $this->settings, $this->hookDispatcher );
+		$instance = new SpecialAdmin( $this->store, $this->settings, $this->hookDispatcher, $this->jobFactory, $this->jobQueue );
 
 		$instance->getContext()->setTitle(
 			MediaWikiServices::getInstance()->getTitleFactory()->newFromText( 'SemanticMadiaWiki' )
@@ -100,7 +108,7 @@ class SpecialAdminTest extends TestCase {
 		$this->testEnvironment->overrideUserPermissions( $user, [] );
 
 		$query = '';
-		$instance = new SpecialAdmin( $this->store, $this->settings, $this->hookDispatcher );
+		$instance = new SpecialAdmin( $this->store, $this->settings, $this->hookDispatcher, $this->jobFactory, $this->jobQueue );
 
 		$instance->getContext()->setTitle(
 			MediaWikiServices::getInstance()->getTitleFactory()->newFromText( 'SemanticMadiaWiki' )


### PR DESCRIPTION
## Summary

Convert the `JobFactory` + `JobQueue` cluster to constructor injection so the corresponding service-locator calls disappear from instance methods. Four `Special:SMWAdmin` task handlers, the wrapping `TaskHandlerFactory`, `SpecialAdmin`, and the eight production `Job` subclasses that still reached `ApplicationFactory::getInstance()` are migrated to `private readonly` constructor parameters wired via the `JobClasses` / `SpecialPages` ObjectFactory specs in `extension.json`.

## Scope

**Task handlers and special page:**
- `DataRefreshJobTaskHandler`, `DisposeJobTaskHandler`, `FulltextSearchTableRebuildJobTaskHandler`, `PropertyStatsRebuildJobTaskHandler`: drop `ApplicationFactory::getInstance()->newJobFactory()` / `->getJobQueue()` from `handleRequest()` / `getRefreshJob()`; receive both services as constructor parameters.
- `TaskHandlerFactory`: receive `JobFactory` and `JobQueue`, forward them to the four task handlers above.
- `SpecialAdmin`: receive both services, forward them to `TaskHandlerFactory`. `extension.json`'s `SpecialPages.SMWAdmin.services` extended with `SMW.JobFactory` and `SMW.JobQueue`.

**Job classes:**
- `RefreshJob`, `EntityIdDisposerJob`, `FulltextSearchTableRebuildJob`, `ChangePropagationDispatchJob`, `ChangePropagationUpdateJob`, `DeferredConstraintCheckUpdateJob`, `IndexerRecoveryJob`, `FileIngestJob`: instance-method locator calls replaced with constructor-injected services. The matching `JobClasses` entries in `extension.json` gain `SMW.JobFactory` / `SMW.JobQueue` in their `services:` arrays; three entries previously expressed as bare class-name strings (`smw.changePropagationUpdate`, `smw.changePropagationClassUpdate`, `smw.deferredConstraintCheckUpdateJob`) are upgraded to the ObjectFactory spec form.
- `ChangePropagationClassUpdateJob` is collateral: it inherits from `ChangePropagationUpdateJob`, so its constructor signature was updated to match.
- `ChangePropagationDispatchJob::newChangePropagationUpdateJob()` and `newChangePropagationClassUpdateJob()` previously constructed the inner jobs directly with `new`. They now route through `$this->jobFactory->newChangePropagation{,Class}UpdateJob()` so the spec-based DI takes effect for the inner jobs too.

**Tests:** seven `JobTest` classes and three `SpecialAdmin*` / `TaskHandlerFactory` test classes are updated to pass mocks via the constructor. `TestEnvironment::registerObject('JobFactory'|'JobQueue', ...)` calls used by the static-path tests below are retained.

## Static-method exceptions

The following static helpers cannot be constructor-injected (no `$this` in static scope) and continue to use the locator:

- `ChangePropagationDispatchJob::planAsJob()`, `cleanUp()`, `hasPendingJobs()`, `getPendingJobsCount()`
- `DeferredConstraintCheckUpdateJob::pushJob()`
- `IndexerRecoveryJob::pushFromDocument()`, `pushFromParams()`, `makeCacheKey()`
- `FileIngestJob::pushIngestJob()`
- `Job::batchInsert()` (base class)

Two jobs (`DeferredConstraintCheckUpdateJob`, `ChangePropagationUpdateJob`) retain a `?JobFactory $jobFactory = null` constructor parameter with a `?? ApplicationFactory::getInstance()->getJobFactory()` fallback because their static `pushJob()` helpers and the related subclass forwarder use `new self(...)` directly, bypassing the `JobClasses` ObjectFactory spec. Both fallbacks carry inline comments explaining the rationale.

## Verification

- Full unit suite: 7081 tests, 14508 assertions, 6 skipped, 0 errors, 0 failures (+9 assertions vs master from added mock expectations).
- PHPCS clean on all 28 changed PHP files.
- Live smoke: anonymous `Special:SMWAdmin` redirects to canonical `Special:SemanticMediaWiki` and renders the SMW-specific `smw-admin-permission-missing` message, proving `SpecialAdmin` constructs end-to-end with the five injected services.
- Spec-route probe: all 10 SMW `JobClasses` commands construct cleanly via `JobFactory::newJob()` through the updated `services:` arrays.

## Test plan

- [ ] Visit `Special:SMWAdmin` as a user with `smw-admin` permission; verify the four maintenance task forms render and submit (data refresh, dispose, property stats rebuild, fulltext rebuild).
- [ ] Trigger a category-related save to enqueue a `ChangePropagationDispatchJob` and confirm the dispatched `ChangePropagationUpdateJob` / `ChangePropagationClassUpdateJob` run.
- [ ] On an Elastic-store wiki, upload a file and confirm `FileIngestJob` runs; trigger a recovery path and confirm `IndexerRecoveryJob` runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)