### PR TITLE
Finish UpdateJob constructor injection

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -269,7 +269,16 @@
 	"JobClasses": {
 		"smw.update": {
 			"class": "SMW\\MediaWiki\\Jobs\\UpdateJob",
-			"services": [ "SMW.Store" ]
+			"services": [
+				"SMW.Store",
+				"SMW.Settings",
+				"SMW.PageCreator",
+				"SMW.PageUpdaterFactory",
+				"SMW.SerializerFactory",
+				"SMW.ContentParserFactory",
+				"SMW.ParserDataFactory",
+				"SMW.Logger"
+			]
 		},
 		"smw.refresh": {
 			"class": "SMW\\MediaWiki\\Jobs\\RefreshJob",

--- a/src/MediaWiki/Jobs/ContentParserFactory.php
+++ b/src/MediaWiki/Jobs/ContentParserFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SMW\MediaWiki\Jobs;
+
+use MediaWiki\Parser\Parser;
+use MediaWiki\Title\Title;
+use SMW\MediaWiki\RevisionGuard;
+use SMW\Parser\ContentParser;
+
+/**
+ * Constructs `ContentParser` instances bound to a specific `Title`.
+ *
+ * Extracted to lift `UpdateJob` (and any future callers) off
+ * `ServicesFactory::getInstance()->newContentParser(...)`.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class ContentParserFactory {
+
+	public function __construct(
+		private readonly Parser $parser,
+		private readonly RevisionGuard $revisionGuard,
+	) {
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function newContentParser( Title $title ): ContentParser {
+		$contentParser = new ContentParser( $title, $this->parser );
+		$contentParser->setRevisionGuard( $this->revisionGuard );
+
+		return $contentParser;
+	}
+
+}

--- a/src/MediaWiki/Jobs/PageUpdaterFactory.php
+++ b/src/MediaWiki/Jobs/PageUpdaterFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace SMW\MediaWiki\Jobs;
+
+use SMW\MediaWiki\PageUpdater;
+use SMW\Services\ServicesFactory;
+
+/**
+ * Constructs fresh `PageUpdater` instances on demand.
+ *
+ * `PageUpdater` accumulates per-use state (page queue, transaction
+ * deferrals), so jobs that need one must request a fresh instance per
+ * invocation rather than receive a shared singleton via the ObjectFactory
+ * spec.
+ *
+ * Internally delegates to `ServicesFactory::newPageUpdater()` to reuse the
+ * existing connection / `TransactionalCallableUpdate` / logger wiring.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class PageUpdaterFactory {
+
+	public function __construct(
+		private readonly ServicesFactory $servicesFactory,
+	) {
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function newPageUpdater(): PageUpdater {
+		return $this->servicesFactory->newPageUpdater();
+	}
+
+}

--- a/src/MediaWiki/Jobs/ParserDataFactory.php
+++ b/src/MediaWiki/Jobs/ParserDataFactory.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace SMW\MediaWiki\Jobs;
+
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Title\Title;
+use Psr\Log\LoggerInterface;
+use SMW\ParserData;
+
+/**
+ * Constructs `ParserData` instances bound to a specific `Title` and
+ * `ParserOutput`.
+ *
+ * Extracted to lift `UpdateJob` (and any future callers) off
+ * `ServicesFactory::getInstance()->newParserData(...)`.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class ParserDataFactory {
+
+	public function __construct(
+		private readonly LoggerInterface $logger,
+	) {
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function newParserData( Title $title, ParserOutput $parserOutput ): ParserData {
+		$parserData = new ParserData( $title, $parserOutput );
+		$parserData->setLogger( $this->logger );
+
+		return $parserData;
+	}
+
+}

--- a/src/MediaWiki/Jobs/UpdateJob.php
+++ b/src/MediaWiki/Jobs/UpdateJob.php
@@ -5,13 +5,16 @@ namespace SMW\MediaWiki\Jobs;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Title\Title;
+use Psr\Log\LoggerInterface;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\Enum;
 use SMW\Listener\EventListener\EventHandler;
 use SMW\MediaWiki\Job;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\MediaWiki\PageCreator;
+use SMW\SerializerFactory;
+use SMW\Settings;
 use SMW\Store;
 
 /**
@@ -21,12 +24,6 @@ use SMW\Store;
  * Update jobs are created if, when saving an article,
  * it is detected that the content of other pages must be re-parsed as well (e.g.
  * due to some type change).
- *
- * Partial DI: Store is injected via the JobClasses ObjectFactory spec. The
- * remaining collaborators (PageCreator, PageUpdater, SerializerFactory,
- * ParserData, ContentParser, MediaWikiLogger) are still resolved through
- * ApplicationFactory because they are not registered as global SMW.X
- * services.
  *
  * @note This job does not update the page display or parser cache, so in general
  * it might happen that part of the wiki page still displays old data (e.g.
@@ -57,7 +54,17 @@ class UpdateJob extends Job {
 	 */
 	const SEMANTIC_DATA = 'semanticData';
 
-	private ?ApplicationFactory $applicationFactory = null;
+	private readonly Settings $settings;
+
+	private readonly PageCreator $pageCreator;
+
+	private readonly PageUpdaterFactory $pageUpdaterFactory;
+
+	private readonly SerializerFactory $serializerFactory;
+
+	private readonly ContentParserFactory $contentParserFactory;
+
+	private readonly ParserDataFactory $parserDataFactory;
 
 	/**
 	 * @since  1.9
@@ -65,16 +72,28 @@ class UpdateJob extends Job {
 	public function __construct(
 		Title $title,
 		array $params,
-		Store $store
+		Store $store,
+		Settings $settings,
+		PageCreator $pageCreator,
+		PageUpdaterFactory $pageUpdaterFactory,
+		SerializerFactory $serializerFactory,
+		ContentParserFactory $contentParserFactory,
+		ParserDataFactory $parserDataFactory,
+		LoggerInterface $logger
 	) {
 		parent::__construct( 'smw.update', $title, $params );
 		$this->setStore( $store );
 		$this->title = $title;
 		$this->removeDuplicates = true;
+		$this->settings = $settings;
+		$this->pageCreator = $pageCreator;
+		$this->pageUpdaterFactory = $pageUpdaterFactory;
+		$this->serializerFactory = $serializerFactory;
+		$this->contentParserFactory = $contentParserFactory;
+		$this->parserDataFactory = $parserDataFactory;
+		$this->setLogger( $logger );
 
-		$this->isEnabledJobQueue(
-			ApplicationFactory::getInstance()->getSettings()->get( 'smwgEnableUpdateJobs' )
-		);
+		$this->isEnabledJobQueue( $settings->get( 'smwgEnableUpdateJobs' ) );
 	}
 
 	/**
@@ -87,8 +106,6 @@ class UpdateJob extends Job {
 		}
 
 		MediaWikiServices::getInstance()->getLinkCache()->clear();
-
-		$this->applicationFactory ??= ApplicationFactory::getInstance();
 
 		if ( !$this->hasParameter( self::FORCED_UPDATE ) && $this->matchesLastModified( $this->getTitle() ) ) {
 			return true;
@@ -114,13 +131,13 @@ class UpdateJob extends Job {
 			WikiPage::newFromTitle( $title )
 		);
 
-		$wikiPage = $this->applicationFactory->newPageCreator()->createPage( $title );
+		$wikiPage = $this->pageCreator->createPage( $title );
 
 		if ( $lastModified !== $wikiPage->getTimestamp() ) {
 			return false;
 		}
 
-		$pageUpdater = $this->applicationFactory->newPageUpdater();
+		$pageUpdater = $this->pageUpdaterFactory->newPageUpdater();
 		$pageUpdater->addPage( $title );
 		$pageUpdater->waitOnTransactionIdle();
 		$pageUpdater->doPurgeParserCache();
@@ -168,7 +185,7 @@ class UpdateJob extends Job {
 	private function set_data( $semanticData ): bool {
 		$this->setParameter( 'updateType', 'SemanticData' );
 
-		$semanticData = $this->applicationFactory->newSerializerFactory()->newSemanticDataDeserializer()->deserialize(
+		$semanticData = $this->serializerFactory->newSemanticDataDeserializer()->deserialize(
 			$semanticData
 		);
 
@@ -176,7 +193,7 @@ class UpdateJob extends Job {
 			new Property( Property::TYPE_CHANGE_PROP )
 		);
 
-		$parserData = $this->applicationFactory->newParserData(
+		$parserData = $this->parserDataFactory->newParserData(
 			$this->getTitle(),
 			new ParserOutput()
 		);
@@ -194,7 +211,7 @@ class UpdateJob extends Job {
 	private function parse_content(): bool {
 		$this->setParameter( 'updateType', 'ContentParse' );
 
-		$contentParser = $this->applicationFactory->newContentParser( $this->getTitle() );
+		$contentParser = $this->contentParserFactory->newContentParser( $this->getTitle() );
 		$contentParser->parse();
 
 		if ( !( $contentParser->getOutput() instanceof ParserOutput ) ) {
@@ -202,7 +219,7 @@ class UpdateJob extends Job {
 			return false;
 		}
 
-		$parserData = $this->applicationFactory->newParserData(
+		$parserData = $this->parserDataFactory->newParserData(
 			$this->getTitle(),
 			$contentParser->getOutput()
 		);
@@ -218,7 +235,7 @@ class UpdateJob extends Job {
 	}
 
 	private function updateStore( $parserData ): bool {
-		$this->applicationFactory->getMediaWikiLogger()->info(
+		$this->logger->info(
 			'Job UpdateJob {title} Type: {updateType} Origin: {origin} '
 				. 'isForcedUpdate: {forcedUpdate}',
 			[

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -3,6 +3,7 @@
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use Onoi\Cache\Cache;
+use Psr\Log\LoggerInterface;
 use SMW\CacheFactory;
 use SMW\Connection\ConnectionManager;
 use SMW\ConstraintFactory;
@@ -25,6 +26,9 @@ use SMW\MediaWiki\Connection\ConnectionProvider;
 use SMW\MediaWiki\HookDispatcher;
 use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\JobQueue;
+use SMW\MediaWiki\Jobs\ContentParserFactory;
+use SMW\MediaWiki\Jobs\PageUpdaterFactory;
+use SMW\MediaWiki\Jobs\ParserDataFactory;
 use SMW\MediaWiki\ManualEntryLogger;
 use SMW\MediaWiki\MediaWikiNsContentReader;
 use SMW\MediaWiki\MwCollaboratorFactory;
@@ -540,6 +544,55 @@ return [
 			$servicesFactory->getProtectionValidator(),
 			$servicesFactory->getPermissionManager()
 		);
+	},
+
+	'SMW.ContentParserFactory' => static function ( MediaWikiServices $services ): ContentParserFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'ContentParserFactory' ) ) {
+			return $servicesFactory->getContentParserFactory();
+		}
+
+		return new ContentParserFactory(
+			$services->getParser(),
+			$servicesFactory->getRevisionGuard()
+		);
+	},
+
+	'SMW.ParserDataFactory' => static function ( MediaWikiServices $services ): ParserDataFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'ParserDataFactory' ) ) {
+			return $servicesFactory->getParserDataFactory();
+		}
+
+		return new ParserDataFactory(
+			$servicesFactory->getMediaWikiLogger()
+		);
+	},
+
+	'SMW.PageUpdaterFactory' => static function ( MediaWikiServices $services ): PageUpdaterFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'PageUpdaterFactory' ) ) {
+			return $servicesFactory->getPageUpdaterFactory();
+		}
+
+		return new PageUpdaterFactory( $servicesFactory );
+	},
+
+	'SMW.Logger' => static function ( MediaWikiServices $services ): LoggerInterface {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'Logger' ) ) {
+			return $servicesFactory->getLogger();
+		}
+
+		// Route through getMediaWikiLogger() rather than calling
+		// LoggerFactory::getInstance( 'smw' ) directly, so callers see the
+		// SMW\Utils\Logger role-filter wrapper rather than a raw PSR-3
+		// channel logger.
+		return $servicesFactory->getMediaWikiLogger();
 	},
 
 	'SMW.PropertyLabelFinder' => static function ( MediaWikiServices $services ): PropertyLabelFinder {

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -55,6 +55,9 @@ use SMW\MediaWiki\HookDispatcher;
 use SMW\MediaWiki\IndicatorRegistry;
 use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\JobQueue;
+use SMW\MediaWiki\Jobs\ContentParserFactory;
+use SMW\MediaWiki\Jobs\PageUpdaterFactory;
+use SMW\MediaWiki\Jobs\ParserDataFactory;
 use SMW\MediaWiki\MagicWordsFinder;
 use SMW\MediaWiki\ManualEntryLogger;
 use SMW\MediaWiki\MediaWikiNsContentReader;
@@ -343,6 +346,10 @@ class ServicesFactory {
 			'CacheFactory' => fn () => $this->getCacheFactory(),
 			'TitleFactory' => fn () => $this->getTitleFactory(),
 			'PageCreator' => fn () => $this->getPageCreator(),
+			'ContentParserFactory' => fn () => $this->getContentParserFactory(),
+			'ParserDataFactory' => fn () => $this->getParserDataFactory(),
+			'PageUpdaterFactory' => fn () => $this->getPageUpdaterFactory(),
+			'Logger' => fn () => $this->getLogger(),
 			'MwCollaboratorFactory' => fn () => $this->getMwCollaboratorFactory(),
 			'NamespaceExaminer' => fn () => $this->getNamespaceExaminer(),
 			'DataValueServiceFactory' => fn () => $this->getDataValueServiceFactory(),
@@ -663,6 +670,50 @@ class ServicesFactory {
 		}
 
 		return MediaWikiServices::getInstance()->getService( 'SMW.PageCreator' );
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getContentParserFactory(): ContentParserFactory {
+		if ( array_key_exists( 'ContentParserFactory', $this->testOverrides ) ) {
+			return $this->testOverrides['ContentParserFactory'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.ContentParserFactory' );
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getParserDataFactory(): ParserDataFactory {
+		if ( array_key_exists( 'ParserDataFactory', $this->testOverrides ) ) {
+			return $this->testOverrides['ParserDataFactory'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.ParserDataFactory' );
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getPageUpdaterFactory(): PageUpdaterFactory {
+		if ( array_key_exists( 'PageUpdaterFactory', $this->testOverrides ) ) {
+			return $this->testOverrides['PageUpdaterFactory'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.PageUpdaterFactory' );
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getLogger(): LoggerInterface {
+		if ( array_key_exists( 'Logger', $this->testOverrides ) ) {
+			return $this->testOverrides['Logger'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.Logger' );
 	}
 
 	/**

--- a/tests/phpunit/Unit/MediaWiki/Jobs/ContentParserFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/ContentParserFactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace SMW\Tests\Unit\MediaWiki\Jobs;
+
+use MediaWiki\Parser\Parser;
+use MediaWiki\Title\Title;
+use PHPUnit\Framework\TestCase;
+use SMW\MediaWiki\Jobs\ContentParserFactory;
+use SMW\MediaWiki\RevisionGuard;
+use SMW\Parser\ContentParser;
+
+/**
+ * @covers \SMW\MediaWiki\Jobs\ContentParserFactory
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ *
+ * @author mwjames
+ */
+class ContentParserFactoryTest extends TestCase {
+
+	public function testCanConstruct() {
+		$this->assertInstanceOf(
+			ContentParserFactory::class,
+			new ContentParserFactory(
+				$this->createMock( Parser::class ),
+				$this->createMock( RevisionGuard::class )
+			)
+		);
+	}
+
+	public function testNewContentParserReturnsContentParserBoundToTitle() {
+		$title = $this->createMock( Title::class );
+
+		$instance = new ContentParserFactory(
+			$this->createMock( Parser::class ),
+			$this->createMock( RevisionGuard::class )
+		);
+
+		$this->assertInstanceOf(
+			ContentParser::class,
+			$instance->newContentParser( $title )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Jobs/PageUpdaterFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/PageUpdaterFactoryTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace SMW\Tests\Unit\MediaWiki\Jobs;
+
+use PHPUnit\Framework\TestCase;
+use SMW\MediaWiki\Jobs\PageUpdaterFactory;
+use SMW\MediaWiki\PageUpdater;
+use SMW\Services\ServicesFactory;
+
+/**
+ * @covers \SMW\MediaWiki\Jobs\PageUpdaterFactory
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ *
+ * @author mwjames
+ */
+class PageUpdaterFactoryTest extends TestCase {
+
+	public function testCanConstruct() {
+		$this->assertInstanceOf(
+			PageUpdaterFactory::class,
+			new PageUpdaterFactory( $this->createMock( ServicesFactory::class ) )
+		);
+	}
+
+	public function testNewPageUpdaterDelegatesToServicesFactory() {
+		$pageUpdater = $this->createMock( PageUpdater::class );
+
+		$servicesFactory = $this->createMock( ServicesFactory::class );
+		$servicesFactory->expects( $this->once() )
+			->method( 'newPageUpdater' )
+			->willReturn( $pageUpdater );
+
+		$instance = new PageUpdaterFactory( $servicesFactory );
+
+		$this->assertSame(
+			$pageUpdater,
+			$instance->newPageUpdater()
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Jobs/ParserDataFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/ParserDataFactoryTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace SMW\Tests\Unit\MediaWiki\Jobs;
+
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Title\Title;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use SMW\MediaWiki\Jobs\ParserDataFactory;
+use SMW\ParserData;
+
+/**
+ * @covers \SMW\MediaWiki\Jobs\ParserDataFactory
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ *
+ * @author mwjames
+ */
+class ParserDataFactoryTest extends TestCase {
+
+	public function testCanConstruct() {
+		$this->assertInstanceOf(
+			ParserDataFactory::class,
+			new ParserDataFactory( $this->createMock( LoggerInterface::class ) )
+		);
+	}
+
+	public function testNewParserDataReturnsParserDataBoundToTitleAndOutput() {
+		$title = $this->createMock( Title::class );
+		$parserOutput = new ParserOutput();
+
+		$instance = new ParserDataFactory( $this->createMock( LoggerInterface::class ) );
+
+		$this->assertInstanceOf(
+			ParserData::class,
+			$instance->newParserData( $title, $parserOutput )
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Jobs/UpdateJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/UpdateJobTest.php
@@ -3,15 +3,23 @@
 namespace SMW\Tests\Unit\MediaWiki\Jobs;
 
 use MediaWiki\DAO\WikiAwareEntity;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use ParserOutput;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
 use SMW\DataItems\Blob;
 use SMW\DataItems\WikiPage;
+use SMW\MediaWiki\Jobs\ContentParserFactory;
+use SMW\MediaWiki\Jobs\PageUpdaterFactory;
+use SMW\MediaWiki\Jobs\ParserDataFactory;
 use SMW\MediaWiki\Jobs\UpdateJob;
+use SMW\MediaWiki\PageCreator;
+use SMW\MediaWiki\PageUpdater;
 use SMW\Parser\ContentParser;
+use SMW\ParserData;
+use SMW\SerializerFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Settings;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
@@ -30,14 +38,19 @@ class UpdateJobTest extends TestCase {
 	private TestEnvironment $testEnvironment;
 	private $semanticDataFactory;
 	private $semanticDataSerializer;
+	private Settings $settings;
+	private $pageCreator;
+	private $pageUpdaterFactory;
+	private $serializerFactory;
+	private $contentParser;
+	private $contentParserFactory;
+	private $parserData;
+	private $parserDataFactory;
+	private $logger;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		// UpdateJob still resolves ContentParser, PageCreator, PageUpdater,
-		// SerializerFactory, ParserData and MediaWikiLogger through
-		// ApplicationFactory; the test environment lets these collaborators
-		// be swapped via registerObject() without touching global state.
 		$this->testEnvironment = new TestEnvironment( [
 			'smwgMainCacheType'        => 'hash',
 			'smwgEnableUpdateJobs' => false,
@@ -47,6 +60,34 @@ class UpdateJobTest extends TestCase {
 
 		$this->semanticDataFactory = $this->testEnvironment->getUtilityFactory()->newSemanticDataFactory();
 		$this->semanticDataSerializer = ApplicationFactory::getInstance()->newSerializerFactory()->newSemanticDataSerializer();
+
+		$this->settings = Settings::newFromArray( [ 'smwgEnableUpdateJobs' => false ] );
+
+		$this->pageCreator = $this->createMock( PageCreator::class );
+
+		$pageUpdater = $this->createMock( PageUpdater::class );
+		$this->pageUpdaterFactory = $this->createMock( PageUpdaterFactory::class );
+		$this->pageUpdaterFactory->method( 'newPageUpdater' )->willReturn( $pageUpdater );
+
+		// Use a real SerializerFactory; the SEMANTIC_DATA / CHANGE_PROP
+		// paths need to round-trip real data through its deserializer.
+		$this->serializerFactory = new SerializerFactory(
+			$this->createMock( Store::class )
+		);
+
+		$this->contentParser = $this->createMock( ContentParser::class );
+		$this->contentParserFactory = $this->createMock( ContentParserFactory::class );
+		$this->contentParserFactory->method( 'newContentParser' )->willReturn( $this->contentParser );
+
+		$this->parserData = $this->createMock( ParserData::class );
+		// updateStore() reaches `$parserData->getSemanticData()->setOption(...)`,
+		// so a non-null SemanticData is needed for chains that reach updateStore.
+		$this->parserData->method( 'getSemanticData' )
+			->willReturn( $this->semanticDataFactory->newEmptySemanticData( 'UpdateJobTestSubject' ) );
+		$this->parserDataFactory = $this->createMock( ParserDataFactory::class );
+		$this->parserDataFactory->method( 'newParserData' )->willReturn( $this->parserData );
+
+		$this->logger = $this->createMock( LoggerInterface::class );
 	}
 
 	protected function tearDown(): void {
@@ -75,6 +116,21 @@ class UpdateJobTest extends TestCase {
 		return $store;
 	}
 
+	private function newUpdateJob( Title $title, array $params, Store $store ): UpdateJob {
+		return new UpdateJob(
+			$title,
+			$params,
+			$store,
+			$this->settings,
+			$this->pageCreator,
+			$this->pageUpdaterFactory,
+			$this->serializerFactory,
+			$this->contentParserFactory,
+			$this->parserDataFactory,
+			$this->logger
+		);
+	}
+
 	public function testCanConstruct() {
 		$title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
@@ -82,7 +138,7 @@ class UpdateJobTest extends TestCase {
 
 		$this->assertInstanceOf(
 			UpdateJob::class,
-			new UpdateJob( $title, [], $this->newStoreWithIdTable() )
+			$this->newUpdateJob( $title, [], $this->newStoreWithIdTable() )
 		);
 	}
 
@@ -95,10 +151,10 @@ class UpdateJobTest extends TestCase {
 			->method( 'exists' )
 			->willReturn( true );
 
-		$instance = new UpdateJob( $title, [], $this->newStoreWithIdTable() );
+		$instance = $this->newUpdateJob( $title, [], $this->newStoreWithIdTable() );
 		$instance->isEnabledJobQueue( false );
 
-		$this->assertFalse(	$instance->run() );
+		$this->assertFalse( $instance->run() );
 	}
 
 	public function testJobWithInvalidTitle() {
@@ -118,9 +174,7 @@ class UpdateJobTest extends TestCase {
 			->method( 'exists' )
 			->willReturn( false );
 
-		$this->testEnvironment->registerObject( 'ContentParser', null );
-
-		$instance = new UpdateJob( $title, [], $this->newStoreWithIdTable() );
+		$instance = $this->newUpdateJob( $title, [], $this->newStoreWithIdTable() );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertTrue( $instance->run() );
@@ -135,17 +189,11 @@ class UpdateJobTest extends TestCase {
 			->method( 'exists' )
 			->willReturn( true );
 
-		$contentParser = $this->getMockBuilder( ContentParser::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$contentParser->expects( $this->once() )
+		$this->contentParser->expects( $this->once() )
 			->method( 'getOutput' )
 			->willReturn( null );
 
-		$this->testEnvironment->registerObject( 'ContentParser', $contentParser );
-
-		$instance = new UpdateJob( $title, [], $this->newStoreWithIdTable() );
+		$instance = $this->newUpdateJob( $title, [], $this->newStoreWithIdTable() );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertFalse( $instance->run() );
@@ -164,50 +212,20 @@ class UpdateJobTest extends TestCase {
 			->method( 'getNamespace' )
 			->willReturn( 0 );
 
-		$title->expects( $this->once() )
+		$title->expects( $this->atLeastOnce() )
 			->method( 'exists' )
 			->willReturn( true );
 
-		$contentParser = $this->getMockBuilder( ContentParser::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$contentParser->expects( $this->atLeastOnce() )
+		$this->contentParser->expects( $this->atLeastOnce() )
 			->method( 'getOutput' )
 			->willReturn( new ParserOutput );
 
-		$this->testEnvironment->registerObject( 'ContentParser', $contentParser );
+		// The injected ParserData mock receives the persist call once the
+		// parsed output has been threaded back through ParserDataFactory.
+		$this->parserData->expects( $this->atLeastOnce() )
+			->method( 'updateStore' );
 
-		$idTable = $this->getMockBuilder( '\stdClass' )
-			->setMethods( [ 'exists', 'findAssociatedRev' ] )
-			->getMock();
-
-		$idTable->expects( $this->atLeastOnce() )
-			->method( 'exists' )
-			->willReturn( true );
-
-		$idTable->expects( $this->any() )
-			->method( 'findAssociatedRev' )
-			->willReturn( 42 );
-
-		$store = $this->getMockBuilder( SQLStore::class )
-			->disableOriginalConstructor()
-			->setMethods( [ 'clearData', 'getObjectIds' ] )
-			->getMock();
-
-		$store->expects( $this->any() )
-			->method( 'getObjectIds' )
-			->willReturn( $idTable );
-
-		$store->expects( $this->once() )
-			->method( 'clearData' );
-
-		// ParserData::updateStore() goes through ApplicationFactory and uses
-		// the Store registered there; mirror the injected store on the
-		// service locator so DataUpdater sees the same idTable.
-		$this->testEnvironment->registerObject( 'Store', $store );
-
-		$instance = new UpdateJob( $title, [], $store );
+		$instance = $this->newUpdateJob( $title, [], $this->newStoreWithIdTable() );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertTrue( $instance->run() );
@@ -240,15 +258,9 @@ class UpdateJobTest extends TestCase {
 				->willReturn( WikiAwareEntity::LOCAL );
 		}
 
-		$contentParser = $this->getMockBuilder( ContentParser::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$contentParser->expects( $this->atLeastOnce() )
+		$this->contentParser->expects( $this->atLeastOnce() )
 			->method( 'getOutput' )
 			->willReturn( new ParserOutput );
-
-		$this->testEnvironment->registerObject( 'ContentParser', $contentParser );
 
 		$idTable = $this->getMockBuilder( '\stdClass' )
 			->setMethods( [ 'exists', 'findAssociatedRev' ] )
@@ -267,32 +279,35 @@ class UpdateJobTest extends TestCase {
 			->method( 'getPropertyValues' )
 			->willReturn( [] );
 
-		$instance = new UpdateJob( $title, [ 'shallowUpdate' => true ], $store );
+		$instance = $this->newUpdateJob( $title, [ 'shallowUpdate' => true ], $store );
 		$instance->isEnabledJobQueue( false );
 
 		$this->assertTrue( $instance->run() );
 	}
 
 	public function testJobOnSerializedSemanticData() {
-		$title = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __METHOD__ );
-
-		$store = $this->getMockBuilder( Store::class )
+		$title = $this->getMockBuilder( Title::class )
 			->disableOriginalConstructor()
-			->setMethods( [ 'updateData' ] )
-			->getMockForAbstractClass();
+			->getMock();
 
-		$store->expects( $this->once() )
-			->method( 'updateData' );
+		$title->expects( $this->any() )
+			->method( 'exists' )
+			->willReturn( true );
 
 		$semanticData = $this->semanticDataSerializer->serialize(
 			$this->semanticDataFactory->newEmptySemanticData( __METHOD__ )
 		);
 
-		$instance = new UpdateJob( $title,
+		// `set_data()` threads the deserialized SemanticData through
+		// ParserDataFactory; the injected ParserData mock must see updateStore.
+		$this->parserData->expects( $this->atLeastOnce() )
+			->method( 'updateStore' );
+
+		$instance = $this->newUpdateJob( $title,
 			[
 				UpdateJob::SEMANTIC_DATA => $semanticData
 			],
-			$store
+			$this->newStoreWithIdTable()
 		);
 
 		$instance->isEnabledJobQueue( false );
@@ -305,25 +320,33 @@ class UpdateJobTest extends TestCase {
 	public function testJobOnChangePropagation() {
 		$subject = WikiPage::newFromText( __METHOD__, SMW_NS_PROPERTY );
 
+		$title = $this->getMockBuilder( Title::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$title->expects( $this->any() )
+			->method( 'exists' )
+			->willReturn( true );
+
 		$semanticData = $this->semanticDataSerializer->serialize(
 			$this->semanticDataFactory->newEmptySemanticData( __METHOD__ )
 		);
 
 		$store = $this->getMockBuilder( Store::class )
 			->disableOriginalConstructor()
-			->setMethods( [ 'updateData', 'getPropertyValues' ] )
+			->setMethods( [ 'getPropertyValues' ] )
 			->getMockForAbstractClass();
 
 		$store->expects( $this->any() )
 			->method( 'getPropertyValues' )
 			->willReturn( [ new Blob( json_encode( $semanticData ) ) ] );
 
-		$store->expects( $this->once() )
-			->method( 'updateData' );
+		// CHANGE_PROP flows through change_propagation -> set_data, which
+		// hits ParserData::updateStore via the injected factory.
+		$this->parserData->expects( $this->atLeastOnce() )
+			->method( 'updateStore' );
 
-		$this->testEnvironment->registerObject( 'Store', $store );
-
-		$instance = new UpdateJob( $subject->getTitle(),
+		$instance = $this->newUpdateJob( $title,
 			[
 				UpdateJob::CHANGE_PROP => $subject->getSerialization()
 			],


### PR DESCRIPTION
## Summary

`UpdateJob` previously documented a partial-DI state: `Store` was injected via the `JobClasses` ObjectFactory spec, but seven further collaborators (`Settings`, `PageCreator`, `PageUpdater`, `SerializerFactory`, `ContentParser`, `ParserData`, and the MediaWiki logger) were still resolved through `ApplicationFactory::getInstance()` from instance methods. All seven now arrive via the constructor, the in-class "Partial DI" docstring is removed, and the four `TestEnvironment::registerObject( 'ContentParser', ... )` calls in `UpdateJobTest` are dropped.

## Scope

**New factories under `src/MediaWiki/Jobs/`:**

- `ContentParserFactory` wraps `Parser` + `RevisionGuard` and exposes `newContentParser( Title )`. It mirrors `ServicesFactory::newContentParser` including the `setRevisionGuard` step.
- `ParserDataFactory` wraps `LoggerInterface` and exposes `newParserData( Title, ParserOutput )`. It mirrors `ServicesFactory::newParserData` including the `setLogger` step.
- `PageUpdaterFactory` wraps the `ServicesFactory` and exposes `newPageUpdater()`. Each call returns a fresh `PageUpdater` so the per-use state (page queue, transactional deferrals) does not leak across jobs constructed in the same process. The factory deliberately delegates to `ServicesFactory::newPageUpdater()` to reuse the existing connection / `TransactionalCallableUpdate` / logger wiring; this is documented inline as a pragmatic shortcut.

**Service wiring (`src/Services/ServiceWiring.php`):**

- `SMW.ContentParserFactory`, `SMW.ParserDataFactory`, `SMW.PageUpdaterFactory`, `SMW.Logger` registered with the standard `hasTestOverride( ... )` pattern.
- `SMW.Logger` delegates to `$servicesFactory->getMediaWikiLogger()` so callers see the `SMW\Utils\Logger` role-filter wrapper rather than a raw PSR-3 channel logger; an inline comment documents the intent.

**`ServicesFactory` (`src/Services/ServicesFactory.php`):**

- New accessors `getContentParserFactory()`, `getParserDataFactory()`, `getPageUpdaterFactory()`, `getLogger()`, each test-override aware with `@since 7.0.0`.
- Matching entries in the `singleton()` alias map.

**`extension.json`:**

- The `smw.update` `JobClasses` entry's `services:` array grows from `[ "SMW.Store" ]` to `[ "SMW.Store", "SMW.Settings", "SMW.PageCreator", "SMW.PageUpdaterFactory", "SMW.SerializerFactory", "SMW.ContentParserFactory", "SMW.ParserDataFactory", "SMW.Logger" ]`. The positional order matches the new constructor signature.

**`UpdateJob` (`src/MediaWiki/Jobs/UpdateJob.php`):**

- Constructor now declares all collaborators as typed parameters (`Settings`, `PageCreator`, `PageUpdaterFactory`, `SerializerFactory`, `ContentParserFactory`, `ParserDataFactory`, `LoggerInterface`) on top of the existing `Title`, `array`, `Store`.
- The new parameters are stored on `private readonly` typed properties to match the file's existing typed-property + manual-assignment style. The logger is routed through `LoggerAwareTrait::setLogger()` to avoid colliding with the parent `Job` class's non-readonly `$logger` property.
- Every `ApplicationFactory::getInstance()` / `applicationFactory` reference inside instance methods is gone. The lazy stash property is removed.
- The class-level "Partial DI" docstring is removed.

**Tests:**

- `UpdateJobTest` restructures `setUp()` to create shared mocks for every new dependency. A private `newUpdateJob()` helper constructs jobs through those mocks; tests call it instead of `new UpdateJob()`. Four `TestEnvironment::registerObject( 'ContentParser', ... )` calls are removed.
- Three pre-existing tests (`testJobWithValidRevision`, `testJobOnSerializedSemanticData`, `testJobOnChangePropagation`) previously asserted on leaf-level `Store::clearData` / `Store::updateData`, relying on the locator chain to wire `ParserData` to `Store`. With `ParserData` now a true mock, the chain stops at the DI boundary; those assertions are reshaped to `ParserData::updateStore()` was called. Round-trip coverage from input bytes to the Store remains in the existing `UpdateJobRoundtripTest` integration suite.
- Three new test classes (`ContentParserFactoryTest`, `ParserDataFactoryTest`, `PageUpdaterFactoryTest`) cover the new factories.

## Verification

- Full unit suite (`composer phpunit -- --testsuite=semantic-mediawiki-unit`): 7091 tests, 14518 assertions, 6 skipped, 0 errors, 0 failures (vs `bfba3e79`'s 7085 / 14506 baseline — added 6 new factory tests).
- Targeted: `UpdateJobTest` 8 tests / 17 assertions, `ContentParserFactoryTest` 2 / 2, `ParserDataFactoryTest` 2 / 2, `PageUpdaterFactoryTest` 2 / 3.
- PHPCS clean on all 11 changed files.
- DI resolution probe: every new `SMW.X` service resolves through the global container; `JobFactory::newJob( 'smw.update', ... )` successfully constructs a fully-injected `UpdateJob`.
- Live smoke: `php maintenance/run.php edit ... UpdateJobSmokeTestPage <<<'[[Has property::DI test value]]'` followed by `SemanticMediaWiki:rebuildData --page UpdateJobSmokeTestPage` both completed end-to-end against the dev wiki, exercising the production `UpdateJob` path through the real `ContentParser` / `ParserData` chain.
- Integration suite hit the same pre-existing `Clock was set back; sequence number incremented` flake in MediaWiki core's `GlobalIdGenerator` that surfaces on this dev environment for `JSONScript` tests; stack trace is entirely outside any class touched by this PR.

## Test plan

- [ ] Trigger an `UpdateJob` via property-change propagation on a wiki with `smwgEnableUpdateJobs = true` and confirm the job runs without throwing.
- [ ] Confirm `SemanticMediaWiki:rebuildData --page <Title>` still picks up edits and refreshes the store.
- [ ] On an Elastic-store wiki, confirm Elastic-store side-effects still fire after an `UpdateJob` run (covered by the round-trip integration suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)