### PR TITLE
Fix empty maintenance scripts list in Special:SemanticMediaWiki

### DIFF
--- a/src/MediaWiki/Specials/Admin/MaintenanceTaskHandler.php
+++ b/src/MediaWiki/Specials/Admin/MaintenanceTaskHandler.php
@@ -3,6 +3,7 @@
 namespace SMW\MediaWiki\Specials\Admin;
 
 use MediaWiki\Html\Html;
+use MediaWiki\Maintenance\Maintenance;
 use MediaWiki\Request\WebRequest;
 use ReflectionClass;
 use SMW\Localizer\Message;
@@ -160,9 +161,7 @@ class MaintenanceTaskHandler extends TaskHandler implements ActionableTask {
 
 			$reflectionClass = new ReflectionClass( $class );
 
-			if (
-				!$reflectionClass->getParentClass() ||
-				$reflectionClass->getParentClass()->getName() !== 'Maintenance' ) {
+			if ( !$reflectionClass->isSubclassOf( Maintenance::class ) ) {
 				continue;
 			}
 


### PR DESCRIPTION

<img width="1588" height="1107" alt="image" src="https://github.com/user-attachments/assets/fa177d3e-c8bc-4d19-8453-6a69690a7306" />

## Summary

The "maintenance scripts" sub-tab of Special:SemanticMediaWiki rendered an empty list. The discovery loop in `MaintenanceTaskHandler::buildHTML()` filtered every script out.

## Cause

MediaWiki core moved `Maintenance` into the `MediaWiki\Maintenance` namespace, with `class_alias( Maintenance::class, 'Maintenance' )` shimming the legacy bare name. `ReflectionClass::getParentClass()->getName()` returns the canonical FQN, never the alias, so the previous check `$reflectionClass->getParentClass()->getName() !== 'Maintenance'` always evaluated true and `continue`d past every Maintenance subclass.

## Fix

Import `MediaWiki\Maintenance\Maintenance` and use `$reflectionClass->isSubclassOf( Maintenance::class )` instead. Drops the now-redundant null-parent guard (`isSubclassOf` returns false for classes with no parent) and naturally accepts indirect subclasses (e.g. via `LoggedUpdateMaintenance`).

Fixes #6870

## Test plan

- [x] PHPCS and PHPUnit (`MaintenanceTaskHandler`, `SpecialAdmin`) pass.
- [x] Reflection probe inside the dev container against a stub `extends MediaWiki\Maintenance\Maintenance` class: old check FAIL, new check PASS.
- [x] Smoke test in a dev wiki: Special:SemanticMediaWiki, Maintenance tab, "maintenance scripts" sub-tab lists the SMW maintenance scripts grouped under "update" / "rebuild" / ungrouped.