### PR TITLE
Complete handler DI for four ApplicationFactory-using hook handlers

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -125,7 +125,8 @@
 			"class": "SMW\\MediaWiki\\Hooks\\RejectParserCacheValue",
 			"services": [
 				"SMW.NamespaceExaminer",
-				"SMW.Logger"
+				"SMW.Logger",
+				"SMW.DependencyValidatorFactory"
 			]
 		},
 		"SemanticMediaWiki.SkinAfterContent": {
@@ -212,7 +213,10 @@
 			"class": "SMW\\MediaWiki\\Hooks\\ArticleProtectComplete",
 			"services": [
 				"SMW.Settings",
-				"SMW.Logger"
+				"SMW.Logger",
+				"SMW.MwCollaboratorFactory",
+				"SMW.RevisionGuard",
+				"SMW.DataItemFactory"
 			]
 		},
 		"SemanticMediaWiki.ArticleViewHeader": {
@@ -220,7 +224,8 @@
 			"services": [
 				"SMW.Store",
 				"SMW.NamespaceExaminer",
-				"SMW.Settings"
+				"SMW.Settings",
+				"SMW.DependencyValidatorFactory"
 			]
 		},
 		"SemanticMediaWiki.RevisionFromEditComplete": {
@@ -229,7 +234,9 @@
 				"SMW.PropertyAnnotatorFactory",
 				"SMW.SchemaFactory",
 				"SMW.Store",
-				"SMW.EventDispatcher"
+				"SMW.EventDispatcher",
+				"SMW.MwCollaboratorFactory",
+				"UserFactory"
 			]
 		},
 		"SemanticMediaWiki.LinksUpdateComplete": {

--- a/src/DependencyValidatorFactory.php
+++ b/src/DependencyValidatorFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace SMW;
+
+use MediaWiki\Parser\ParserCache;
+use MediaWiki\Parser\ParserOptions;
+use SMW\EventDispatcher\EventDispatcher;
+use SMW\SQLStore\QueryDependency\DependencyLinksValidator;
+use WikiPage;
+
+/**
+ * Produces a fully-configured {@link DependencyValidator} for the
+ * `RejectParserCacheValue` and `ArticleViewHeader` hooks, which both need a
+ * per-request validator keyed on the current parser-output eTag.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class DependencyValidatorFactory {
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function __construct(
+		private readonly NamespaceExaminer $namespaceExaminer,
+		private readonly DependencyLinksValidator $dependencyLinksValidator,
+		private readonly EntityCache $entityCache,
+		private readonly EventDispatcher $eventDispatcher,
+		private readonly ParserCache $parserCache,
+	) {
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function newFor( WikiPage $page, ParserOptions $options ): DependencyValidator {
+		$eTag = 'W/"' . $this->parserCache->makeParserOutputKey( $page, $options ) .
+			'--' . $page->getTouched() . '"';
+
+		$dependencyValidator = new DependencyValidator(
+			$this->namespaceExaminer,
+			$this->dependencyLinksValidator,
+			$this->entityCache,
+			$eTag,
+			Site::getCacheExpireTime( 'parser' )
+		);
+
+		$dependencyValidator->setEventDispatcher( $this->eventDispatcher );
+
+		return $dependencyValidator;
+	}
+
+}

--- a/src/DependencyValidatorFactory.php
+++ b/src/DependencyValidatorFactory.php
@@ -5,13 +5,19 @@ namespace SMW;
 use MediaWiki\Parser\ParserCache;
 use MediaWiki\Parser\ParserOptions;
 use SMW\EventDispatcher\EventDispatcher;
-use SMW\SQLStore\QueryDependency\DependencyLinksValidator;
+use SMW\SQLStore\QueryDependencyLinksStoreFactory;
 use WikiPage;
 
 /**
  * Produces a fully-configured {@link DependencyValidator} for the
  * `RejectParserCacheValue` and `ArticleViewHeader` hooks, which both need a
  * per-request validator keyed on the current parser-output eTag.
+ *
+ * `QueryDependencyLinksStoreFactory` (not a pre-resolved
+ * `DependencyLinksValidator`) is held so each `newFor()` call builds a fresh
+ * validator. `DependencyLinksValidator` transitively captures `Store`, and
+ * `HookContainer` caches handler instances across service-container resets, so
+ * a captured validator could otherwise outlive the `Store` it was built with.
  *
  * @license GPL-2.0-or-later
  * @since 7.0.0
@@ -23,7 +29,7 @@ class DependencyValidatorFactory {
 	 */
 	public function __construct(
 		private readonly NamespaceExaminer $namespaceExaminer,
-		private readonly DependencyLinksValidator $dependencyLinksValidator,
+		private readonly QueryDependencyLinksStoreFactory $queryDependencyLinksStoreFactory,
 		private readonly EntityCache $entityCache,
 		private readonly EventDispatcher $eventDispatcher,
 		private readonly ParserCache $parserCache,
@@ -39,7 +45,7 @@ class DependencyValidatorFactory {
 
 		$dependencyValidator = new DependencyValidator(
 			$this->namespaceExaminer,
-			$this->dependencyLinksValidator,
+			$this->queryDependencyLinksStoreFactory->newDependencyLinksValidator(),
 			$this->entityCache,
 			$eTag,
 			Site::getCacheExpireTime( 'parser' )

--- a/src/MediaWiki/Hooks/ArticleProtectComplete.php
+++ b/src/MediaWiki/Hooks/ArticleProtectComplete.php
@@ -4,9 +4,12 @@ namespace SMW\MediaWiki\Hooks;
 
 use MediaWiki\Page\Hook\ArticleProtectCompleteHook;
 use Psr\Log\LoggerInterface;
+use SMW\DataItemFactory;
 use SMW\Localizer\Message;
+use SMW\MediaWiki\MwCollaboratorFactory;
+use SMW\MediaWiki\RevisionGuard;
+use SMW\ParserData;
 use SMW\Property\Annotators\EditProtectedPropertyAnnotator;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Settings;
 
 /**
@@ -34,6 +37,9 @@ class ArticleProtectComplete implements ArticleProtectCompleteHook {
 	public function __construct(
 		private readonly Settings $settings,
 		private readonly LoggerInterface $logger,
+		private readonly MwCollaboratorFactory $mwCollaboratorFactory,
+		private readonly RevisionGuard $revisionGuard,
+		private readonly DataItemFactory $dataItemFactory,
 	) {
 	}
 
@@ -46,12 +52,9 @@ class ArticleProtectComplete implements ArticleProtectCompleteHook {
 			return true;
 		}
 
-		$applicationFactory = ApplicationFactory::getInstance();
-		$revisionGuard = $applicationFactory->singleton( 'RevisionGuard' );
-
-		$editInfo = $applicationFactory->newMwCollaboratorFactory()->newEditInfo(
+		$editInfo = $this->mwCollaboratorFactory->newEditInfo(
 			$wikiPage,
-			$revisionGuard->newRevisionFromPage( $wikiPage ),
+			$this->revisionGuard->newRevisionFromPage( $wikiPage ),
 			$user
 		);
 
@@ -64,10 +67,7 @@ class ArticleProtectComplete implements ArticleProtectCompleteHook {
 			return true;
 		}
 
-		$parserData = $applicationFactory->newParserData(
-			$wikiPage->getTitle(),
-			$output
-		);
+		$parserData = new ParserData( $wikiPage->getTitle(), $output );
 
 		$this->doPrepareData( $protect, $parserData );
 		$parserData->setOrigin( 'ArticleProtectComplete' );
@@ -83,8 +83,7 @@ class ArticleProtectComplete implements ArticleProtectCompleteHook {
 		$isRestrictedUpdate = true;
 		$isAnnotationBySystem = false;
 
-		$dataItemFactory = ApplicationFactory::getInstance()->getDataItemFactory();
-		$property = $dataItemFactory->newDIProperty( '_EDIP' );
+		$property = $this->dataItemFactory->newDIProperty( '_EDIP' );
 
 		$dataItems = $parserData->getSemanticData()->getPropertyValues( $property );
 		$dataItem = end( $dataItems );
@@ -103,7 +102,7 @@ class ArticleProtectComplete implements ArticleProtectCompleteHook {
 			$isRestrictedUpdate = false;
 			$parserData->getSemanticData()->addPropertyObjectValue(
 				$property,
-				$dataItemFactory->newDIBoolean( true )
+				$this->dataItemFactory->newDIBoolean( true )
 			);
 		}
 
@@ -117,7 +116,7 @@ class ArticleProtectComplete implements ArticleProtectCompleteHook {
 			$isRestrictedUpdate = false;
 			$parserData->getSemanticData()->removePropertyObjectValue(
 				$property,
-				$dataItemFactory->newDIBoolean( true )
+				$this->dataItemFactory->newDIBoolean( true )
 			);
 		}
 

--- a/src/MediaWiki/Hooks/ArticleProtectComplete.php
+++ b/src/MediaWiki/Hooks/ArticleProtectComplete.php
@@ -68,6 +68,7 @@ class ArticleProtectComplete implements ArticleProtectCompleteHook {
 		}
 
 		$parserData = new ParserData( $wikiPage->getTitle(), $output );
+		$parserData->setLogger( $this->logger );
 
 		$this->doPrepareData( $protect, $parserData );
 		$parserData->setOrigin( 'ArticleProtectComplete' );

--- a/src/MediaWiki/Hooks/ArticleViewHeader.php
+++ b/src/MediaWiki/Hooks/ArticleViewHeader.php
@@ -7,12 +7,11 @@ use MediaWiki\Page\Hook\ArticleViewHeaderHook;
 use MediaWiki\Title\Title;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DependencyValidatorFactory;
 use SMW\Localizer\Message;
 use SMW\MediaWiki\Jobs\ChangePropagationDispatchJob;
 use SMW\NamespaceExaminer;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Settings;
-use SMW\Site;
 use SMW\Store;
 
 /**
@@ -35,6 +34,7 @@ class ArticleViewHeader implements ArticleViewHeaderHook {
 		private readonly Store $store,
 		private readonly NamespaceExaminer $namespaceExaminer,
 		private readonly Settings $settings,
+		private readonly DependencyValidatorFactory $dependencyValidatorFactory,
 	) {
 	}
 
@@ -59,17 +59,11 @@ class ArticleViewHeader implements ArticleViewHeaderHook {
 			$pcache = $this->updateCategoryTop( $title, $article->getContext()->getOutput() );
 		}
 
-		$applicationFactory = ApplicationFactory::getInstance();
-		$parserCache = $applicationFactory->create( 'ParserCache' );
 		$wikiPage = $article->getPage();
 
-		$dependencyValidator = $applicationFactory->newDependencyValidator(
-			$this->getETag( $parserCache, $wikiPage, $wikiPage->makeParserOptions( 'canonical' ) ),
-			Site::getCacheExpireTime( 'parser' )
-		);
-
-		$dependencyValidator->setEventDispatcher(
-			$applicationFactory->getEventDispatcher()
+		$dependencyValidator = $this->dependencyValidatorFactory->newFor(
+			$wikiPage,
+			$wikiPage->makeParserOptions( 'canonical' )
 		);
 
 		if ( $dependencyValidator->hasArchaicDependencies( $subject ) ) {
@@ -77,11 +71,6 @@ class ArticleViewHeader implements ArticleViewHeaderHook {
 		}
 
 		return true;
-	}
-
-	private function getETag( $parserCache, $page, $pOpts ): string {
-		return 'W/"' . $parserCache->makeParserOutputKey( $page, $pOpts ) .
-			"--" . $page->getTouched() . '"';
 	}
 
 	private function updateCategoryTop( Title $title, $output ): bool {

--- a/src/MediaWiki/Hooks/RejectParserCacheValue.php
+++ b/src/MediaWiki/Hooks/RejectParserCacheValue.php
@@ -5,9 +5,8 @@ namespace SMW\MediaWiki\Hooks;
 use MediaWiki\Hook\RejectParserCacheValueHook;
 use Psr\Log\LoggerInterface;
 use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DependencyValidatorFactory;
 use SMW\NamespaceExaminer;
-use SMW\Services\ServicesFactory as ApplicationFactory;
-use SMW\Site;
 
 /**
  * @see https://www.mediawiki.org/wiki/Manual:Hooks/RejectParserCacheValue
@@ -25,6 +24,7 @@ class RejectParserCacheValue implements RejectParserCacheValueHook {
 	public function __construct(
 		private readonly NamespaceExaminer $namespaceExaminer,
 		private readonly LoggerInterface $logger,
+		private readonly DependencyValidatorFactory $dependencyValidatorFactory,
 	) {
 	}
 
@@ -38,21 +38,9 @@ class RejectParserCacheValue implements RejectParserCacheValueHook {
 			return true;
 		}
 
-		$applicationFactory = ApplicationFactory::getInstance();
-		$parserCache = $applicationFactory->create( 'ParserCache' );
+		$dependencyValidator = $this->dependencyValidatorFactory->newFor( $wikiPage, $parserOptions );
 
-		$dependencyValidator = $applicationFactory->newDependencyValidator(
-			$this->getETag( $parserCache, $wikiPage, $parserOptions ),
-			Site::getCacheExpireTime( 'parser' )
-		);
-
-		$dependencyValidator->setEventDispatcher(
-			$applicationFactory->getEventDispatcher()
-		);
-
-		$subject = DIWikiPage::newFromTitle( $title );
-
-		if ( $dependencyValidator->canKeepParserCache( $subject ) ) {
+		if ( $dependencyValidator->canKeepParserCache( DIWikiPage::newFromTitle( $title ) ) ) {
 			return true;
 		}
 
@@ -66,11 +54,6 @@ class RejectParserCacheValue implements RejectParserCacheValueHook {
 		// Return false to reject an otherwise usable cached value from the
 		// parser cache
 		return false;
-	}
-
-	private function getETag( $parserCache, $page, $pOpts ): string {
-		return 'W/"' . $parserCache->makeParserOutputKey( $page, $pOpts ) .
-			"--" . $page->getTouched() . '"';
 	}
 
 }

--- a/src/MediaWiki/Hooks/RevisionFromEditComplete.php
+++ b/src/MediaWiki/Hooks/RevisionFromEditComplete.php
@@ -3,16 +3,16 @@
 namespace SMW\MediaWiki\Hooks;
 
 use Exception;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Page\Hook\RevisionFromEditCompleteHook;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Title\Title;
+use MediaWiki\User\UserFactory;
 use SMW\EventDispatcher\EventDispatcher;
+use SMW\MediaWiki\MwCollaboratorFactory;
 use SMW\ParserData;
 use SMW\Property\AnnotatorFactory as PropertyAnnotatorFactory;
 use SMW\Schema\Schema;
 use SMW\Schema\SchemaFactory;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
 
 /**
@@ -42,6 +42,8 @@ class RevisionFromEditComplete implements RevisionFromEditCompleteHook {
 		private readonly SchemaFactory $schemaFactory,
 		private readonly Store $store,
 		private readonly EventDispatcher $eventDispatcher,
+		private readonly MwCollaboratorFactory $mwCollaboratorFactory,
+		private readonly UserFactory $userFactory,
 	) {
 	}
 
@@ -49,17 +51,15 @@ class RevisionFromEditComplete implements RevisionFromEditCompleteHook {
 	 * @since 7.0.0
 	 */
 	public function onRevisionFromEditComplete( $wikiPage, $rev, $originalRevId, $user, &$tags ) {
-		$applicationFactory = ApplicationFactory::getInstance();
-		$mwCollaboratorFactory = $applicationFactory->newMwCollaboratorFactory();
+		$userObject = $this->userFactory->newFromUserIdentity( $user );
 
-		$userObject = MediaWikiServices::getInstance()->getUserFactory()->newFromUserIdentity( $user );
-		$editInfo = $mwCollaboratorFactory->newEditInfo(
+		$editInfo = $this->mwCollaboratorFactory->newEditInfo(
 			$wikiPage,
 			$rev,
 			$userObject
 		);
 
-		$pageInfoProvider = $mwCollaboratorFactory->newPageInfoProvider(
+		$pageInfoProvider = $this->mwCollaboratorFactory->newPageInfoProvider(
 			$wikiPage,
 			$rev,
 			$userObject
@@ -79,10 +79,7 @@ class RevisionFromEditComplete implements RevisionFromEditCompleteHook {
 			return;
 		}
 
-		$parserData = ApplicationFactory::getInstance()->newParserData(
-			$title,
-			$parserOutput
-		);
+		$parserData = new ParserData( $title, $parserOutput );
 
 		$this->addPredefinedPropertyAnnotation(
 			$parserData,

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -832,7 +832,7 @@ return [
 
 		return new DependencyValidatorFactory(
 			$servicesFactory->getNamespaceExaminer(),
-			$servicesFactory->getQueryDependencyLinksStoreFactory()->newDependencyLinksValidator(),
+			$servicesFactory->getQueryDependencyLinksStoreFactory(),
 			$servicesFactory->getEntityCache(),
 			$servicesFactory->getEventDispatcher(),
 			$services->getParserCache()

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -8,6 +8,7 @@ use SMW\CacheFactory;
 use SMW\Connection\ConnectionManager;
 use SMW\ConstraintFactory;
 use SMW\DataItemFactory;
+use SMW\DependencyValidatorFactory;
 use SMW\DisplayTitleFinder;
 use SMW\Elastic\ElasticFactory;
 use SMW\EntityCache;
@@ -824,6 +825,18 @@ return [
 
 	'SMW.EventDispatcher' => static function ( MediaWikiServices $services ): EventDispatcher {
 		return ServicesFactory::getInstance()->getEventDispatcher();
+	},
+
+	'SMW.DependencyValidatorFactory' => static function ( MediaWikiServices $services ): DependencyValidatorFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		return new DependencyValidatorFactory(
+			$servicesFactory->getNamespaceExaminer(),
+			$servicesFactory->getQueryDependencyLinksStoreFactory()->newDependencyLinksValidator(),
+			$servicesFactory->getEntityCache(),
+			$servicesFactory->getEventDispatcher(),
+			$services->getParserCache()
+		);
 	},
 
 	'SMW.PersonalUrls' => static function ( MediaWikiServices $services ): PersonalUrls {

--- a/tests/phpunit/Unit/DependencyValidatorFactoryTest.php
+++ b/tests/phpunit/Unit/DependencyValidatorFactoryTest.php
@@ -11,6 +11,7 @@ use SMW\EntityCache;
 use SMW\EventDispatcher\EventDispatcher;
 use SMW\NamespaceExaminer;
 use SMW\SQLStore\QueryDependency\DependencyLinksValidator;
+use SMW\SQLStore\QueryDependencyLinksStoreFactory;
 use WikiPage;
 
 /**
@@ -23,7 +24,7 @@ use WikiPage;
 class DependencyValidatorFactoryTest extends TestCase {
 
 	private NamespaceExaminer $namespaceExaminer;
-	private DependencyLinksValidator $dependencyLinksValidator;
+	private QueryDependencyLinksStoreFactory $queryDependencyLinksStoreFactory;
 	private EntityCache $entityCache;
 	private EventDispatcher $eventDispatcher;
 	private ParserCache $parserCache;
@@ -32,7 +33,7 @@ class DependencyValidatorFactoryTest extends TestCase {
 		parent::setUp();
 
 		$this->namespaceExaminer = $this->createMock( NamespaceExaminer::class );
-		$this->dependencyLinksValidator = $this->createMock( DependencyLinksValidator::class );
+		$this->queryDependencyLinksStoreFactory = $this->createMock( QueryDependencyLinksStoreFactory::class );
 		$this->entityCache = $this->createMock( EntityCache::class );
 		$this->eventDispatcher = $this->createMock( EventDispatcher::class );
 		$this->parserCache = $this->createMock( ParserCache::class );
@@ -41,7 +42,7 @@ class DependencyValidatorFactoryTest extends TestCase {
 	private function newInstance(): DependencyValidatorFactory {
 		return new DependencyValidatorFactory(
 			$this->namespaceExaminer,
-			$this->dependencyLinksValidator,
+			$this->queryDependencyLinksStoreFactory,
 			$this->entityCache,
 			$this->eventDispatcher,
 			$this->parserCache
@@ -66,9 +67,29 @@ class DependencyValidatorFactoryTest extends TestCase {
 			->with( $wikiPage, $parserOptions )
 			->willReturn( 'parsercache-key' );
 
+		$this->queryDependencyLinksStoreFactory->expects( $this->once() )
+			->method( 'newDependencyLinksValidator' )
+			->willReturn( $this->createMock( DependencyLinksValidator::class ) );
+
 		$validator = $this->newInstance()->newFor( $wikiPage, $parserOptions );
 
 		$this->assertInstanceOf( DependencyValidator::class, $validator );
+	}
+
+	public function testNewForBuildsAFreshValidatorPerCall(): void {
+		$wikiPage = $this->createMock( WikiPage::class );
+		$parserOptions = $this->createMock( ParserOptions::class );
+
+		// Each invocation must request a fresh validator from the factory so
+		// that a cached handler instance cannot retain a stale Store-bound
+		// validator across service-container resets.
+		$this->queryDependencyLinksStoreFactory->expects( $this->exactly( 2 ) )
+			->method( 'newDependencyLinksValidator' )
+			->willReturn( $this->createMock( DependencyLinksValidator::class ) );
+
+		$instance = $this->newInstance();
+		$instance->newFor( $wikiPage, $parserOptions );
+		$instance->newFor( $wikiPage, $parserOptions );
 	}
 
 }

--- a/tests/phpunit/Unit/DependencyValidatorFactoryTest.php
+++ b/tests/phpunit/Unit/DependencyValidatorFactoryTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace SMW\Tests\Unit;
+
+use MediaWiki\Parser\ParserCache;
+use MediaWiki\Parser\ParserOptions;
+use PHPUnit\Framework\TestCase;
+use SMW\DependencyValidator;
+use SMW\DependencyValidatorFactory;
+use SMW\EntityCache;
+use SMW\EventDispatcher\EventDispatcher;
+use SMW\NamespaceExaminer;
+use SMW\SQLStore\QueryDependency\DependencyLinksValidator;
+use WikiPage;
+
+/**
+ * @covers \SMW\DependencyValidatorFactory
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class DependencyValidatorFactoryTest extends TestCase {
+
+	private NamespaceExaminer $namespaceExaminer;
+	private DependencyLinksValidator $dependencyLinksValidator;
+	private EntityCache $entityCache;
+	private EventDispatcher $eventDispatcher;
+	private ParserCache $parserCache;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->namespaceExaminer = $this->createMock( NamespaceExaminer::class );
+		$this->dependencyLinksValidator = $this->createMock( DependencyLinksValidator::class );
+		$this->entityCache = $this->createMock( EntityCache::class );
+		$this->eventDispatcher = $this->createMock( EventDispatcher::class );
+		$this->parserCache = $this->createMock( ParserCache::class );
+	}
+
+	private function newInstance(): DependencyValidatorFactory {
+		return new DependencyValidatorFactory(
+			$this->namespaceExaminer,
+			$this->dependencyLinksValidator,
+			$this->entityCache,
+			$this->eventDispatcher,
+			$this->parserCache
+		);
+	}
+
+	public function testCanConstruct(): void {
+		$this->assertInstanceOf(
+			DependencyValidatorFactory::class,
+			$this->newInstance()
+		);
+	}
+
+	public function testNewForReturnsConfiguredValidator(): void {
+		$wikiPage = $this->createMock( WikiPage::class );
+		$wikiPage->method( 'getTouched' )->willReturn( '20260526120000' );
+
+		$parserOptions = $this->createMock( ParserOptions::class );
+
+		$this->parserCache->expects( $this->once() )
+			->method( 'makeParserOutputKey' )
+			->with( $wikiPage, $parserOptions )
+			->willReturn( 'parsercache-key' );
+
+		$validator = $this->newInstance()->newFor( $wikiPage, $parserOptions );
+
+		$this->assertInstanceOf( DependencyValidator::class, $validator );
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleProtectCompleteTest.php
@@ -2,10 +2,18 @@
 
 namespace SMW\Tests\Unit\MediaWiki\Hooks;
 
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Revision\RevisionRecord;
+use MediaWiki\Title\Title;
 use MediaWiki\User\User;
 use PHPUnit\Framework\TestCase;
+use SMW\DataItemFactory;
 use SMW\Localizer\Message;
+use SMW\MediaWiki\EditInfo;
 use SMW\MediaWiki\Hooks\ArticleProtectComplete;
+use SMW\MediaWiki\MwCollaboratorFactory;
+use SMW\MediaWiki\RevisionGuard;
+use SMW\Property\Annotators\EditProtectedPropertyAnnotator;
 use SMW\Settings;
 use SMW\Tests\TestEnvironment;
 use WikiPage;
@@ -24,17 +32,29 @@ class ArticleProtectCompleteTest extends TestCase {
 	private $spyLogger;
 	private $testEnvironment;
 	private $settings;
+	private $mwCollaboratorFactory;
+	private $revisionGuard;
+	private $dataItemFactory;
+	private $editInfo;
+	private $semanticDataFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
-
+		$this->dataItemFactory = new DataItemFactory();
+		$this->semanticDataFactory = $this->testEnvironment->getUtilityFactory()->newSemanticDataFactory();
 		$this->spyLogger = $this->testEnvironment->getUtilityFactory()->newSpyLogger();
 
-		$this->settings = $this->getMockBuilder( Settings::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->settings = $this->createMock( Settings::class );
+
+		$this->editInfo = $this->createMock( EditInfo::class );
+
+		$this->mwCollaboratorFactory = $this->createMock( MwCollaboratorFactory::class );
+		$this->mwCollaboratorFactory->method( 'newEditInfo' )->willReturn( $this->editInfo );
+
+		$this->revisionGuard = $this->createMock( RevisionGuard::class );
+		$this->revisionGuard->method( 'newRevisionFromPage' )->willReturn( $this->createMock( RevisionRecord::class ) );
 	}
 
 	protected function tearDown(): void {
@@ -42,33 +62,134 @@ class ArticleProtectCompleteTest extends TestCase {
 		parent::tearDown();
 	}
 
+	private function newInstance(): ArticleProtectComplete {
+		return new ArticleProtectComplete(
+			$this->settings,
+			$this->spyLogger,
+			$this->mwCollaboratorFactory,
+			$this->revisionGuard,
+			$this->dataItemFactory
+		);
+	}
+
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			ArticleProtectComplete::class,
-			new ArticleProtectComplete( $this->settings, $this->spyLogger )
+			$this->newInstance()
 		);
 	}
 
 	public function testProcessOnSelfInvokedReason() {
-		$instance = new ArticleProtectComplete( $this->settings, $this->spyLogger );
-
-		$wikiPage = $this->getMockBuilder( WikiPage::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$user = $this->getMockBuilder( User::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$wikiPage = $this->createMock( WikiPage::class );
+		$user = $this->createMock( User::class );
 
 		$protections = [];
 		$reason = Message::get( 'smw-edit-protection-auto-update' );
 
 		$this->assertTrue(
-			$instance->onArticleProtectComplete( $wikiPage, $user, $protections, $reason )
+			$this->newInstance()->onArticleProtectComplete( $wikiPage, $user, $protections, $reason )
 		);
 
 		$this->assertStringContainsString(
 			'No changes required, invoked by own process',
+			$this->spyLogger->getMessagesAsString()
+		);
+	}
+
+	public function testProcessOnMissingParserOutput() {
+		$this->editInfo->expects( $this->once() )
+			->method( 'getOutput' )
+			->willReturn( null );
+
+		$wikiPage = $this->createMock( WikiPage::class );
+		$user = $this->createMock( User::class );
+
+		$this->assertTrue(
+			$this->newInstance()->onArticleProtectComplete( $wikiPage, $user, [ 'edit' => 'sysop' ], 'foo' )
+		);
+
+		$this->assertStringContainsString(
+			'Missing ParserOutput',
+			$this->spyLogger->getMessagesAsString()
+		);
+	}
+
+	public function testProcessOnMatchableEditProtectionToAddAnnotation() {
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData(
+			$this->dataItemFactory->newDIWikiPage( __METHOD__, NS_SPECIAL )
+		);
+
+		$parserOutput = $this->createMock( ParserOutput::class );
+		$parserOutput->method( 'getExtensionData' )->willReturn( $semanticData );
+
+		$title = $this->createMock( Title::class );
+		$title->method( 'getDBKey' )->willReturn( 'Foo' );
+		$title->method( 'getNamespace' )->willReturn( NS_SPECIAL );
+		$title->method( 'getLatestRevID' )->willReturn( 9900 );
+
+		$wikiPage = $this->createMock( WikiPage::class );
+		$wikiPage->method( 'getTitle' )->willReturn( $title );
+
+		$user = $this->createMock( User::class );
+
+		$this->editInfo->expects( $this->once() )
+			->method( 'getOutput' )
+			->willReturn( $parserOutput );
+
+		$this->settings->method( 'get' )
+			->with( 'smwgEditProtectionRight' )
+			->willReturn( 'Foo' );
+
+		$protections = [ 'edit' => 'Foo' ];
+
+		$this->newInstance()->onArticleProtectComplete( $wikiPage, $user, $protections, '' );
+
+		$this->assertStringContainsString(
+			'ArticleProtectComplete addProperty `Is edit protected`',
+			$this->spyLogger->getMessagesAsString()
+		);
+	}
+
+	public function testProcessOnUnmatchableEditProtectionToRemoveAnnotation() {
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData(
+			$this->dataItemFactory->newDIWikiPage( __METHOD__, NS_SPECIAL )
+		);
+
+		$dataItem = $this->dataItemFactory->newDIBoolean( true );
+		$dataItem->setOption( EditProtectedPropertyAnnotator::SYSTEM_ANNOTATION, true );
+
+		$semanticData->addPropertyObjectValue(
+			$this->dataItemFactory->newDIProperty( '_EDIP' ),
+			$dataItem
+		);
+
+		$parserOutput = $this->createMock( ParserOutput::class );
+		$parserOutput->method( 'getExtensionData' )->willReturn( $semanticData );
+
+		$title = $this->createMock( Title::class );
+		$title->method( 'getDBKey' )->willReturn( 'Foo' );
+		$title->method( 'getNamespace' )->willReturn( NS_SPECIAL );
+		$title->method( 'getLatestRevID' )->willReturn( 9901 );
+
+		$wikiPage = $this->createMock( WikiPage::class );
+		$wikiPage->method( 'getTitle' )->willReturn( $title );
+
+		$user = $this->createMock( User::class );
+
+		$this->editInfo->expects( $this->once() )
+			->method( 'getOutput' )
+			->willReturn( $parserOutput );
+
+		$this->settings->method( 'get' )
+			->with( 'smwgEditProtectionRight' )
+			->willReturn( 'Foo2' );
+
+		$protections = [ 'edit' => 'Foo' ];
+
+		$this->newInstance()->onArticleProtectComplete( $wikiPage, $user, $protections, '' );
+
+		$this->assertStringContainsString(
+			'ArticleProtectComplete removeProperty `Is edit protected`',
 			$this->spyLogger->getMessagesAsString()
 		);
 	}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleViewHeaderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleViewHeaderTest.php
@@ -5,16 +5,19 @@ namespace SMW\Tests\Unit\MediaWiki\Hooks;
 use Article;
 use MediaWiki\Context\RequestContext;
 use MediaWiki\Output\OutputPage;
+use MediaWiki\Parser\ParserOptions;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
+use SMW\DependencyValidator;
+use SMW\DependencyValidatorFactory;
 use SMW\MediaWiki\Hooks\ArticleViewHeader;
 use SMW\NamespaceExaminer;
 use SMW\Settings;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\Store;
-use Throwable;
+use WikiPage as MwWikiPage;
 
 /**
  * @covers \SMW\MediaWiki\Hooks\ArticleViewHeader
@@ -30,34 +33,54 @@ class ArticleViewHeaderTest extends TestCase {
 	private $store;
 	private $namespaceExaminer;
 	private $settings;
+	private $dependencyValidator;
+	private $dependencyValidatorFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->namespaceExaminer = $this->getMockBuilder( NamespaceExaminer::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->namespaceExaminer = $this->createMock( NamespaceExaminer::class );
 
-		$entityIdManager = $this->getMockBuilder( EntityIdManager::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$entityIdManager = $this->createMock( EntityIdManager::class );
 
 		$this->store = $this->getMockBuilder( Store::class )
 			->disableOriginalConstructor()
 			->setMethods( [ 'getObjectIds' ] )
 			->getMockForAbstractClass();
 
-		$this->store->expects( $this->any() )
-			->method( 'getObjectIds' )
-			->willReturn( $entityIdManager );
+		$this->store->method( 'getObjectIds' )->willReturn( $entityIdManager );
 
 		$this->settings = $this->createMock( Settings::class );
+
+		$this->dependencyValidator = $this->createMock( DependencyValidator::class );
+
+		$this->dependencyValidatorFactory = $this->createMock( DependencyValidatorFactory::class );
+		$this->dependencyValidatorFactory->method( 'newFor' )->willReturn( $this->dependencyValidator );
+	}
+
+	private function newInstance(): ArticleViewHeader {
+		return new ArticleViewHeader(
+			$this->store,
+			$this->namespaceExaminer,
+			$this->settings,
+			$this->dependencyValidatorFactory
+		);
+	}
+
+	private function newArticleFor( $title ): Article {
+		$wikiPage = $this->createMock( MwWikiPage::class );
+		$wikiPage->method( 'makeParserOptions' )->willReturn( $this->createMock( ParserOptions::class ) );
+
+		$article = $this->createMock( Article::class );
+		$article->method( 'getTitle' )->willReturn( $title );
+		$article->method( 'getPage' )->willReturn( $wikiPage );
+		return $article;
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			ArticleViewHeader::class,
-			new ArticleViewHeader( $this->store, $this->namespaceExaminer, $this->settings )
+			$this->newInstance()
 		);
 	}
 
@@ -65,9 +88,7 @@ class ArticleViewHeaderTest extends TestCase {
 		$subject = WikiPage::newFromText( __METHOD__, NS_CATEGORY );
 		$property = new Property( Property::TYPE_CHANGE_PROP );
 
-		$this->namespaceExaminer->expects( $this->any() )
-			->method( 'isSemanticEnabled' )
-			->willReturn( true );
+		$this->namespaceExaminer->method( 'isSemanticEnabled' )->willReturn( true );
 
 		$this->settings->method( 'get' )
 			->willReturnMap( [
@@ -84,90 +105,73 @@ class ArticleViewHeaderTest extends TestCase {
 			->with( $property )
 			->willReturn( true );
 
-		$this->store->expects( $this->any() )
-			->method( 'getSemanticData' )
-			->willReturn( $semanticData );
+		$this->store->method( 'getSemanticData' )->willReturn( $semanticData );
 
-		$output = $this->getMockBuilder( OutputPage::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$output = $this->createMock( OutputPage::class );
+		$output->expects( $this->once() )->method( 'addHTML' );
 
-		$output->expects( $this->once() )
-			->method( 'addHTML' );
+		$context = $this->createMock( RequestContext::class );
+		$context->method( 'getOutput' )->willReturn( $output );
 
-		$context = $this->getMockBuilder( RequestContext::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$wikiPage = $this->createMock( MwWikiPage::class );
+		$wikiPage->method( 'makeParserOptions' )->willReturn( $this->createMock( ParserOptions::class ) );
 
-		$context->expects( $this->any() )
-			->method( 'getOutput' )
-			->willReturn( $output );
-
-		$page = $this->getMockBuilder( Article::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$page->expects( $this->any() )
-			->method( 'getTitle' )
-			->willReturn( $subject->getTitle() );
-
-		$page->expects( $this->any() )
-			->method( 'getContext' )
-			->willReturn( $context );
-
-		$instance = new ArticleViewHeader(
-			$this->store,
-			$this->namespaceExaminer,
-			$this->settings
-		);
+		$page = $this->createMock( Article::class );
+		$page->method( 'getTitle' )->willReturn( $subject->getTitle() );
+		$page->method( 'getContext' )->willReturn( $context );
+		$page->method( 'getPage' )->willReturn( $wikiPage );
 
 		$outputDone = '';
 		$useParserCache = '';
 
-		// Only the category-top branch is exercised here; the dependency
-		// validator branch needs a fully wired ApplicationFactory and is
-		// covered by HooksTest.
-		try {
-			$instance->onArticleViewHeader( $page, $outputDone, $useParserCache );
-		} catch ( Throwable $e ) {
-			// Downstream dependency-validator branch is not wired in this
-			// unit-test scope.
-		}
+		$this->newInstance()->onArticleViewHeader( $page, $outputDone, $useParserCache );
 
-		$this->assertFalse(
-			$useParserCache
-		);
+		$this->assertFalse( $useParserCache );
 	}
 
 	public function testProcessOnNoCategory() {
 		$subject = WikiPage::newFromText( __METHOD__ );
 
-		$this->namespaceExaminer->expects( $this->any() )
-			->method( 'isSemanticEnabled' )
-			->willReturn( false );
+		$this->namespaceExaminer->method( 'isSemanticEnabled' )->willReturn( false );
 
-		$page = $this->getMockBuilder( Article::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$page->expects( $this->any() )
-			->method( 'getTitle' )
-			->willReturn( $subject->getTitle() );
-
-		$page->expects( $this->never() )
-			->method( 'getContext' );
-
-		$instance = new ArticleViewHeader(
-			$this->store,
-			$this->namespaceExaminer,
-			$this->settings
-		);
+		$page = $this->createMock( Article::class );
+		$page->method( 'getTitle' )->willReturn( $subject->getTitle() );
+		$page->expects( $this->never() )->method( 'getContext' );
 
 		$outputDone = '';
 		$useParserCache = '';
 
 		$this->assertTrue(
-			$instance->onArticleViewHeader( $page, $outputDone, $useParserCache )
+			$this->newInstance()->onArticleViewHeader( $page, $outputDone, $useParserCache )
+		);
+	}
+
+	public function testHasArchaicDependency() {
+		$subject = WikiPage::newFromText( __METHOD__ );
+
+		$this->namespaceExaminer->method( 'isSemanticEnabled' )->willReturn( true );
+
+		$this->settings->method( 'get' )
+			->willReturnMap( [
+				[ 'smwgChangePropagationWatchlist', [ '_SUBC' ] ],
+			] );
+
+		$this->dependencyValidator->expects( $this->once() )
+			->method( 'hasArchaicDependencies' )
+			->willReturn( true );
+
+		$this->dependencyValidator->expects( $this->once() )
+			->method( 'markTitle' );
+
+		$outputDone = '';
+		$useParserCache = '';
+
+		$this->assertTrue(
+			$this->newInstance()->onArticleViewHeader(
+				$this->newArticleFor( $subject->getTitle() ),
+				$outputDone,
+				$useParserCache
+			)
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/RejectParserCacheValueTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/RejectParserCacheValueTest.php
@@ -2,9 +2,12 @@
 
 namespace SMW\Tests\Unit\MediaWiki\Hooks;
 
+use MediaWiki\Parser\ParserOptions;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
+use SMW\DependencyValidator;
+use SMW\DependencyValidatorFactory;
 use SMW\MediaWiki\Hooks\RejectParserCacheValue;
 use SMW\NamespaceExaminer;
 use SMW\Tests\TestEnvironment;
@@ -24,19 +27,20 @@ class RejectParserCacheValueTest extends TestCase {
 	private $testEnvironment;
 	private $namespaceExaminer;
 	private $logger;
+	private $dependencyValidator;
+	private $dependencyValidatorFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
 
-		$this->namespaceExaminer = $this->getMockBuilder( NamespaceExaminer::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->namespaceExaminer = $this->createMock( NamespaceExaminer::class );
+		$this->logger = $this->createMock( LoggerInterface::class );
+		$this->dependencyValidator = $this->createMock( DependencyValidator::class );
 
-		$this->logger = $this->getMockBuilder( LoggerInterface::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->dependencyValidatorFactory = $this->createMock( DependencyValidatorFactory::class );
+		$this->dependencyValidatorFactory->method( 'newFor' )->willReturn( $this->dependencyValidator );
 	}
 
 	protected function tearDown(): void {
@@ -44,37 +48,80 @@ class RejectParserCacheValueTest extends TestCase {
 		parent::tearDown();
 	}
 
+	private function newInstance(): RejectParserCacheValue {
+		return new RejectParserCacheValue(
+			$this->namespaceExaminer,
+			$this->logger,
+			$this->dependencyValidatorFactory
+		);
+	}
+
+	private function newPage( Title $title ): WikiPage {
+		$page = $this->createMock( WikiPage::class );
+		$page->method( 'getTitle' )->willReturn( $title );
+		return $page;
+	}
+
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			RejectParserCacheValue::class,
-			new RejectParserCacheValue( $this->namespaceExaminer, $this->logger )
+			$this->newInstance()
 		);
 	}
 
 	public function testProcessOnDisabledNamespace() {
-		$title = $this->getMockBuilder( Title::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$page = $this->getMockBuilder( WikiPage::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$page->expects( $this->once() )
-			->method( 'getTitle' )
-			->willReturn( $title );
+		$title = $this->createMock( Title::class );
 
 		$this->namespaceExaminer->expects( $this->once() )
 			->method( 'isSemanticEnabled' )
 			->willReturn( false );
 
-		$instance = new RejectParserCacheValue(
-			$this->namespaceExaminer,
-			$this->logger
-		);
+		$this->dependencyValidatorFactory->expects( $this->never() )->method( 'newFor' );
 
 		$this->assertTrue(
-			$instance->onRejectParserCacheValue( null, $page, null )
+			$this->newInstance()->onRejectParserCacheValue( null, $this->newPage( $title ), null )
+		);
+	}
+
+	public function testProcesCanKeepParserCache() {
+		$title = $this->createMock( Title::class );
+		$title->method( 'getNamespace' )->willReturn( NS_MAIN );
+
+		$this->namespaceExaminer->expects( $this->once() )
+			->method( 'isSemanticEnabled' )
+			->willReturn( true );
+
+		$this->dependencyValidator->expects( $this->once() )
+			->method( 'canKeepParserCache' )
+			->willReturn( true );
+
+		$this->assertTrue(
+			$this->newInstance()->onRejectParserCacheValue(
+				null,
+				$this->newPage( $title ),
+				$this->createMock( ParserOptions::class )
+			)
+		);
+	}
+
+	public function testProcesCanNOTKeepParserCache() {
+		$title = $this->createMock( Title::class );
+		$title->method( 'getNamespace' )->willReturn( NS_MAIN );
+
+		$this->namespaceExaminer->expects( $this->once() )
+			->method( 'isSemanticEnabled' )
+			->willReturn( true );
+
+		$this->dependencyValidator->expects( $this->once() )
+			->method( 'canKeepParserCache' )
+			->willReturn( false );
+
+		$this->assertFalse(
+			$this->newInstance()->onRejectParserCacheValue(
+				null,
+				$this->newPage( $title ),
+				$this->createMock( ParserOptions::class )
+			)
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/RejectParserCacheValueTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/RejectParserCacheValueTest.php
@@ -83,7 +83,7 @@ class RejectParserCacheValueTest extends TestCase {
 		);
 	}
 
-	public function testProcesCanKeepParserCache() {
+	public function testProcessCanKeepParserCache() {
 		$title = $this->createMock( Title::class );
 		$title->method( 'getNamespace' )->willReturn( NS_MAIN );
 
@@ -104,7 +104,7 @@ class RejectParserCacheValueTest extends TestCase {
 		);
 	}
 
-	public function testProcesCanNOTKeepParserCache() {
+	public function testProcessCanNOTKeepParserCache() {
 		$title = $this->createMock( Title::class );
 		$title->method( 'getNamespace' )->willReturn( NS_MAIN );
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/RevisionFromEditCompleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/RevisionFromEditCompleteTest.php
@@ -2,13 +2,27 @@
 
 namespace SMW\Tests\Unit\MediaWiki\Hooks;
 
+use Exception;
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Title\Title;
+use MediaWiki\User\User;
+use MediaWiki\User\UserFactory;
+use MediaWiki\User\UserIdentity;
 use PHPUnit\Framework\TestCase;
 use SMW\EventDispatcher\EventDispatcher;
+use SMW\MediaWiki\EditInfo;
 use SMW\MediaWiki\Hooks\RevisionFromEditComplete;
+use SMW\MediaWiki\MwCollaboratorFactory;
+use SMW\MediaWiki\PageInfoProvider;
 use SMW\Property\AnnotatorFactory;
+use SMW\Property\Annotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\PredefinedPropertyAnnotator;
+use SMW\Property\Annotators\SchemaPropertyAnnotator;
 use SMW\Schema\SchemaFactory;
+use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use WikiPage;
 
 /**
  * @covers \SMW\MediaWiki\Hooks\RevisionFromEditComplete
@@ -26,6 +40,10 @@ class RevisionFromEditCompleteTest extends TestCase {
 	private $propertyAnnotatorFactory;
 	private $schemaFactory;
 	private $store;
+	private $mwCollaboratorFactory;
+	private $userFactory;
+	private $editInfo;
+	private $pageInfoProvider;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -36,17 +54,27 @@ class RevisionFromEditCompleteTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$this->eventDispatcher = $this->getMockBuilder( EventDispatcher::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->eventDispatcher = $this->createMock( EventDispatcher::class );
+		$this->schemaFactory = $this->createMock( SchemaFactory::class );
 
-		$this->propertyAnnotatorFactory = $this->getMockBuilder( AnnotatorFactory::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$nullAnnotator = $this->createMock( NullPropertyAnnotator::class );
+		$predefinedAnnotator = $this->createMock( PredefinedPropertyAnnotator::class );
+		$schemaAnnotator = $this->createMock( SchemaPropertyAnnotator::class );
 
-		$this->schemaFactory = $this->getMockBuilder( SchemaFactory::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->propertyAnnotatorFactory = $this->createMock( AnnotatorFactory::class );
+		$this->propertyAnnotatorFactory->method( 'newNullPropertyAnnotator' )->willReturn( $nullAnnotator );
+		$this->propertyAnnotatorFactory->method( 'newPredefinedPropertyAnnotator' )->willReturn( $predefinedAnnotator );
+		$this->propertyAnnotatorFactory->method( 'newSchemaPropertyAnnotator' )->willReturn( $schemaAnnotator );
+
+		$this->editInfo = $this->createMock( EditInfo::class );
+		$this->pageInfoProvider = $this->createMock( PageInfoProvider::class );
+
+		$this->mwCollaboratorFactory = $this->createMock( MwCollaboratorFactory::class );
+		$this->mwCollaboratorFactory->method( 'newEditInfo' )->willReturn( $this->editInfo );
+		$this->mwCollaboratorFactory->method( 'newPageInfoProvider' )->willReturn( $this->pageInfoProvider );
+
+		$this->userFactory = $this->createMock( UserFactory::class );
+		$this->userFactory->method( 'newFromUserIdentity' )->willReturn( $this->createMock( User::class ) );
 	}
 
 	protected function tearDown(): void {
@@ -54,15 +82,136 @@ class RevisionFromEditCompleteTest extends TestCase {
 		parent::tearDown();
 	}
 
+	private function newInstance( ?Store $store = null ): RevisionFromEditComplete {
+		return new RevisionFromEditComplete(
+			$this->propertyAnnotatorFactory,
+			$this->schemaFactory,
+			$store ?? $this->store,
+			$this->eventDispatcher,
+			$this->mwCollaboratorFactory,
+			$this->userFactory
+		);
+	}
+
+	private function newWikiPageWithTitle( Title $title ): WikiPage {
+		$wikiPage = $this->createMock( WikiPage::class );
+		$wikiPage->method( 'getTitle' )->willReturn( $title );
+		return $wikiPage;
+	}
+
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			RevisionFromEditComplete::class,
-			new RevisionFromEditComplete(
-				$this->propertyAnnotatorFactory,
-				$this->schemaFactory,
-				$this->store,
-				$this->eventDispatcher
-			)
+			$this->newInstance()
+		);
+	}
+
+	public function testProcess_NoParserOutput() {
+		$title = $this->createMock( Title::class );
+
+		$this->editInfo->expects( $this->once() )
+			->method( 'getOutput' )
+			->willReturn( null );
+
+		$this->schemaFactory->expects( $this->never() )->method( 'newSchema' );
+		$this->eventDispatcher->expects( $this->never() )->method( 'dispatch' );
+
+		$tags = [];
+		$this->newInstance()->onRevisionFromEditComplete(
+			$this->newWikiPageWithTitle( $title ),
+			null,
+			0,
+			$this->createMock( UserIdentity::class ),
+			$tags
+		);
+	}
+
+	public function testProcess_OnSchemaNamespace() {
+		$parserOutput = $this->createMock( ParserOutput::class );
+
+		$title = $this->createMock( Title::class );
+		$title->method( 'getDBKey' )->willReturn( 'Foo' );
+		$title->method( 'getNamespace' )->willReturn( SMW_NS_SCHEMA );
+
+		$this->editInfo->method( 'getOutput' )->willReturn( $parserOutput );
+
+		$this->schemaFactory->expects( $this->once() )->method( 'newSchema' );
+
+		$this->eventDispatcher->expects( $this->atLeastOnce() )
+			->method( 'dispatch' )
+			->withConsecutive(
+				[ $this->equalTo( 'InvalidateResultCache' ) ],
+				[ $this->equalTo( 'InvalidateEntityCache' ) ]
+			);
+
+		$tags = [];
+		$this->newInstance()->onRevisionFromEditComplete(
+			$this->newWikiPageWithTitle( $title ),
+			null,
+			0,
+			$this->createMock( UserIdentity::class ),
+			$tags
+		);
+	}
+
+	public function testProcess_OnSchemaNamespace_InvalidSchema() {
+		$parserOutput = $this->createMock( ParserOutput::class );
+
+		$title = $this->createMock( Title::class );
+		$title->method( 'getDBKey' )->willReturn( 'Foo' );
+		$title->method( 'getNamespace' )->willReturn( SMW_NS_SCHEMA );
+
+		$this->editInfo->method( 'getOutput' )->willReturn( $parserOutput );
+
+		$this->schemaFactory->expects( $this->once() )
+			->method( 'newSchema' )
+			->willThrowException( new Exception() );
+
+		$this->eventDispatcher->expects( $this->atLeastOnce() )
+			->method( 'dispatch' )
+			->withConsecutive(
+				[ $this->equalTo( 'InvalidateResultCache' ) ],
+				[ $this->equalTo( 'InvalidateEntityCache' ) ]
+			);
+
+		$tags = [];
+		$this->newInstance()->onRevisionFromEditComplete(
+			$this->newWikiPageWithTitle( $title ),
+			null,
+			0,
+			$this->createMock( UserIdentity::class ),
+			$tags
+		);
+	}
+
+	public function testProcess_OnConceptNamespace() {
+		$store = $this->createMock( SQLStore::class );
+		$store->expects( $this->once() )->method( 'deleteConceptCache' );
+
+		$parserOutput = $this->createMock( ParserOutput::class );
+
+		$title = $this->createMock( Title::class );
+		$title->method( 'getDBKey' )->willReturn( 'Foo' );
+		$title->method( 'getNamespace' )->willReturn( SMW_NS_CONCEPT );
+
+		$this->editInfo->method( 'getOutput' )->willReturn( $parserOutput );
+
+		$this->schemaFactory->expects( $this->never() )->method( 'newSchema' );
+
+		$this->eventDispatcher->expects( $this->atLeastOnce() )
+			->method( 'dispatch' )
+			->withConsecutive(
+				[ $this->equalTo( 'InvalidateResultCache' ) ],
+				[ $this->equalTo( 'InvalidateEntityCache' ) ]
+			);
+
+		$tags = [];
+		$this->newInstance( $store )->onRevisionFromEditComplete(
+			$this->newWikiPageWithTitle( $title ),
+			null,
+			0,
+			$this->createMock( UserIdentity::class ),
+			$tags
 		);
 	}
 


### PR DESCRIPTION
## Summary

First slice of issue #6876. Four hook handlers under `src/MediaWiki/Hooks/` still resolved secondary dependencies via `ApplicationFactory::getInstance()->newX()` from inside their hook bodies. That pattern blocked unit-level mocking and forced 8 test methods across these four files to be dropped during the declarative-`HookHandlers` migration (#6875).

This PR converts the four mechanical cases to full constructor DI and restores the dropped tests. The remaining items in #6876 (per-user services, `LinksUpdateComplete::isReady`, `SpecialStatsAddExtra`, `EventDispatcherAwareTrait` sweep) need design discussion and ship as follow-up PRs.

## Per-handler conversion

| Handler                    | Added constructor arguments                                 |
| -------------------------- | ----------------------------------------------------------- |
| `ArticleProtectComplete`   | `MwCollaboratorFactory`, `RevisionGuard`, `DataItemFactory` |
| `RevisionFromEditComplete` | `MwCollaboratorFactory`, `UserFactory`                      |
| `RejectParserCacheValue`   | `DependencyValidatorFactory` (new)                          |
| `ArticleViewHeader`        | `DependencyValidatorFactory` (new)                          |

After this PR, none of these four handlers reference `ApplicationFactory::getInstance()` or `MediaWikiServices::getInstance()` from their hook method bodies.

## `DependencyValidatorFactory` (new)

`src/DependencyValidatorFactory.php` wraps the legacy `ServicesFactory::newDependencyValidator` chain. Both `RejectParserCacheValue` and `ArticleViewHeader` previously duplicated the same eTag computation, post-construction `setEventDispatcher` call and `Site::getCacheExpireTime( 'parser' )` TTL lookup; the factory absorbs all three behind a single `newFor( WikiPage, ParserOptions )` entry point. Service registration lives in `ServiceWiring.php` as `SMW.DependencyValidatorFactory`.

`RevisionFromEditComplete` is the first SMW handler to reference an unprefixed MediaWiki core service (`UserFactory`) in its `services:` array. The `ObjectFactory` spec resolves it through `MediaWikiServices` directly, no wrapper entry needed. `HookHandlersConstructionTest` exercises this on every CI run.

## Why no `ParserDataFactory`

`ParserData( Title, ParserOutput )` is constructed inline in the two handlers that need it. A dedicated factory wrapper would be one method delegating to `new ParserData(...)`, since `ParserData` is a two-argument data carrier and the dropped tests never mocked it. The two callers do, however, need to wire the PSR-3 logger after construction (see "Staleness and gotchas" below).

## Tests restored

8 unit-test methods dropped during #6875 are restored in this PR:

- `ArticleProtectCompleteTest::testProcessOnMatchableEditProtectionToAddAnnotation`
- `ArticleProtectCompleteTest::testProcessOnUnmatchableEditProtectionToRemoveAnnotation`
- `RevisionFromEditCompleteTest::testProcess_NoParserOutput`
- `RevisionFromEditCompleteTest::testProcess_OnSchemaNamespace`
- `RevisionFromEditCompleteTest::testProcess_OnConceptNamespace`
- `RejectParserCacheValueTest::testProcessCanKeepParserCache`
- `RejectParserCacheValueTest::testProcessCanNOTKeepParserCache`
- `ArticleViewHeaderTest::testHasArchaicDependency`

The restored tests are not character-for-character revivals. The new hook signatures take per-call data (`WikiPage`, `RevisionRecord`, `User`, `ParserOptions`) that the old `process()` methods received at construction, so the test setup mocks the factory that produces the per-call object rather than the per-call object itself.

Two extra defensive cases were added alongside: `testProcessOnMissingParserOutput` on `ArticleProtectComplete` covers the `getOutput() === null` early-return, and `DependencyValidatorFactoryTest` covers construction plus a happy-path `newFor` returning a configured `DependencyValidator`.

## Staleness and gotchas

`DependencyValidatorFactory` captures `DependencyLinksValidator` at construction time, which transitively captures `Store`. `HookContainer` caches handler instances across service-container resets, so a test that resets services after the handler is built would see a stale `Store` through the factory. The risk profile is the same as the existing `ArticleViewHeader` constructor, which already captures `Store` directly. Neither this handler nor `RejectParserCacheValue` was on the lazy-Store list maintained for the seven handlers that #6875 documented as exposed to JSON-script tests that mutate services mid-test, so the risk is theoretical for this slice.

`ArticleProtectComplete::onArticleProtectComplete` calls `$parserData->updateStore( true )` after building `ParserData` inline. `ParserData::updateStore` logs through PSR-3 on the `DataUpdater::isSkippable === true` branch. The prior `ApplicationFactory::newParserData` call wired a logger immediately after construction; the inline `new ParserData(...)` does not. The handler's own injected `LoggerInterface` is now passed straight to `ParserData::setLogger` to restore that behaviour. `RevisionFromEditComplete` only calls `copyToParserOutput()` (no logger access), so no fix needed there.

## Test plan

- [x] CI passes
- [ ] Reviewer verifies the per-handler `services:` arrays in `extension.json` match the constructor signatures
- [ ] Reviewer spot-checks one or two of the restored tests against the original assertions at the parent commit of #6875

Refs #6876