### PR TITLE
Harden against XSS: enable Phan SecurityCheck rules and escape special-page / Ask UI message output

### DIFF
--- a/.phan/config.php
+++ b/.phan/config.php
@@ -19,8 +19,6 @@ $config['suppress_issue_types'] = array_merge(
 		'PhanUndeclaredTypeThrowsType',
 		'PhanUndeclaredVariable',
 		'PhanUndeclaredVariableAssignOp',
-		'SecurityCheck-DoubleEscaped',
-		'SecurityCheck-XSS',
 
 		// Both local and global vendor directories have to be analysed
 		'PhanRedefinedClassReference',

--- a/src/DataValues/ErrorValue.php
+++ b/src/DataValues/ErrorValue.php
@@ -54,7 +54,11 @@ class ErrorValue extends DataValue {
 	}
 
 	public function getShortHTMLText( $linker = null ): string {
-		return htmlspecialchars( $this->getShortWikiText( $linker ) );
+		// Errors are always rendered as the encoded error tooltip, which is already-safe
+		// HTML built (and internally escaped) by smwfEncodeMessages(). Mirror
+		// getLongHTMLText() and return it directly. Routing through getShortWikiText()
+		// would return the raw, unescaped m_caption on the construction path.
+		return $this->getErrorText();
 	}
 
 	public function getLongWikiText( $linked = null ) {

--- a/src/MediaWiki/Hooks/BeforePageDisplay.php
+++ b/src/MediaWiki/Hooks/BeforePageDisplay.php
@@ -113,7 +113,7 @@ class BeforePageDisplay implements BeforePageDisplayHook {
 		$isUpgradeFlag = $isUpgrade !== null ? 2 : 1;
 		$count = count( $incompleteTasks );
 
-		$titleHtml = Html::rawElement( 'strong', [], Message::get( 'smw-title' ) );
+		$titleHtml = Html::element( 'strong', [], Message::get( 'smw-title' ) );
 		$note = Html::rawElement( 'span',
 			[
 				'style' => 'color: var( --color-subtle, #54595d ); font-size: 0.75rem;'

--- a/src/MediaWiki/Page/Page.php
+++ b/src/MediaWiki/Page/Page.php
@@ -53,7 +53,7 @@ abstract class Page extends Article {
 
 		if ( !$this->getOption( 'SMW_EXTENSION_LOADED' ) ) {
 			$outputPage->setPageTitle( $this->getTitle()->getPrefixedText() );
-			$outputPage->addHTML( wfMessage( 'smw-semantics-not-enabled' )->text() );
+			$outputPage->addHTML( wfMessage( 'smw-semantics-not-enabled' )->escaped() );
 			return;
 		}
 

--- a/src/MediaWiki/Renderer/HtmlColumnListRenderer.php
+++ b/src/MediaWiki/Renderer/HtmlColumnListRenderer.php
@@ -57,7 +57,7 @@ class HtmlColumnListRenderer {
 	 * @return HtmlColumnListRenderer
 	 */
 	public function setColumnListClass( $columnListClass ): static {
-		$this->columnListClass = htmlspecialchars( $columnListClass );
+		$this->columnListClass = $columnListClass;
 		return $this;
 	}
 

--- a/src/MediaWiki/Renderer/HtmlFormRenderer.php
+++ b/src/MediaWiki/Renderer/HtmlFormRenderer.php
@@ -388,7 +388,7 @@ class HtmlFormRenderer {
 			'id'     => $this->defaultPrefix . "-{$this->name}",
 			'name'   => $this->name,
 			'method' => in_array( $this->method, [ 'get', 'post' ] ) ? $this->method : 'get',
-			'action' => htmlspecialchars( $this->actionUrl ?: $GLOBALS['wgScript'] )
+			'action' => $this->actionUrl ?: $GLOBALS['wgScript']
 		], Html::hidden(
 			'title',
 			strtok( $this->title->getPrefixedText() ?? '', '/' )

--- a/src/MediaWiki/Search/ProfileForm/Forms/Field.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/Field.php
@@ -27,11 +27,17 @@ class Field {
 			$attributes['class'] .= " smw-$type-tooltip";
 		}
 
+		// create() may set $attributes['tooltip'] to rendered (escaped) Highlighter HTML.
+		// input() pulls it out into element content (never into an attribute); select()
+		// has no tooltip support and no caller passes one. Phan taints the whole array and
+		// cannot track the per-key handling, so it reports a double escape that cannot occur.
 		if ( $type === 'input' ) {
+			// @phan-suppress-next-line SecurityCheck-DoubleEscaped
 			return $this->input( $attributes );
 		}
 
 		if ( $type === 'select' ) {
+			// @phan-suppress-next-line SecurityCheck-DoubleEscaped
 			return $this->select( $attributes );
 		}
 

--- a/src/MediaWiki/Search/ProfileForm/Forms/Field.php
+++ b/src/MediaWiki/Search/ProfileForm/Forms/Field.php
@@ -28,9 +28,9 @@ class Field {
 		}
 
 		// create() may set $attributes['tooltip'] to rendered (escaped) Highlighter HTML.
-		// input() pulls it out into element content (never into an attribute); select()
-		// has no tooltip support and no caller passes one. Phan taints the whole array and
-		// cannot track the per-key handling, so it reports a double escape that cannot occur.
+		// input() pulls it out into element content and select() unsets it; neither emits
+		// it as an attribute. Phan taints the whole array and cannot track the per-key
+		// handling, so it reports a double escape that cannot occur.
 		if ( $type === 'input' ) {
 			// @phan-suppress-next-line SecurityCheck-DoubleEscaped
 			return $this->input( $attributes );
@@ -85,6 +85,10 @@ class Field {
 			$selected = $attributes['selected'];
 			unset( $attributes['selected'] );
 		}
+
+		// Selects have no tooltip support; drop any rendered tooltip so it cannot
+		// leak into a literal tooltip="..." attribute on the <select>.
+		unset( $attributes['tooltip'] );
 
 		foreach ( $list as $key => $value ) {
 

--- a/src/MediaWiki/Specials/Ask/FormatListWidget.php
+++ b/src/MediaWiki/Specials/Ask/FormatListWidget.php
@@ -44,7 +44,7 @@ class FormatListWidget {
 			}
 		}
 
-		$defaultLocalizedName = htmlspecialchars( $printer->getName() ) . ' (' . Message::get( 'smw_ask_defaultformat', Message::TEXT, Message::USER_LANGUAGE ) . ')';
+		$defaultLocalizedName = htmlspecialchars( $printer->getName() ) . ' (' . Message::get( 'smw_ask_defaultformat', Message::ESCAPED, Message::USER_LANGUAGE ) . ')';
 		$defaultName = $printer->getName();
 
 		$default = '';

--- a/src/MediaWiki/Specials/Ask/HelpWidget.php
+++ b/src/MediaWiki/Specials/Ask/HelpWidget.php
@@ -34,7 +34,7 @@ class HelpWidget {
 				[
 					'style' => 'font-size: 1.2em; margin-left:0px'
 				],
-				Message::get( 'smw-ask-format', Message::TEXT, Message::USER_LANGUAGE )
+				Message::get( 'smw-ask-format', Message::ESCAPED, Message::USER_LANGUAGE )
 			) . Html::rawElement(
 				'ul',
 				[],
@@ -59,7 +59,7 @@ class HelpWidget {
 				[
 					'style' => 'font-size: 1.2em; margin-left:0px'
 				],
-				Message::get( 'smw-ask-input-assistance', Message::TEXT, Message::USER_LANGUAGE )
+				Message::get( 'smw-ask-input-assistance', Message::ESCAPED, Message::USER_LANGUAGE )
 			)
 		);
 
@@ -71,22 +71,22 @@ class HelpWidget {
 			Html::rawElement(
 				'li',
 				[],
-				Message::get( 'smw-ask-condition-input-assistance-property', Message::TEXT, Message::USER_LANGUAGE )
+				Message::get( 'smw-ask-condition-input-assistance-property', Message::ESCAPED, Message::USER_LANGUAGE )
 			) .
 			Html::rawElement(
 				'li',
 				[],
-				Message::get( 'smw-ask-condition-input-assistance-category', Message::TEXT, Message::USER_LANGUAGE )
+				Message::get( 'smw-ask-condition-input-assistance-category', Message::ESCAPED, Message::USER_LANGUAGE )
 			) .
 			Html::rawElement(
 				'li',
 				[],
-				Message::get( 'smw-ask-condition-input-assistance-concept', Message::TEXT, Message::USER_LANGUAGE )
+				Message::get( 'smw-ask-condition-input-assistance-concept', Message::ESCAPED, Message::USER_LANGUAGE )
 			)
 		);
 
 		$html = HtmlModal::modal(
-			Message::get( 'smw-cheat-sheet', Message::TEXT, Message::USER_LANGUAGE ),
+			Message::get( 'smw-cheat-sheet', Message::ESCAPED, Message::USER_LANGUAGE ),
 			$text,
 			[
 				'id' => 'ask-help',

--- a/src/MediaWiki/Specials/Ask/HelpWidget.php
+++ b/src/MediaWiki/Specials/Ask/HelpWidget.php
@@ -71,17 +71,17 @@ class HelpWidget {
 			Html::rawElement(
 				'li',
 				[],
-				Message::get( 'smw-ask-condition-input-assistance-property', Message::ESCAPED, Message::USER_LANGUAGE )
+				Message::get( 'smw-ask-condition-input-assistance-property', Message::PARSE, Message::USER_LANGUAGE )
 			) .
 			Html::rawElement(
 				'li',
 				[],
-				Message::get( 'smw-ask-condition-input-assistance-category', Message::ESCAPED, Message::USER_LANGUAGE )
+				Message::get( 'smw-ask-condition-input-assistance-category', Message::PARSE, Message::USER_LANGUAGE )
 			) .
 			Html::rawElement(
 				'li',
 				[],
-				Message::get( 'smw-ask-condition-input-assistance-concept', Message::ESCAPED, Message::USER_LANGUAGE )
+				Message::get( 'smw-ask-condition-input-assistance-concept', Message::PARSE, Message::USER_LANGUAGE )
 			)
 		);
 

--- a/src/MediaWiki/Specials/Ask/HtmlForm.php
+++ b/src/MediaWiki/Specials/Ask/HtmlForm.php
@@ -192,7 +192,7 @@ class HtmlForm {
 
 		$htmlTabs->tab(
 			'smw-askt-result',
-			wfMessage( 'smw-ask-tab-result' )->text(),
+			wfMessage( 'smw-ask-tab-result' )->escaped(),
 			[
 				'hide' => $isEmpty,
 				'class' => $isFromCache ? ' result-cache' : ''
@@ -203,7 +203,7 @@ class HtmlForm {
 
 		$htmlTabs->tab(
 			'smw-askt-code',
-			wfMessage( 'smw-ask-tab-code' )->text(),
+			wfMessage( 'smw-ask-tab-code' )->escaped(),
 			[
 				'hide' => $this->isBorrowedMode || $isEmpty
 			]
@@ -248,7 +248,7 @@ class HtmlForm {
 		if ( !$isEmpty ) {
 			$htmlTabs->tab(
 				'smw-askt-extra',
-				wfMessage( 'smw-ask-tab-extra' )->text(),
+				wfMessage( 'smw-ask-tab-extra' )->escaped(),
 				[
 					'class' => 'smw-tab-right'
 				]

--- a/src/MediaWiki/Specials/Ask/HtmlForm.php
+++ b/src/MediaWiki/Specials/Ask/HtmlForm.php
@@ -268,7 +268,7 @@ class HtmlForm {
 				}
 
 				if ( $links !== [] ) {
-					$infoText .= '<h3>' . wfMessage( 'smw-ask-extra-other' )->text() . '</h3>';
+					$infoText .= '<h3>' . wfMessage( 'smw-ask-extra-other' )->escaped() . '</h3>';
 					$infoText .= '<ul><li>' . implode( '</li><li>', $links ) . '</li></ul>';
 				}
 			} else {

--- a/src/MediaWiki/Specials/Ask/LinksWidget.php
+++ b/src/MediaWiki/Specials/Ask/LinksWidget.php
@@ -39,7 +39,7 @@ class LinksWidget {
 			Html::rawElement(
 				'legend',
 				[],
-				Message::get( 'smw-ask-search', Message::TEXT, Message::USER_LANGUAGE )
+				Message::get( 'smw-ask-search', Message::ESCAPED, Message::USER_LANGUAGE )
 			) . $html
 		);
 	}

--- a/src/MediaWiki/Specials/Ask/LinksWidget.php
+++ b/src/MediaWiki/Specials/Ask/LinksWidget.php
@@ -219,7 +219,7 @@ class LinksWidget {
 					[
 						'id' => 'search-action',
 						'type'  => 'submit',
-						'value' => wfMessage( 'smw_ask_submit' )->escaped()
+						'value' => wfMessage( 'smw_ask_submit' )->text()
 					]
 				) .
 				Html::element(

--- a/src/MediaWiki/Specials/Ask/NavigationLinksWidget.php
+++ b/src/MediaWiki/Specials/Ask/NavigationLinksWidget.php
@@ -48,7 +48,7 @@ class NavigationLinksWidget {
 			[
 				'href' => '#options'
 			],
-			Message::get( 'smw-ask-options', Message::TEXT, Message::USER_LANGUAGE )
+			Message::get( 'smw-ask-options', Message::ESCAPED, Message::USER_LANGUAGE )
 		);
 
 		$lLinks['search'] = Html::rawElement(
@@ -56,7 +56,7 @@ class NavigationLinksWidget {
 			[
 				'href' => '#search'
 			],
-			Message::get( 'smw-ask-search', Message::TEXT, Message::USER_LANGUAGE )
+			Message::get( 'smw-ask-search', Message::ESCAPED, Message::USER_LANGUAGE )
 		);
 
 		$lLinks['result'] = Html::rawElement(
@@ -64,7 +64,7 @@ class NavigationLinksWidget {
 			[
 				'href' => '#result'
 			],
-			Message::get( 'smw-ask-result', Message::TEXT, Message::USER_LANGUAGE )
+			Message::get( 'smw-ask-result', Message::ESCAPED, Message::USER_LANGUAGE )
 		);
 
 		$rLinks['empty'] = Html::rawElement(
@@ -72,7 +72,7 @@ class NavigationLinksWidget {
 			[
 				'href' => $title->getLocalURL()
 			],
-			Message::get( 'smw-ask-empty', Message::TEXT, Message::USER_LANGUAGE )
+			Message::get( 'smw-ask-empty', Message::ESCAPED, Message::USER_LANGUAGE )
 		);
 
 		$rLinks['help'] = HtmlModal::link(
@@ -169,7 +169,7 @@ class NavigationLinksWidget {
 		$userLanguage = Localizer::getInstance()->getUserLanguage();
 
 		$html =	'<b>' .
-				Message::get( 'smw_result_results', Message::TEXT, Message::USER_LANGUAGE ) . ' ' . $userLanguage->formatNum( $offset + 1 ) .
+				Message::get( 'smw_result_results', Message::ESCAPED, Message::USER_LANGUAGE ) . ' ' . $userLanguage->formatNum( $offset + 1 ) .
 			' &#150; ' .
 				$userLanguage->formatNum( $offset + $count ) .
 			'</b>&#160;';

--- a/src/MediaWiki/Specials/Ask/ParametersWidget.php
+++ b/src/MediaWiki/Specials/Ask/ParametersWidget.php
@@ -72,7 +72,7 @@ class ParametersWidget {
 			Html::rawElement(
 				'span',
 				[],
-				Message::get( 'smw-ask-parameters', Message::TEXT, Message::USER_LANGUAGE ) . $toggle
+				Message::get( 'smw-ask-parameters', Message::ESCAPED, Message::USER_LANGUAGE ) . $toggle
 			)
 		) . Html::rawElement(
 			'div',

--- a/src/MediaWiki/Specials/Ask/QueryInputWidget.php
+++ b/src/MediaWiki/Specials/Ask/QueryInputWidget.php
@@ -26,7 +26,7 @@ class QueryInputWidget {
 
 		$table .= HtmlDivTable::row(
 			HtmlDivTable::cell(
-				"<fieldset><legend>" . Message::get( 'smw_ask_queryhead', Message::TEXT, Message::USER_LANGUAGE ) . "</legend>" .
+				"<fieldset><legend>" . Message::get( 'smw_ask_queryhead', Message::ESCAPED, Message::USER_LANGUAGE ) . "</legend>" .
 				'<textarea id="ask-query-condition" class="smw-ask-query-condition" name="q" rows="6" placeholder="...">' .
 				htmlspecialchars( $queryString ) . '</textarea></fieldset>',
 				[ 'class' => 'smw-ask-condition slowfade' ]
@@ -36,7 +36,7 @@ class QueryInputWidget {
 					'style' => 'width:10px; border:0px; padding: 0px;'
 				]
 			) . HtmlDivTable::cell(
-				"<fieldset><legend>" . Message::get( 'smw_ask_printhead', Message::TEXT, Message::USER_LANGUAGE ) . "</legend>" .
+				"<fieldset><legend>" . Message::get( 'smw_ask_printhead', Message::ESCAPED, Message::USER_LANGUAGE ) . "</legend>" .
 				'<textarea id="smw-property-input" class="smw-ask-query-printout" name="po" rows="6" placeholder="...">' .
 				htmlspecialchars( $printoutString ?? '' ) . '</textarea></fieldset>',
 				[ 'class' => 'smw-ask-printhead slowfade' ]

--- a/src/MediaWiki/Specials/Ask/SortWidget.php
+++ b/src/MediaWiki/Specials/Ask/SortWidget.php
@@ -104,7 +104,7 @@ class SortWidget {
 						'name' => "sort_num[]",
 						'size' => '35',
 						'class' => 'smw-property-input autocomplete-arrow',
-						'value' => htmlspecialchars( $sorts[$i] )
+						'value' => $sorts[$i]
 					]
 			);
 

--- a/src/MediaWiki/Specials/Ask/SortWidget.php
+++ b/src/MediaWiki/Specials/Ask/SortWidget.php
@@ -64,7 +64,7 @@ class SortWidget {
 				Html::rawElement(
 					'span',
 					[],
-					Message::get( 'smw-ask-options-sort', Message::TEXT, Message::USER_LANGUAGE )
+					Message::get( 'smw-ask-options-sort', Message::ESCAPED, Message::USER_LANGUAGE )
 				)
 			) . Html::rawElement(
 				'div',
@@ -114,13 +114,13 @@ class SortWidget {
 				$html .= 'selected="selected" ';
 			}
 
-			$html .= 'value="asc">' . Message::get( 'smw_ask_ascorder', Message::TEXT, Message::USER_LANGUAGE ) . '</option><option ';
+			$html .= 'value="asc">' . Message::get( 'smw_ask_ascorder', Message::ESCAPED, Message::USER_LANGUAGE ) . '</option><option ';
 
 			if ( $order == 'desc' ) {
 				$html .= 'selected="selected" ';
 			}
 
-			$html .= 'value="desc">' . Message::get( 'smw_ask_descorder', Message::TEXT, Message::USER_LANGUAGE ) . "</option>";
+			$html .= 'value="desc">' . Message::get( 'smw_ask_descorder', Message::ESCAPED, Message::USER_LANGUAGE ) . "</option>";
 
 			if ( self::$randSortingSupport ) {
 				$html .= '<option ';
@@ -129,22 +129,22 @@ class SortWidget {
 					$html .= 'selected="selected" ';
 				}
 
-				$html .= 'value="rand">' . Message::get( 'smw-ask-order-rand', Message::TEXT, Message::USER_LANGUAGE ) . '</option>';
+				$html .= 'value="rand">' . Message::get( 'smw-ask-order-rand', Message::ESCAPED, Message::USER_LANGUAGE ) . '</option>';
 			}
 
 			$html .= '</select>';
-			$html .= '<span class="smw-ask-sort-delete"><a class="smw-ask-sort-delete-action" data-target="sort_div_' . $i . '" >' . Message::get( 'delete', Message::TEXT, Message::USER_LANGUAGE ) . '</a></span>';
+			$html .= '<span class="smw-ask-sort-delete"><a class="smw-ask-sort-delete-action" data-target="sort_div_' . $i . '" >' . Message::get( 'delete', Message::ESCAPED, Message::USER_LANGUAGE ) . '</a></span>';
 
 			$result .= Html::rawElement( 'div', [ 'id' => "sort_div_$i", 'class' => "smw-ask-sort-input" ], $html );
 		}
 
 		$result .= '<div id="sorting_starter" style="display: none"><input type="text" name="sort_num[]" size="35" class="smw-property-input autocomplete-arrow" />';
 		$result .= '<select name="order_num[]">' . "\n";
-		$result .= '	<option value="asc">' . Message::get( 'smw_ask_ascorder', Message::TEXT, Message::USER_LANGUAGE ) . "</option>\n";
-		$result .= '	<option value="desc">' . Message::get( 'smw_ask_descorder', Message::TEXT, Message::USER_LANGUAGE ) . "</option>\n";
+		$result .= '	<option value="asc">' . Message::get( 'smw_ask_ascorder', Message::ESCAPED, Message::USER_LANGUAGE ) . "</option>\n";
+		$result .= '	<option value="desc">' . Message::get( 'smw_ask_descorder', Message::ESCAPED, Message::USER_LANGUAGE ) . "</option>\n";
 
 		if ( self::$randSortingSupport ) {
-			$result .= '	<option value="rand">' . Message::get( 'smw-ask-order-rand', Message::TEXT, Message::USER_LANGUAGE ) . "</option>\n";
+			$result .= '	<option value="rand">' . Message::get( 'smw-ask-order-rand', Message::ESCAPED, Message::USER_LANGUAGE ) . "</option>\n";
 		}
 
 		$result .= "</select>";
@@ -161,7 +161,7 @@ class SortWidget {
 				[
 					'class' => 'smw-ask-sort-add-action'
 				],
-				Message::get( 'smw-ask-sort-add-action', Message::TEXT, Message::USER_LANGUAGE )
+				Message::get( 'smw-ask-sort-add-action', Message::ESCAPED, Message::USER_LANGUAGE )
 			)
 		);
 	}

--- a/src/MediaWiki/Specials/PageProperty/PageBuilder.php
+++ b/src/MediaWiki/Specials/PageProperty/PageBuilder.php
@@ -129,7 +129,7 @@ class PageBuilder {
 		$this->htmlFormRenderer
 			->setName( 'pageproperty' )
 			->withFieldset()
-			->addParagraph( Message::get( 'smw_pp_docu', Message::TEXT, Message::USER_LANGUAGE ) )
+			->addParagraph( Message::get( 'smw_pp_docu', Message::ESCAPED, Message::USER_LANGUAGE ) )
 			->addPaging(
 				(int)$this->options->safeGet( 'limit', 20 ),
 				(int)$this->options->safeGet( 'offset', 0 ),

--- a/src/MediaWiki/Specials/PropertyLabelSimilarity/ContentsBuilder.php
+++ b/src/MediaWiki/Specials/PropertyLabelSimilarity/ContentsBuilder.php
@@ -63,7 +63,7 @@ class ContentsBuilder {
 		if ( $result !== [] ) {
 			$html .= '<pre>' . json_encode( $result, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '</pre>';
 		} else {
-			$html .= $this->msg( 'smw-property-label-similarity-noresult' );
+			$html .= $this->msg( 'smw-property-label-similarity-noresult', Message::ESCAPED );
 		}
 
 		return $html;

--- a/src/MediaWiki/Specials/SearchByProperty/PageBuilder.php
+++ b/src/MediaWiki/Specials/SearchByProperty/PageBuilder.php
@@ -73,7 +73,7 @@ class PageBuilder {
 		}
 
 		if ( $resultList === '' || $resultList === null ) {
-			$resultList = $this->msg( 'smw_result_noresults' )->text();
+			$resultList = $this->msg( 'smw_result_noresults' )->escaped();
 		}
 
 		$pageDescription = Html::rawElement(

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -155,9 +155,9 @@ class SpecialAsk extends SpecialPage {
 		$out->addHTML( HelpWidget::html() );
 
 		if ( $request->getCheck( 'bHelp' ) ) {
-			$helpLink = $this->msg( $request->getVal( 'bHelp' ) )->escaped();
+			$helpLink = $this->msg( $request->getVal( 'bHelp' ) )->text();
 		} else {
-			$helpLink = $this->msg( 'smw_ask_doculink' )->escaped();
+			$helpLink = $this->msg( 'smw_ask_doculink' )->text();
 		}
 
 		$this->addHelpLink( $helpLink, true );

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -214,7 +214,7 @@ class SpecialBrowse extends SpecialPage {
 			] );
 		}
 
-		$this->addHelpLink( $this->msg( 'smw-specials-browse-helplink' )->escaped(), true );
+		$this->addHelpLink( $this->msg( 'smw-specials-browse-helplink' )->text(), true );
 	}
 
 	/**

--- a/src/MediaWiki/Specials/SpecialConcepts.php
+++ b/src/MediaWiki/Specials/SpecialConcepts.php
@@ -71,7 +71,7 @@ class SpecialConcepts extends SpecialPage {
 			$html = $this->getHtml( $diWikiPages, $limit, $offset );
 		}
 
-		$this->addHelpLink( $this->msg( 'smw-helplink-concepts' )->escaped(), true );
+		$this->addHelpLink( $this->msg( 'smw-helplink-concepts' )->text(), true );
 
 		$out->setPageTitle( $this->msg( 'concepts' )->text() );
 		$out->addHTML( $html );
@@ -247,7 +247,7 @@ class SpecialConcepts extends SpecialPage {
 				'div',
 				[ 'class' => 'smw-page-navigation' ],
 				$paginationHtml
-			) . Html::element(
+			) . Html::rawElement(
 				'div',
 				[ 'class' => $key, 'style' => 'margin-top:10px;margin-bottom:10px;' ],
 				$this->msg( $key, $resultNumber )->parse()

--- a/src/MediaWiki/Specials/SpecialFacetedSearch.php
+++ b/src/MediaWiki/Specials/SpecialFacetedSearch.php
@@ -47,7 +47,7 @@ class SpecialFacetedSearch extends SpecialPage {
 		$output = $this->getOutput();
 		$request = $this->getRequest();
 
-		$this->addHelpLink( $this->msg( 'smw-specials-facetedsearch-helplink' )->escaped(), true );
+		$this->addHelpLink( $this->msg( 'smw-specials-facetedsearch-helplink' )->text(), true );
 
 		$output->addModuleStyles(
 			[

--- a/src/MediaWiki/Specials/SpecialMissingRedirectAnnotations.php
+++ b/src/MediaWiki/Specials/SpecialMissingRedirectAnnotations.php
@@ -141,7 +141,7 @@ class SpecialMissingRedirectAnnotations extends SpecialPage {
 				[
 					'class' => 'smw-breadcrumb-arrow-right'
 				]
-			) . Html::rawElement(
+			) . Html::element(
 				'a',
 				[
 					'href' => SkinComponentUtils::makeSpecialUrl( 'Specialpages', $query ) . '#Semantic_MediaWiki'

--- a/src/MediaWiki/Specials/SpecialMissingRedirectAnnotations.php
+++ b/src/MediaWiki/Specials/SpecialMissingRedirectAnnotations.php
@@ -109,17 +109,17 @@ class SpecialMissingRedirectAnnotations extends SpecialPage {
 				[
 					'style' => 'font-style:normal;margin-top:20px;'
 				],
-				$this->msg( 'smw-missingredirects-noresult' )->text()
+				$this->msg( 'smw-missingredirects-noresult' )->escaped()
 			);
 		} else {
 			$html .= Html::rawElement(
 				'h2',
 				[],
-				$this->msg( 'smw-missingredirects-list' )->text()
+				$this->msg( 'smw-missingredirects-list' )->escaped()
 			) . Html::rawElement(
 				'p',
 				[],
-				$this->msg( 'smw-missingredirects-list-intro', $count )->text()
+				$this->msg( 'smw-missingredirects-list-intro', $count )->escaped()
 			) . Html::rawElement(
 				'div',
 				[],

--- a/src/MediaWiki/Specials/SpecialOWLExport.php
+++ b/src/MediaWiki/Specials/SpecialOWLExport.php
@@ -108,24 +108,24 @@ class SpecialOWLExport extends SpecialPage {
 		$user = $this->getUser();
 
 		$html = '<form name="tripleSearch" action="" method="POST">' . "\n" .
-					'<p>' . $this->msg( 'smw_exportrdf_docu' )->text() . "</p>\n" .
+					'<p>' . $this->msg( 'smw_exportrdf_docu' )->escaped() . "</p>\n" .
 					'<input type="hidden" name="postform" value="1"/>' . "\n" .
 					'<textarea name="pages" cols="40" rows="10"></textarea><br />' . "\n";
 
 		if ( $user->isAllowed( 'delete' ) || $smwgAllowRecursiveExport ) {
-			$html .= '<input type="checkbox" name="recursive" value="1" id="rec">&#160;<label for="rec">' . $this->msg( 'smw_exportrdf_recursive' )->text() . '</label></input><br />' . "\n";
+			$html .= '<input type="checkbox" name="recursive" value="1" id="rec">&#160;<label for="rec">' . $this->msg( 'smw_exportrdf_recursive' )->escaped() . '</label></input><br />' . "\n";
 		}
 
 		if ( $user->isAllowed( 'delete' ) || $smwgExportBacklinks ) {
-			$html .= '<input type="checkbox" name="backlinks" value="1" default="true" id="bl">&#160;<label for="bl">' . $this->msg( 'smw_exportrdf_backlinks' )->text() . '</label></input><br />' . "\n";
+			$html .= '<input type="checkbox" name="backlinks" value="1" default="true" id="bl">&#160;<label for="bl">' . $this->msg( 'smw_exportrdf_backlinks' )->escaped() . '</label></input><br />' . "\n";
 		}
 
 		if ( $user->isAllowed( 'delete' ) || $smwgExportAll ) {
 			$html .= '<br />';
-			$html .= '<input type="text" name="date" value="' . date( DATE_W3C, mktime( 0, 0, 0, 1, 1, 2000 ) ) . '" id="date">&#160;<label for="ea">' . $this->msg( 'smw_exportrdf_lastdate' )->text() . '</label></input><br />' . "\n";
+			$html .= '<input type="text" name="date" value="' . date( DATE_W3C, mktime( 0, 0, 0, 1, 1, 2000 ) ) . '" id="date">&#160;<label for="ea">' . $this->msg( 'smw_exportrdf_lastdate' )->escaped() . '</label></input><br />' . "\n";
 		}
 
-		$html .= '<br /><input type="submit"  value="' . $this->msg( 'smw_exportrdf_submit' )->text() . "\"/>\n</form>";
+		$html .= '<br /><input type="submit"  value="' . $this->msg( 'smw_exportrdf_submit' )->escaped() . "\"/>\n</form>";
 
 		$out->addHTML( $html );
 	}

--- a/src/MediaWiki/Specials/SpecialOWLExport.php
+++ b/src/MediaWiki/Specials/SpecialOWLExport.php
@@ -122,7 +122,7 @@ class SpecialOWLExport extends SpecialPage {
 
 		if ( $user->isAllowed( 'delete' ) || $smwgExportAll ) {
 			$html .= '<br />';
-			$html .= '<input type="text" name="date" value="' . date( DATE_W3C, mktime( 0, 0, 0, 1, 1, 2000 ) ) . '" id="date">&#160;<label for="ea">' . $this->msg( 'smw_exportrdf_lastdate' )->escaped() . '</label></input><br />' . "\n";
+			$html .= '<input type="text" name="date" value="' . date( DATE_W3C, mktime( 0, 0, 0, 1, 1, 2000 ) ) . '" id="date">&#160;<label for="date">' . $this->msg( 'smw_exportrdf_lastdate' )->escaped() . '</label></input><br />' . "\n";
 		}
 
 		$html .= '<br /><input type="submit"  value="' . $this->msg( 'smw_exportrdf_submit' )->escaped() . "\"/>\n</form>";

--- a/src/MediaWiki/Specials/SpecialPageProperty.php
+++ b/src/MediaWiki/Specials/SpecialPageProperty.php
@@ -77,7 +77,7 @@ class SpecialPageProperty extends SpecialPage {
 		);
 
 		$this->addHelpLink(
-			$this->msg( 'smw-special-pageproperty-helplink' )->escaped(),
+			$this->msg( 'smw-special-pageproperty-helplink' )->text(),
 			true
 		);
 
@@ -137,7 +137,7 @@ class SpecialPageProperty extends SpecialPage {
 		// No property given, no results
 		if ( $propname === '' ) {
 			$html .= $pageBuilder->buildForm();
-			$html .= $this->msg( 'smw_result_noresults' )->text();
+			$html .= $this->msg( 'smw_result_noresults' )->escaped();
 		} else {
 
 			$requestOptions = new RequestOptions();

--- a/src/MediaWiki/Specials/SpecialPendingTaskList.php
+++ b/src/MediaWiki/Specials/SpecialPendingTaskList.php
@@ -26,7 +26,7 @@ class SpecialPendingTaskList extends SpecialPage {
 	 */
 	public function execute( $query ): bool {
 		$this->addHelpLink(
-			$this->msg( 'smw-helplink', 'Pending_tasks' )->escaped(),
+			$this->msg( 'smw-helplink', 'Pending_tasks' )->text(),
 			true
 		);
 

--- a/src/MediaWiki/Specials/SpecialPropertyLabelSimilarity.php
+++ b/src/MediaWiki/Specials/SpecialPropertyLabelSimilarity.php
@@ -119,7 +119,7 @@ class SpecialPropertyLabelSimilarity extends SpecialPage {
 				[
 					'class' => 'smw-breadcrumb-arrow-right'
 				]
-			) . Html::rawElement(
+			) . Html::element(
 				'a',
 				[
 					'href' => SkinComponentUtils::makeSpecialUrl( 'Specialpages', $query ) . '#Semantic_MediaWiki'

--- a/src/MediaWiki/Specials/SpecialTypes.php
+++ b/src/MediaWiki/Specials/SpecialTypes.php
@@ -560,7 +560,7 @@ class SpecialTypes extends SpecialPage {
 
 		// Add human readable group label
 		foreach ( $contents as $group => $values ) {
-			$groupLabel = Message::get( "smw-type-$group", Message::TEXT, Message::USER_LANGUAGE );
+			$groupLabel = Message::get( "smw-type-$group", Message::ESCAPED, Message::USER_LANGUAGE );
 			$contents[$groupLabel] = $values;
 			unset( $contents[$group] );
 		}

--- a/src/MediaWiki/Specials/SpecialTypes.php
+++ b/src/MediaWiki/Specials/SpecialTypes.php
@@ -201,7 +201,7 @@ class SpecialTypes extends SpecialPage {
 			);
 		}
 
-		$this->addHelpLink( $this->msg( 'smw-specials-bytype-helplink', $typeLabel )->escaped(), true );
+		$this->addHelpLink( $this->msg( 'smw-specials-bytype-helplink', $typeLabel )->text(), true );
 
 		$pagingLimit = $this->settings->dotGet( 'smwgPagingLimit.type' );
 

--- a/src/ParserFunctions/ConceptParserFunction.php
+++ b/src/ParserFunctions/ConceptParserFunction.php
@@ -139,6 +139,11 @@ class ConceptParserFunction {
 	}
 
 	private function getRdfLink( Title $title ): Infolink {
+		// The caption is a static i18n message and this Infolink is only ever rendered
+		// as wikitext (getRdfLink()->getWikiText()), where the caption is link display
+		// text, not raw HTML. Phan flags the caption via Infolink's HTML-output sink,
+		// which this call path never reaches.
+		// @phan-suppress-next-line SecurityCheck-XSS
 		return Infolink::newInternalLink(
 			wfMessage( 'smw_viewasrdf' )->text(),
 			$title->getPageLanguage()->getNsText( NS_SPECIAL ) . ':ExportRDF/' . $title->getPrefixedText(), 'rdflink'

--- a/src/ParserFunctions/SectionTag.php
+++ b/src/ParserFunctions/SectionTag.php
@@ -58,8 +58,6 @@ class SectionTag {
 		$title = $this->parser->getTitle();
 
 		foreach ( $args as $name => $value ) {
-			$value = htmlspecialchars( $value );
-
 			if ( $name === 'class' ) {
 				$attributes['class'] = $value;
 			}

--- a/src/Query/ResultPrinters/TableResultPrinter.php
+++ b/src/Query/ResultPrinters/TableResultPrinter.php
@@ -127,6 +127,10 @@ class TableResultPrinter extends ResultPrinter {
 				$mode = $this->isHTML && $isPlain ? SMW_OUTPUT_WIKI : $outputMode;
 				$text = $pr->getText( $mode, ( $isPlain ? null : $this->mLinker ) );
 				$headerList[] = $pr->getCanonicalLabel();
+				// $attributes['class'] is a CSS class built from the (stripped) column
+				// label; HtmlTable escapes attributes once. Phan over-taints it via the
+				// print-request label source.
+				// @phan-suppress-next-line SecurityCheck-DoubleEscaped
 				$this->htmlTable->header( ( $text === '' ? '&nbsp;' : $text ), $attributes );
 			}
 		}
@@ -136,6 +140,9 @@ class TableResultPrinter extends ResultPrinter {
 		$subject = $res->getNext();
 		while ( $subject ) {
 			$rowNumber++;
+			// $columnClasses are CSS classes built from the (stripped) column labels and
+			// escaped once at the cell sink; phan over-taints them via the label source.
+			// @phan-suppress-next-line SecurityCheck-DoubleEscaped
 			$this->getRowForSubject( $subject, $outputMode, $columnClasses );
 
 			$this->htmlTable->row(
@@ -273,7 +280,7 @@ class TableResultPrinter extends ResultPrinter {
 			}
 
 			if ( $this->isDataTable && $sortKey !== '' ) {
-				$attributes['data-order'] = htmlspecialchars( $sortKey );
+				$attributes['data-order'] = $sortKey;
 			}
 
 			$alignment = trim( $printRequest->getParameter( 'align' ) );
@@ -282,10 +289,7 @@ class TableResultPrinter extends ResultPrinter {
 				$attributes['style'] = "text-align:$alignment;";
 			}
 
-			$width = htmlspecialchars(
-				trim( $printRequest->getParameter( 'width' ) ),
-				ENT_QUOTES
-			);
+			$width = trim( $printRequest->getParameter( 'width' ) );
 
 			if ( $width ) {
 				$attributes['style'] = ( isset( $attributes['style'] ) ? $attributes['style'] . ' ' : '' ) . "width:$width;";

--- a/src/QueryPages/PropertiesQueryPage.php
+++ b/src/QueryPages/PropertiesQueryPage.php
@@ -166,7 +166,7 @@ class PropertiesQueryPage extends QueryPage {
 
 			// @todo Should use numParams for $useCount?
 			return $this->msg( 'smw_property_template_notype' )
-				->rawParams( $proplink )->numParams( $useCount )->text() . ' ' .
+				->rawParams( $proplink )->numParams( $useCount )->escaped() . ' ' .
 				$this->getMessageFormatter()
 					->setType( 'warning' )
 					->escape( false )->getHtml();

--- a/src/QueryPages/QueryPage.php
+++ b/src/QueryPages/QueryPage.php
@@ -191,7 +191,7 @@ abstract class QueryPage extends MWQueryPage {
 
 		return Xml::tags( 'form', [
 			'method' => 'get',
-			'action' => htmlspecialchars( $GLOBALS['wgScript'] ),
+			'action' => $GLOBALS['wgScript'],
 			'class' => 'plainlinks'
 		], Html::hidden( 'title', $this->getContext()->getTitle()->getPrefixedText() ) .
 			Xml::fieldset( $this->msg( 'smw-special-property-searchform-options' )->text(),

--- a/src/QueryPages/UnusedPropertiesQueryPage.php
+++ b/src/QueryPages/UnusedPropertiesQueryPage.php
@@ -179,10 +179,11 @@ class UnusedPropertiesQueryPage extends QueryPage {
 				->getShortHtmlText( $this->getLinker() );
 		}
 
-		return $this->msg(
-			'smw-unusedproperty-template', $propertyLink,
-			$typeDataValue->getLongHTMLText( $this->getLinker() )
-		)->text() . ' ' . $this->getMessageFormatter()->getHtml();
+		return $this->msg( 'smw-unusedproperty-template' )
+			->rawParams(
+				$propertyLink,
+				$typeDataValue->getLongHTMLText( $this->getLinker() )
+			)->escaped() . ' ' . $this->getMessageFormatter()->getHtml();
 	}
 
 	/**

--- a/src/QueryPages/WantedPropertiesQueryPage.php
+++ b/src/QueryPages/WantedPropertiesQueryPage.php
@@ -106,7 +106,7 @@ class WantedPropertiesQueryPage extends QueryPage {
 			[
 				'class' => 'smw-special-filter'
 			],
-			$this->msg( 'smw-special-wantedproperties-filter-label' )->text() .
+			$this->msg( 'smw-special-wantedproperties-filter-label' )->escaped() .
 			'&nbsp;' .
 			Html::rawElement(
 				'span',

--- a/src/Utils/HtmlTable.php
+++ b/src/Utils/HtmlTable.php
@@ -90,6 +90,10 @@ class HtmlTable {
 		$rows = [];
 
 		foreach ( $this->headers as $i => $header ) {
+			// $header['attributes'] holds caller-supplied HTML attributes (e.g. a CSS
+			// class derived from a query label); Html::rawElement escapes them once.
+			// Phan over-taints the value through the print-request label source.
+			// @phan-suppress-next-line SecurityCheck-DoubleEscaped
 			$headers[] = Html::rawElement( 'th', $header['attributes'], $header['content'] );
 		}
 
@@ -105,6 +109,9 @@ class HtmlTable {
 
 		foreach ( $this->headers as $hIndex => $header ) {
 			$cells = [];
+			// See buildTable(): the attributes are caller-supplied and escaped once by
+			// Html::rawElement; phan over-taints them via the print-request label.
+			// @phan-suppress-next-line SecurityCheck-DoubleEscaped
 			$headerItem = Html::rawElement( 'th', $header['attributes'], $header['content'] );
 
 			foreach ( $this->rows as $rIndex => $row ) {

--- a/src/Utils/HtmlTabs.php
+++ b/src/Utils/HtmlTabs.php
@@ -108,6 +108,10 @@ class HtmlTabs {
 			$attributes['dir'] = 'rtl';
 		}
 
+		// The 'data-mw-subtab' attribute holds JSON-encoded tab HTML for JS consumption;
+		// the inner HTML is intentionally escaped both as JSON and as an HTML attribute
+		// (two distinct layers), which phan reports as a double escape.
+		// @phan-suppress-next-line SecurityCheck-DoubleEscaped
 		return Html::rawElement(
 			'div',
 			$attributes,

--- a/src/Utils/Pager.php
+++ b/src/Utils/Pager.php
@@ -151,14 +151,14 @@ class Pager {
 		if ( $offset > 0 ) {
 			$plink = self::numLink( $title, max( $offset - $limit, 0 ), $limit, $query, $prev, 'prevn-title', $language );
 		} else {
-			$plink = Html::element( 'a', [ 'class' => 'page-link link-disabled' ], htmlspecialchars( $prev ) );
+			$plink = Html::element( 'a', [ 'class' => 'page-link link-disabled' ], $prev );
 		}
 
 		# Make 'next' link
 		$next = wfMessage( 'smw-next' )->inLanguage( $language )->title( $title )->numParams( $limit )->text();
 
 		if ( $atend ) {
-			$nlink = Html::element( 'a', [ 'class' => 'page-link link-disabled' ], htmlspecialchars( $next ) );
+			$nlink = Html::element( 'a', [ 'class' => 'page-link link-disabled' ], $next );
 		} else {
 			$nlink = self::numLink( $title, $offset + $limit, $limit, $query, $next, 'nextn-title', $language );
 		}


### PR DESCRIPTION
## What

A two-part XSS / output-escaping hardening:

1. Remove the `SecurityCheck-XSS` and `SecurityCheck-DoubleEscaped` suppressions from the Phan config and resolve every finding they surface, so the taint checker now enforces both rules.
2. Escape interface-message output that several special pages and the Ask UI widgets were emitting unescaped, found by testing under the `x-xss` pseudo-language (`$wgUseXssLanguage`). Phan does not catch these (it cannot trace SMW's `Message` wrapper or message-key-as-variable lookups), so they are complementary to part 1.

## Part 1: Phan SecurityCheck findings

**Genuine bug fixes**
- `ErrorValue::getShortHTMLText()` re-escaped the error tooltip HTML produced by `smwfEncodeMessages()`, so the markup rendered as literal text on the loaded-error path. It now returns `getErrorText()` directly, mirroring `getLongHTMLText()` (routing through `getShortWikiText()` would return the raw caption on the construction path).
- `SpecialConcepts` passed `->parse()` HTML to `Html::element()`, which escapes content, so the markup rendered as literal tags; switched to `Html::rawElement()`.
- Removed redundant `htmlspecialchars()` on values handed to auto-escaping sinks (`Html::element` content; `Html::rawElement` / `Xml::tags` attribute values) in `Pager`, `SortWidget`, `TableResultPrinter`, `SectionTag`, `QueryPage`, `HtmlFormRenderer` and `HtmlColumnListRenderer`, which produced double-escaped output.

**Escaping corrections**
- The special pages that pass a help URL to `addHelpLink()` now use `->text()` rather than `->escaped()` (core escapes the URL into the `href`, so `->escaped()` double-escaped it).
- Hand-built HTML that interpolated unescaped `Message::text()` now uses `->escaped()` (`Page`, `SpecialPageProperty`, `PageBuilder`, `SpecialMissingRedirectAnnotations`, `SpecialOWLExport`).

A few taint-analysis false positives are handled with documented inline `@phan-suppress-next-line` annotations (CSS classes derived from query labels, JSON-encoded tab data, and an attributes array whose escaped key is consumed as element content).

## Part 2: Unescaped interface-message output

Several special pages and Ask UI widgets concatenated interface messages directly into HTML as raw `Message::TEXT` / `->text()`, so a message containing HTML metacharacters (for example via a `MediaWiki:` namespace override, or an unescaped user-controlled parameter) would be injected unescaped. Each output site is now escaped according to its context (content, attribute, or wikitext), keeping intentional-HTML parameters raw via `rawParams()`.

Covers the SMW page-indicator title, the Special pages breadcrumb, the property-list templates (`Properties`, `UnusedProperties`, `WantedProperties`), the type group labels, the `PageProperty` documentation note, the `PropertyLabelSimilarity` no-result message, and the Ask UI widgets (`SortWidget`, `HelpWidget`, `NavigationLinksWidget`, `LinksWidget`, `ParametersWidget`, `HtmlForm` tabs, `FormatListWidget`, `QueryInputWidget`). Verified with `x-xss`: no SMW special page emits an unescaped message probe after these changes.

## Out of scope

The DataValue / value-formatting layer (for example `MonolingualTextValueFormatter`, `ImportValue`) also has unescaped message output under `x-xss`, but those methods serve both wikitext and HTML output from the same path, so correct fixes need per-output-type handling and careful value-rendering regression testing. That hardening will be done separately to keep this change reviewable and low-risk.

## Testing
- `composer phan`: no `SecurityCheck` findings.
- `composer analyze`: clean for `src/`.
- Unit tests for the affected classes pass.
- Browser and `x-xss` smoke tests of the affected special pages: correct rendering, no console errors, no unescaped message probes.