### PR TITLE
Begin onoi/cache removal: convert leaf cache consumers to BagOStuff

### DIFF
--- a/src/Elastic/Connection/DummyClient.php
+++ b/src/Elastic/Connection/DummyClient.php
@@ -3,10 +3,10 @@
 namespace SMW\Elastic\Connection;
 
 use Elasticsearch\Client as ElasticClient;
-use Onoi\Cache\Cache;
-use Onoi\Cache\NullCache;
 use Psr\Log\NullLogger;
 use SMW\Elastic\Config;
+use Wikimedia\ObjectCache\BagOStuff;
+use Wikimedia\ObjectCache\EmptyBagOStuff;
 
 /**
  * @private
@@ -24,11 +24,11 @@ class DummyClient extends Client {
 	public function __construct(
 		// @phan-suppress-next-line PhanUndeclaredTypeParameter,PhanUndeclaredTypeProperty
 		protected ?ElasticClient $client = null,
-		private ?Cache $cache = null,
+		private ?BagOStuff $cache = null,
 		private ?Config $config = null,
 	) {
 		if ( $this->cache === null ) {
-			$this->cache = new NullCache();
+			$this->cache = new EmptyBagOStuff();
 		}
 
 		if ( $this->config === null ) {

--- a/src/PropertyAliasFinder.php
+++ b/src/PropertyAliasFinder.php
@@ -2,8 +2,8 @@
 
 namespace SMW;
 
-use Onoi\Cache\Cache;
 use SMW\Localizer\Message;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -23,7 +23,7 @@ class PropertyAliasFinder {
 	 */
 	const CACHE_TTL = 604800;
 
-	private Cache $cache;
+	private BagOStuff $cache;
 
 	/**
 	 * Array with entries "property alias" => "property id"
@@ -50,11 +50,11 @@ class PropertyAliasFinder {
 	/**
 	 * @since 2.4
 	 *
-	 * @param Cache $cache
+	 * @param BagOStuff $cache
 	 * @param array $propertyAliases
 	 * @param array $canonicalPropertyAliases
 	 */
-	public function __construct( Cache $cache, array $propertyAliases = [], array $canonicalPropertyAliases = [] ) {
+	public function __construct( BagOStuff $cache, array $propertyAliases = [], array $canonicalPropertyAliases = [] ) {
 		$this->cache = $cache;
 		$this->canonicalPropertyAliases = $canonicalPropertyAliases;
 
@@ -106,7 +106,7 @@ class PropertyAliasFinder {
 			]
 		);
 
-		$propertyAliases = $this->cache->fetch( $key );
+		$propertyAliases = $this->cache->get( $key );
 		if ( $propertyAliases !== false ) {
 			return $propertyAliases;
 		}
@@ -117,7 +117,7 @@ class PropertyAliasFinder {
 			$propertyAliases[Message::get( $msgKey, Message::TEXT, $languageCode )] = $id;
 		}
 
-		$this->cache->save( $key, $propertyAliases, self::CACHE_TTL );
+		$this->cache->set( $key, $propertyAliases, self::CACHE_TTL );
 
 		return $propertyAliases;
 	}

