### PR TITLE
Inject Store into ArticlePurge and SoftwareInfo declaratively

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -196,6 +196,7 @@
 		"SemanticMediaWiki.ArticlePurge": {
 			"class": "SMW\\MediaWiki\\Hooks\\ArticlePurge",
 			"services": [
+				"SMW.Store",
 				"SMW.Cache",
 				"SMW.Settings",
 				"SMW.EventDispatcher"
@@ -323,7 +324,10 @@
 			"class": "SMW\\MediaWiki\\Hooks\\SpecialSearchProfiles"
 		},
 		"SemanticMediaWiki.SoftwareInfo": {
-			"class": "SMW\\MediaWiki\\Hooks\\SoftwareInfo"
+			"class": "SMW\\MediaWiki\\Hooks\\SoftwareInfo",
+			"services": [
+				"SMW.Store"
+			]
 		},
 		"SemanticMediaWiki.BlockIpComplete": {
 			"class": "SMW\\MediaWiki\\Hooks\\BlockIpComplete",

--- a/src/MediaWiki/Hooks/ArticlePurge.php
+++ b/src/MediaWiki/Hooks/ArticlePurge.php
@@ -8,7 +8,6 @@ use Onoi\Cache\Cache;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\EventDispatcher\EventDispatcher;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Settings;
 use SMW\Store;
 
@@ -33,6 +32,7 @@ class ArticlePurge implements ArticlePurgeHook {
 	 * @since 7.0.0
 	 */
 	public function __construct(
+		private readonly Store $store,
 		private readonly Cache $cache,
 		private readonly Settings $settings,
 		private readonly EventDispatcher $eventDispatcher,
@@ -54,7 +54,7 @@ class ArticlePurge implements ArticlePurgeHook {
 		}
 
 		if ( $this->settings->get( 'smwgQueryResultCacheRefreshOnPurge' ) ) {
-			$this->invalidateResultCache( ApplicationFactory::getInstance()->getStore(), $title );
+			$this->invalidateResultCache( $title );
 		}
 
 		$context = [
@@ -67,8 +67,8 @@ class ArticlePurge implements ArticlePurgeHook {
 		return true;
 	}
 
-	private function invalidateResultCache( Store $store, Title $title ): void {
-		$dependency_list = $store->getPropertyValues(
+	private function invalidateResultCache( Title $title ): void {
+		$dependency_list = $this->store->getPropertyValues(
 			WikiPage::newFromTitle( $title ),
 			new Property( '_ASK' )
 		);

--- a/src/MediaWiki/Hooks/SoftwareInfo.php
+++ b/src/MediaWiki/Hooks/SoftwareInfo.php
@@ -3,7 +3,7 @@
 namespace SMW\MediaWiki\Hooks;
 
 use MediaWiki\Hook\SoftwareInfoHook;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Store;
 
 /**
  * @see https://www.mediawiki.org/wiki/Manual:Hooks/SoftwareInfo
@@ -16,9 +16,16 @@ class SoftwareInfo implements SoftwareInfoHook {
 	/**
 	 * @since 7.0.0
 	 */
+	public function __construct(
+		private readonly Store $store,
+	) {
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
 	public function onSoftwareInfo( &$software ) {
-		$store = ApplicationFactory::getInstance()->getStore();
-		$info = $store->getConnection( 'elastic' )->getSoftwareInfo();
+		$info = $this->store->getConnection( 'elastic' )->getSoftwareInfo();
 
 		if ( !isset( $software[$info['component']] ) && $info['version'] !== null ) {
 			$software[$info['component']] = $info['version'];

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
@@ -8,6 +8,7 @@ use SMW\Factbox\CachedFactbox;
 use SMW\MediaWiki\Hooks\ArticlePurge;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Settings;
+use SMW\Store;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockTitle;
 use WikiPage;
@@ -72,7 +73,9 @@ class ArticlePurgeTest extends TestCase {
 				[ 'smwgQueryResultCacheRefreshOnPurge', $setup['smwgQueryResultCacheRefreshOnPurge'] ],
 			] );
 
-		$instance = new ArticlePurge( $this->cache, $settings, $this->eventDispatcher );
+		$store = $this->createMock( Store::class );
+
+		$instance = new ArticlePurge( $store, $this->cache, $settings, $this->eventDispatcher );
 
 		$cacheFactory = $this->applicationFactory->newCacheFactory();
 		$factboxCacheKey = CachedFactbox::makeCacheKey( $pageId );


### PR DESCRIPTION
## Summary

`ArticlePurge` and `SoftwareInfo` are the last two `src/MediaWiki/Hooks/` handlers that still resolve `Store` lazily through `ApplicationFactory::getInstance()->getStore()` inside method bodies. Neither hook fires before the service container is ready (`ArticlePurge` runs on `?action=purge`; `SoftwareInfo` runs on Special:Version), so there is no boot-order reason to defer. Both now receive `Store` through the declarative `HookHandlers.services` array, matching the pattern already used by `ArticleDelete`, `ArticleViewHeader`, `RevisionFromEditComplete`, and the other store-using sibling handlers.

## Changes

- `ArticlePurge`: `Store` becomes the first promoted-readonly constructor parameter; `invalidateResultCache()` drops its `Store` argument and reads `$this->store`.
- `SoftwareInfo`: gains a constructor (the class had none) that promotes `Store`; `onSoftwareInfo()` reads `$this->store` instead of looking it up.
- `extension.json`: `SMW.Store` prepended to the `SemanticMediaWiki.ArticlePurge` `services:` array; new `services: [\"SMW.Store\"]` for `SemanticMediaWiki.SoftwareInfo`.
- `ArticlePurgeTest`: passes a mocked `Store` as the new first ctor argument.

## Out of scope

`ExtensionSchemaUpdates` keeps its lazy lookup. The hook only runs during \`update.php\`, the lazy and injected paths would both resolve the same \`MediaWikiServices\` singleton, and the churn is not worth the blast radius for an installer-only path.

## Test plan

- [x] Unit suite stays green (\`composer phpunit -- --testsuite semantic-mediawiki-unit\`).
- [x] Integration suite stays green; new ctor arity is reached during real container resolution.
- [ ] Special:Version still reports the Elastic store software-info row (manual smoke when CI is green).
- [x] \`?action=purge\` with \`\$smwgQueryResultCacheRefreshOnPurge = true\` still emits an InvalidateResultCache event (manual smoke).

Refs #6876