### PR TITLE
Inject PageCreator into DataUpdater, ProtectionValidator and CategoryPropertyAnnotator

### DIFF
--- a/src/DataUpdater.php
+++ b/src/DataUpdater.php
@@ -13,6 +13,7 @@ use SMW\DataItems\WikiPage as DIWikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\EventDispatcher\EventDispatcherAwareTrait;
 use SMW\MediaWiki\Deferred\TransactionalCallableUpdate as DeferredUpdate;
+use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\RevisionGuardAwareTrait;
 use SMW\Property\ChangePropagationNotifier;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -47,6 +48,8 @@ class DataUpdater {
 
 	private ChangePropagationNotifier $changePropagationNotifier;
 
+	private PageCreator $pageCreator;
+
 	private ?bool $canCreateUpdateJob = null;
 
 	/**
@@ -74,11 +77,13 @@ class DataUpdater {
 	public function __construct(
 		Store $store,
 		SemanticData $semanticData,
-		ChangePropagationNotifier $changePropagationNotifier
+		ChangePropagationNotifier $changePropagationNotifier,
+		PageCreator $pageCreator
 	) {
 		$this->store = $store;
 		$this->semanticData = $semanticData;
 		$this->changePropagationNotifier = $changePropagationNotifier;
+		$this->pageCreator = $pageCreator;
 	}
 
 	/**
@@ -240,9 +245,7 @@ class DataUpdater {
 		$user = null;
 		$title = $this->getSubject()->getTitle();
 
-		$wikiPage = $applicationFactory->newPageCreator()->createPage(
-			$title
-		);
+		$wikiPage = $this->pageCreator->createPage( $title );
 
 		// For example, when using `SemanticApprovedRevs` the guard here ensures
 		// that the revision reference is the same that lead to an update during

--- a/src/Property/AnnotatorFactory.php
+++ b/src/Property/AnnotatorFactory.php
@@ -4,6 +4,7 @@ namespace SMW\Property;
 
 use MediaWiki\Title\Title;
 use SMW\DataModel\SemanticData;
+use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\RedirectTargetFinder;
 use SMW\PageInfo;
 use SMW\Property\Annotators\AttachmentLinkPropertyAnnotator;
@@ -32,7 +33,10 @@ class AnnotatorFactory {
 	/**
 	 * @since 7.0.0
 	 */
-	public function __construct( private readonly Store $store ) {
+	public function __construct(
+		private readonly Store $store,
+		private readonly PageCreator $pageCreator,
+	) {
 	}
 
 	/**
@@ -213,7 +217,8 @@ class AnnotatorFactory {
 		$categoryPropertyAnnotator = new CategoryPropertyAnnotator(
 			$propertyAnnotator,
 			$categories,
-			$this->store
+			$this->store,
+			$this->pageCreator
 		);
 
 		$categoryPropertyAnnotator->showHiddenCategories(

--- a/src/Property/Annotators/CategoryPropertyAnnotator.php
+++ b/src/Property/Annotators/CategoryPropertyAnnotator.php
@@ -6,10 +6,10 @@ use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\DataValueFactory;
+use SMW\MediaWiki\PageCreator;
 use SMW\Parser\AnnotationProcessor;
 use SMW\ProcessingErrorMsgHandler;
 use SMW\Property\Annotator;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
 
 /**
@@ -46,6 +46,7 @@ class CategoryPropertyAnnotator extends PropertyAnnotatorDecorator {
 		Annotator $propertyAnnotator,
 		private readonly array $categories,
 		private readonly Store $store,
+		private readonly PageCreator $pageCreator,
 	) {
 		parent::__construct( $propertyAnnotator );
 	}
@@ -168,7 +169,7 @@ class CategoryPropertyAnnotator extends PropertyAnnotatorDecorator {
 	private function isHiddenCategory( $catName ): bool {
 		if ( $this->hiddenCategories === null ) {
 
-			$wikipage = ApplicationFactory::getInstance()->newPageCreator()->createPage(
+			$wikipage = $this->pageCreator->createPage(
 				$this->getSemanticData()->getSubject()->getTitle()
 			);
 

--- a/src/Protection/ProtectionValidator.php
+++ b/src/Protection/ProtectionValidator.php
@@ -10,8 +10,8 @@ use SMW\DataItems\WikiPage;
 use SMW\EntityCache;
 use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
 use SMW\Listener\ChangeListener\ChangeRecord;
+use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\PermissionManager;
-use SMW\Services\ServicesFactory;
 use SMW\Store;
 
 /**
@@ -47,6 +47,7 @@ class ProtectionValidator {
 		private readonly Store $store,
 		private readonly EntityCache $entityCache,
 		private readonly PermissionManager $permissionManager,
+		private readonly PageCreator $pageCreator,
 	) {
 	}
 
@@ -192,7 +193,7 @@ class ProtectionValidator {
 			return $this->importPerformerProtectionLookupCache[$key];
 		}
 
-		$creator = ServicesFactory::getInstance()->newPageCreator()
+		$creator = $this->pageCreator
 			->createPage( $title )
 			->getCreator();
 

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -288,7 +288,7 @@ return [
 			return $servicesFactory->getPropertyAnnotatorFactory();
 		}
 
-		return new AnnotatorFactory( $servicesFactory->getStore() );
+		return new AnnotatorFactory( $servicesFactory->getStore(), $servicesFactory->getPageCreator() );
 	},
 
 	'SMW.ConnectionProvider' => static function ( MediaWikiServices $services ): ConnectionProvider {
@@ -506,7 +506,8 @@ return [
 		$protectionValidator = new ProtectionValidator(
 			$servicesFactory->getStore(),
 			$servicesFactory->getEntityCache(),
-			$servicesFactory->getPermissionManager()
+			$servicesFactory->getPermissionManager(),
+			$servicesFactory->getPageCreator()
 		);
 
 		$protectionValidator->setImportPerformers(

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -871,7 +871,8 @@ class ServicesFactory {
 		$dataUpdater = new DataUpdater(
 			$this->getStore(),
 			$semanticData,
-			$changePropagationNotifier
+			$changePropagationNotifier,
+			$this->getPageCreator()
 		);
 
 		$dataUpdater->isCommandLineMode(

--- a/tests/phpunit/Unit/Property/AnnotatorFactoryTest.php
+++ b/tests/phpunit/Unit/Property/AnnotatorFactoryTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Unit\Property;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
+use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\RedirectTargetFinder;
 use SMW\PageInfo;
 use SMW\Property\Annotator;
@@ -32,16 +33,18 @@ use SMW\Store;
 class AnnotatorFactoryTest extends TestCase {
 
 	private Store $store;
+	private PageCreator $pageCreator;
 
 	protected function setUp(): void {
 		parent::setUp();
 		$this->store = $this->createMock( Store::class );
+		$this->pageCreator = $this->createMock( PageCreator::class );
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			AnnotatorFactory::class,
-			new AnnotatorFactory( $this->store )
+			new AnnotatorFactory( $this->store, $this->pageCreator )
 		);
 	}
 
@@ -50,7 +53,7 @@ class AnnotatorFactoryTest extends TestCase {
 			->setConstructorArgs( [ WikiPage::newFromText( 'Foo' ) ] )
 			->getMock();
 
-		$instance = new AnnotatorFactory( $this->store );
+		$instance = new AnnotatorFactory( $this->store, $this->pageCreator );
 
 		$this->assertInstanceOf(
 			NullPropertyAnnotator::class,
@@ -67,7 +70,7 @@ class AnnotatorFactoryTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new AnnotatorFactory( $this->store );
+		$instance = new AnnotatorFactory( $this->store, $this->pageCreator );
 
 		$this->assertInstanceOf(
 			RedirectPropertyAnnotator::class,
@@ -84,7 +87,7 @@ class AnnotatorFactoryTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new AnnotatorFactory( $this->store );
+		$instance = new AnnotatorFactory( $this->store, $this->pageCreator );
 
 		$this->assertInstanceOf(
 			PredefinedPropertyAnnotator::class,
@@ -97,7 +100,7 @@ class AnnotatorFactoryTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new AnnotatorFactory( $this->store );
+		$instance = new AnnotatorFactory( $this->store, $this->pageCreator );
 
 		$this->assertInstanceOf(
 			SortKeyPropertyAnnotator::class,
@@ -110,7 +113,7 @@ class AnnotatorFactoryTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new AnnotatorFactory( $this->store );
+		$instance = new AnnotatorFactory( $this->store, $this->pageCreator );
 
 		$this->assertInstanceOf(
 			TranslationPropertyAnnotator::class,
@@ -123,7 +126,7 @@ class AnnotatorFactoryTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new AnnotatorFactory( $this->store );
+		$instance = new AnnotatorFactory( $this->store, $this->pageCreator );
 
 		$this->assertInstanceOf(
 			CategoryPropertyAnnotator::class,
@@ -136,7 +139,7 @@ class AnnotatorFactoryTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new AnnotatorFactory( $this->store );
+		$instance = new AnnotatorFactory( $this->store, $this->pageCreator );
 
 		$this->assertInstanceOf(
 			MandatoryTypePropertyAnnotator::class,
@@ -149,7 +152,7 @@ class AnnotatorFactoryTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new AnnotatorFactory( $this->store );
+		$instance = new AnnotatorFactory( $this->store, $this->pageCreator );
 
 		$this->assertInstanceOf(
 			SchemaPropertyAnnotator::class,
@@ -162,7 +165,7 @@ class AnnotatorFactoryTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$instance = new AnnotatorFactory( $this->store );
+		$instance = new AnnotatorFactory( $this->store, $this->pageCreator );
 
 		$this->assertInstanceOf(
 			AttachmentLinkPropertyAnnotator::class,

--- a/tests/phpunit/Unit/Property/Annotators/CategoryPropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/CategoryPropertyAnnotatorTest.php
@@ -29,6 +29,7 @@ class CategoryPropertyAnnotatorTest extends TestCase {
 	private $semanticDataValidator;
 	private $testEnvironment;
 	private $store;
+	private $pageCreator;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -41,6 +42,10 @@ class CategoryPropertyAnnotatorTest extends TestCase {
 		$this->store = $this->getMockBuilder( Store::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
+
+		$this->pageCreator = $this->getMockBuilder( PageCreator::class )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	protected function tearDown(): void {
@@ -56,7 +61,8 @@ class CategoryPropertyAnnotatorTest extends TestCase {
 		$instance = new CategoryPropertyAnnotator(
 			new NullPropertyAnnotator( $semanticData ),
 			[],
-			$this->store
+			$this->store,
+			$this->pageCreator
 		);
 
 		$this->assertInstanceOf(
@@ -76,7 +82,8 @@ class CategoryPropertyAnnotatorTest extends TestCase {
 		$instance = new CategoryPropertyAnnotator(
 			new NullPropertyAnnotator( $semanticData ),
 			$parameters['categories'],
-			$this->store
+			$this->store,
+			$this->pageCreator
 		);
 
 		$instance->showHiddenCategories(
@@ -118,7 +125,8 @@ class CategoryPropertyAnnotatorTest extends TestCase {
 		$instance = new CategoryPropertyAnnotator(
 			new NullPropertyAnnotator( $parserData->getSemanticData() ),
 			$parameters['categories'],
-			$this->store
+			$this->store,
+			$this->pageCreator
 		);
 
 		$instance->showHiddenCategories(
@@ -174,15 +182,11 @@ class CategoryPropertyAnnotatorTest extends TestCase {
 			->setSubject( new WikiPage( __METHOD__, $parameters['namespace'], '' ) )
 			->newEmptySemanticData();
 
-		$this->testEnvironment->registerObject(
-			'PageCreator',
-			$pageCreator
-		);
-
 		$instance = new CategoryPropertyAnnotator(
 			new NullPropertyAnnotator( $semanticData ),
 			$parameters['categories'],
-			$this->store
+			$this->store,
+			$pageCreator
 		);
 
 		$instance->showHiddenCategories(
@@ -226,7 +230,8 @@ class CategoryPropertyAnnotatorTest extends TestCase {
 		$instance = new CategoryPropertyAnnotator(
 			new NullPropertyAnnotator( $semanticData ),
 			[ 'Bar' ],
-			$store
+			$store,
+			$this->pageCreator
 		);
 
 		$instance->useCategoryRedirect(

--- a/tests/phpunit/Unit/Property/Annotators/ChainablePropertyAnnotatorTest.php
+++ b/tests/phpunit/Unit/Property/Annotators/ChainablePropertyAnnotatorTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Unit\Property\Annotators;
 
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\Property;
+use SMW\MediaWiki\PageCreator;
 use SMW\PageInfo;
 use SMW\Property\Annotators\CategoryPropertyAnnotator;
 use SMW\Property\Annotators\NullPropertyAnnotator;
@@ -49,7 +50,8 @@ class ChainablePropertyAnnotatorTest extends TestCase {
 		$categoryPropertyAnnotator = new CategoryPropertyAnnotator(
 			new NullPropertyAnnotator( $semanticData ),
 			$parameters['categories'],
-			$this->createMock( Store::class )
+			$this->createMock( Store::class ),
+			$this->createMock( PageCreator::class )
 		);
 
 		$categoryPropertyAnnotator->showHiddenCategories(

--- a/tests/phpunit/Unit/Protection/ProtectionValidatorTest.php
+++ b/tests/phpunit/Unit/Protection/ProtectionValidatorTest.php
@@ -33,6 +33,7 @@ class ProtectionValidatorTest extends TestCase {
 	private $store;
 	private $entityCache;
 	private $permissionManager;
+	private $pageCreator;
 	private $testEnvironment;
 
 	protected function setUp(): void {
@@ -53,6 +54,10 @@ class ProtectionValidatorTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$this->pageCreator = $this->getMockBuilder( PageCreator::class )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->testEnvironment = new TestEnvironment();
 	}
 
@@ -64,7 +69,7 @@ class ProtectionValidatorTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			ProtectionValidator::class,
-			new ProtectionValidator( $this->store, $this->entityCache, $this->permissionManager )
+			new ProtectionValidator( $this->store, $this->entityCache, $this->permissionManager, $this->pageCreator )
 		);
 	}
 
@@ -72,7 +77,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$instance->setEditProtectionRight(
@@ -103,7 +109,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$instance->setEditProtectionRight(
@@ -133,7 +140,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$this->assertTrue(
@@ -155,7 +163,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$this->assertFalse(
@@ -177,7 +186,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$this->assertFalse(
@@ -194,7 +204,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$instance->setChangePropagationProtection(
@@ -220,7 +231,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$this->assertTrue(
@@ -237,7 +249,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$instance->setChangePropagationProtection(
@@ -253,7 +266,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$instance->setCreateProtectionRight(
@@ -282,7 +296,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$instance->setCreateProtectionRight(
@@ -298,7 +313,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$this->assertFalse(
@@ -310,7 +326,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$this->assertFalse(
@@ -330,7 +347,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$this->assertFalse(
@@ -367,8 +385,6 @@ class ProtectionValidatorTest extends TestCase {
 			->method( 'createPage' )
 			->willReturn( $wikiPage );
 
-		$this->testEnvironment->registerObject( 'PageCreator', $pageCreator );
-
 		$user = $this->getMockBuilder( User::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -376,7 +392,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$pageCreator
 		);
 
 		$instance->setImportPerformers(
@@ -417,8 +434,6 @@ class ProtectionValidatorTest extends TestCase {
 			->method( 'createPage' )
 			->willReturn( $wikiPage );
 
-		$this->testEnvironment->registerObject( 'PageCreator', $pageCreator );
-
 		$user = $this->getMockBuilder( User::class )
 			->disableOriginalConstructor()
 			->getMock();
@@ -430,7 +445,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$pageCreator
 		);
 
 		$instance->setImportPerformers(
@@ -456,7 +472,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$this->store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$instance->registerPropertyChangeListener( $propertyChangeListener );
@@ -492,7 +509,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$property = $this->dataItemFactory->newDIProperty( '_CHGPRO' );
@@ -530,7 +548,8 @@ class ProtectionValidatorTest extends TestCase {
 		$instance = new ProtectionValidator(
 			$store,
 			$this->entityCache,
-			$this->permissionManager
+			$this->permissionManager,
+			$this->pageCreator
 		);
 
 		$property = $this->dataItemFactory->newDIProperty( '_CHGPRO' );

--- a/tests/phpunit/Unit/Updater/DataUpdaterTest.php
+++ b/tests/phpunit/Unit/Updater/DataUpdaterTest.php
@@ -41,6 +41,7 @@ class DataUpdaterTest extends TestCase {
 	private $eventDispatcher;
 	private $revisionGuard;
 	private SpecificationLookup $propertySpecificationLookup;
+	private $pageCreator;
 	private $revision;
 
 	protected function setUp(): void {
@@ -71,6 +72,10 @@ class DataUpdaterTest extends TestCase {
 			->getMock();
 
 		$this->changePropagationNotifier = $this->getMockBuilder( ChangePropagationNotifier::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->pageCreator = $this->getMockBuilder( PageCreator::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -114,7 +119,7 @@ class DataUpdaterTest extends TestCase {
 
 		$this->assertInstanceOf(
 			DataUpdater::class,
-			new DataUpdater( $this->store, $semanticData, $this->changePropagationNotifier )
+			new DataUpdater( $this->store, $semanticData, $this->changePropagationNotifier, $this->pageCreator )
 		);
 	}
 
@@ -132,7 +137,8 @@ class DataUpdaterTest extends TestCase {
 		$instance = new DataUpdater(
 			$this->store,
 			$semanticData,
-			$this->changePropagationNotifier
+			$this->changePropagationNotifier,
+			$this->pageCreator
 		);
 
 		$instance->setEventDispatcher(
@@ -158,7 +164,8 @@ class DataUpdaterTest extends TestCase {
 		$instance = new DataUpdater(
 			$this->store,
 			$semanticData,
-			$this->changePropagationNotifier
+			$this->changePropagationNotifier,
+			$this->pageCreator
 		);
 
 		$instance->setEventDispatcher(
@@ -217,8 +224,6 @@ class DataUpdaterTest extends TestCase {
 			->method( 'createPage' )
 			->willReturn( $wikiPage );
 
-		$this->testEnvironment->registerObject( 'PageCreator', $pageCreator );
-
 		$this->revisionGuard->expects( $this->any() )
 			->method( 'newRevisionFromPage' )
 			->willReturn( $revision );
@@ -230,7 +235,8 @@ class DataUpdaterTest extends TestCase {
 		$instance = new DataUpdater(
 			$store,
 			$semanticData,
-			$this->changePropagationNotifier
+			$this->changePropagationNotifier,
+			$pageCreator
 		);
 
 		$instance->setRevisionGuard(
@@ -289,8 +295,6 @@ class DataUpdaterTest extends TestCase {
 			->method( 'createPage' )
 			->willReturn( $wikiPage );
 
-		$this->testEnvironment->registerObject( 'PageCreator', $pageCreator );
-
 		$this->revisionGuard->expects( $this->any() )
 			->method( 'getRevision' )
 			->willReturn( null );
@@ -298,7 +302,8 @@ class DataUpdaterTest extends TestCase {
 		$instance = new DataUpdater(
 			$store,
 			$semanticData,
-			$this->changePropagationNotifier
+			$this->changePropagationNotifier,
+			$pageCreator
 		);
 
 		$instance->canCreateUpdateJob(
@@ -330,7 +335,8 @@ class DataUpdaterTest extends TestCase {
 		$instance = new DataUpdater(
 			$this->store,
 			$semanticData,
-			$this->changePropagationNotifier
+			$this->changePropagationNotifier,
+			$this->pageCreator
 		);
 
 		$instance->setEventDispatcher(
@@ -355,7 +361,8 @@ class DataUpdaterTest extends TestCase {
 		$instance = new DataUpdater(
 			$this->store,
 			$semanticData,
-			$this->changePropagationNotifier
+			$this->changePropagationNotifier,
+			$this->pageCreator
 		);
 
 		$instance->setEventDispatcher(
@@ -416,8 +423,6 @@ class DataUpdaterTest extends TestCase {
 			->method( 'createPage' )
 			->willReturn( $wikiPage );
 
-		$this->testEnvironment->registerObject( 'PageCreator', $pageCreator );
-
 		$this->revisionGuard->expects( $this->any() )
 			->method( 'getRevision' )
 			->willReturn( $revision );
@@ -425,7 +430,8 @@ class DataUpdaterTest extends TestCase {
 		$instance = new DataUpdater(
 			$store,
 			$semanticData,
-			$this->changePropagationNotifier
+			$this->changePropagationNotifier,
+			$pageCreator
 		);
 
 		$instance->setRevisionGuard(
@@ -470,7 +476,6 @@ class DataUpdaterTest extends TestCase {
 			->method( 'createPage' )
 			->willReturn( $wikiPage );
 
-		$this->testEnvironment->registerObject( 'PageCreator', $pageCreator );
 		$this->revisionGuard->expects( $this->any() )
 			->method( 'getRevision' )
 			->willReturn( $revision );
@@ -510,7 +515,8 @@ class DataUpdaterTest extends TestCase {
 		$instance = new DataUpdater(
 			$store,
 			$semanticData,
-			$this->changePropagationNotifier
+			$this->changePropagationNotifier,
+			$pageCreator
 		);
 
 		$instance->setEventDispatcher(


### PR DESCRIPTION
## Summary

Convert three production classes (`ProtectionValidator`, `DataUpdater`, `CategoryPropertyAnnotator`) and the wrapping `AnnotatorFactory` from service-locator lookups of `SMW\MediaWiki\PageCreator` to constructor injection. Each class now receives `PageCreator` as a constructor parameter; the matching `ServiceWiring` entries pass `$servicesFactory->getPageCreator()`.

`ServicesFactory::getPageCreator()` still routes through `hasTestOverride('PageCreator')`, so transitive callers that pre-register a `PageCreator` mock via `TestEnvironment::registerObject(...)` continue to work without modification. The single remaining `registerObject('PageCreator', ...)` in `ParserAfterTidyTest` exercises one such transitive path and is intentionally left untouched.

## Scope

**Production (6 files):**
- `ProtectionValidator`: ctor signature extended to `(Store, EntityCache, PermissionManager, PageCreator)`; locator call in `isClassifiedAsImportPerformerProtected()` replaced with `$this->pageCreator`; unused `SMW\Services\ServicesFactory` import removed.
- `DataUpdater`: ctor signature extended to `(Store, SemanticData, ChangePropagationNotifier, PageCreator)`; locator call in `runUpdate()` replaced with `$this->pageCreator`. The `ApplicationFactory::getInstance()` reference at the top of `runUpdate()` is retained because it still resolves other services (`getSettings()`, etc.) that are out of scope for this slice.
- `CategoryPropertyAnnotator`: ctor signature extended to `(Annotator, array, Store, PageCreator)`; locator call in `isHiddenCategory()` replaced with `$this->pageCreator->createPage(...)`; unused `SMW\Services\ServicesFactory as ApplicationFactory` import removed.
- `AnnotatorFactory`: receives `PageCreator` as a second promoted ctor parameter and forwards it to every `new CategoryPropertyAnnotator(...)` in `newCategoryPropertyAnnotator()`.
- `src/Services/ServiceWiring.php`: `SMW.ProtectionValidator` and `SMW.PropertyAnnotatorFactory` entries pass the new service.
- `src/Services/ServicesFactory.php`: `newDataUpdater()` passes the new service.

**Tests (5 files):** `ProtectionValidatorTest`, `DataUpdaterTest`, `CategoryPropertyAnnotatorTest`, `AnnotatorFactoryTest`, `ChainablePropertyAnnotatorTest` receive the new mock via the constructor; seven `TestEnvironment::registerObject('PageCreator', ...)` calls are removed (two in `ProtectionValidatorTest`, four in `DataUpdaterTest`, one in `CategoryPropertyAnnotatorTest`).

## Out of scope

- `Hooks::onFileUpload()` still resolves `PageCreator` via `ApplicationFactory::getInstance()->newPageCreator()`. Hook closures are not wired through the global service container in the same way, and converting that path warrants a separate PR.
- `ParserCachePurgeJob::getWikiPage()` and the static `Job::batchInsert` family still use the locator. Static-method paths cannot be constructor-injected.
- The remaining `registerObject('PageCreator', ...)` call in `ParserAfterTidyTest` (one site) exercises a transitive path through `ServicesFactory::newDataUpdater()` which still respects `hasTestOverride('PageCreator')`. It will be addressed in a later slice that targets `ParserAfterTidy` itself.

## Test plan

- [x] Full unit suite: 7081 tests, 14508 assertions, 6 skipped, 0 errors / 0 failures.
- [x] Targeted: `ProtectionValidatorTest` 19/33, `DataUpdaterTest` 11/29, `CategoryPropertyAnnotatorTest` 10/51, `ChainablePropertyAnnotatorTest` 1/12, `AnnotatorFactoryTest` 10/10.
- [x] PHPCS clean on all 11 changed files.
- [x] DI resolution probe: `SMW.ProtectionValidator`, `SMW.PropertyAnnotatorFactory`, `DataUpdater` via `ServicesFactory::newDataUpdater()`, and `CategoryPropertyAnnotator` via `AnnotatorFactory` all resolve cleanly through MediaWiki's service container.
- [x] Live smoke: editing a wiki page with `[[Category:Sandbox]]` content succeeded end-to-end against the dev wiki; SMW persisted `_MDAT` and `_SKEY` for the new page (proving DataUpdater + AnnotatorFactory + CategoryPropertyAnnotator chain runs through with the injected `PageCreator`).
- [ ] Integration suite: hits a pre-existing flaky `"Clock was set back; sequence number incremented"` error in MediaWiki core's `GlobalIdGenerator` (stack trace lands in `JSONScriptTestCaseRunner` → `EditInfo` → MW core revision rendering, with none of the classes touched by this PR in the trace). CI's clock should be stable enough for this not to recur there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)