--- a/src/PropertyRegistry.php
+++ b/src/PropertyRegistry.php
@@ -66,7 +66,7 @@ class PropertyRegistry {
 		$lang = $localizer->getLang();
 
 		$propertyAliasFinder = new PropertyAliasFinder(
-			$applicationFactory->getCache(),
+			$applicationFactory->getObjectCache(),
 			$lang->getPropertyAliases(),
 			$lang->getCanonicalPropertyAliases()
 		);

--- a/src/Schema/SchemaFactory.php
+++ b/src/Schema/SchemaFactory.php
@@ -152,7 +152,7 @@ class SchemaFactory {
 		return new SchemaFinder(
 			$store,
 			$applicationFactory->getPropertySpecificationLookup(),
-			$applicationFactory->getCache()
+			$applicationFactory->getObjectCache()
 		);
 	}
 

--- a/src/Schema/SchemaFinder.php
+++ b/src/Schema/SchemaFinder.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Schema;
 
-use Onoi\Cache\Cache;
 use SMW\DataItems\Blob;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Property;
@@ -11,6 +10,7 @@ use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
 use SMW\Listener\ChangeListener\ChangeRecord;
 use SMW\Property\SpecificationLookup;
 use SMW\Store;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @private
@@ -40,7 +40,7 @@ class SchemaFinder {
 	public function __construct(
 		private readonly Store $store,
 		private readonly SpecificationLookup $propertySpecificationLookup,
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 	) {
 		$this->cacheTTL = 60 * 60 * 24 * 7;
 	}
@@ -121,7 +121,7 @@ class SchemaFinder {
 		$schemaList = [];
 		$key = smwfCacheKey( self::CACHE_NAMESPACE, [ self::TYPE_LIST, $type ] );
 
-		$subjects = $this->cache->fetch( $key );
+		$subjects = $this->cache->get( $key );
 		if ( $subjects === false ) {
 			$subjects = [];
 
@@ -134,7 +134,7 @@ class SchemaFinder {
 				$subjects[] = $dataItem->getSerialization();
 			}
 
-			$this->cache->save( $key, $subjects, $this->cacheTTL );
+			$this->cache->set( $key, $subjects, $this->cacheTTL );
 		}
 
 		foreach ( $subjects as $subject ) {

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -93,6 +93,7 @@ use SMW\Store;
 use SMW\StoreFactory;
 use SMW\Utils\Stats;
 use SMW\Utils\TempFile;
+use Wikimedia\ObjectCache\BagOStuff;
 use Wikimedia\Rdbms\IConnectionProvider;
 use WikiPage;
 
@@ -759,6 +760,21 @@ class ServicesFactory {
 		}
 
 		return MediaWikiServices::getInstance()->getService( 'SMW.Cache' );
+	}
+
+	/**
+	 * Resolve a MediaWiki-native BagOStuff for the configured main cache type.
+	 *
+	 * Unlike getCache(), which returns the Onoi composite still consumed by
+	 * EntityCache and other callers, this returns the bare BagOStuff that
+	 * consumers migrate onto as the onoi/cache dependency is removed.
+	 *
+	 * @since 7.0.0
+	 */
+	public function getObjectCache( $cacheType = null ): BagOStuff {
+		return MediaWikiServices::getInstance()->getObjectCacheFactory()->getInstance(
+			$cacheType ?? ( new CacheFactory() )->getMainCacheType()
+		);
 	}
 
 	/**

--- a/tests/phpunit/Unit/PropertyAliasFinderTest.php
+++ b/tests/phpunit/Unit/PropertyAliasFinderTest.php
@@ -2,10 +2,10 @@
 
 namespace SMW\Tests\Unit;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\PropertyAliasFinder;
 use SMW\Store;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\PropertyAliasFinder
@@ -24,7 +24,7 @@ class PropertyAliasFinderTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -106,7 +106,7 @@ class PropertyAliasFinderTest extends TestCase {
 
 	public function testGetKnownPropertyAliasesByLanguageCodeCached() {
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( [ '⧼smw-bar⧽' => '_Foo' ] );
 
 		$instance = new PropertyAliasFinder(
@@ -129,7 +129,7 @@ class PropertyAliasFinderTest extends TestCase {
 
 	public function testGetKnownPropertyAliasesByLanguageCode() {
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( false );
 
 		$instance = new PropertyAliasFinder(

--- a/tests/phpunit/Unit/PropertyRegistryTest.php
+++ b/tests/phpunit/Unit/PropertyRegistryTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Unit;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\Property;
 use SMW\DataTypeRegistry;
@@ -10,6 +9,7 @@ use SMW\PropertyAliasFinder;
 use SMW\PropertyLabelFinder;
 use SMW\PropertyRegistry;
 use SMW\Store;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\PropertyRegistry
@@ -28,7 +28,7 @@ class PropertyRegistryTest extends TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdCacheManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdCacheManagerTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Unit\SQLStore\EntityStore;
 use Onoi\Cache\Cache;
 use Onoi\Cache\FixedInMemoryLruCache;
 use PHPUnit\Framework\TestCase;
+use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 
@@ -42,6 +43,97 @@ class IdCacheManagerTest extends TestCase {
 
 		$this->assertIsString( $result );
 		$this->assertSame( 20, strlen( $result ), 'SHA-1 raw binary should be 20 bytes' );
+	}
+
+	/**
+	 * Golden master for the persisted `smw_hash` format. `computeSha1` output is
+	 * written verbatim to the indexed `smw_object_ids.smw_hash` column
+	 * (`EntityIdManager`) and recomputed and compared for equality on every
+	 * lookup (`EntityIdFinder`), so these bytes must never change. A failure here
+	 * means the on-disk hash format drifted and would orphan every existing row
+	 * and trigger a store-wide rewrite. The algorithm is frozen byte-for-byte:
+	 * `sha1( json_encode( $args ), true )`.
+	 *
+	 * @dataProvider computeSha1GoldenProvider
+	 */
+	public function testComputeSha1GoldenValues( array|string $args, string $expectedHex ) {
+		$result = IdCacheManager::computeSha1( $args );
+
+		$this->assertSame( 20, strlen( $result ), 'raw binary sha1 must be 20 bytes' );
+		$this->assertSame( $expectedHex, bin2hex( $result ) );
+	}
+
+	public static function computeSha1GoldenProvider(): array {
+		return [
+			'empty array' => [ [], '97d170e1550eee4afc0af065b78cda302a97674c' ],
+			'title ns0' => [ [ 'Foo', 0, '', '' ], 'ebb1b47f7cf43a5a58d3c6cc58f3c3bb8b9246e6' ],
+			'title ns14' => [ [ 'Foo', 14, '', '' ], 'ba82960e597903f175fe3bcd337107a8561794f5' ],
+			'title ns102' => [ [ 'Foo', 102, '', '' ], '909d8ab26ea49adb7e1b106bc47602050d07d19f' ],
+			'title with interwiki' => [ [ 'Foo', 0, 'iw', '' ], '02d4cb9bfd6bca88085334899bfdedd7362c4ffa' ],
+			'title with subobject' => [ [ 'Foo', 0, '', '_QUERY1' ], 'b8bd3168279b9fb7166cf470b0fe0c2f183b2d4e' ],
+			'underscore dbkey' => [ [ 'Foo_Bar', 0, '', '' ], 'b57057ac8a6b3c1581452e19d6f1fc9d74d7e358' ],
+			'multibyte title' => [ [ "F\u{00F3}o", 0, '', '' ], '932cfaa8d156c512b9ae15b2ce7a27c70928dd41' ],
+			'string scalar arg' => [ 'foo', 'd465e627f9946f2fa0d2dc0fc04e5385bc6cd46d' ],
+		];
+	}
+
+	/**
+	 * The `(int)` namespace cast applied at every `computeSha1` callsite is
+	 * load-bearing: `json_encode( 0 )` and `json_encode( "0" )` differ, so a
+	 * refactor that dropped the cast would silently change the persisted hash.
+	 */
+	public function testComputeSha1NamespaceCastIsLoadBearing() {
+		$intNamespace = IdCacheManager::computeSha1( [ 'Foo', 0, '', '' ] );
+		$stringNamespace = IdCacheManager::computeSha1( [ 'Foo', '0', '', '' ] );
+
+		$this->assertNotSame(
+			bin2hex( $intNamespace ),
+			bin2hex( $stringNamespace ),
+			'int and string namespace must not collide; the (int) cast matters'
+		);
+		$this->assertSame( '50c2318b07f3d9e418a8f45106d1d43ee08b450b', bin2hex( $stringNamespace ) );
+	}
+
+	/**
+	 * `WikiPage::getSha1` duplicates the `computeSha1` algorithm and feeds the
+	 * same persisted `smw_hash` column, so the two must stay byte-identical.
+	 *
+	 * @covers \SMW\SQLStore\EntityStore\IdCacheManager::computeSha1
+	 * @covers \SMW\DataItems\WikiPage::getSha1
+	 * @dataProvider wikiPageSha1Provider
+	 */
+	public function testWikiPageGetSha1MatchesComputeSha1( string $dbkey, int $namespace, string $interwiki, string $subobject ) {
+		$dataItem = new WikiPage( $dbkey, $namespace, $interwiki, $subobject );
+
+		$this->assertSame(
+			bin2hex( IdCacheManager::computeSha1( [ $dbkey, $namespace, $interwiki, $subobject ] ) ),
+			bin2hex( $dataItem->getSha1() )
+		);
+	}
+
+	public static function wikiPageSha1Provider(): array {
+		return [
+			'plain' => [ 'Foo', 0, '', '' ],
+			'category ns' => [ 'Foo', 14, '', '' ],
+			'interwiki' => [ 'Foo', 0, 'iw', '' ],
+			'subobject' => [ 'Foo', 0, '', '_QUERY1' ],
+		];
+	}
+
+	/**
+	 * `Property::getSha1` likewise mirrors `computeSha1` for the property
+	 * namespace and must stay byte-identical.
+	 *
+	 * @covers \SMW\SQLStore\EntityStore\IdCacheManager::computeSha1
+	 * @covers \SMW\DataItems\Property::getSha1
+	 */
+	public function testPropertyGetSha1MatchesComputeSha1() {
+		$property = new Property( 'Foo' );
+
+		$this->assertSame(
+			bin2hex( IdCacheManager::computeSha1( [ 'Foo', SMW_NS_PROPERTY, '', '' ] ) ),
+			bin2hex( $property->getSha1() )
+		);
 	}
 
 	public function testGet() {

--- a/tests/phpunit/Unit/Schema/SchemaFinderTest.php
+++ b/tests/phpunit/Unit/Schema/SchemaFinderTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Unit\Schema;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\Blob;
 use SMW\DataItems\Property;
@@ -13,6 +12,7 @@ use SMW\Property\SpecificationLookup;
 use SMW\Schema\SchemaFinder;
 use SMW\Schema\SchemaList;
 use SMW\Store;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\Schema\SchemaFinder
@@ -27,7 +27,7 @@ class SchemaFinderTest extends TestCase {
 
 	private $store;
 	private $propertySpecificationLookup;
-	private Cache $cache;
+	private $cache;
 
 	protected function setUp(): void {
 		$this->store = $this->getMockBuilder( Store::class )
@@ -38,7 +38,7 @@ class SchemaFinderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -55,7 +55,7 @@ class SchemaFinderTest extends TestCase {
 		$data[] = new Blob( json_encode( [ 'Foo' => [ 'Foobar' => 'test' ], [ 'Foo' => 'Bar' ] ] ) );
 
 		$this->cache->expects( $this->any() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( false );
 
 		$this->store->expects( $this->any() )


### PR DESCRIPTION
## What

Starts removing Semantic MediaWiki's dependency on the third-party `onoi/cache` package by moving independent leaf cache consumers onto MediaWiki core cache primitives, and pins the persisted hash format the entity store relies on.

## Changes

- Add `ServicesFactory::getObjectCache()`, a resolver returning a `BagOStuff` for the configured main cache type. This is the target consumers move onto as `onoi/cache` is removed.
- Convert `PropertyAliasFinder`, `SchemaFinder` and the Elastic `DummyClient` from the `Onoi\Cache\Cache` interface to `BagOStuff` (and `EmptyBagOStuff` for the no-op client), rewiring their construction sites to `getObjectCache()`. Cache reads and writes use `get` and `set`.
- Add characterization tests pinning the `computeSha1` output, which is written verbatim to the indexed `smw_object_ids.smw_hash` column and read back for equality, so its byte format must not drift. Covers the two raw twins `WikiPage::getSha1` and `Property::getSha1`.

## Scope

The shared `SMW.Cache` service stays on the existing composite cache, which `EntityCache` and other consumers still require (they call `contains()` and `getStats()`, which `BagOStuff` does not provide). This converts only the leaves that resolve their own cache, leaving the shared service and remaining consumers for follow-ups.

Affected unit tests inject a `BagOStuff` mock.