### PR TITLE
JobFactory: cover elastic types in newByType and drop dead assignment

### DIFF
--- a/src/MediaWiki/JobFactory.php
+++ b/src/MediaWiki/JobFactory.php
@@ -87,6 +87,8 @@ class JobFactory {
 			'smw.changePropagationDispatch' => 'smw.changePropagationDispatch',
 			'smw.changePropagationUpdate' => 'smw.changePropagationUpdate',
 			'smw.changePropagationClassUpdate' => 'smw.changePropagationClassUpdate',
+			'smw.elasticFileIngest' => 'smw.elasticFileIngest',
+			'smw.elasticIndexerRecovery' => 'smw.elasticIndexerRecovery',
 			default => throw new RuntimeException( "Unable to match $type to a valid Job type" ),
 		};
 

--- a/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
@@ -300,9 +300,7 @@ class ChangePropagationDispatchJob extends Job {
 			$this->getTitle()->getText()
 		);
 
-		$semanticData = $this->store->getSemanticData(
-			$subject
-		);
+		$this->store->getSemanticData( $subject );
 
 		$key = smwfCacheKey( self::CACHE_NAMESPACE, $subject->getHash() );
 

--- a/tests/phpunit/Unit/MediaWiki/JobFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/JobFactoryTest.php
@@ -4,6 +4,8 @@ namespace SMW\Tests\Unit\MediaWiki;
 
 use MediaWiki\MediaWikiServices;
 use PHPUnit\Framework\TestCase;
+use SMW\Elastic\Jobs\FileIngestJob;
+use SMW\Elastic\Jobs\IndexerRecoveryJob;
 use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\Jobs\ChangePropagationClassUpdateJob;
 use SMW\MediaWiki\Jobs\ChangePropagationDispatchJob;
@@ -80,6 +82,8 @@ class JobFactoryTest extends TestCase {
 			[ 'smw.changePropagationUpdate', ChangePropagationUpdateJob::class ],
 			[ 'smw.changePropagationClassUpdate', ChangePropagationClassUpdateJob::class ],
 			[ 'smw.parserCachePurge', ParserCachePurgeJob::class ],
+			[ 'smw.elasticFileIngest', FileIngestJob::class ],
+			[ 'smw.elasticIndexerRecovery', IndexerRecoveryJob::class ],
 		];
 	}
 


### PR DESCRIPTION
## Summary

Follow-up addressing two [CodeRabbit comments](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6856) left on #6856.

`JobFactory::newByType()` is the generic by-type dispatcher used by the four `Special:SMWAdmin` maintenance task handlers and the `smwtask` API entrypoint (`Api/Tasks/InsertJobTask.php`). Its `match` arm previously listed 11 commands but did not cover `smw.elasticFileIngest` or `smw.elasticIndexerRecovery`, both of which are registered in `extension.json`'s `JobClasses`. Any caller that passed either of those types through `newByType()` would hit the default `RuntimeException` rather than receive the registered job. This PR adds the two missing arms and extends `JobFactoryTest::typeProvider()` so the dispatch and the null-title fallback are both covered.

`ChangePropagationDispatchJob::dispatchFromData()` carried a dead assignment to a local `$semanticData` after `$this->store->getSemanticData( $subject )`. The fetch is retained because `SQLStore::getSemanticData()` populates the Store's internal fact-book cache as a side effect of the property-change dispatch that follows, but the assignment is dropped (and the call collapsed onto a single line), which also clears the long-standing `PHPMD UnusedLocalVariable` warning at this site.

## Test plan

- [x] `composer phpunit -- tests/phpunit/Unit/MediaWiki/JobFactoryTest.php` (28 tests / 28 assertions, was 24 / 24)
- [x] `composer phpunit -- tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php` (8 / 15)
- [x] `vendor/bin/phpcs -sp` on the three changed files: clean
- [ ] Trigger one of the elastic jobs via `?action=smwtask&task=elasticFileIngest...` and confirm the job is enqueued rather than 500-ing

🤖 Generated with [Claude Code](https://claude.com/claude-code)