### PR TITLE
Complete handler DI for OutputPageParserOutput

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -140,7 +140,12 @@
 				"SMW.NamespaceExaminer",
 				"SMW.FactboxText",
 				"SMW.FactboxFactory",
-				"UserOptionsLookup"
+				"UserOptionsLookup",
+				"SMW.PermissionManager",
+				"SMW.IndicatorRegistryFactory",
+				"SMW.PostProcHandlerFactory",
+				"SMW.InTextAnnotationParserFactory",
+				"SMW.Logger"
 			]
 		},
 		"SemanticMediaWiki.OutputPageCheckLastModified": {

--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -7,10 +7,16 @@ use MediaWiki\Output\OutputPage;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Title\Title;
 use MediaWiki\User\Options\UserOptionsLookup;
+use Psr\Log\LoggerInterface;
 use SMW\Factbox\FactboxFactory;
 use SMW\Factbox\FactboxText;
+use SMW\MediaWiki\IndicatorRegistryFactory;
+use SMW\MediaWiki\Permission\PermissionExaminer;
+use SMW\MediaWiki\PermissionManager;
+use SMW\MediaWiki\PostProcHandlerFactory;
 use SMW\NamespaceExaminer;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Parser\InTextAnnotationParserFactory;
+use SMW\ParserData;
 
 /**
  * OutputPageParserOutput hook is called after parse, before the HTML is
@@ -39,6 +45,11 @@ class OutputPageParserOutput implements OutputPageParserOutputHook {
 		private readonly FactboxText $factboxText,
 		private readonly FactboxFactory $factboxFactory,
 		private readonly UserOptionsLookup $userOptionsLookup,
+		private readonly PermissionManager $permissionManager,
+		private readonly IndicatorRegistryFactory $indicatorRegistryFactory,
+		private readonly PostProcHandlerFactory $postProcHandlerFactory,
+		private readonly InTextAnnotationParserFactory $inTextAnnotationParserFactory,
+		private readonly LoggerInterface $logger,
 	) {
 	}
 
@@ -60,11 +71,9 @@ class OutputPageParserOutput implements OutputPageParserOutputHook {
 		$request = $context->getRequest();
 		$user = $outputPage->getUser();
 
-		$applicationFactory = ApplicationFactory::getInstance();
-		$permissionExaminer = $applicationFactory->newPermissionExaminer( $user );
+		$permissionExaminer = new PermissionExaminer( $this->permissionManager, $user );
 
-		$indicatorRegistry = $applicationFactory->create(
-			'IndicatorRegistry',
+		$indicatorRegistry = $this->indicatorRegistryFactory->newFor(
 			(bool)$this->userOptionsLookup->getOption(
 				$user,
 				GetPreferences::SHOW_ENTITY_ISSUE_PANEL,
@@ -96,9 +105,7 @@ class OutputPageParserOutput implements OutputPageParserOutputHook {
 			return '';
 		}
 
-		$applicationFactory = ApplicationFactory::getInstance();
-
-		$postProcHandler = $applicationFactory->newPostProcHandler( $parserOutput );
+		$postProcHandler = $this->postProcHandlerFactory->newFor( $parserOutput );
 
 		$html = $postProcHandler->getHtml(
 			$title,
@@ -144,12 +151,10 @@ class OutputPageParserOutput implements OutputPageParserOutputHook {
 
 			$text = $parserOutput->getContentHolderText();
 
-			$parserData = ApplicationFactory::getInstance()->newParserData(
-				$outputPage->getTitle(),
-				$parserOutput
-			);
+			$parserData = new ParserData( $outputPage->getTitle(), $parserOutput );
+			$parserData->setLogger( $this->logger );
 
-			$inTextAnnotationParser = ApplicationFactory::getInstance()->newInTextAnnotationParser( $parserData );
+			$inTextAnnotationParser = $this->inTextAnnotationParserFactory->newFor( $parserData );
 			$inTextAnnotationParser->parse( $text );
 
 			return $parserData->getOutput();

--- a/src/MediaWiki/IndicatorRegistryFactory.php
+++ b/src/MediaWiki/IndicatorRegistryFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use SMW\Indicator\EntityExaminerIndicatorsFactory;
+use SMW\Store;
+
+/**
+ * Produces a fully-configured {@link IndicatorRegistry} for the
+ * `OutputPageParserOutput` hook. The hook needs a fresh registry per request
+ * because whether the user has the entity-issue panel enabled is a per-user
+ * preference, and the registry exposes that behaviour by conditionally
+ * attaching the `EntityExaminerCompositeIndicatorProvider`.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class IndicatorRegistryFactory {
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function __construct(
+		private readonly Store $store,
+		private readonly EntityExaminerIndicatorsFactory $entityExaminerIndicatorsFactory,
+	) {
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function newFor( bool $withEntityExaminer ): IndicatorRegistry {
+		$indicatorRegistry = new IndicatorRegistry();
+
+		if ( !$withEntityExaminer ) {
+			return $indicatorRegistry;
+		}
+
+		$indicatorRegistry->addIndicatorProvider(
+			$this->entityExaminerIndicatorsFactory->newEntityExaminerIndicatorProvider( $this->store )
+		);
+
+		return $indicatorRegistry;
+	}
+
+}

--- a/src/MediaWiki/IndicatorRegistryFactory.php
+++ b/src/MediaWiki/IndicatorRegistryFactory.php
@@ -3,7 +3,7 @@
 namespace SMW\MediaWiki;
 
 use SMW\Indicator\EntityExaminerIndicatorsFactory;
-use SMW\Store;
+use SMW\Services\ServicesFactory;
 
 /**
  * Produces a fully-configured {@link IndicatorRegistry} for the
@@ -11,6 +11,14 @@ use SMW\Store;
  * because whether the user has the entity-issue panel enabled is a per-user
  * preference, and the registry exposes that behaviour by conditionally
  * attaching the `EntityExaminerCompositeIndicatorProvider`.
+ *
+ * `Store` is resolved through `ServicesFactory::getInstance()->getStore()`
+ * inside `newFor()`. `HookContainer` caches handler instances across
+ * service-container resets, and the `EntityExaminerCompositeIndicatorProvider`
+ * transitively captures `Store`. Capturing `Store` at factory-construction
+ * time would let the resulting provider outlive the `Store` it was wired
+ * with. The lazy resolution matches the behaviour of the legacy
+ * `ServicesFactory::newIndicatorRegistry()`.
  *
  * @license GPL-2.0-or-later
  * @since 7.0.0
@@ -21,7 +29,6 @@ class IndicatorRegistryFactory {
 	 * @since 7.0.0
 	 */
 	public function __construct(
-		private readonly Store $store,
 		private readonly EntityExaminerIndicatorsFactory $entityExaminerIndicatorsFactory,
 	) {
 	}
@@ -37,7 +44,9 @@ class IndicatorRegistryFactory {
 		}
 
 		$indicatorRegistry->addIndicatorProvider(
-			$this->entityExaminerIndicatorsFactory->newEntityExaminerIndicatorProvider( $this->store )
+			$this->entityExaminerIndicatorsFactory->newEntityExaminerIndicatorProvider(
+				ServicesFactory::getInstance()->getStore()
+			)
 		);
 
 		return $indicatorRegistry;

--- a/src/MediaWiki/PostProcHandlerFactory.php
+++ b/src/MediaWiki/PostProcHandlerFactory.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SMW\MediaWiki;
+
+use MediaWiki\Parser\ParserOutput;
+use Onoi\Cache\Cache;
+use SMW\PostProcHandler;
+use SMW\Settings;
+
+/**
+ * Produces a {@link PostProcHandler} for the `OutputPageParserOutput` hook.
+ * The handler is per-`ParserOutput`, so construction must be deferred until
+ * the hook fires; the factory captures the long-lived cache and settings
+ * dependencies.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class PostProcHandlerFactory {
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function __construct(
+		private readonly Cache $cache,
+		private readonly Settings $settings,
+	) {
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function newFor( ParserOutput $parserOutput ): PostProcHandler {
+		$postProcHandler = new PostProcHandler( $parserOutput, $this->cache );
+
+		$postProcHandler->setOptions(
+			$this->settings->get( 'smwgPostEditUpdate' ) +
+			[ 'smwgEnabledQueryDependencyLinksStore' => $this->settings->get( 'smwgEnabledQueryDependencyLinksStore' ) ] +
+			[ 'smwgEnabledFulltextSearch' => $this->settings->get( 'smwgEnabledFulltextSearch' ) ]
+		);
+
+		return $postProcHandler;
+	}
+
+}

--- a/src/Parser/InTextAnnotationParserFactory.php
+++ b/src/Parser/InTextAnnotationParserFactory.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace SMW\Parser;
+
+use SMW\MediaWiki\HookDispatcher;
+use SMW\MediaWiki\MwCollaboratorFactory;
+use SMW\ParserData;
+use SMW\Settings;
+
+/**
+ * Produces a configured {@link InTextAnnotationParser} for the
+ * `OutputPageParserOutput` hook's `oldid` branch, which re-parses cached
+ * parser output through SMW's in-text annotation parser to recover
+ * annotations from the historical revision.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class InTextAnnotationParserFactory {
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function __construct(
+		private readonly MwCollaboratorFactory $mwCollaboratorFactory,
+		private readonly Settings $settings,
+		private readonly HookDispatcher $hookDispatcher,
+	) {
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function newFor( ParserData $parserData ): InTextAnnotationParser {
+		$linksProcessor = new LinksProcessor();
+		$linksProcessor->isStrictMode(
+			$this->settings->isFlagSet( 'smwgParserFeatures', SMW_PARSER_STRICT )
+		);
+
+		$inTextAnnotationParser = new InTextAnnotationParser(
+			$parserData,
+			$linksProcessor,
+			$this->mwCollaboratorFactory->newMagicWordsFinder(),
+			$this->mwCollaboratorFactory->newRedirectTargetFinder()
+		);
+
+		$inTextAnnotationParser->isLinksInValues(
+			$this->settings->isFlagSet( 'smwgParserFeatures', SMW_PARSER_LINV )
+		);
+
+		$inTextAnnotationParser->showErrors(
+			$this->settings->isFlagSet( 'smwgParserFeatures', SMW_PARSER_INL_ERROR )
+		);
+
+		$inTextAnnotationParser->setHookDispatcher( $this->hookDispatcher );
+
+		return $inTextAnnotationParser;
+	}
+
+}

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -729,10 +729,7 @@ return [
 	},
 
 	'SMW.IndicatorRegistryFactory' => static function ( MediaWikiServices $services ): IndicatorRegistryFactory {
-		$servicesFactory = ServicesFactory::getInstance();
-
 		return new IndicatorRegistryFactory(
-			$servicesFactory->getStore(),
 			new EntityExaminerIndicatorsFactory()
 		);
 	},
@@ -750,7 +747,7 @@ return [
 		$servicesFactory = ServicesFactory::getInstance();
 
 		return new InTextAnnotationParserFactory(
-			$servicesFactory->newMwCollaboratorFactory(),
+			$services->getService( 'SMW.MwCollaboratorFactory' ),
 			$servicesFactory->getSettings(),
 			$servicesFactory->getHookDispatcher()
 		);

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -15,6 +15,7 @@ use SMW\EventDispatcher\EventDispatcher;
 use SMW\Factbox\FactboxFactory;
 use SMW\Factbox\FactboxText;
 use SMW\HierarchyLookup;
+use SMW\Indicator\EntityExaminerIndicatorsFactory;
 use SMW\InMemoryPoolCache;
 use SMW\IteratorFactory;
 use SMW\Listener\EventListener\EventListeners\InvalidateEntityCacheEventListener;
@@ -28,6 +29,7 @@ use SMW\MediaWiki\HookDispatcher;
 use SMW\MediaWiki\Hooks\ArticleDelete;
 use SMW\MediaWiki\Hooks\PersonalUrls;
 use SMW\MediaWiki\Hooks\UserChange;
+use SMW\MediaWiki\IndicatorRegistryFactory;
 use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\JobQueue;
 use SMW\MediaWiki\Jobs\ContentParserFactory;
@@ -39,9 +41,11 @@ use SMW\MediaWiki\MwCollaboratorFactory;
 use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\Permission\TitlePermissions;
 use SMW\MediaWiki\PermissionManager;
+use SMW\MediaWiki\PostProcHandlerFactory;
 use SMW\MediaWiki\RevisionGuard;
 use SMW\MediaWiki\TitleFactory;
 use SMW\NamespaceExaminer;
+use SMW\Parser\InTextAnnotationParserFactory;
 use SMW\ParserFunctionFactory;
 use SMW\Property\AnnotatorFactory;
 use SMW\Property\SpecificationLookup;
@@ -722,6 +726,34 @@ return [
 		}
 
 		return new MwCollaboratorFactory( $servicesFactory );
+	},
+
+	'SMW.IndicatorRegistryFactory' => static function ( MediaWikiServices $services ): IndicatorRegistryFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		return new IndicatorRegistryFactory(
+			$servicesFactory->getStore(),
+			new EntityExaminerIndicatorsFactory()
+		);
+	},
+
+	'SMW.PostProcHandlerFactory' => static function ( MediaWikiServices $services ): PostProcHandlerFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		return new PostProcHandlerFactory(
+			$servicesFactory->getCache(),
+			$servicesFactory->getSettings()
+		);
+	},
+
+	'SMW.InTextAnnotationParserFactory' => static function ( MediaWikiServices $services ): InTextAnnotationParserFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		return new InTextAnnotationParserFactory(
+			$servicesFactory->newMwCollaboratorFactory(),
+			$servicesFactory->getSettings(),
+			$servicesFactory->getHookDispatcher()
+		);
 	},
 
 	'SMW.NamespaceExaminer' => static function ( MediaWikiServices $services ): NamespaceExaminer {

--- a/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Unit\MediaWiki\Hooks;
 
 use MediaWiki\Context\RequestContext;
+use MediaWiki\MediaWikiServices;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Request\FauxRequest;
@@ -179,7 +180,7 @@ class OutputPageParserOutputTest extends TestCase {
 	}
 
 	public function testProcessForSimpleFactboxBuild() {
-		$languageFactory = \MediaWiki\MediaWikiServices::getInstance()->getLanguageFactory();
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
 		$language = $languageFactory->getLanguage( 'en' );
 
 		$title = $this->makeTitleForFactboxBuild( __METHOD__, $language );
@@ -200,7 +201,7 @@ class OutputPageParserOutputTest extends TestCase {
 	}
 
 	public function testProcessForOldid() {
-		$languageFactory = \MediaWiki\MediaWikiServices::getInstance()->getLanguageFactory();
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
 		$language = $languageFactory->getLanguage( 'en' );
 
 		$title = $this->makeTitleForFactboxBuild( __METHOD__, $language );
@@ -220,7 +221,9 @@ class OutputPageParserOutputTest extends TestCase {
 		$this->inTextAnnotationParserFactory->expects( $this->once() )
 			->method( 'newFor' )
 			->willReturn( $this->inTextAnnotationParser );
-		$this->inTextAnnotationParser->expects( $this->once() )->method( 'parse' );
+		$this->inTextAnnotationParser->expects( $this->once() )
+			->method( 'parse' )
+			->with( 'test' );
 
 		$parserOutput = $this->makeParserOutput( $this->newSemanticDataFor( $title ) );
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -2,14 +2,28 @@
 
 namespace SMW\Tests\Unit\MediaWiki\Hooks;
 
+use MediaWiki\Context\RequestContext;
 use MediaWiki\Output\OutputPage;
 use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Request\FauxRequest;
 use MediaWiki\User\Options\UserOptionsLookup;
+use MediaWiki\User\User;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataModel\SemanticData;
 use SMW\Factbox\FactboxFactory;
 use SMW\Factbox\FactboxText;
 use SMW\MediaWiki\Hooks\OutputPageParserOutput;
+use SMW\MediaWiki\IndicatorRegistry;
+use SMW\MediaWiki\IndicatorRegistryFactory;
+use SMW\MediaWiki\PermissionManager;
+use SMW\MediaWiki\PostProcHandlerFactory;
 use SMW\NamespaceExaminer;
+use SMW\Parser\InTextAnnotationParser;
+use SMW\Parser\InTextAnnotationParserFactory;
+use SMW\PostProcHandler;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockTitle;
@@ -32,6 +46,14 @@ class OutputPageParserOutputTest extends TestCase {
 	private $userOptionsLookup;
 	private FactboxText $factboxText;
 	private FactboxFactory $factboxFactory;
+	private $permissionManager;
+	private $indicatorRegistry;
+	private $indicatorRegistryFactory;
+	private $postProcHandler;
+	private $postProcHandlerFactory;
+	private $inTextAnnotationParser;
+	private $inTextAnnotationParserFactory;
+	private $logger;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -46,17 +68,27 @@ class OutputPageParserOutputTest extends TestCase {
 			]
 		);
 
-		$this->namespaceExaminer = $this->getMockBuilder( NamespaceExaminer::class )
-			->disableOriginalConstructor()
-			->getMock();
-
+		$this->namespaceExaminer = $this->createMock( NamespaceExaminer::class );
 		$this->userOptionsLookup = $this->createMock( UserOptionsLookup::class );
-
 		$this->factboxText = $this->applicationFactory->getFactboxText();
+		$this->factboxFactory = $this->createMock( FactboxFactory::class );
 
-		$this->factboxFactory = $this->getMockBuilder( FactboxFactory::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->permissionManager = $this->createMock( PermissionManager::class );
+
+		$this->indicatorRegistry = $this->createMock( IndicatorRegistry::class );
+		$this->indicatorRegistryFactory = $this->createMock( IndicatorRegistryFactory::class );
+		$this->indicatorRegistryFactory->method( 'newFor' )->willReturn( $this->indicatorRegistry );
+
+		$this->postProcHandler = $this->createMock( PostProcHandler::class );
+		$this->postProcHandler->method( 'getHtml' )->willReturn( '' );
+		$this->postProcHandlerFactory = $this->createMock( PostProcHandlerFactory::class );
+		$this->postProcHandlerFactory->method( 'newFor' )->willReturn( $this->postProcHandler );
+
+		$this->inTextAnnotationParser = $this->createMock( InTextAnnotationParser::class );
+		$this->inTextAnnotationParserFactory = $this->createMock( InTextAnnotationParserFactory::class );
+		$this->inTextAnnotationParserFactory->method( 'newFor' )->willReturn( $this->inTextAnnotationParser );
+
+		$this->logger = $this->createMock( LoggerInterface::class );
 	}
 
 	protected function tearDown(): void {
@@ -64,24 +96,34 @@ class OutputPageParserOutputTest extends TestCase {
 		parent::tearDown();
 	}
 
+	private function newInstance(): OutputPageParserOutput {
+		return new OutputPageParserOutput(
+			$this->namespaceExaminer,
+			$this->factboxText,
+			$this->factboxFactory,
+			$this->userOptionsLookup,
+			$this->permissionManager,
+			$this->indicatorRegistryFactory,
+			$this->postProcHandlerFactory,
+			$this->inTextAnnotationParserFactory,
+			$this->logger
+		);
+	}
+
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			OutputPageParserOutput::class,
-			new OutputPageParserOutput( $this->namespaceExaminer, $this->factboxText, $this->factboxFactory, $this->userOptionsLookup )
+			$this->newInstance()
 		);
 	}
 
 	public function testProcessReturnsEarlyForSpecialPage() {
 		$title = MockTitle::buildMock( __METHOD__ . 'mock-specialpage' );
-
 		$title->expects( $this->atLeastOnce() )
 			->method( 'isSpecialPage' )
 			->willReturn( true );
 
-		$outputPage = $this->getMockBuilder( OutputPage::class )
-			->disableOriginalConstructor()
-			->getMock();
-
+		$outputPage = $this->createMock( OutputPage::class );
 		$outputPage->expects( $this->atLeastOnce() )
 			->method( 'getTitle' )
 			->willReturn( $title );
@@ -89,30 +131,39 @@ class OutputPageParserOutputTest extends TestCase {
 		$this->namespaceExaminer->expects( $this->never() )
 			->method( 'isSemanticEnabled' );
 
-		$instance = new OutputPageParserOutput(
-			$this->namespaceExaminer,
-			$this->factboxText,
-			$this->factboxFactory,
-			$this->userOptionsLookup
-		);
+		$parserOutput = new ParserOutput();
+		$this->newInstance()->onOutputPageParserOutput( $outputPage, $parserOutput );
+
+		$this->assertFalse( $this->factboxText->hasText() );
+	}
+
+	public function testProcessReturnsEarlyForRedirect() {
+		$title = MockTitle::buildMock( __METHOD__ . 'mock-redirect' );
+		$title->expects( $this->atLeastOnce() )
+			->method( 'isRedirect' )
+			->willReturn( true );
+
+		$outputPage = $this->createMock( OutputPage::class );
+		$outputPage->expects( $this->atLeastOnce() )
+			->method( 'getTitle' )
+			->willReturn( $title );
+
+		$this->namespaceExaminer->expects( $this->never() )
+			->method( 'isSemanticEnabled' );
 
 		$parserOutput = new ParserOutput();
-		$instance->onOutputPageParserOutput( $outputPage, $parserOutput );
+		$this->newInstance()->onOutputPageParserOutput( $outputPage, $parserOutput );
 
 		$this->assertFalse( $this->factboxText->hasText() );
 	}
 
 	public function testProcessReturnsEarlyForDisabledNamespace() {
 		$title = MockTitle::buildMock( __METHOD__ . 'title-ns-disabled' );
-
 		$title->expects( $this->atLeastOnce() )
 			->method( 'getNamespace' )
 			->willReturn( NS_MAIN );
 
-		$outputPage = $this->getMockBuilder( OutputPage::class )
-			->disableOriginalConstructor()
-			->getMock();
-
+		$outputPage = $this->createMock( OutputPage::class );
 		$outputPage->expects( $this->atLeastOnce() )
 			->method( 'getTitle' )
 			->willReturn( $title );
@@ -121,17 +172,100 @@ class OutputPageParserOutputTest extends TestCase {
 			->method( 'isSemanticEnabled' )
 			->willReturn( false );
 
-		$instance = new OutputPageParserOutput(
-			$this->namespaceExaminer,
-			$this->factboxText,
-			$this->factboxFactory,
-			$this->userOptionsLookup
-		);
-
 		$parserOutput = new ParserOutput();
-		$instance->onOutputPageParserOutput( $outputPage, $parserOutput );
+		$this->newInstance()->onOutputPageParserOutput( $outputPage, $parserOutput );
 
 		$this->assertFalse( $this->factboxText->hasText() );
+	}
+
+	public function testProcessForSimpleFactboxBuild() {
+		$languageFactory = \MediaWiki\MediaWikiServices::getInstance()->getLanguageFactory();
+		$language = $languageFactory->getLanguage( 'en' );
+
+		$title = $this->makeTitleForFactboxBuild( __METHOD__, $language );
+		$outputPage = $this->makeOutputPageWithContext( $title, $language, new RequestContext() );
+
+		$this->namespaceExaminer->method( 'isSemanticEnabled' )->willReturn( true );
+
+		$this->factboxFactory->method( 'newCachedFactbox' )
+			->willReturn( $this->applicationFactory->create( 'FactboxFactory' )->newCachedFactbox() );
+
+		$parserOutput = $this->makeParserOutput( $this->newSemanticDataFor( $title ) );
+
+		$this->newInstance()->onOutputPageParserOutput( $outputPage, $parserOutput );
+
+		// The Factbox is built and stored in `FactboxText`.
+		$subject = WikiPage::newFromTitle( $title );
+		$this->assertStringContainsString( $subject->getDBKey(), $this->factboxText->getText() );
+	}
+
+	public function testProcessForOldid() {
+		$languageFactory = \MediaWiki\MediaWikiServices::getInstance()->getLanguageFactory();
+		$language = $languageFactory->getLanguage( 'en' );
+
+		$title = $this->makeTitleForFactboxBuild( __METHOD__, $language );
+
+		$context = new RequestContext();
+		$context->setRequest( new FauxRequest( [ 'oldid' => 9001 ], true ) );
+		$outputPage = $this->makeOutputPageWithContext( $title, $language, $context );
+
+		$this->namespaceExaminer->method( 'isSemanticEnabled' )->willReturn( true );
+
+		$this->factboxFactory->method( 'newCachedFactbox' )
+			->willReturn( $this->applicationFactory->create( 'FactboxFactory' )->newCachedFactbox() );
+
+		// The oldid branch must funnel the cached ParserOutput through
+		// SMW's in-text annotation parser to recover annotations from the
+		// historical revision.
+		$this->inTextAnnotationParserFactory->expects( $this->once() )
+			->method( 'newFor' )
+			->willReturn( $this->inTextAnnotationParser );
+		$this->inTextAnnotationParser->expects( $this->once() )->method( 'parse' );
+
+		$parserOutput = $this->makeParserOutput( $this->newSemanticDataFor( $title ) );
+
+		$this->newInstance()->onOutputPageParserOutput( $outputPage, $parserOutput );
+	}
+
+	private function makeTitleForFactboxBuild( string $name, $language ) {
+		$title = MockTitle::buildMock( $name );
+		$title->expects( $this->atLeastOnce() )->method( 'exists' )->willReturn( true );
+		$title->expects( $this->atLeastOnce() )->method( 'getNamespace' )->willReturn( NS_MAIN );
+		$title->expects( $this->atLeastOnce() )->method( 'getPageLanguage' )->willReturn( $language );
+		$title->expects( $this->atLeastOnce() )->method( 'getArticleID' )->willReturn( 9098 );
+		return $title;
+	}
+
+	private function makeOutputPageWithContext( $title, $language, $context ): OutputPage {
+		$outputPage = $this->createMock( OutputPage::class );
+		$outputPage->method( 'getTitle' )->willReturn( $title );
+		$outputPage->method( 'getContext' )->willReturn( $context );
+		$outputPage->method( 'getLanguage' )->willReturn( $language );
+		$outputPage->method( 'getUser' )->willReturn( $this->createMock( User::class ) );
+		return $outputPage;
+	}
+
+	private function newSemanticDataFor( $title ): SemanticData {
+		$subject = WikiPage::newFromTitle( $title );
+
+		$semanticData = $this->getMockBuilder( SemanticData::class )
+			->setConstructorArgs( [ WikiPage::newFromText( 'Foo' ) ] )
+			->getMock();
+
+		$semanticData->method( 'getSubject' )->willReturn( $subject );
+		$semanticData->method( 'hasVisibleProperties' )->willReturn( true );
+		$semanticData->method( 'getSubSemanticData' )->willReturn( [] );
+		$semanticData->method( 'getPropertyValues' )->willReturn( [ WikiPage::newFromTitle( $title ) ] );
+		$semanticData->method( 'getProperties' )->willReturn( [ new Property( __METHOD__ . 'property' ) ] );
+
+		return $semanticData;
+	}
+
+	private function makeParserOutput( SemanticData $data ): ParserOutput {
+		$parserOutput = new ParserOutput();
+		$parserOutput->setExtensionData( 'smwdata', $data );
+		$parserOutput->setContentHolderText( 'test' );
+		return $parserOutput;
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/IndicatorRegistryFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/IndicatorRegistryFactoryTest.php
@@ -8,6 +8,7 @@ use SMW\Indicator\EntityExaminerIndicatorsFactory;
 use SMW\MediaWiki\IndicatorRegistry;
 use SMW\MediaWiki\IndicatorRegistryFactory;
 use SMW\Store;
+use SMW\Tests\TestEnvironment;
 
 /**
  * @covers \SMW\MediaWiki\IndicatorRegistryFactory
@@ -18,23 +19,23 @@ use SMW\Store;
  */
 class IndicatorRegistryFactoryTest extends TestCase {
 
-	private Store $store;
+	private TestEnvironment $testEnvironment;
 	private EntityExaminerIndicatorsFactory $entityExaminerIndicatorsFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
+		$this->testEnvironment = new TestEnvironment();
 		$this->entityExaminerIndicatorsFactory = $this->createMock( EntityExaminerIndicatorsFactory::class );
 	}
 
+	protected function tearDown(): void {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
 	private function newInstance(): IndicatorRegistryFactory {
-		return new IndicatorRegistryFactory(
-			$this->store,
-			$this->entityExaminerIndicatorsFactory
-		);
+		return new IndicatorRegistryFactory( $this->entityExaminerIndicatorsFactory );
 	}
 
 	public function testCanConstruct(): void {
@@ -54,11 +55,17 @@ class IndicatorRegistryFactoryTest extends TestCase {
 	}
 
 	public function testNewForAttachesEntityExaminerProviderWhenRequested(): void {
+		$store = $this->getMockBuilder( Store::class )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$this->testEnvironment->registerObject( 'Store', $store );
+
 		$provider = $this->createMock( EntityExaminerCompositeIndicatorProvider::class );
 
 		$this->entityExaminerIndicatorsFactory->expects( $this->once() )
 			->method( 'newEntityExaminerIndicatorProvider' )
-			->with( $this->store )
+			->with( $store )
 			->willReturn( $provider );
 
 		$registry = $this->newInstance()->newFor( true );

--- a/tests/phpunit/Unit/MediaWiki/IndicatorRegistryFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/IndicatorRegistryFactoryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace SMW\Tests\Unit\MediaWiki;
+
+use PHPUnit\Framework\TestCase;
+use SMW\Indicator\EntityExaminerIndicators\EntityExaminerCompositeIndicatorProvider;
+use SMW\Indicator\EntityExaminerIndicatorsFactory;
+use SMW\MediaWiki\IndicatorRegistry;
+use SMW\MediaWiki\IndicatorRegistryFactory;
+use SMW\Store;
+
+/**
+ * @covers \SMW\MediaWiki\IndicatorRegistryFactory
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class IndicatorRegistryFactoryTest extends TestCase {
+
+	private Store $store;
+	private EntityExaminerIndicatorsFactory $entityExaminerIndicatorsFactory;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->store = $this->getMockBuilder( Store::class )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+		$this->entityExaminerIndicatorsFactory = $this->createMock( EntityExaminerIndicatorsFactory::class );
+	}
+
+	private function newInstance(): IndicatorRegistryFactory {
+		return new IndicatorRegistryFactory(
+			$this->store,
+			$this->entityExaminerIndicatorsFactory
+		);
+	}
+
+	public function testCanConstruct(): void {
+		$this->assertInstanceOf(
+			IndicatorRegistryFactory::class,
+			$this->newInstance()
+		);
+	}
+
+	public function testNewForReturnsEmptyRegistryWhenEntityExaminerNotRequested(): void {
+		$this->entityExaminerIndicatorsFactory->expects( $this->never() )
+			->method( 'newEntityExaminerIndicatorProvider' );
+
+		$registry = $this->newInstance()->newFor( false );
+
+		$this->assertInstanceOf( IndicatorRegistry::class, $registry );
+	}
+
+	public function testNewForAttachesEntityExaminerProviderWhenRequested(): void {
+		$provider = $this->createMock( EntityExaminerCompositeIndicatorProvider::class );
+
+		$this->entityExaminerIndicatorsFactory->expects( $this->once() )
+			->method( 'newEntityExaminerIndicatorProvider' )
+			->with( $this->store )
+			->willReturn( $provider );
+
+		$registry = $this->newInstance()->newFor( true );
+
+		$this->assertInstanceOf( IndicatorRegistry::class, $registry );
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/PostProcHandlerFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/PostProcHandlerFactoryTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace SMW\Tests\Unit\MediaWiki;
+
+use MediaWiki\Parser\ParserOutput;
+use Onoi\Cache\Cache;
+use PHPUnit\Framework\TestCase;
+use SMW\MediaWiki\PostProcHandlerFactory;
+use SMW\PostProcHandler;
+use SMW\Settings;
+
+/**
+ * @covers \SMW\MediaWiki\PostProcHandlerFactory
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class PostProcHandlerFactoryTest extends TestCase {
+
+	private Cache $cache;
+	private Settings $settings;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->cache = $this->createMock( Cache::class );
+		$this->settings = $this->createMock( Settings::class );
+	}
+
+	private function newInstance(): PostProcHandlerFactory {
+		return new PostProcHandlerFactory( $this->cache, $this->settings );
+	}
+
+	public function testCanConstruct(): void {
+		$this->assertInstanceOf(
+			PostProcHandlerFactory::class,
+			$this->newInstance()
+		);
+	}
+
+	public function testNewForReturnsConfiguredHandler(): void {
+		$this->settings->method( 'get' )
+			->willReturnMap( [
+				[ 'smwgPostEditUpdate', [ 'check' => true ] ],
+				[ 'smwgEnabledQueryDependencyLinksStore', false ],
+				[ 'smwgEnabledFulltextSearch', false ],
+			] );
+
+		$parserOutput = $this->createMock( ParserOutput::class );
+
+		$handler = $this->newInstance()->newFor( $parserOutput );
+
+		$this->assertInstanceOf( PostProcHandler::class, $handler );
+	}
+
+}

--- a/tests/phpunit/Unit/Parser/InTextAnnotationParserFactoryTest.php
+++ b/tests/phpunit/Unit/Parser/InTextAnnotationParserFactoryTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace SMW\Tests\Unit\Parser;
+
+use PHPUnit\Framework\TestCase;
+use SMW\MediaWiki\HookDispatcher;
+use SMW\MediaWiki\MagicWordsFinder;
+use SMW\MediaWiki\MwCollaboratorFactory;
+use SMW\MediaWiki\RedirectTargetFinder;
+use SMW\Parser\InTextAnnotationParser;
+use SMW\Parser\InTextAnnotationParserFactory;
+use SMW\ParserData;
+use SMW\Settings;
+
+/**
+ * @covers \SMW\Parser\InTextAnnotationParserFactory
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class InTextAnnotationParserFactoryTest extends TestCase {
+
+	private MwCollaboratorFactory $mwCollaboratorFactory;
+	private Settings $settings;
+	private HookDispatcher $hookDispatcher;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->mwCollaboratorFactory = $this->createMock( MwCollaboratorFactory::class );
+		$this->settings = $this->createMock( Settings::class );
+		$this->hookDispatcher = $this->createMock( HookDispatcher::class );
+	}
+
+	private function newInstance(): InTextAnnotationParserFactory {
+		return new InTextAnnotationParserFactory(
+			$this->mwCollaboratorFactory,
+			$this->settings,
+			$this->hookDispatcher
+		);
+	}
+
+	public function testCanConstruct(): void {
+		$this->assertInstanceOf(
+			InTextAnnotationParserFactory::class,
+			$this->newInstance()
+		);
+	}
+
+	public function testNewForReturnsConfiguredParser(): void {
+		$this->mwCollaboratorFactory->expects( $this->once() )
+			->method( 'newMagicWordsFinder' )
+			->willReturn( $this->createMock( MagicWordsFinder::class ) );
+
+		$this->mwCollaboratorFactory->expects( $this->once() )
+			->method( 'newRedirectTargetFinder' )
+			->willReturn( $this->createMock( RedirectTargetFinder::class ) );
+
+		$parserData = $this->createMock( ParserData::class );
+
+		$parser = $this->newInstance()->newFor( $parserData );
+
+		$this->assertInstanceOf( InTextAnnotationParser::class, $parser );
+	}
+
+}


### PR DESCRIPTION
## Summary

Third slice of issue #6876, on top of #6883 and #6884. Converts `OutputPageParserOutput` off all five `ApplicationFactory::getInstance()` lookups it previously did inside the hook body.

After this PR, `OutputPageParserOutput` references neither `ApplicationFactory::getInstance()` nor `MediaWikiServices::getInstance()` from its hook method bodies, satisfying the acceptance criterion in #6876 for this handler.

## Per-call construction

The handler still needs five collaborators that depend on per-request data (`User`, `ParserOutput`, `ParserData`, per-user preference). Each is now reached through constructor-injected factories or by inline construction.

| Was                                                          | Becomes                                                                         |
| ------------------------------------------------------------ | ------------------------------------------------------------------------------- |
| `$applicationFactory->newPermissionExaminer( $user )`        | `new PermissionExaminer( $this->permissionManager, $user )` (inline)            |
| `$applicationFactory->create( 'IndicatorRegistry', $bool )`  | `$this->indicatorRegistryFactory->newFor( $bool )` (new factory)                |
| `$applicationFactory->newPostProcHandler( $parserOutput )`   | `$this->postProcHandlerFactory->newFor( $parserOutput )` (new factory)          |
| `$applicationFactory->newParserData( $title, $parserOutput )` | `new ParserData( $title, $parserOutput ); $parserData->setLogger( $this->logger );` (inline) |
| `$applicationFactory->newInTextAnnotationParser( $parserData )` | `$this->inTextAnnotationParserFactory->newFor( $parserData )` (new factory) |

## New classes

| Class                                                       | Purpose                                                                      |
| ----------------------------------------------------------- | ---------------------------------------------------------------------------- |
| `SMW\MediaWiki\IndicatorRegistryFactory`                    | Builds a per-user `IndicatorRegistry`; resolves `Store` lazily in `newFor()` |
| `SMW\MediaWiki\PostProcHandlerFactory`                      | Builds a per-`ParserOutput` `PostProcHandler` with options applied           |
| `SMW\Parser\InTextAnnotationParserFactory`                  | Builds a configured `InTextAnnotationParser` for the `oldid` re-parse path   |

Each registered as `SMW.IndicatorRegistryFactory`, `SMW.PostProcHandlerFactory`, `SMW.InTextAnnotationParserFactory` in `ServiceWiring.php`. Each has a dedicated unit test alongside.

`extension.json` adds the four new service refs (`SMW.PermissionManager`, the three new factories, `SMW.Logger`) to the `SemanticMediaWiki.OutputPageParserOutput` `services:` list.

## Lazy `Store` resolution in `IndicatorRegistryFactory`

The `EntityExaminerCompositeIndicatorProvider` returned by `EntityExaminerIndicatorsFactory::newEntityExaminerIndicatorProvider( Store )` transitively holds the passed `Store`. `HookContainer` caches handler instances across service-container resets, so capturing `Store` at factory-construction time would let the resulting provider outlive the `Store` it was wired with.

`IndicatorRegistryFactory::newFor()` therefore resolves `Store` through `ServicesFactory::getInstance()->getStore()` at call time. That accessor consults `testOverrides` first and otherwise hits the per-`MediaWikiServices`-instance cached `SMW.Store`, which is invalidated on container reset alongside any test override. The behaviour matches what the legacy `ServicesFactory::newIndicatorRegistry()` did at the call site.

This is the same pattern that #6883 applied to `DependencyValidatorFactory`.

## Tests restored

Three test cases that were dropped during the declarative `HookHandlers` migration are restored on the back of the new mock surface:

- `testProcessReturnsEarlyForRedirect` (explicit in the #6876 checklist)
- `testProcessForOldid` (explicit in the #6876 checklist; exercises the re-parse branch through a mocked `InTextAnnotationParserFactory` and asserts `parse()` receives the `getContentHolderText()` value)
- `testProcessForSimpleFactboxBuild` (could not run before this PR because the inline `ApplicationFactory` chain could not be mocked; bonus)

Each new factory class also has its own unit test (`IndicatorRegistryFactoryTest`, `PostProcHandlerFactoryTest`, `InTextAnnotationParserFactoryTest`).

## Verification

- `composer phpunit -- --testsuite semantic-mediawiki-unit` — 7028 tests, 0 failures, 7 pre-existing skips
- `HookHandlersConstructionTest` — 55/55
- `phpcs -sp` on all changed files — clean
- Browser smoke against the dev wiki, signed in as `WikiSysop`:
  - Standard page view of `SmokePage6876` renders normally with `mw-indicator-smw-entity-examiner` attached (`IndicatorRegistryFactory` exercised)
  - `?oldid=13` enters the re-parse branch (`new ParserData()` + `InTextAnnotationParserFactory` exercised); `mw-revision` banner shown; indicator still attached
  - `Special:Version` hits the special-page early-return without error
  - Zero console errors across all flows; zero new PHP entries in apache log

## Test plan

- [x] CI passes
- [ ] Reviewer verifies `extension.json` services match the new constructor signature
- [ ] Reviewer checks that the lazy-`Store` resolution in `IndicatorRegistryFactory` mirrors the pattern landed in #6883

Refs #6876