### PR TITLE
Grant smw-admin to sysop by default

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -349,6 +349,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 ### Enhancements
 
+* The `smw-admin` right is now granted to the `sysop` group by default, so wiki administrators can reach `Special:SemanticMediaWiki` out of the box without first joining the `smwadministrator` group. The `smwadministrator` group is retained for installs that want SMW administration to be a separate role; revoke the new default with `$wgGroupPermissions['sysop']['smw-admin'] = false;` in `LocalSettings.php`.
 * Changed `smw_hash` storage from hex-encoded to raw binary, reducing the hash index size and improving query performance on large wikis. Column type changes from `VARBINARY(40)` to `BINARY(20)` on MySQL/MariaDB and SQLite, and from `TEXT` to `BYTEA` on PostgreSQL. Existing hashes are converted automatically during `update.php`. ([#6587](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6587))
 * Improved pagination performance on Special:Properties and Special:UnusedProperties by switching from OFFSET-based to cursor-based pagination. Browsing deep pages is now significantly faster on wikis with many properties. ([#6559](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6559))
   * Navigation links now use `after=` and `before=` URL parameters instead of `offset=`. Existing `offset=` bookmarks continue to work.

--- a/extension.json
+++ b/extension.json
@@ -137,6 +137,9 @@
 		"smw-vieweditpageinfo"
 	],
 	"GroupPermissions": {
+		"sysop": {
+			"smw-admin": true
+		},
 		"smwadministrator": {
 			"smw-admin": true
 		},


### PR DESCRIPTION
## Summary

Wiki administrators (the `sysop` group) cannot reach `Special:SemanticMediaWiki` on a fresh install until they discover the `smwadministrator` group and add themselves to it. Grant `smw-admin` to `sysop` by default so SMW is administrable out of the box.

## Rationale

- Recurring source of out-of-the-box friction; the discovery step has no real security benefit.
- The special page is a diagnostics dashboard; the maintenance scripts listed there are CLI-only, so no destructive operation runs from the UI.
- `sysop` is MediaWiki's canonical operator tier, where most extensions grant their administrative rights.

The `smwadministrator` group is retained for installs that want SMW administration to be a separate role. Operators that want to keep the previous behaviour can opt out with one line in `LocalSettings.php`:

```php
$wgGroupPermissions['sysop']['smw-admin'] = false;
```

## Test plan

- [x] On a fresh install, a user in `sysop` can access `Special:SemanticMediaWiki` without first joining `smwadministrator`.
- [x] On an install that explicitly sets `$wgGroupPermissions['sysop']['smw-admin'] = false;`, sysops are denied access (the override still wins).