### PR TITLE
Finish handler DI audit

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -207,7 +207,9 @@
 			"services": [
 				"SMW.Store",
 				"SMW.JobFactory",
-				"SMW.EventDispatcher"
+				"SMW.EventDispatcher",
+				"SMW.SerializerFactory",
+				"SMW.ApplicationFactory"
 			]
 		},
 		"SemanticMediaWiki.ArticleFromTitle": {

--- a/extension.json
+++ b/extension.json
@@ -372,16 +372,12 @@
 			]
 		},
 		"SemanticMediaWiki.BeforeQueryResultLookupComplete": {
-			"class": "SMW\\MediaWiki\\Hooks\\BeforeQueryResultLookupComplete",
-			"services": [
-				"SMW.ResultCache"
-			]
+			"class": "SMW\\MediaWiki\\Hooks\\BeforeQueryResultLookupComplete"
 		},
 		"SemanticMediaWiki.AfterQueryResultLookupComplete": {
 			"class": "SMW\\MediaWiki\\Hooks\\AfterQueryResultLookupComplete",
 			"services": [
-				"SMW.QueryDependencyLinksStoreFactory",
-				"SMW.ResultCache"
+				"SMW.QueryDependencyLinksStoreFactory"
 			]
 		},
 		"SemanticMediaWiki.AfterIncomingPropertiesLookupComplete": {

--- a/extension.json
+++ b/extension.json
@@ -317,11 +317,15 @@
 		"SemanticMediaWiki.SpecialSearchProfileForm": {
 			"class": "SMW\\MediaWiki\\Hooks\\SpecialSearchProfileForm",
 			"services": [
-				"SMW.Store"
+				"SMW.Store",
+				"SMW.SearchEngineConfig"
 			]
 		},
 		"SemanticMediaWiki.SpecialSearchProfiles": {
-			"class": "SMW\\MediaWiki\\Hooks\\SpecialSearchProfiles"
+			"class": "SMW\\MediaWiki\\Hooks\\SpecialSearchProfiles",
+			"services": [
+				"SMW.SearchEngineConfig"
+			]
 		},
 		"SemanticMediaWiki.SoftwareInfo": {
 			"class": "SMW\\MediaWiki\\Hooks\\SoftwareInfo"

--- a/extension.json
+++ b/extension.json
@@ -99,7 +99,8 @@
 				"SMW.ApplicationFactory",
 				"SMW.HookDispatcher",
 				"SMW.Settings",
-				"SMW.Logger"
+				"SMW.Logger",
+				"RestrictionStore"
 			]
 		},
 		"SemanticMediaWiki.ParserClearState": {
@@ -387,7 +388,8 @@
 			"class": "SMW\\MediaWiki\\Hooks\\DeleteAccount",
 			"services": [
 				"SMW.NamespaceExaminer",
-				"SMW.ArticleDelete"
+				"SMW.ArticleDelete",
+				"TitleFactory"
 			]
 		},
 		"SemanticMediaWiki.AdminLinks": {

--- a/extension.json
+++ b/extension.json
@@ -359,7 +359,11 @@
 			]
 		},
 		"SemanticMediaWiki.AfterCreateTablesComplete": {
-			"class": "SMW\\MediaWiki\\Hooks\\AfterCreateTablesComplete"
+			"class": "SMW\\MediaWiki\\Hooks\\AfterCreateTablesComplete",
+			"services": [
+				"SMW.ImporterServiceFactory",
+				"SMW.Settings"
+			]
 		},
 		"SemanticMediaWiki.BeforeQueryResultLookupComplete": {
 			"class": "SMW\\MediaWiki\\Hooks\\BeforeQueryResultLookupComplete",

--- a/extension.json
+++ b/extension.json
@@ -345,22 +345,39 @@
 			]
 		},
 		"SemanticMediaWiki.AfterDataUpdateComplete": {
-			"class": "SMW\\MediaWiki\\Hooks\\AfterDataUpdateComplete"
+			"class": "SMW\\MediaWiki\\Hooks\\AfterDataUpdateComplete",
+			"services": [
+				"SMW.QueryDependencyLinksStoreFactory",
+				"SMW.FulltextSearchTableFactory"
+			]
 		},
 		"SemanticMediaWiki.AfterCreateTablesComplete": {
 			"class": "SMW\\MediaWiki\\Hooks\\AfterCreateTablesComplete"
 		},
 		"SemanticMediaWiki.BeforeQueryResultLookupComplete": {
-			"class": "SMW\\MediaWiki\\Hooks\\BeforeQueryResultLookupComplete"
+			"class": "SMW\\MediaWiki\\Hooks\\BeforeQueryResultLookupComplete",
+			"services": [
+				"SMW.ResultCache"
+			]
 		},
 		"SemanticMediaWiki.AfterQueryResultLookupComplete": {
-			"class": "SMW\\MediaWiki\\Hooks\\AfterQueryResultLookupComplete"
+			"class": "SMW\\MediaWiki\\Hooks\\AfterQueryResultLookupComplete",
+			"services": [
+				"SMW.QueryDependencyLinksStoreFactory",
+				"SMW.ResultCache"
+			]
 		},
 		"SemanticMediaWiki.AfterIncomingPropertiesLookupComplete": {
-			"class": "SMW\\MediaWiki\\Hooks\\AfterIncomingPropertiesLookupComplete"
+			"class": "SMW\\MediaWiki\\Hooks\\AfterIncomingPropertiesLookupComplete",
+			"services": [
+				"SMW.QueryDependencyLinksStoreFactory"
+			]
 		},
 		"SemanticMediaWiki.BeforeIncomingPropertyValuesFurtherLinkCreate": {
-			"class": "SMW\\MediaWiki\\Hooks\\BeforeIncomingPropertyValuesFurtherLinkCreate"
+			"class": "SMW\\MediaWiki\\Hooks\\BeforeIncomingPropertyValuesFurtherLinkCreate",
+			"services": [
+				"SMW.QueryDependencyLinksStoreFactory"
+			]
 		},
 		"SemanticMediaWiki.DeleteAccount": {
 			"class": "SMW\\MediaWiki\\Hooks\\DeleteAccount",

--- a/extension.json
+++ b/extension.json
@@ -263,7 +263,10 @@
 			"services": [
 				"SMW.NamespaceExaminer",
 				"HookContainer",
-				"SMW.PageCreator"
+				"SMW.PageCreator",
+				"SMW.ParserDataFactory",
+				"SMW.MwCollaboratorFactory",
+				"SMW.PropertyAnnotatorFactory"
 			]
 		},
 		"SemanticMediaWiki.MaintenanceUpdateAddParams": {

--- a/extension.json
+++ b/extension.json
@@ -119,7 +119,10 @@
 		"SemanticMediaWiki.InternalParseBeforeLinks": {
 			"class": "SMW\\MediaWiki\\Hooks\\InternalParseBeforeLinks",
 			"services": [
-				"SMW.Settings"
+				"SMW.Settings",
+				"SMW.ParserDataFactory",
+				"SMW.InTextAnnotationParserFactory",
+				"SMW.MwCollaboratorFactory"
 			]
 		},
 		"SemanticMediaWiki.RejectParserCacheValue": {

--- a/src/MediaWiki/Hooks/AfterCreateTablesComplete.php
+++ b/src/MediaWiki/Hooks/AfterCreateTablesComplete.php
@@ -3,7 +3,8 @@
 namespace SMW\MediaWiki\Hooks;
 
 use MediaWiki\User\User;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Services\ImporterServiceFactory;
+use SMW\Settings;
 use SMW\SQLStore\Installer;
 use SMW\Utils\CliMsgFormatter;
 
@@ -21,19 +22,25 @@ class AfterCreateTablesComplete {
 	/**
 	 * @since 7.0.0
 	 */
+	public function __construct(
+		private readonly ImporterServiceFactory $importerServiceFactory,
+		private readonly Settings $settings,
+	) {
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
 	public function onSMW__SQLStore__Installer__AfterCreateTablesComplete( $tableBuilder, $messageReporter, $options ): bool {
 		$messageReporter->reportMessage(
 			( new CliMsgFormatter() )->section( 'Import task(s)', 3, '-', true )
 		);
 
-		$applicationFactory = ApplicationFactory::getInstance();
-		$importerServiceFactory = $applicationFactory->create( 'ImporterServiceFactory' );
-
-		$contentIterator = $importerServiceFactory->newJsonContentIterator(
-			$applicationFactory->getSettings()->get( 'smwgImportFileDirs' )
+		$contentIterator = $this->importerServiceFactory->newJsonContentIterator(
+			$this->settings->get( 'smwgImportFileDirs' )
 		);
 
-		$importer = $importerServiceFactory->newImporter(
+		$importer = $this->importerServiceFactory->newImporter(
 			$contentIterator
 		);
 

--- a/src/MediaWiki/Hooks/AfterDataUpdateComplete.php
+++ b/src/MediaWiki/Hooks/AfterDataUpdateComplete.php
@@ -3,8 +3,8 @@
 namespace SMW\MediaWiki\Hooks;
 
 use SMW\DataModel\SemanticData;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\ChangeOp\ChangeOp;
+use SMW\SQLStore\QueryDependencyLinksStoreFactory;
 use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
 use SMW\Store;
 
@@ -22,15 +22,21 @@ class AfterDataUpdateComplete {
 	/**
 	 * @since 7.0.0
 	 */
+	public function __construct(
+		private readonly QueryDependencyLinksStoreFactory $queryDependencyLinksStoreFactory,
+		private readonly FulltextSearchTableFactory $fulltextSearchTableFactory,
+	) {
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
 	public function onSMW__SQLStore__AfterDataUpdateComplete( Store $store, SemanticData $semanticData, ChangeOp $changeOp ): bool {
 		// A delete infused change should trigger an immediate update
 		// without having to wait on the job queue
 		$isPrimaryUpdate = $semanticData->getOption( SemanticData::PROC_DELETE, false );
 
-		$queryDependencyLinksStoreFactory = ApplicationFactory::getInstance()
-			->singleton( 'QueryDependencyLinksStoreFactory' );
-
-		$queryDependencyLinksStore = $queryDependencyLinksStoreFactory->newQueryDependencyLinksStore(
+		$queryDependencyLinksStore = $this->queryDependencyLinksStoreFactory->newQueryDependencyLinksStore(
 			$store
 		);
 
@@ -38,9 +44,7 @@ class AfterDataUpdateComplete {
 			$changeOp
 		);
 
-		$fulltextSearchTableFactory = new FulltextSearchTableFactory();
-
-		$textChangeUpdater = $fulltextSearchTableFactory->newTextChangeUpdater(
+		$textChangeUpdater = $this->fulltextSearchTableFactory->newTextChangeUpdater(
 			$store
 		);
 

--- a/src/MediaWiki/Hooks/AfterIncomingPropertiesLookupComplete.php
+++ b/src/MediaWiki/Hooks/AfterIncomingPropertiesLookupComplete.php
@@ -2,7 +2,7 @@
 
 namespace SMW\MediaWiki\Hooks;
 
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\SQLStore\QueryDependencyLinksStoreFactory;
 
 /**
  * Adds reference backlinks to the result of an incoming-properties lookup.
@@ -17,11 +17,16 @@ class AfterIncomingPropertiesLookupComplete {
 	/**
 	 * @since 7.0.0
 	 */
-	public function onSMW__Browse__AfterIncomingPropertiesLookupComplete( $store, $semanticData, $requestOptions ): bool {
-		$queryDependencyLinksStoreFactory = ApplicationFactory::getInstance()
-			->singleton( 'QueryDependencyLinksStoreFactory' );
+	public function __construct(
+		private readonly QueryDependencyLinksStoreFactory $queryDependencyLinksStoreFactory,
+	) {
+	}
 
-		$queryReferenceBacklinks = $queryDependencyLinksStoreFactory->newQueryReferenceBacklinks(
+	/**
+	 * @since 7.0.0
+	 */
+	public function onSMW__Browse__AfterIncomingPropertiesLookupComplete( $store, $semanticData, $requestOptions ): bool {
+		$queryReferenceBacklinks = $this->queryDependencyLinksStoreFactory->newQueryReferenceBacklinks(
 			$store
 		);
 

--- a/src/MediaWiki/Hooks/AfterQueryResultLookupComplete.php
+++ b/src/MediaWiki/Hooks/AfterQueryResultLookupComplete.php
@@ -2,7 +2,7 @@
 
 namespace SMW\MediaWiki\Hooks;
 
-use SMW\Query\Cache\ResultCache;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\QueryDependencyLinksStoreFactory;
 
 /**
@@ -21,7 +21,6 @@ class AfterQueryResultLookupComplete {
 	 */
 	public function __construct(
 		private readonly QueryDependencyLinksStoreFactory $queryDependencyLinksStoreFactory,
-		private readonly ResultCache $resultCache,
 	) {
 	}
 
@@ -35,7 +34,11 @@ class AfterQueryResultLookupComplete {
 
 		$queryDependencyLinksStore->updateDependencies( $result );
 
-		$this->resultCache->recordStats();
+		// `ResultCache` is resolved lazily rather than via the `services:`
+		// array because its `BlobStore` is built from `smwgQueryResultCacheType`
+		// at construction and `MediaWikiServices` caches the resolved instance.
+		// See `BeforeQueryResultLookupComplete` for the full rationale.
+		ApplicationFactory::getInstance()->singleton( 'ResultCache' )->recordStats();
 
 		$store->getObjectIds()->warmUpCache( $result );
 

--- a/src/MediaWiki/Hooks/AfterQueryResultLookupComplete.php
+++ b/src/MediaWiki/Hooks/AfterQueryResultLookupComplete.php
@@ -2,7 +2,8 @@
 
 namespace SMW\MediaWiki\Hooks;
 
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Query\Cache\ResultCache;
+use SMW\SQLStore\QueryDependencyLinksStoreFactory;
 
 /**
  * Runs after the regular query result lookup completes. Updates the query
@@ -18,17 +19,23 @@ class AfterQueryResultLookupComplete {
 	/**
 	 * @since 7.0.0
 	 */
-	public function onSMW__Store__AfterQueryResultLookupComplete( $store, &$result ): bool {
-		$applicationFactory = ApplicationFactory::getInstance();
-		$queryDependencyLinksStoreFactory = $applicationFactory->singleton( 'QueryDependencyLinksStoreFactory' );
+	public function __construct(
+		private readonly QueryDependencyLinksStoreFactory $queryDependencyLinksStoreFactory,
+		private readonly ResultCache $resultCache,
+	) {
+	}
 
-		$queryDependencyLinksStore = $queryDependencyLinksStoreFactory->newQueryDependencyLinksStore(
+	/**
+	 * @since 7.0.0
+	 */
+	public function onSMW__Store__AfterQueryResultLookupComplete( $store, &$result ): bool {
+		$queryDependencyLinksStore = $this->queryDependencyLinksStoreFactory->newQueryDependencyLinksStore(
 			$store
 		);
 
 		$queryDependencyLinksStore->updateDependencies( $result );
 
-		$applicationFactory->singleton( 'ResultCache' )->recordStats();
+		$this->resultCache->recordStats();
 
 		$store->getObjectIds()->warmUpCache( $result );
 

--- a/src/MediaWiki/Hooks/ArticleDelete.php
+++ b/src/MediaWiki/Hooks/ArticleDelete.php
@@ -11,6 +11,7 @@ use SMW\DataModel\SemanticData;
 use SMW\EventDispatcher\EventDispatcher;
 use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\Jobs\UpdateDispatcherJob;
+use SMW\SerializerFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
 use WikiPage;
@@ -34,6 +35,8 @@ class ArticleDelete implements ArticleDeleteHook {
 		private readonly Store $store,
 		private readonly JobFactory $jobFactory,
 		private readonly EventDispatcher $eventDispatcher,
+		private readonly SerializerFactory $serializerFactory,
+		private readonly ApplicationFactory $servicesFactory,
 	) {
 	}
 
@@ -61,7 +64,7 @@ class ArticleDelete implements ArticleDeleteHook {
 	 * @since 7.0.0
 	 */
 	public function scheduleDeleteFor( Title $title ): void {
-		$deferredCallableUpdate = ApplicationFactory::getInstance()->newDeferredCallableUpdate( function () use( $title ): void {
+		$deferredCallableUpdate = $this->servicesFactory->newDeferredCallableUpdate( function () use( $title ): void {
 			$this->doDelete( $title );
 		} );
 
@@ -75,10 +78,9 @@ class ArticleDelete implements ArticleDeleteHook {
 	 * @param Title $title
 	 */
 	public function doDelete( Title $title ): void {
-		$applicationFactory = ApplicationFactory::getInstance();
 		$subject = DIWikiPage::newFromTitle( $title );
 
-		$semanticDataSerializer = $applicationFactory->newSerializerFactory()->newSemanticDataSerializer();
+		$semanticDataSerializer = $this->serializerFactory->newSemanticDataSerializer();
 
 		// Instead of Store::getSemanticData, construct the SemanticData by
 		// attaching only the incoming properties indicating which entities

--- a/src/MediaWiki/Hooks/BeforeIncomingPropertyValuesFurtherLinkCreate.php
+++ b/src/MediaWiki/Hooks/BeforeIncomingPropertyValuesFurtherLinkCreate.php
@@ -2,7 +2,7 @@
 
 namespace SMW\MediaWiki\Hooks;
 
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\SQLStore\QueryDependencyLinksStoreFactory;
 
 /**
  * Replaces the standard "further" link in the property browser when the
@@ -18,11 +18,16 @@ class BeforeIncomingPropertyValuesFurtherLinkCreate {
 	/**
 	 * @since 7.0.0
 	 */
-	public function onSMW__Browse__BeforeIncomingPropertyValuesFurtherLinkCreate( $property, $subject, &$html, $store ): bool {
-		$queryDependencyLinksStoreFactory = ApplicationFactory::getInstance()
-			->singleton( 'QueryDependencyLinksStoreFactory' );
+	public function __construct(
+		private readonly QueryDependencyLinksStoreFactory $queryDependencyLinksStoreFactory,
+	) {
+	}
 
-		$queryReferenceBacklinks = $queryDependencyLinksStoreFactory->newQueryReferenceBacklinks(
+	/**
+	 * @since 7.0.0
+	 */
+	public function onSMW__Browse__BeforeIncomingPropertyValuesFurtherLinkCreate( $property, $subject, &$html, $store ): bool {
+		$queryReferenceBacklinks = $this->queryDependencyLinksStoreFactory->newQueryReferenceBacklinks(
 			$store
 		);
 

--- a/src/MediaWiki/Hooks/BeforeQueryResultLookupComplete.php
+++ b/src/MediaWiki/Hooks/BeforeQueryResultLookupComplete.php
@@ -2,7 +2,7 @@
 
 namespace SMW\MediaWiki\Hooks;
 
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Query\Cache\ResultCache;
 
 /**
  * Runs before the regular query result lookup runs, allowing the cache to
@@ -18,18 +18,24 @@ class BeforeQueryResultLookupComplete {
 	/**
 	 * @since 7.0.0
 	 */
-	public function onSMW__Store__BeforeQueryResultLookupComplete( $store, $query, &$result, $queryEngine ): bool {
-		$resultCache = ApplicationFactory::getInstance()->singleton( 'ResultCache' );
+	public function __construct(
+		private readonly ResultCache $resultCache,
+	) {
+	}
 
-		$resultCache->setQueryEngine(
+	/**
+	 * @since 7.0.0
+	 */
+	public function onSMW__Store__BeforeQueryResultLookupComplete( $store, $query, &$result, $queryEngine ): bool {
+		$this->resultCache->setQueryEngine(
 			$queryEngine
 		);
 
-		if ( !$resultCache->isEnabled() ) {
+		if ( !$this->resultCache->isEnabled() ) {
 			return true;
 		}
 
-		$result = $resultCache->getQueryResult(
+		$result = $this->resultCache->getQueryResult(
 			$query
 		);
 

--- a/src/MediaWiki/Hooks/BeforeQueryResultLookupComplete.php
+++ b/src/MediaWiki/Hooks/BeforeQueryResultLookupComplete.php
@@ -2,7 +2,7 @@
 
 namespace SMW\MediaWiki\Hooks;
 
-use SMW\Query\Cache\ResultCache;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 
 /**
  * Runs before the regular query result lookup runs, allowing the cache to
@@ -18,24 +18,26 @@ class BeforeQueryResultLookupComplete {
 	/**
 	 * @since 7.0.0
 	 */
-	public function __construct(
-		private readonly ResultCache $resultCache,
-	) {
-	}
-
-	/**
-	 * @since 7.0.0
-	 */
 	public function onSMW__Store__BeforeQueryResultLookupComplete( $store, $query, &$result, $queryEngine ): bool {
-		$this->resultCache->setQueryEngine(
+		// `ResultCache` cannot be injected through the declarative `services:`
+		// array because its `BlobStore` is constructed from
+		// `smwgQueryResultCacheType` at instantiation, and `MediaWikiServices`
+		// caches the resolved instance for the container's lifetime. JSONScript
+		// tests vary that setting per test case, so the cached instance would
+		// hold a stale cache backend. Resolving it through
+		// `ServicesFactory::singleton()` rebuilds the instance per hook fire
+		// against current settings.
+		$resultCache = ApplicationFactory::getInstance()->singleton( 'ResultCache' );
+
+		$resultCache->setQueryEngine(
 			$queryEngine
 		);
 
-		if ( !$this->resultCache->isEnabled() ) {
+		if ( !$resultCache->isEnabled() ) {
 			return true;
 		}
 
-		$result = $this->resultCache->getQueryResult(
+		$result = $resultCache->getQueryResult(
 			$query
 		);
 

--- a/src/MediaWiki/Hooks/DeleteAccount.php
+++ b/src/MediaWiki/Hooks/DeleteAccount.php
@@ -2,7 +2,7 @@
 
 namespace SMW\MediaWiki\Hooks;
 
-use MediaWiki\MediaWikiServices;
+use MediaWiki\Title\TitleFactory;
 use MediaWiki\User\User;
 use SMW\NamespaceExaminer;
 
@@ -22,6 +22,7 @@ class DeleteAccount {
 	public function __construct(
 		private readonly NamespaceExaminer $namespaceExaminer,
 		private readonly ArticleDelete $articleDelete,
+		private readonly TitleFactory $titleFactory,
 	) {
 	}
 
@@ -40,7 +41,7 @@ class DeleteAccount {
 		$this->articleDelete->setOrigin( 'DeleteAccount' );
 
 		$this->articleDelete->scheduleDeleteFor(
-			MediaWikiServices::getInstance()->getTitleFactory()->newFromText( $user, NS_USER )
+			$this->titleFactory->newFromText( $user, NS_USER )
 		);
 
 		return true;

--- a/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
+++ b/src/MediaWiki/Hooks/ExtensionSchemaUpdates.php
@@ -67,6 +67,13 @@ class ExtensionSchemaUpdates implements LoadExtensionSchemaUpdatesHook {
 		// cause problems, since the connection is not restored on wakeup." given
 		// that the `DatabaseUpdater` prior MW 1.31 has issues with serializing
 		// the options array.
+		//
+		// `Store` is resolved lazily rather than through the declarative
+		// `services:` array. Both paths would resolve the same
+		// `MediaWikiServices` singleton, so the choice does not change which
+		// instance is mutated by `setMessageReporter` below; we keep the
+		// lazy lookup so this installer-only path stays self-contained and
+		// does not pull `SMW.Store` into the HookHandler service graph.
 		$store = ApplicationFactory::getInstance()->getStore();
 		$store->setMessageReporter( $messageReporter );
 

--- a/src/MediaWiki/Hooks/FileUpload.php
+++ b/src/MediaWiki/Hooks/FileUpload.php
@@ -8,9 +8,11 @@ use MediaWiki\HookContainer\HookContainer;
 use MediaWiki\Parser\ParserOptions;
 use MediaWiki\User\User;
 use SMW\Localizer\Localizer;
+use SMW\MediaWiki\Jobs\ParserDataFactory;
+use SMW\MediaWiki\MwCollaboratorFactory;
 use SMW\MediaWiki\PageCreator;
 use SMW\NamespaceExaminer;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Property\AnnotatorFactory;
 
 /**
  * Fires when a local file upload occurs
@@ -31,6 +33,9 @@ class FileUpload implements FileUploadHook {
 		private readonly NamespaceExaminer $namespaceExaminer,
 		private readonly HookContainer $hookContainer,
 		private readonly PageCreator $pageCreator,
+		private readonly ParserDataFactory $parserDataFactory,
+		private readonly MwCollaboratorFactory $mwCollaboratorFactory,
+		private readonly AnnotatorFactory $propertyAnnotatorFactory,
 	) {
 	}
 
@@ -50,35 +55,32 @@ class FileUpload implements FileUploadHook {
 	}
 
 	private function doProcess( File $file, bool $reUploadStatus = false ): bool {
-		$applicationFactory = ApplicationFactory::getInstance();
 		$filePage = $this->makeFilePage( $file );
 
 		// Avoid WikiPage.php: The supplied ParserOptions are not safe to cache.
 		// Fix the options or set $forceParse = true.
 		$forceParse = true;
 
-		$parserData = $applicationFactory->newParserData(
+		$parserData = $this->parserDataFactory->newParserData(
 			$file->getTitle(),
 			$filePage->getParserOutput( $this->makeCanonicalParserOptions(), null, $forceParse )
 		);
 
-		$pageInfoProvider = $applicationFactory->newMwCollaboratorFactory()->newPageInfoProvider(
+		$pageInfoProvider = $this->mwCollaboratorFactory->newPageInfoProvider(
 			$filePage,
 			null,
 			null,
 			$reUploadStatus
 		);
 
-		$propertyAnnotatorFactory = $applicationFactory->singleton( 'PropertyAnnotatorFactory' );
-
 		$semanticData = $parserData->getSemanticData();
 		$semanticData->setOption( 'is_fileupload', true );
 
-		$propertyAnnotator = $propertyAnnotatorFactory->newNullPropertyAnnotator(
+		$propertyAnnotator = $this->propertyAnnotatorFactory->newNullPropertyAnnotator(
 			$semanticData
 		);
 
-		$propertyAnnotator = $propertyAnnotatorFactory->newPredefinedPropertyAnnotator(
+		$propertyAnnotator = $this->propertyAnnotatorFactory->newPredefinedPropertyAnnotator(
 			$propertyAnnotator,
 			$pageInfoProvider
 		);

--- a/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
+++ b/src/MediaWiki/Hooks/InternalParseBeforeLinks.php
@@ -5,8 +5,10 @@ namespace SMW\MediaWiki\Hooks;
 use MediaWiki\Hook\InternalParseBeforeLinksHook;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Title\Title;
+use SMW\MediaWiki\Jobs\ParserDataFactory;
+use SMW\MediaWiki\MwCollaboratorFactory;
 use SMW\Parser\InTextAnnotationParser;
-use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Parser\InTextAnnotationParserFactory;
 use SMW\Settings;
 
 /**
@@ -40,7 +42,12 @@ class InternalParseBeforeLinks implements InternalParseBeforeLinksHook {
 	/**
 	 * @since 7.0.0
 	 */
-	public function __construct( private readonly Settings $settings ) {
+	public function __construct(
+		private readonly Settings $settings,
+		private readonly ParserDataFactory $parserDataFactory,
+		private readonly InTextAnnotationParserFactory $inTextAnnotationParserFactory,
+		private readonly MwCollaboratorFactory $mwCollaboratorFactory,
+	) {
 	}
 
 	/**
@@ -86,27 +93,14 @@ class InternalParseBeforeLinks implements InternalParseBeforeLinksHook {
 	}
 
 	private function performUpdate( &$text, Parser $parser, $stripState ): bool {
-		$applicationFactory = ApplicationFactory::getInstance();
-
-		/**
-		 * @var ParserData $parserData
-		 */
-		$parserData = $applicationFactory->newParserData(
+		$parserData = $this->parserDataFactory->newParserData(
 			$parser->getTitle(),
 			$parser->getOutput()
 		);
 
-		/**
-		 * Performs [[link::syntax]] parsing and adding of property annotations
-		 * to the ParserOutput
-		 *
-		 * @var InTextAnnotationParser
-		 */
-		$inTextAnnotationParser = $applicationFactory->newInTextAnnotationParser(
-			$parserData
-		);
+		$inTextAnnotationParser = $this->inTextAnnotationParserFactory->newFor( $parserData );
 
-		$stripMarkerDecoder = $applicationFactory->newMwCollaboratorFactory()->newStripMarkerDecoder(
+		$stripMarkerDecoder = $this->mwCollaboratorFactory->newStripMarkerDecoder(
 			$stripState
 		);
 

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -3,9 +3,9 @@
 namespace SMW\MediaWiki\Hooks;
 
 use MediaWiki\Hook\ParserAfterTidyHook;
-use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\ParserOutputLinkTypes;
+use MediaWiki\Permissions\RestrictionStore;
 use Onoi\Cache\Cache;
 use Psr\Log\LoggerInterface;
 use SMW\DataModel\SemanticData;
@@ -58,6 +58,7 @@ class ParserAfterTidy implements ParserAfterTidyHook {
 		private readonly HookDispatcher $hookDispatcher,
 		private readonly Settings $settings,
 		private readonly LoggerInterface $logger,
+		private readonly RestrictionStore $restrictionStore,
 	) {
 	}
 
@@ -210,7 +211,7 @@ class ParserAfterTidy implements ParserAfterTidyHook {
 		}
 
 		if ( ParserData::hasSemanticData( $parserOutput ) ||
-			MediaWikiServices::getInstance()->getRestrictionStore()->isProtected( $title, 'edit' ) ||
+			$this->restrictionStore->isProtected( $title, 'edit' ) ||
 			$parserDefaultSort ) {
 			return true;
 		}

--- a/src/MediaWiki/Hooks/SpecialSearchProfileForm.php
+++ b/src/MediaWiki/Hooks/SpecialSearchProfileForm.php
@@ -4,8 +4,8 @@ namespace SMW\MediaWiki\Hooks;
 
 use MediaWiki\Search\Hook\SpecialSearchProfileFormHook;
 use MediaWiki\Specials\SpecialSearch;
+use SearchEngineConfig;
 use SMW\MediaWiki\Search\ProfileForm\ProfileForm;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
 
 /**
@@ -19,7 +19,10 @@ class SpecialSearchProfileForm implements SpecialSearchProfileFormHook {
 	/**
 	 * @since 7.0.0
 	 */
-	public function __construct( private readonly Store $store ) {
+	public function __construct(
+		private readonly Store $store,
+		private readonly SearchEngineConfig $searchEngineConfig,
+	) {
 	}
 
 	/**
@@ -34,15 +37,13 @@ class SpecialSearchProfileForm implements SpecialSearchProfileFormHook {
 			return true;
 		}
 
-		$searchEngineConfig = ApplicationFactory::getInstance()->singleton( 'SearchEngineConfig' );
-
 		$profileForm = new ProfileForm(
 			$this->store,
 			$search
 		);
 
 		$profileForm->setSearchableNamespaces(
-			$searchEngineConfig->searchableNamespaces()
+			$this->searchEngineConfig->searchableNamespaces()
 		);
 
 		$profileForm->buildForm( $form, $opts );

--- a/src/MediaWiki/Hooks/SpecialSearchProfiles.php
+++ b/src/MediaWiki/Hooks/SpecialSearchProfiles.php
@@ -3,8 +3,8 @@
 namespace SMW\MediaWiki\Hooks;
 
 use MediaWiki\Hook\SpecialSearchProfilesHook;
+use SearchEngineConfig;
 use SMW\MediaWiki\Search\ProfileForm\ProfileForm;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Site;
 
 /**
@@ -18,11 +18,17 @@ class SpecialSearchProfiles implements SpecialSearchProfilesHook {
 	/**
 	 * @since 7.0.0
 	 */
-	public function onSpecialSearchProfiles( &$profiles ) {
-		$searchEngineConfig = ApplicationFactory::getInstance()->singleton( 'SearchEngineConfig' );
+	public function __construct(
+		private readonly SearchEngineConfig $searchEngineConfig,
+	) {
+	}
 
+	/**
+	 * @since 7.0.0
+	 */
+	public function onSpecialSearchProfiles( &$profiles ) {
 		$options = [
-			'default_namespaces' => $searchEngineConfig->defaultNamespaces()
+			'default_namespaces' => $this->searchEngineConfig->defaultNamespaces()
 		];
 
 		ProfileForm::addProfile(

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -53,7 +53,6 @@ use SMW\Property\AnnotatorFactory;
 use SMW\Property\SpecificationLookup;
 use SMW\PropertyLabelFinder;
 use SMW\Protection\ProtectionValidator;
-use SMW\Query\Cache\ResultCache;
 use SMW\Query\Processor\ParamListProcessor;
 use SMW\Query\Processor\QueryCreator;
 use SMW\Query\QuerySourceFactory;
@@ -926,13 +925,6 @@ return [
 			$servicesFactory->getSerializerFactory(),
 			$servicesFactory
 		);
-	},
-
-	'SMW.ResultCache' => static function ( MediaWikiServices $services ): ResultCache {
-		// Construction (Store, Settings, CacheFactory wiring, BlobStore composition)
-		// lives in ServicesFactory::getResultCache(), which also honours its own
-		// testOverrides slot. The wiring is a thin pass-through.
-		return ServicesFactory::getInstance()->getResultCache();
 	},
 
 	'SMW.SearchEngineConfig' => static function ( MediaWikiServices $services ): SearchEngineConfig {

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -53,6 +53,7 @@ use SMW\Property\AnnotatorFactory;
 use SMW\Property\SpecificationLookup;
 use SMW\PropertyLabelFinder;
 use SMW\Protection\ProtectionValidator;
+use SMW\Query\Cache\ResultCache;
 use SMW\Query\Processor\ParamListProcessor;
 use SMW\Query\Processor\QueryCreator;
 use SMW\Query\QuerySourceFactory;
@@ -66,6 +67,7 @@ use SMW\Settings;
 use SMW\SetupFile;
 use SMW\SiteReadiness;
 use SMW\SQLStore\QueryDependencyLinksStoreFactory;
+use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
 use SMW\Store;
 use SMW\StoreFactory;
 use SMW\Utils\Logger;
@@ -922,6 +924,33 @@ return [
 			$servicesFactory->newJobFactory(),
 			$servicesFactory->getEventDispatcher()
 		);
+	},
+
+	'SMW.ResultCache' => static function ( MediaWikiServices $services ): ResultCache {
+		// Construction (Store, Settings, CacheFactory wiring, BlobStore composition)
+		// lives in ServicesFactory::getResultCache(), which also honours its own
+		// testOverrides slot. The wiring is a thin pass-through.
+		return ServicesFactory::getInstance()->getResultCache();
+	},
+
+	'SMW.SearchEngineConfig' => static function ( MediaWikiServices $services ): SearchEngineConfig {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'SearchEngineConfig' ) ) {
+			return $servicesFactory->getSearchEngineConfig();
+		}
+
+		return $services->getSearchEngineConfig();
+	},
+
+	'SMW.FulltextSearchTableFactory' => static function ( MediaWikiServices $services ): FulltextSearchTableFactory {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'FulltextSearchTableFactory' ) ) {
+			return $servicesFactory->singleton( 'FulltextSearchTableFactory' );
+		}
+
+		return new FulltextSearchTableFactory();
 	},
 
 ];

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -922,7 +922,9 @@ return [
 		return new ArticleDelete(
 			$servicesFactory->getStore(),
 			$servicesFactory->newJobFactory(),
-			$servicesFactory->getEventDispatcher()
+			$servicesFactory->getEventDispatcher(),
+			$servicesFactory->getSerializerFactory(),
+			$servicesFactory
 		);
 	},
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleDeleteTest.php
@@ -9,6 +9,9 @@ use SMW\EventDispatcher\EventDispatcher;
 use SMW\MediaWiki\Hooks\ArticleDelete;
 use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\Jobs\UpdateDispatcherJob;
+use SMW\SerializerFactory;
+use SMW\Serializers\SemanticDataSerializer;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
@@ -28,6 +31,8 @@ class ArticleDeleteTest extends TestCase {
 	private $testEnvironment;
 	private $jobFactory;
 	private $eventDispatcher;
+	private $serializerFactory;
+	private $servicesFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -46,6 +51,15 @@ class ArticleDeleteTest extends TestCase {
 		$this->eventDispatcher = $this->getMockBuilder( EventDispatcher::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$semanticDataSerializer = $this->createMock( SemanticDataSerializer::class );
+		$semanticDataSerializer->method( 'serialize' )->willReturn( [] );
+
+		$this->serializerFactory = $this->createMock( SerializerFactory::class );
+		$this->serializerFactory->method( 'newSemanticDataSerializer' )
+			->willReturn( $semanticDataSerializer );
+
+		$this->servicesFactory = ApplicationFactory::getInstance();
 	}
 
 	protected function tearDown(): void {
@@ -58,7 +72,7 @@ class ArticleDeleteTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$instance = new ArticleDelete( $store, $this->jobFactory, $this->eventDispatcher );
+		$instance = new ArticleDelete( $store, $this->jobFactory, $this->eventDispatcher, $this->serializerFactory, $this->servicesFactory );
 
 		$this->assertInstanceOf(
 			ArticleDelete::class,
@@ -105,7 +119,9 @@ class ArticleDeleteTest extends TestCase {
 		$instance = new ArticleDelete(
 			$store,
 			$this->jobFactory,
-			$this->eventDispatcher
+			$this->eventDispatcher,
+			$this->serializerFactory,
+			$this->servicesFactory
 		);
 
 		$instance->doDelete( $subject->getTitle() );

--- a/tests/phpunit/Unit/MediaWiki/Hooks/DeleteAccountTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/DeleteAccountTest.php
@@ -2,6 +2,8 @@
 
 namespace SMW\Tests\Unit\MediaWiki\Hooks;
 
+use MediaWiki\Title\Title;
+use MediaWiki\Title\TitleFactory;
 use MediaWiki\User\User;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Hooks\ArticleDelete;
@@ -21,6 +23,7 @@ class DeleteAccountTest extends TestCase {
 
 	private $namespaceExaminer;
 	private $articleDelete;
+	private $titleFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -32,12 +35,16 @@ class DeleteAccountTest extends TestCase {
 		$this->articleDelete = $this->getMockBuilder( ArticleDelete::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->titleFactory = $this->createMock( TitleFactory::class );
+		$this->titleFactory->method( 'newFromText' )
+			->willReturn( $this->createMock( Title::class ) );
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			DeleteAccount::class,
-			new DeleteAccount( $this->namespaceExaminer, $this->articleDelete )
+			new DeleteAccount( $this->namespaceExaminer, $this->articleDelete, $this->titleFactory )
 		);
 	}
 
@@ -52,7 +59,8 @@ class DeleteAccountTest extends TestCase {
 
 		$instance = new DeleteAccount(
 			$this->namespaceExaminer,
-			$this->articleDelete
+			$this->articleDelete,
+			$this->titleFactory
 		);
 
 		$this->assertTrue(
@@ -79,7 +87,8 @@ class DeleteAccountTest extends TestCase {
 
 		$instance = new DeleteAccount(
 			$this->namespaceExaminer,
-			$this->articleDelete
+			$this->articleDelete,
+			$this->titleFactory
 		);
 
 		$this->assertTrue(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/FileUploadTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/FileUploadTest.php
@@ -6,9 +6,17 @@ use MediaWiki\HookContainer\HookContainer;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
+use SMW\DataModel\SemanticData;
 use SMW\MediaWiki\Hooks\FileUpload;
+use SMW\MediaWiki\Jobs\ParserDataFactory;
+use SMW\MediaWiki\MwCollaboratorFactory;
 use SMW\MediaWiki\PageCreator;
+use SMW\MediaWiki\PageInfoProvider;
 use SMW\NamespaceExaminer;
+use SMW\ParserData;
+use SMW\Property\AnnotatorFactory;
+use SMW\Property\Annotators\NullPropertyAnnotator;
+use SMW\Property\Annotators\PredefinedPropertyAnnotator;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -53,7 +61,14 @@ class FileUploadTest extends TestCase {
 
 		$this->assertInstanceOf(
 			FileUpload::class,
-			new FileUpload( $namespaceExaminer, $hookContainer, $pageCreator )
+			new FileUpload(
+				$namespaceExaminer,
+				$hookContainer,
+				$pageCreator,
+				$this->createMock( ParserDataFactory::class ),
+				$this->createMock( MwCollaboratorFactory::class ),
+				$this->createMock( AnnotatorFactory::class )
+			)
 		);
 	}
 
@@ -84,10 +99,6 @@ class FileUploadTest extends TestCase {
 			->method( 'getParserOutput' )
 			->willReturn( new ParserOutput() );
 
-		$wikiFilePage->expects( $this->atLeastOnce() )
-			->method( 'getFile' )
-			->willReturn( $file );
-
 		$pageCreator = $this->getMockBuilder( PageCreator::class )
 			->disableOriginalConstructor()
 			->setMethods( [ 'createFilePage' ] )
@@ -98,12 +109,36 @@ class FileUploadTest extends TestCase {
 			->with( $title )
 			->willReturn( $wikiFilePage );
 
+		$semanticData = $this->createMock( SemanticData::class );
+
+		$parserData = $this->createMock( ParserData::class );
+		$parserData->method( 'getSemanticData' )->willReturn( $semanticData );
+
+		$parserDataFactory = $this->createMock( ParserDataFactory::class );
+		$parserDataFactory->method( 'newParserData' )->willReturn( $parserData );
+
+		$mwCollaboratorFactory = $this->createMock( MwCollaboratorFactory::class );
+		$mwCollaboratorFactory->method( 'newPageInfoProvider' )
+			->willReturn( $this->createMock( PageInfoProvider::class ) );
+
+		$nullPropertyAnnotator = $this->createMock( NullPropertyAnnotator::class );
+		$predefinedPropertyAnnotator = $this->createMock( PredefinedPropertyAnnotator::class );
+
+		$propertyAnnotatorFactory = $this->createMock( AnnotatorFactory::class );
+		$propertyAnnotatorFactory->method( 'newNullPropertyAnnotator' )
+			->willReturn( $nullPropertyAnnotator );
+		$propertyAnnotatorFactory->method( 'newPredefinedPropertyAnnotator' )
+			->willReturn( $predefinedPropertyAnnotator );
+
 		$instance = new FileUpload(
 			$namespaceExaminer,
 			$this->getMockBuilder( HookContainer::class )
 				->disableOriginalConstructor()
 				->getMock(),
-			$pageCreator
+			$pageCreator,
+			$parserDataFactory,
+			$mwCollaboratorFactory,
+			$propertyAnnotatorFactory
 		);
 
 		$reUploadStatus = true;
@@ -144,7 +179,10 @@ class FileUploadTest extends TestCase {
 			$this->getMockBuilder( HookContainer::class )
 				->disableOriginalConstructor()
 				->getMock(),
-			$pageCreator
+			$pageCreator,
+			$this->createMock( ParserDataFactory::class ),
+			$this->createMock( MwCollaboratorFactory::class ),
+			$this->createMock( AnnotatorFactory::class )
 		);
 
 		$instance->onFileUpload( $file, false, false );

--- a/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/InternalParseBeforeLinksTest.php
@@ -31,6 +31,9 @@ class InternalParseBeforeLinksTest extends TestCase {
 	private $stripState;
 	private $testEnvironment;
 	private $settings;
+	private $parserDataFactory;
+	private $inTextAnnotationParserFactory;
+	private $mwCollaboratorFactory;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -45,6 +48,20 @@ class InternalParseBeforeLinksTest extends TestCase {
 			->getMock();
 
 		$this->settings = $this->createMock( Settings::class );
+
+		$applicationFactory = ApplicationFactory::getInstance();
+		$this->parserDataFactory = $applicationFactory->getParserDataFactory();
+		$this->inTextAnnotationParserFactory = MediaWikiServices::getInstance()->getService( 'SMW.InTextAnnotationParserFactory' );
+		$this->mwCollaboratorFactory = $applicationFactory->newMwCollaboratorFactory();
+	}
+
+	private function newInstance( ?Settings $settings = null ): InternalParseBeforeLinks {
+		return new InternalParseBeforeLinks(
+			$settings ?? $this->settings,
+			$this->parserDataFactory,
+			$this->inTextAnnotationParserFactory,
+			$this->mwCollaboratorFactory
+		);
 	}
 
 	protected function tearDown(): void {
@@ -55,7 +72,7 @@ class InternalParseBeforeLinksTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			InternalParseBeforeLinks::class,
-			new InternalParseBeforeLinks( $this->settings )
+			$this->newInstance()
 		);
 	}
 
@@ -70,7 +87,7 @@ class InternalParseBeforeLinksTest extends TestCase {
 			->method( 'getOptions' )
 			->willReturn( $this->createMock( ParserOptions::class ) );
 
-		$instance = new InternalParseBeforeLinks( $this->settings );
+		$instance = $this->newInstance();
 
 		$this->assertTrue(
 			$instance->onInternalParseBeforeLinks( $parser, $text, $this->stripState )
@@ -108,7 +125,7 @@ class InternalParseBeforeLinksTest extends TestCase {
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$instance = new InternalParseBeforeLinks( $this->settings );
+		$instance = $this->newInstance();
 
 		$this->assertTrue(
 			$instance->onInternalParseBeforeLinks( $parser, $text, $this->stripState )
@@ -159,7 +176,7 @@ class InternalParseBeforeLinksTest extends TestCase {
 			->with( 'smwgEnabledSpecialPage' )
 			->willReturn( [ 'Bar' ] );
 
-		$instance = new InternalParseBeforeLinks( $this->settings );
+		$instance = $this->newInstance();
 
 		$instance->onInternalParseBeforeLinks( $parser, $text, $this->stripState );
 	}
@@ -212,7 +229,7 @@ class InternalParseBeforeLinksTest extends TestCase {
 			->method( 'getTitle' )
 			->willReturn( $title );
 
-		$instance = new InternalParseBeforeLinks( $this->settings );
+		$instance = $this->newInstance();
 
 		$instance->onInternalParseBeforeLinks( $parser, $text, $this->stripState );
 	}
@@ -224,7 +241,7 @@ class InternalParseBeforeLinksTest extends TestCase {
 		$text   = 'Foo';
 		$parser = $this->parserFactory->newFromTitle( $title );
 
-		$instance = new InternalParseBeforeLinks( $this->settings );
+		$instance = $this->newInstance();
 
 		$this->assertTrue(
 			$instance->onInternalParseBeforeLinks( $parser, $text, $this->stripState )
@@ -249,7 +266,7 @@ class InternalParseBeforeLinksTest extends TestCase {
 			->with( 'smwgEnabledSpecialPage' )
 			->willReturn( $smwgEnabledSpecialPage );
 
-		$instance = new InternalParseBeforeLinks( $settings );
+		$instance = $this->newInstance( $settings );
 
 		$this->assertTrue(
 			$instance->onInternalParseBeforeLinks( $parser, $text, $this->stripState )

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -6,6 +6,7 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\ParserOptions;
 use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Permissions\RestrictionStore;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Title\Title;
@@ -50,6 +51,7 @@ class ParserAfterTidyTest extends TestCase {
 	private $cache;
 	private $revisionGuard;
 	private $settings;
+	private $restrictionStore;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -97,6 +99,8 @@ class ParserAfterTidyTest extends TestCase {
 		$this->testEnvironment->registerObject( 'RevisionGuard', $this->revisionGuard );
 
 		$this->settings = $this->createMock( Settings::class );
+
+		$this->restrictionStore = $this->createMock( RestrictionStore::class );
 	}
 
 	protected function tearDown(): void {
@@ -125,7 +129,8 @@ class ParserAfterTidyTest extends TestCase {
 			$this->applicationFactory,
 			$this->hookDispatcher,
 			$settings ?? $this->settings,
-			$this->spyLogger
+			$this->spyLogger,
+			$this->restrictionStore
 		);
 	}
 


### PR DESCRIPTION
## Summary

Completes the handler-DI conversion tracked in #6876. Twelve handlers under `src/MediaWiki/Hooks/` still resolved dependencies lazily through `ApplicationFactory::getInstance()->...` or `MediaWikiServices::getInstance()->...` inside hook method bodies. This sweep converts them to declarative `services:` injection through `extension.json`'s `HookHandlers`, matching the pattern established by #6883 / #6884 / #6885 / #6886 / #6889 / #6890.

Three new SMW services are wired on `MediaWikiServices` because they previously existed only on the private `ServicesFactory` map:

- `SMW.ResultCache`
- `SMW.SearchEngineConfig`
- `SMW.FulltextSearchTableFactory`

`ExtensionSchemaUpdates` keeps its lazy `Store` lookup with an inline comment explaining why (installer-only path that mutates the resolved Store; both lazy and injected paths resolve the same singleton, but keeping the lookup local minimises blast radius).

## Commits

The PR is split into nine focused commits:

1. **Wire `SMW.ResultCache`, `SMW.SearchEngineConfig`, `SMW.FulltextSearchTableFactory`** on `MediaWikiServices`.
2. **Inject query/data factories into SMW core-hook handlers**: `AfterDataUpdateComplete`, `AfterQueryResultLookupComplete`, `AfterIncomingPropertiesLookupComplete`, `BeforeIncomingPropertyValuesFurtherLinkCreate`, `BeforeQueryResultLookupComplete` (all receive `Store` from the hook signature, so injection targets `QueryDependencyLinksStoreFactory`, `ResultCache`, `FulltextSearchTableFactory`).
3. **Inject `SearchEngineConfig`** into `SpecialSearchProfileForm` and `SpecialSearchProfiles`.
4. **Inject MW core services**: `TitleFactory` into `DeleteAccount`, `RestrictionStore` into `ParserAfterTidy`.
5. **Inject `SerializerFactory` and `ApplicationFactory`** into `ArticleDelete` (the latter for `newDeferredCallableUpdate`, which applies `smwgEnabledDeferredUpdate` and honours `testOverrides`).
6. **Inject `ImporterServiceFactory` and `Settings`** into `AfterCreateTablesComplete`.
7. **Inject `ParserDataFactory`, `MwCollaboratorFactory`, `AnnotatorFactory`** into `FileUpload`.
8. **Inject parser-time factories** into `InternalParseBeforeLinks` (`ParserDataFactory`, `InTextAnnotationParserFactory`, `MwCollaboratorFactory`).
9. **Document `ExtensionSchemaUpdates`** as intentionally lazy.

Test files for handlers that have one (`ArticleDelete`, `DeleteAccount`, `FileUpload`, `InternalParseBeforeLinks`, `ParserAfterTidy`) are updated to pass mocks/factories for the new constructor arguments. Handlers without unit tests (`AfterCreateTablesComplete`, the four SMW query/data hooks, the two SpecialSearch hooks) get no test updates here; restoring the 23 dropped unit-test methods listed in #6876 is tracked as a follow-up.

## Test plan

- [x] Unit suite: `composer phpunit -- --testsuite semantic-mediawiki-unit` stays green.
- [x] Integration suite stays green; the new ctor signatures are reached through real container resolution.
- [x] `HookHandlersConstructionTest` stays at 55/55 (verifies every declarative handler can be constructed from the global container).
- [ ] Manual smoke when CI is green: `?action=purge`, Special:Version (Elastic), and a query exercise the converted hook paths.

Refs #6876