### PR TITLE
Inject DataTypeRegistry into SpecialStatsAddExtra

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -303,7 +303,8 @@
 		"SemanticMediaWiki.SpecialStatsAddExtra": {
 			"class": "SMW\\MediaWiki\\Hooks\\SpecialStatsAddExtra",
 			"services": [
-				"SMW.Store"
+				"SMW.Store",
+				"SMW.DataTypeRegistry"
 			]
 		},
 		"SemanticMediaWiki.SpecialSearchResultsPrepend": {

--- a/src/MediaWiki/Hooks/SpecialStatsAddExtra.php
+++ b/src/MediaWiki/Hooks/SpecialStatsAddExtra.php
@@ -43,7 +43,10 @@ class SpecialStatsAddExtra implements SpecialStatsAddExtraHook {
 	/**
 	 * @since 7.0.0
 	 */
-	public function __construct( private readonly Store $store ) {
+	public function __construct(
+		private readonly Store $store,
+		private readonly DataTypeRegistry $dataTypeRegistry,
+	) {
 	}
 
 	/**
@@ -63,8 +66,7 @@ class SpecialStatsAddExtra implements SpecialStatsAddExtraHook {
 
 	private function copyStatistics( array &$extraStats, $language ): void {
 		$statistics = $this->store->getStatistics();
-		$dataTypeLabels = DataTypeRegistry::getInstance()->getKnownTypeLabels();
-		$statistics['DATATYPECOUNT'] = count( $dataTypeLabels );
+		$statistics['DATATYPECOUNT'] = count( $this->dataTypeRegistry->getKnownTypeLabels() );
 
 		if ( isset( $statistics['_cache'] ) ) {
 			$header = 'smw-statistics-cached';

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -8,6 +8,7 @@ use SMW\CacheFactory;
 use SMW\Connection\ConnectionManager;
 use SMW\ConstraintFactory;
 use SMW\DataItemFactory;
+use SMW\DataTypeRegistry;
 use SMW\DependencyValidatorFactory;
 use SMW\DisplayTitleFinder;
 use SMW\Elastic\ElasticFactory;
@@ -474,6 +475,16 @@ return [
 		}
 
 		return new DataItemFactory();
+	},
+
+	'SMW.DataTypeRegistry' => static function ( MediaWikiServices $services ): DataTypeRegistry {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'DataTypeRegistry' ) ) {
+			return $servicesFactory->getDataTypeRegistry();
+		}
+
+		return DataTypeRegistry::getInstance();
 	},
 
 	'SMW.QueryDependencyLinksStoreFactory' => static function ( MediaWikiServices $services ): QueryDependencyLinksStoreFactory {

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -27,6 +27,7 @@ use SMW\Connection\ConnectionManager;
 use SMW\ConstraintFactory;
 use SMW\DataItemFactory;
 use SMW\DataModel\SemanticData;
+use SMW\DataTypeRegistry;
 use SMW\DataUpdater;
 use SMW\DataValueFactory;
 use SMW\DependencyValidator;
@@ -597,6 +598,17 @@ class ServicesFactory {
 		}
 
 		return MediaWikiServices::getInstance()->getService( 'SMW.Settings' );
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getDataTypeRegistry(): DataTypeRegistry {
+		if ( array_key_exists( 'DataTypeRegistry', $this->testOverrides ) ) {
+			return $this->testOverrides['DataTypeRegistry'];
+		}
+
+		return MediaWikiServices::getInstance()->getService( 'SMW.DataTypeRegistry' );
 	}
 
 	/**

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SpecialStatsAddExtraTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SpecialStatsAddExtraTest.php
@@ -99,28 +99,28 @@ class SpecialStatsAddExtraTest extends TestCase {
 		$extraStats = [];
 		$instance->onSpecialStatsAddExtra( $extraStats, $this->newContext() );
 
-		$dataTypeEntry = $this->findStatEntryByCount( $extraStats, 1 );
-		$this->assertNotNull(
-			$dataTypeEntry,
-			'expected an entry with number=1 corresponding to count( [ "Bar" ] )'
+		// `SpecialStatsAddExtra::copyStatistics()` iterates `messageMapper` in
+		// insertion order. For this fixture (only `QUERY`, `QUERYFORMATS`, and
+		// the registry-derived `DATATYPECOUNT` are populated) that ordering
+		// yields exactly three entries under the `smw-statistics` header:
+		// [0] `QUERY`, [1] the `foo` `QUERYFORMATS` row, [2] `DATATYPECOUNT`.
+		// Asserting on position + count locks the seam to its actual slot
+		// rather than "some entry somewhere with that number".
+		$this->assertArrayHasKey( 'smw-statistics', $extraStats );
+		$this->assertCount( 3, $extraStats['smw-statistics'] );
+
+		$this->assertSame( 2002, $extraStats['smw-statistics'][0]['number'] );
+		$this->assertSame( 9999, $extraStats['smw-statistics'][1]['number'] );
+		$this->assertSame( 1, $extraStats['smw-statistics'][2]['number'] );
+
+		// `DATATYPECOUNT` renders the `smw-statistics-datatype-count` message,
+		// which contains the `Special:Types` link target in every locale.
+		// This binds the count-1 entry to the registry-driven row rather than
+		// any other future statistic that happens to evaluate to 1.
+		$this->assertStringContainsString(
+			'Special:Types',
+			$extraStats['smw-statistics'][2]['name']
 		);
-
-		$queryEntry = $this->findStatEntryByCount( $extraStats, 2002 );
-		$this->assertNotNull( $queryEntry, 'expected the QUERY entry' );
-
-		$queryFormatEntry = $this->findStatEntryByCount( $extraStats, 9999 );
-		$this->assertNotNull( $queryFormatEntry, 'expected the QUERYFORMATS "foo" entry' );
-	}
-
-	private function findStatEntryByCount( array $extraStats, int $number ): ?array {
-		foreach ( $extraStats as $entries ) {
-			foreach ( $entries as $entry ) {
-				if ( is_array( $entry ) && ( $entry['number'] ?? null ) === $number ) {
-					return $entry;
-				}
-			}
-		}
-		return null;
 	}
 
 	public function matchArray( array $matcher, $searchValue ) {

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SpecialStatsAddExtraTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SpecialStatsAddExtraTest.php
@@ -6,6 +6,7 @@ use MediaWiki\Context\IContextSource;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Output\OutputPage;
 use PHPUnit\Framework\TestCase;
+use SMW\DataTypeRegistry;
 use SMW\MediaWiki\Hooks\SpecialStatsAddExtra;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
@@ -21,6 +22,18 @@ use SMW\Store;
  */
 class SpecialStatsAddExtraTest extends TestCase {
 
+	private function newStoreMock(): Store {
+		return $this->getMockBuilder( Store::class )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+	}
+
+	private function newDataTypeRegistryMock( array $knownTypeLabels = [] ): DataTypeRegistry {
+		$registry = $this->createMock( DataTypeRegistry::class );
+		$registry->method( 'getKnownTypeLabels' )->willReturn( $knownTypeLabels );
+		return $registry;
+	}
+
 	protected function tearDown(): void {
 		ApplicationFactory::clear();
 
@@ -28,13 +41,9 @@ class SpecialStatsAddExtraTest extends TestCase {
 	}
 
 	public function testCanConstruct() {
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
 		$this->assertInstanceOf(
 			SpecialStatsAddExtra::class,
-			new SpecialStatsAddExtra( $store )
+			new SpecialStatsAddExtra( $this->newStoreMock(), $this->newDataTypeRegistryMock() )
 		);
 	}
 
@@ -46,17 +55,14 @@ class SpecialStatsAddExtraTest extends TestCase {
 			$this->markTestSkipped( 'SMW_EXTENSION_LOADED is not defined in this environment' );
 		}
 
-		$store = $this->getMockBuilder( Store::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
-
+		$store = $this->newStoreMock();
 		$store->expects( $this->atLeastOnce() )
 			->method( 'getStatistics' )
 			->willReturn( $setup['statistics'] );
 
 		$extraStats = $setup['extraStats'];
 
-		$instance = new SpecialStatsAddExtra( $store );
+		$instance = new SpecialStatsAddExtra( $store, $this->newDataTypeRegistryMock() );
 
 		$context = $this->newContext();
 
@@ -67,6 +73,54 @@ class SpecialStatsAddExtraTest extends TestCase {
 		$this->assertTrue(
 			$this->matchArray( $extraStats, $expected['statistics'] )
 		);
+	}
+
+	public function testProcess_InjectedDataTypeRegistryDrivesDataTypeCount() {
+		if ( !defined( 'SMW_EXTENSION_LOADED' ) ) {
+			$this->markTestSkipped( 'SMW_EXTENSION_LOADED is not defined in this environment' );
+		}
+
+		$store = $this->newStoreMock();
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getStatistics' )
+			->willReturn( [
+				'QUERY' => 2002,
+				'QUERYFORMATS' => [ 'foo' => 9999 ],
+			] );
+
+		// The fake registry exposes a single type label. The handler must read
+		// the count from the injected registry, not from the global
+		// `DataTypeRegistry::getInstance()`.
+		$instance = new SpecialStatsAddExtra(
+			$store,
+			$this->newDataTypeRegistryMock( [ 'Bar' ] )
+		);
+
+		$extraStats = [];
+		$instance->onSpecialStatsAddExtra( $extraStats, $this->newContext() );
+
+		$dataTypeEntry = $this->findStatEntryByCount( $extraStats, 1 );
+		$this->assertNotNull(
+			$dataTypeEntry,
+			'expected an entry with number=1 corresponding to count( [ "Bar" ] )'
+		);
+
+		$queryEntry = $this->findStatEntryByCount( $extraStats, 2002 );
+		$this->assertNotNull( $queryEntry, 'expected the QUERY entry' );
+
+		$queryFormatEntry = $this->findStatEntryByCount( $extraStats, 9999 );
+		$this->assertNotNull( $queryFormatEntry, 'expected the QUERYFORMATS "foo" entry' );
+	}
+
+	private function findStatEntryByCount( array $extraStats, int $number ): ?array {
+		foreach ( $extraStats as $entries ) {
+			foreach ( $entries as $entry ) {
+				if ( is_array( $entry ) && ( $entry['number'] ?? null ) === $number ) {
+					return $entry;
+				}
+			}
+		}
+		return null;
 	}
 
 	public function matchArray( array $matcher, $searchValue ) {


### PR DESCRIPTION
## Summary

Fifth slice against issue #6876. `SpecialStatsAddExtra::copyStatistics()` resolved its data-type-label list through `DataTypeRegistry::getInstance()` directly. That static call blocked the previously-dropped `testProcess_FakeStats` test, which used to drive the registry through `setDataTypeLabels( [ 'Bar' ] )` to control the `DATATYPECOUNT` statistic. After #6875 dropped `setDataTypeLabels` no constructor seam replaced it, so the test could not be restored.

## What changes

- `SpecialStatsAddExtra` constructor gains a second positional argument:
  ```php
  public function __construct(
      private readonly Store $store,
      private readonly DataTypeRegistry $dataTypeRegistry,
  ) {}
  ```
  `copyStatistics()` now reads `$this->dataTypeRegistry->getKnownTypeLabels()`.
- `ServicesFactory::getDataTypeRegistry()` accessor added, with the `testOverrides` guard that the rest of the file uses for commonly-mocked siblings (matches the pattern landed for `getSiteReadiness()` during PR 4 review).
- `SMW.DataTypeRegistry` entry added to `ServiceWiring.php`. Production returns `DataTypeRegistry::getInstance()`; tests register a mock via `TestEnvironment::registerObject('DataTypeRegistry', $mock)`.
- `extension.json` `SemanticMediaWiki.SpecialStatsAddExtra.services` gains `"SMW.DataTypeRegistry"` (now `["SMW.Store", "SMW.DataTypeRegistry"]`).

No behaviour change in production. `SMW.DataTypeRegistry` resolves to the same singleton instance `DataTypeRegistry::getInstance()` returned before, so the handler hits exactly the same code path. The seam exists for testability only.

## Test restored

New `testProcess_InjectedDataTypeRegistryDrivesDataTypeCount` replaces the spirit of the dropped `testProcess_FakeStats`:

- Injects a mock `DataTypeRegistry` whose `getKnownTypeLabels()` returns a single fake label.
- Drives `Store::getStatistics()` to return `QUERY=2002` plus `QUERYFORMATS=[foo=>9999]`.
- Asserts `$extraStats['smw-statistics']` contains exactly three entries in this order: `QUERY` (count 2002), `QUERYFORMATS` `foo` row (count 9999), `DATATYPECOUNT` (count 1).
- The `name` at the `DATATYPECOUNT` position must contain `Special:Types`, which the `smw-statistics-datatype-count` message links to in every locale. This binds the count-1 entry to the registry-driven row rather than any other future statistic that happens to evaluate to 1.

Verified the assertion fails on regressions by temporarily mutating the production code to `count(...) + 99`; the position-2 assertion correctly failed with `100 !== 1`.

## Verification

- `composer phpunit -- --testsuite semantic-mediawiki-unit` — 7050 tests, 0 failures, 7 pre-existing skips
- `HookHandlersConstructionTest` — 55/55
- `SpecialStatsAddExtraTest` — 6/6 (was 5)
- `phpcs -sp` on the 4 changed files — clean
- Browser smoke: `Special:Statistics` renders the SMW section with all rows including `Datatypes: 18`, proving the injected `DataTypeRegistry` flows through to the page

## Test plan

- [x] CI passes
- [ ] Reviewer verifies the `extension.json` services match the new constructor signature
- [ ] Reviewer checks that `ServicesFactory::getDataTypeRegistry()` follows the same `testOverrides` convention as the rest of the file's accessors

Refs #6876