### PR TITLE
Make SMW.ContentParserFactory resolve Parser lazily

### DIFF
--- a/src/MediaWiki/Jobs/ContentParserFactory.php
+++ b/src/MediaWiki/Jobs/ContentParserFactory.php
@@ -2,7 +2,7 @@
 
 namespace SMW\MediaWiki\Jobs;
 
-use MediaWiki\Parser\Parser;
+use Closure;
 use MediaWiki\Title\Title;
 use SMW\MediaWiki\RevisionGuard;
 use SMW\Parser\ContentParser;
@@ -13,22 +13,40 @@ use SMW\Parser\ContentParser;
  * Extracted to lift `UpdateJob` (and any future callers) off
  * `ServicesFactory::getInstance()->newContentParser(...)`.
  *
+ * Parser is resolved through a provider closure rather than captured at
+ * construction time. Eagerly calling `MediaWikiServices::getParser()` in
+ * the wiring would force Parser singleton construction every time this
+ * factory is resolved, which fires `ParserFirstCallInit` against whatever
+ * hook listeners happen to be registered at that moment. In test setups
+ * that resolve this factory before all extension hook listeners are in
+ * place (e.g. via ObjectFactory normalization triggered by
+ * `HookContainer::isRegistered`), the resulting Parser singleton ends up
+ * missing parser-function registrations from downstream extensions.
+ *
  * @license GPL-2.0-or-later
  * @since 7.0.0
  */
 class ContentParserFactory {
 
+	private readonly Closure $parserProvider;
+
+	/**
+	 * @param Closure $parserProvider Returns the MediaWiki Parser; invoked once per
+	 *  `newContentParser()` call. Wrapping `MediaWikiServices::getParser()` in a closure
+	 *  defers Parser singleton construction until a `ContentParser` is actually built.
+	 */
 	public function __construct(
-		private readonly Parser $parser,
+		Closure $parserProvider,
 		private readonly RevisionGuard $revisionGuard,
 	) {
+		$this->parserProvider = $parserProvider;
 	}
 
 	/**
 	 * @since 7.0.0
 	 */
 	public function newContentParser( Title $title ): ContentParser {
-		$contentParser = new ContentParser( $title, $this->parser );
+		$contentParser = new ContentParser( $title, ( $this->parserProvider )() );
 		$contentParser->setRevisionGuard( $this->revisionGuard );
 
 		return $contentParser;

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -2,6 +2,7 @@
 
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\Parser;
 use Onoi\Cache\Cache;
 use Psr\Log\LoggerInterface;
 use SMW\CacheFactory;
@@ -563,7 +564,7 @@ return [
 		}
 
 		return new ContentParserFactory(
-			$services->getParser(),
+			static fn (): Parser => $services->getParser(),
 			$servicesFactory->getRevisionGuard()
 		);
 	},

--- a/tests/phpunit/Integration/Services/ContentParserFactoryLazyParserTest.php
+++ b/tests/phpunit/Integration/Services/ContentParserFactoryLazyParserTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace SMW\Tests\Integration\Services;
+
+use MediaWiki\MediaWikiServices;
+use MediaWikiIntegrationTestCase;
+use SMW\MediaWiki\Jobs\ContentParserFactory;
+
+/**
+ * Pins the property that resolving `SMW.ContentParserFactory` does not
+ * eagerly construct the MediaWiki Parser singleton.
+ *
+ * Background: `SemanticMediaWiki.LinksUpdateComplete`'s HookHandler declares
+ * `SMW.ContentParserFactory` in its `services:` block. `HookContainer`
+ * normalises declarative handlers lazily via `ObjectFactory::createObject()`
+ * the first time something calls `getHandlers()` or `isRegistered()` on the
+ * hook. Any service the handler depends on is therefore resolved at that
+ * moment, well before the test body or even the test class's own `setUp()`
+ * runs.
+ *
+ * If `SMW.ContentParserFactory`'s wiring eagerly calls
+ * `MediaWikiServices::getParser()`, it constructs (and caches) the Parser
+ * singleton at that moment. Any extension that registers a
+ * `ParserFirstCallInit` listener later in the boot sequence (e.g.
+ * SemanticCite, SemanticForms, SemanticGlossary, and several other downstream
+ * extensions that use the `HookContainer::register()` pattern from
+ * `wgExtensionFunctions`) never gets a chance to install their parser
+ * functions against this Parser singleton: their `setFunctionHook()` calls
+ * never happen, and `{{#scite:...}}` style invocations parse as literal
+ * wikitext.
+ *
+ * The regression manifested in SemanticCite's CI run 26573787660 on
+ * 2026-05-28 as 12 JSONScript test failures all showing "Counted properties
+ * include: [_MDAT, _SKEY]", i.e. SCI subobjects never reached the store
+ * because `{{#scite:...}}` never fired. Root cause was the conjunction of
+ * #6886 (added `SMW.ContentParserFactory` to `LinksUpdateComplete`'s
+ * `services:` array) and #6888 (the new `SMWDeclarativeHookReseater` calls
+ * `HookContainer::isRegistered()` for every SMW-declared hook in test setUp,
+ * which triggers the eager-normalisation path).
+ *
+ * The fix is to defer Parser resolution to a closure stored on
+ * `ContentParserFactory` and invoke it inside `newContentParser()`. This
+ * test characterises that contract: any future change that re-introduces
+ * eager `getParser()` at wiring time will fail here, before it ships and
+ * breaks downstream CI.
+ *
+ * @covers \SMW\MediaWiki\Jobs\ContentParserFactory
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ */
+class ContentParserFactoryLazyParserTest extends MediaWikiIntegrationTestCase {
+
+	public function testResolvingContentParserFactoryDoesNotConstructParser(): void {
+		$services = MediaWikiServices::getInstance();
+
+		// Force re-resolution: a cached ContentParserFactory or Parser from a
+		// prior test would make this a no-op assertion.
+		$services->resetServiceForTesting( 'SMW.ContentParserFactory' );
+		$services->resetServiceForTesting( 'Parser' );
+
+		$this->assertNull(
+			$services->peekService( 'Parser' ),
+			'Test precondition: Parser must not be cached before we resolve SMW.ContentParserFactory.'
+		);
+
+		$contentParserFactory = $services->getService( 'SMW.ContentParserFactory' );
+
+		$this->assertInstanceOf( ContentParserFactory::class, $contentParserFactory );
+
+		$this->assertNull(
+			$services->peekService( 'Parser' ),
+			'Resolving SMW.ContentParserFactory must not eagerly construct the Parser singleton. '
+				. 'Eager construction at this point misses ParserFirstCallInit listeners that downstream '
+				. 'extensions register later in the boot sequence (the SemanticCite CI failure on 2026-05-28). '
+				. 'Keep Parser resolution behind a closure invoked inside ContentParserFactory::newContentParser().'
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Jobs/ContentParserFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/ContentParserFactoryTest.php
@@ -21,10 +21,11 @@ use SMW\Parser\ContentParser;
 class ContentParserFactoryTest extends TestCase {
 
 	public function testCanConstruct() {
+		$parser = $this->createMock( Parser::class );
 		$this->assertInstanceOf(
 			ContentParserFactory::class,
 			new ContentParserFactory(
-				$this->createMock( Parser::class ),
+				static fn (): Parser => $parser,
 				$this->createMock( RevisionGuard::class )
 			)
 		);
@@ -32,9 +33,10 @@ class ContentParserFactoryTest extends TestCase {
 
 	public function testNewContentParserReturnsContentParserBoundToTitle() {
 		$title = $this->createMock( Title::class );
+		$parser = $this->createMock( Parser::class );
 
 		$instance = new ContentParserFactory(
-			$this->createMock( Parser::class ),
+			static fn (): Parser => $parser,
 			$this->createMock( RevisionGuard::class )
 		);
 
@@ -42,6 +44,28 @@ class ContentParserFactoryTest extends TestCase {
 			ContentParser::class,
 			$instance->newContentParser( $title )
 		);
+	}
+
+	public function testParserProviderIsCalledLazilyPerNewContentParser() {
+		$title = $this->createMock( Title::class );
+		$parser = $this->createMock( Parser::class );
+		$calls = 0;
+
+		$instance = new ContentParserFactory(
+			static function () use ( $parser, &$calls ): Parser {
+				$calls++;
+				return $parser;
+			},
+			$this->createMock( RevisionGuard::class )
+		);
+
+		$this->assertSame( 0, $calls, 'Parser provider must not be invoked at construction time' );
+
+		$instance->newContentParser( $title );
+		$this->assertSame( 1, $calls, 'Parser provider invoked once per newContentParser call' );
+
+		$instance->newContentParser( $title );
+		$this->assertSame( 2, $calls );
 	}
 
 }


### PR DESCRIPTION
## Summary

`SMW.ContentParserFactory`'s `ServiceWiring` closure called `$services->getParser()` at service-construction time, which built and cached MediaWiki's Parser singleton as a side effect of resolving the service. MediaWiki's `HookContainer` materialises declarative hook handlers lazily via `ObjectFactory::createObject()` whenever a hook is queried (e.g. from `HookContainer::isRegistered()`), so resolving the `LinksUpdateComplete` HookHandler, which depends on `SMW.ContentParserFactory`, eagerly forced Parser construction at the moment any code asked whether `LinksUpdateComplete` was registered.

When `JSONScriptTestCaseRunner::setUp()`'s `SMWDeclarativeHookReseater::reseatDeclarativeHandlers()` calls `isRegistered()` on every SMW-declared hook, this fires before downstream extensions' setUp bodies have re-registered their `ParserFirstCallInit` listeners on the test's current `HookContainer`. The resulting Parser singleton is missing those listeners' `setFunctionHook()` calls, and subsequent page parses see the parser-function syntax as literal wikitext.

The visible downstream symptom: SemanticCite's JSONScript tests fail with `Counted properties include: [_MDAT, _SKEY]` because `{{#scite:...}}` does not expand. See SemanticCite CI run [26573787660](https://github.com/SemanticMediaWiki/SemanticCite/actions/runs/26573787660) on 2026-05-28.

## Fix

Pass a `Closure` returning Parser to `ContentParserFactory`'s constructor instead of a resolved Parser. The closure is invoked once per `newContentParser()` call, so Parser construction is deferred until a `ContentParser` is actually built. By that point all extension hook listeners are in place, and `Parser::__construct` fires `ParserFirstCallInit` against the complete listener set.

The public `newContentParser()` signature is unchanged. The pattern mirrors the existing convention for boot-resolved factories that must not capture mutable services eagerly.

## Test plan

- [x] `ContentParserFactoryTest`: existing tests updated to pass a closure; new test asserts the closure is not invoked at construction time and is invoked once per `newContentParser()` call.
- [x] `ContentParserFactoryLazyParserTest` (new integration test): pins the property that resolving `SMW.ContentParserFactory` does not cache a Parser instance on `MediaWikiServices` as a side effect. Verified to fail against the broken code and pass against the fix.
- [x] `LinksUpdateCompleteTest` and `HookHandlersConstructionTest` continue to pass.
- [x] SemanticCite's `scite-01-simple-intext-reference.json` JSONScript test (the original failure reproducer) passes against the fix.
- [x] PHPCS and Phan clean on touched files.