### PR TITLE
Complete handler DI for the three PermissionExaminer hook handlers

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -162,7 +162,8 @@
 			"services": [
 				"SMW.NamespaceExaminer",
 				"UserOptionsLookup",
-				"SMW.Settings"
+				"SMW.Settings",
+				"SMW.PermissionManager"
 			]
 		},
 		"SemanticMediaWiki.PageMoveComplete": {
@@ -264,7 +265,8 @@
 			"services": [
 				"SMW.SchemaFactory",
 				"SMW.HookDispatcher",
-				"SMW.Settings"
+				"SMW.Settings",
+				"SMW.PermissionManager"
 			]
 		},
 		"SemanticMediaWiki.SkinTemplateNavigationUniversal": {

--- a/src/MediaWiki/Hooks/EditPageForm.php
+++ b/src/MediaWiki/Hooks/EditPageForm.php
@@ -9,8 +9,9 @@ use SMW\DataItems\Property;
 use SMW\GroupPermissions;
 use SMW\Localizer\Message;
 use SMW\Localizer\MessageLocalizerTrait;
+use SMW\MediaWiki\Permission\PermissionExaminer;
+use SMW\MediaWiki\PermissionManager;
 use SMW\NamespaceExaminer;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Settings;
 
 /**
@@ -33,6 +34,7 @@ class EditPageForm implements EditPage__showEditForm_initialHook {
 		private readonly NamespaceExaminer $namespaceExaminer,
 		private readonly UserOptionsLookup $userOptionsLookup,
 		private readonly Settings $settings,
+		private readonly PermissionManager $permissionManager,
 	) {
 	}
 
@@ -43,7 +45,7 @@ class EditPageForm implements EditPage__showEditForm_initialHook {
 	public function onEditPage__showEditForm_initial( $editor, $out ) {
 		$html = '';
 		$user = $out->getUser();
-		$permissionExaminer = ApplicationFactory::getInstance()->newPermissionExaminer( $user );
+		$permissionExaminer = new PermissionExaminer( $this->permissionManager, $user );
 
 		if (
 			$this->settings->get( 'smwgEnabledEditPageHelp' ) &&

--- a/src/MediaWiki/Hooks/GetPreferences.php
+++ b/src/MediaWiki/Hooks/GetPreferences.php
@@ -6,11 +6,12 @@ use MediaWiki\Preferences\Hook\GetPreferencesHook;
 use SMW\GroupPermissions;
 use SMW\Localizer\MessageLocalizerTrait;
 use SMW\MediaWiki\HookDispatcher;
+use SMW\MediaWiki\Permission\PermissionExaminer;
+use SMW\MediaWiki\PermissionManager;
 use SMW\MediaWiki\Specials\FacetedSearch\Exception\DefaultProfileNotFoundException;
 use SMW\MediaWiki\Specials\FacetedSearch\Profile as FacetedSearchProfile;
 use SMW\Schema\Exception\SchemaTypeNotFoundException;
 use SMW\Schema\SchemaFactory;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Settings;
 use SMW\Utils\Logo;
 
@@ -65,6 +66,7 @@ class GetPreferences implements GetPreferencesHook {
 		private readonly SchemaFactory $schemaFactory,
 		private readonly HookDispatcher $hookDispatcher,
 		private readonly Settings $settings,
+		private readonly PermissionManager $permissionManager,
 	) {
 	}
 
@@ -72,9 +74,7 @@ class GetPreferences implements GetPreferencesHook {
 	 * @since 7.0.0
 	 */
 	public function onGetPreferences( $user, &$preferences ) {
-		$permissionExaminer = ApplicationFactory::getInstance()->newPermissionExaminer(
-			$user
-		);
+		$permissionExaminer = new PermissionExaminer( $this->permissionManager, $user );
 
 		$otherPreferences = [];
 		$this->hookDispatcher->onGetPreferences( $user, $otherPreferences );

--- a/src/MediaWiki/Hooks/PersonalUrls.php
+++ b/src/MediaWiki/Hooks/PersonalUrls.php
@@ -6,7 +6,8 @@ use MediaWiki\User\Options\UserOptionsLookup;
 use SkinTemplate;
 use SMW\GroupPermissions;
 use SMW\MediaWiki\JobQueue;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\MediaWiki\Permission\PermissionExaminer;
+use SMW\MediaWiki\PermissionManager;
 use SMW\Settings;
 
 /**
@@ -26,6 +27,7 @@ class PersonalUrls {
 		private readonly JobQueue $jobQueue,
 		private readonly UserOptionsLookup $userOptionsLookup,
 		private readonly Settings $settings,
+		private readonly PermissionManager $permissionManager,
 	) {
 	}
 
@@ -34,7 +36,7 @@ class PersonalUrls {
 	 */
 	public function onPersonalUrls( array &$personal_urls, $title, SkinTemplate $skinTemplate ): bool {
 		$user = $skinTemplate->getUser();
-		$permissionExaminer = ApplicationFactory::getInstance()->newPermissionExaminer( $user );
+		$permissionExaminer = new PermissionExaminer( $this->permissionManager, $user );
 		$watchlist = $this->settings->get( 'smwgJobQueueWatchlist' ) ?: [];
 
 		if (

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -831,7 +831,8 @@ return [
 		return new PersonalUrls(
 			$servicesFactory->getJobQueue(),
 			$services->getUserOptionsLookup(),
-			$servicesFactory->getSettings()
+			$servicesFactory->getSettings(),
+			$servicesFactory->getPermissionManager()
 		);
 	},
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/EditPageFormTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/EditPageFormTest.php
@@ -4,10 +4,14 @@ namespace SMW\Tests\Unit\MediaWiki\Hooks;
 
 use MediaWiki\EditPage\EditPage;
 use MediaWiki\Output\OutputPage;
+use MediaWiki\Title\Title;
 use MediaWiki\User\Options\UserOptionsLookup;
 use MediaWiki\User\User;
 use PHPUnit\Framework\TestCase;
+use SMW\GroupPermissions;
+use SMW\Localizer\MessageLocalizer;
 use SMW\MediaWiki\Hooks\EditPageForm;
+use SMW\MediaWiki\PermissionManager;
 use SMW\NamespaceExaminer;
 use SMW\Settings;
 
@@ -25,26 +29,36 @@ class EditPageFormTest extends TestCase {
 	private $namespaceExaminer;
 	private $userOptionsLookup;
 	private $settings;
+	private $permissionManager;
+	private $messageLocalizer;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->namespaceExaminer = $this->getMockBuilder( NamespaceExaminer::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->userOptionsLookup = $this->getMockBuilder( UserOptionsLookup::class )
-			->disableOriginalConstructor()
-			->getMock();
-
+		$this->namespaceExaminer = $this->createMock( NamespaceExaminer::class );
+		$this->userOptionsLookup = $this->createMock( UserOptionsLookup::class );
 		$this->settings = $this->createMock( Settings::class );
+		$this->permissionManager = $this->createMock( PermissionManager::class );
+		$this->messageLocalizer = $this->createMock( MessageLocalizer::class );
+	}
+
+	private function newInstance(): EditPageForm {
+		return new EditPageForm(
+			$this->namespaceExaminer,
+			$this->userOptionsLookup,
+			$this->settings,
+			$this->permissionManager
+		);
+	}
+
+	private function newOutputFor( User $user ): OutputPage {
+		$out = $this->createMock( OutputPage::class );
+		$out->method( 'getUser' )->willReturn( $user );
+		return $out;
 	}
 
 	public function testCanConstruct() {
-		$this->assertInstanceOf(
-			EditPageForm::class,
-			new EditPageForm( $this->namespaceExaminer, $this->userOptionsLookup, $this->settings )
-		);
+		$this->assertInstanceOf( EditPageForm::class, $this->newInstance() );
 	}
 
 	public function testDisabledHelp() {
@@ -52,38 +66,88 @@ class EditPageFormTest extends TestCase {
 			->with( 'smwgEnabledEditPageHelp' )
 			->willReturn( false );
 
-		$user = $this->getMockBuilder( User::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$user = $this->createMock( User::class );
+		$out = $this->newOutputFor( $user );
 
-		$out = $this->getMockBuilder( OutputPage::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$out->expects( $this->any() )
-			->method( 'getUser' )
-			->willReturn( $user );
-
-		$editPage = $this->getMockBuilder( EditPage::class )
-			->disableOriginalConstructor()
-			->getMock();
-
+		$editPage = $this->createMock( EditPage::class );
 		$editPage->editFormPageTop = '';
 
-		$instance = new EditPageForm(
-			$this->namespaceExaminer,
-			$this->userOptionsLookup,
-			$this->settings
-		);
-
 		$this->assertTrue(
-			$instance->onEditPage__showEditForm_initial( $editPage, $out )
+			$this->newInstance()->onEditPage__showEditForm_initial( $editPage, $out )
 		);
 
-		$this->assertSame(
-			'',
-			$editPage->editFormPageTop
-		);
+		$this->assertSame( '', $editPage->editFormPageTop );
+	}
+
+	public function testDisabledOnUserPreference() {
+		$this->settings->method( 'get' )
+			->with( 'smwgEnabledEditPageHelp' )
+			->willReturn( true );
+
+		$user = $this->createMock( User::class );
+
+		$this->permissionManager->method( 'userHasRight' )
+			->with( $user, GroupPermissions::VIEW_EDITPAGE_INFO )
+			->willReturn( true );
+
+		$this->userOptionsLookup->method( 'getOption' )
+			->with( $user, 'smw-prefs-general-options-disable-editpage-info', false )
+			->willReturn( true );
+
+		$out = $this->newOutputFor( $user );
+
+		$editPage = $this->createMock( EditPage::class );
+		$editPage->editFormPageTop = '';
+
+		$this->newInstance()->onEditPage__showEditForm_initial( $editPage, $out );
+
+		$this->assertSame( '', $editPage->editFormPageTop );
+	}
+
+	/**
+	 * @dataProvider titleProvider
+	 */
+	public function testExtendEditFormPageTop( $title, $namespaces, $isSemanticEnabled, $expected ) {
+		$this->settings->method( 'get' )
+			->with( 'smwgEnabledEditPageHelp' )
+			->willReturn( true );
+
+		$user = $this->createMock( User::class );
+
+		$this->permissionManager->method( 'userHasRight' )
+			->with( $user, GroupPermissions::VIEW_EDITPAGE_INFO )
+			->willReturn( true );
+
+		$this->userOptionsLookup->method( 'getOption' )
+			->with( $user, 'smw-prefs-general-options-disable-editpage-info', false )
+			->willReturn( false );
+
+		$this->namespaceExaminer->method( 'isSemanticEnabled' )
+			->with( $namespaces )
+			->willReturn( $isSemanticEnabled );
+
+		$out = $this->newOutputFor( $user );
+
+		$editPage = $this->createMock( EditPage::class );
+		$editPage->method( 'getTitle' )->willReturn( $title );
+		$editPage->editFormPageTop = '';
+
+		$instance = $this->newInstance();
+		$instance->setMessageLocalizer( $this->messageLocalizer );
+
+		$instance->onEditPage__showEditForm_initial( $editPage, $out );
+
+		$this->assertStringContainsString( $expected, $editPage->editFormPageTop );
+	}
+
+	public function titleProvider() {
+		return [
+			[ Title::newFromText( 'Foo', SMW_NS_PROPERTY ), SMW_NS_PROPERTY, true, 'smw-editpage-property-annotation-enabled' ],
+			[ Title::newFromText( 'Modification date', SMW_NS_PROPERTY ), SMW_NS_PROPERTY, true, 'smw-editpage-property-annotation-disabled' ],
+			[ Title::newFromText( 'Foo', SMW_NS_CONCEPT ), SMW_NS_CONCEPT, true, 'smw-editpage-concept-annotation-enabled' ],
+			[ Title::newFromText( 'Foo', NS_MAIN ), NS_MAIN, true, 'smw-editpage-annotation-enabled' ],
+			[ Title::newFromText( 'Foo', NS_MAIN ), NS_MAIN, false, 'smw-editpage-annotation-disabled' ],
+		];
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Hooks/GetPreferencesTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/GetPreferencesTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Unit\MediaWiki\Hooks;
 
 use MediaWiki\User\User;
 use PHPUnit\Framework\TestCase;
+use SMW\GroupPermissions;
 use SMW\MediaWiki\HookDispatcher;
 use SMW\MediaWiki\Hooks\GetPreferences;
 use SMW\MediaWiki\PermissionManager;
@@ -55,7 +56,13 @@ class GetPreferencesTest extends TestCase {
 	 * @dataProvider keyProvider
 	 */
 	public function testProcess( $key ) {
-		$this->permissionManager->method( 'userHasRight' )->willReturn( true );
+		// Grant only the permission the production code is expected to check
+		// (`VIEW_JOBQUEUE_WATCHLIST`). A blanket `willReturn( true )` would not
+		// detect a regression that replaced this constant with a different one.
+		$this->permissionManager->method( 'userHasRight' )
+			->willReturnCallback(
+				static fn ( $user, $right ): bool => $right === GroupPermissions::VIEW_JOBQUEUE_WATCHLIST
+			);
 
 		$user = $this->createMock( User::class );
 		$preferences = [];

--- a/tests/phpunit/Unit/MediaWiki/Hooks/GetPreferencesTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/GetPreferencesTest.php
@@ -6,6 +6,7 @@ use MediaWiki\User\User;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\HookDispatcher;
 use SMW\MediaWiki\Hooks\GetPreferences;
+use SMW\MediaWiki\PermissionManager;
 use SMW\Schema\SchemaFactory;
 use SMW\Settings;
 
@@ -23,25 +24,30 @@ class GetPreferencesTest extends TestCase {
 	private $hookDispatcher;
 	private $schemaFactory;
 	private $settings;
+	private $permissionManager;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->hookDispatcher = $this->getMockBuilder( HookDispatcher::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->schemaFactory = $this->getMockBuilder( SchemaFactory::class )
-			->disableOriginalConstructor()
-			->getMock();
-
+		$this->hookDispatcher = $this->createMock( HookDispatcher::class );
+		$this->schemaFactory = $this->createMock( SchemaFactory::class );
 		$this->settings = $this->createMock( Settings::class );
+		$this->permissionManager = $this->createMock( PermissionManager::class );
+	}
+
+	private function newInstance(): GetPreferences {
+		return new GetPreferences(
+			$this->schemaFactory,
+			$this->hookDispatcher,
+			$this->settings,
+			$this->permissionManager
+		);
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			GetPreferences::class,
-			new GetPreferences( $this->schemaFactory, $this->hookDispatcher, $this->settings )
+			$this->newInstance()
 		);
 	}
 
@@ -49,44 +55,24 @@ class GetPreferencesTest extends TestCase {
 	 * @dataProvider keyProvider
 	 */
 	public function testProcess( $key ) {
-		$user = $this->getMockBuilder( User::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->permissionManager->method( 'userHasRight' )->willReturn( true );
 
+		$user = $this->createMock( User::class );
 		$preferences = [];
 
-		$instance = new GetPreferences(
-			$this->schemaFactory,
-			$this->hookDispatcher,
-			$this->settings
-		);
+		$this->newInstance()->onGetPreferences( $user, $preferences );
 
-		$instance->onGetPreferences( $user, $preferences );
-
-		$this->assertArrayHasKey(
-			$key,
-			$preferences
-		);
+		$this->assertArrayHasKey( $key, $preferences );
 	}
 
 	public function keyProvider() {
-		$provider[] = [
-			'smw-prefs-intro'
+		return [
+			[ 'smw-prefs-intro' ],
+			[ 'smw-prefs-ask-options-tooltip-display' ],
+			[ 'smw-prefs-general-options-time-correction' ],
+			[ 'smw-prefs-general-options-disable-editpage-info' ],
+			[ 'smw-prefs-general-options-jobqueue-watchlist' ],
 		];
-
-		$provider[] = [
-			'smw-prefs-ask-options-tooltip-display'
-		];
-
-		$provider[] = [
-			'smw-prefs-general-options-time-correction'
-		];
-
-		$provider[] = [
-			'smw-prefs-general-options-disable-editpage-info'
-		];
-
-		return $provider;
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Hooks/PersonalUrlsTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/PersonalUrlsTest.php
@@ -2,13 +2,16 @@
 
 namespace SMW\Tests\Unit\MediaWiki\Hooks;
 
+use MediaWiki\Output\OutputPage;
 use MediaWiki\Title\Title;
 use MediaWiki\User\Options\UserOptionsLookup;
 use MediaWiki\User\User;
 use PHPUnit\Framework\TestCase;
 use SkinTemplate;
+use SMW\GroupPermissions;
 use SMW\MediaWiki\Hooks\PersonalUrls;
 use SMW\MediaWiki\JobQueue;
+use SMW\MediaWiki\PermissionManager;
 use SMW\Settings;
 
 /**
@@ -26,32 +29,31 @@ class PersonalUrlsTest extends TestCase {
 	private $jobQueue;
 	private $userOptionsLookup;
 	private $settings;
+	private $permissionManager;
 	private $user;
 
 	protected function setUp(): void {
-		$this->skinTemplate = $this->getMockBuilder( SkinTemplate::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->jobQueue = $this->getMockBuilder( JobQueue::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->userOptionsLookup = $this->getMockBuilder( UserOptionsLookup::class )
-			->disableOriginalConstructor()
-			->getMock();
-
+		$this->skinTemplate = $this->createMock( SkinTemplate::class );
+		$this->jobQueue = $this->createMock( JobQueue::class );
+		$this->userOptionsLookup = $this->createMock( UserOptionsLookup::class );
 		$this->settings = $this->createMock( Settings::class );
+		$this->permissionManager = $this->createMock( PermissionManager::class );
+		$this->user = $this->createMock( User::class );
+	}
 
-		$this->user = $this->getMockBuilder( User::class )
-			->disableOriginalConstructor()
-			->getMock();
+	private function newInstance(): PersonalUrls {
+		return new PersonalUrls(
+			$this->jobQueue,
+			$this->userOptionsLookup,
+			$this->settings,
+			$this->permissionManager
+		);
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			PersonalUrls::class,
-			new PersonalUrls( $this->jobQueue, $this->userOptionsLookup, $this->settings )
+			$this->newInstance()
 		);
 	}
 
@@ -61,30 +63,41 @@ class PersonalUrlsTest extends TestCase {
 			->with( $this->user, 'smw-prefs-general-options-jobqueue-watchlist', false )
 			->willReturn( false );
 
-		$this->skinTemplate->expects( $this->any() )
-			->method( 'getUser' )
-			->willReturn( $this->user );
+		$this->skinTemplate->method( 'getUser' )->willReturn( $this->user );
 
-		$title = $this->getMockBuilder( Title::class )
-			->disableOriginalConstructor()
-			->getMock();
-
+		$title = $this->createMock( Title::class );
 		$personalUrls = [];
 
-		$instance = new PersonalUrls(
-			$this->jobQueue,
-			$this->userOptionsLookup,
-			$this->settings
-		);
-
 		$this->assertTrue(
-			$instance->onPersonalUrls( $personalUrls, $title, $this->skinTemplate )
+			$this->newInstance()->onPersonalUrls( $personalUrls, $title, $this->skinTemplate )
 		);
 
-		$this->assertArrayNotHasKey(
-			'smw-jobqueue-watchlist',
-			$personalUrls
-		);
+		$this->assertArrayNotHasKey( 'smw-jobqueue-watchlist', $personalUrls );
+	}
+
+	public function testProcessOnJobQueueWatchlist() {
+		$this->userOptionsLookup->method( 'getOption' )
+			->with( $this->user, 'smw-prefs-general-options-jobqueue-watchlist', false )
+			->willReturn( true );
+
+		$this->permissionManager->method( 'userHasRight' )
+			->with( $this->user, GroupPermissions::VIEW_JOBQUEUE_WATCHLIST )
+			->willReturn( true );
+
+		$this->settings->method( 'get' )
+			->with( 'smwgJobQueueWatchlist' )
+			->willReturn( [ 'Foo' ] );
+
+		$output = $this->createMock( OutputPage::class );
+		$this->skinTemplate->method( 'getUser' )->willReturn( $this->user );
+		$this->skinTemplate->method( 'getOutput' )->willReturn( $output );
+
+		$title = $this->createMock( Title::class );
+		$personalUrls = [];
+
+		$this->newInstance()->onPersonalUrls( $personalUrls, $title, $this->skinTemplate );
+
+		$this->assertArrayHasKey( 'smw-jobqueue-watchlist', $personalUrls );
 	}
 
 }


### PR DESCRIPTION
## Summary

Second slice of issue #6876, on top of #6883. Converts the three hook handlers that resolve `PermissionExaminer` via `ApplicationFactory::getInstance()->newPermissionExaminer($user)` to constructor-injected `PermissionManager`:

- `PersonalUrls` (personal menu items)
- `EditPageForm` (edit-page help text)
- `GetPreferences` (`Special:Preferences` SMW section)

After this PR, none of these handlers reference `ApplicationFactory::getInstance()` or `MediaWikiServices::getInstance()` from their hook method bodies.

## Per-handler conversion

| Handler          | Added constructor argument |
| ---------------- | -------------------------- |
| `PersonalUrls`   | `PermissionManager`        |
| `EditPageForm`   | `PermissionManager`        |
| `GetPreferences` | `PermissionManager`        |

Each handler now builds its per-user `PermissionExaminer` inline at the point of use:

```php
$permissionExaminer = new PermissionExaminer( $this->permissionManager, $user );
```

`extension.json` adds `"SMW.PermissionManager"` to each handler's `services:` array. `SMW.PersonalUrls` in `ServiceWiring.php` is updated to pass `$servicesFactory->getPermissionManager()`.

## Why no `PermissionExaminerFactory`

`PermissionExaminer` is a two-argument data carrier (`PermissionManager`, `?User`) with one trivial method `hasPermissionOf( string )`. A `newFor( User )` wrapper would be one-line delegation around `new PermissionExaminer( $this->permissionManager, $user )`, with no eTag computation, no post-construction setters, and no shared cross-handler concern to absorb. Same shape as the inline-`new ParserData(...)` decision in the previous slice. The three handlers are the only callers introduced by this PR; existing consumers (`Indicator/EntityExaminerIndicators/*`, `TaskFactory`, `OutputPageParserOutput`) construct `PermissionExaminer` through different mechanisms and are out of scope.

## Tests

Tests now mock `PermissionManager::userHasRight( User, string )` rather than `PermissionExaminer::hasPermissionOf( string )`. The behavioural assertions translate cleanly, one level deeper against the boundary the handlers actually depend on.

Restored coverage:

- `PersonalUrlsTest::testProcessOnJobQueueWatchlist` (happy-path of the watchlist sidebar injection branch)
- `EditPageFormTest::testDisabledOnUserPreference` (verifies the `smw-prefs-general-options-disable-editpage-info=true` suppression branch)
- `EditPageFormTest::testExtendEditFormPageTop` (parameterised, 5 cases: `_PROPERTY` / `_CONCEPT` / main-namespace messaging variants)
- `GetPreferencesTest`: `keyProvider` gains the `smw-prefs-general-options-jobqueue-watchlist` entry, exercising the conditional preference branch under the `VIEW_JOBQUEUE_WATCHLIST` permission

`GetPreferencesTest::testProcess` uses a scoped `willReturnCallback` (rather than blanket `willReturn( true )`) so a regression replacing the `VIEW_JOBQUEUE_WATCHLIST` constant with any other permission causes the watchlist data row to fail.

After this PR: `PersonalUrlsTest` 3 tests, `EditPageFormTest` 8 tests, `GetPreferencesTest` 6 tests.

## Verification

- `composer phpunit -- --testsuite semantic-mediawiki-unit` — 7026 tests, 0 failures, 7 pre-existing skips
- `HookHandlersConstructionTest` — passes
- `phpcs -sp` on changed files — clean
- Browser smoke against the dev wiki, signed in as `WikiSysop`:
  - `Main_Page` renders cleanly (`PersonalUrls` hook fires, zero console errors)
  - `Special:Preferences` SMW tab renders the full preference list; `jobqueue-watchlist` toggle is correctly absent (`WikiSysop` lacks `smw-viewjobqueuewatchlist` by default)
  - `?action=edit` shows the `smw-editpage-help` block with the `smw-editpage-annotation-enabled` message key for a main-namespace page (`EditPageForm` hook fires correctly)

## Test plan

- [x] CI passes
- [ ] Reviewer verifies the per-handler `services:` arrays in `extension.json` match the constructor signatures
- [ ] Reviewer checks that the `GetPreferencesTest::testProcess` `willReturnCallback` correctly scopes the permission stub

Refs #6876