### PR TITLE
onoi/cache removal: convert more leaf cache consumers to BagOStuff

### DIFF
--- a/src/Elastic/Connection/LockManager.php
+++ b/src/Elastic/Connection/LockManager.php
@@ -2,7 +2,7 @@
 
 namespace SMW\Elastic\Connection;
 
-use Onoi\Cache\Cache;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -22,7 +22,7 @@ class LockManager {
 	/**
 	 * @since 3.1
 	 */
-	public function __construct( private readonly Cache $cache ) {
+	public function __construct( private readonly BagOStuff $cache ) {
 	}
 
 	/**
@@ -34,7 +34,7 @@ class LockManager {
 			self::TYPE_MAINTENANCE
 		);
 
-		return $this->cache->fetch( $key ) !== false;
+		return $this->cache->get( $key ) !== false;
 	}
 
 	/**
@@ -46,7 +46,7 @@ class LockManager {
 			self::TYPE_MAINTENANCE
 		);
 
-		$this->cache->save( $key, true );
+		$this->cache->set( $key, true );
 	}
 
 	/**
@@ -61,7 +61,7 @@ class LockManager {
 			[ 'lock', $type ]
 		);
 
-		$this->cache->save( $key, $version );
+		$this->cache->set( $key, $version );
 	}
 
 	/**
@@ -77,7 +77,7 @@ class LockManager {
 			[ 'lock', $type ]
 		);
 
-		return $this->cache->fetch( $key ) !== false;
+		return $this->cache->get( $key ) !== false;
 	}
 
 	/**
@@ -93,7 +93,7 @@ class LockManager {
 			[ 'lock', $type ]
 		);
 
-		return $this->cache->fetch( $key );
+		return $this->cache->get( $key );
 	}
 
 	/**

--- a/src/Elastic/ElasticFactory.php
+++ b/src/Elastic/ElasticFactory.php
@@ -97,7 +97,7 @@ class ElasticFactory {
 		$applicationFactory = ApplicationFactory::getInstance();
 
 		$connectionProvider = new ConnectionProvider(
-			new LockManager( $applicationFactory->getCache() ),
+			new LockManager( $applicationFactory->getObjectCache() ),
 			$this->newConfig()
 		);
 
@@ -308,7 +308,7 @@ class ElasticFactory {
 
 		$termsLookup = new CachingTermsLookup(
 			new TermsLookup( $store, $queryOptions ),
-			$applicationFactory->getCache()
+			$applicationFactory->getObjectCache()
 		);
 
 		$servicesContainer = new ServicesContainer(

--- a/src/Elastic/QueryEngine/TermsLookup/CachingTermsLookup.php
+++ b/src/Elastic/QueryEngine/TermsLookup/CachingTermsLookup.php
@@ -2,9 +2,9 @@
 
 namespace SMW\Elastic\QueryEngine\TermsLookup;
 
-use Onoi\Cache\Cache;
 use RuntimeException;
 use SMW\Elastic\QueryEngine\Condition;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -26,7 +26,7 @@ class CachingTermsLookup extends TermsLookup {
 	 */
 	public function __construct(
 		private readonly TermsLookup $termsLookup,
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 	) {
 	}
 
@@ -100,7 +100,7 @@ class CachingTermsLookup extends TermsLookup {
 			return $this->quick_cache[$key]['params'];
 		}
 
-		$count = $this->cache->fetch( $key );
+		$count = $this->cache->get( $key );
 		if ( $count !== false ) {
 
 			$info = [
@@ -136,7 +136,7 @@ class CachingTermsLookup extends TermsLookup {
 		$count = $parameters->get( 'count' );
 
 		if ( $count >= $threshold ) {
-			$this->cache->save( $key, $count, $ttl );
+			$this->cache->set( $key, $count, $ttl );
 		}
 
 		$this->quick_cache[$key] = [
@@ -185,7 +185,7 @@ class CachingTermsLookup extends TermsLookup {
 			$threshold
 		);
 
-		$count = $this->cache->fetch( $key );
+		$count = $this->cache->get( $key );
 		if ( $count !== false ) {
 
 			$info = [
@@ -219,7 +219,7 @@ class CachingTermsLookup extends TermsLookup {
 		$count = $parameters->get( 'count' );
 
 		if ( $count >= $threshold ) {
-			$this->cache->save( $key, $count, $ttl );
+			$this->cache->set( $key, $count, $ttl );
 		}
 
 		return $params;
@@ -256,7 +256,7 @@ class CachingTermsLookup extends TermsLookup {
 			$threshold
 		);
 
-		$count = $this->cache->fetch( $key );
+		$count = $this->cache->get( $key );
 		if ( $count !== false ) {
 
 			$info = [
@@ -287,7 +287,7 @@ class CachingTermsLookup extends TermsLookup {
 		$count = $parameters->get( 'count' );
 
 		if ( $count >= $threshold ) {
-			$this->cache->save( $key, $count, $ttl );
+			$this->cache->set( $key, $count, $ttl );
 		}
 
 		return $params;
@@ -323,7 +323,7 @@ class CachingTermsLookup extends TermsLookup {
 			$threshold
 		);
 
-		$count = $this->cache->fetch( $key );
+		$count = $this->cache->get( $key );
 		if ( $count !== false ) {
 
 			$info = [
@@ -358,7 +358,7 @@ class CachingTermsLookup extends TermsLookup {
 		$count = $parameters->get( 'count' );
 
 		if ( $count >= $threshold ) {
-			$this->cache->save( $key, $count, $ttl );
+			$this->cache->set( $key, $count, $ttl );
 		}
 
 		return $params;

--- a/src/HierarchyLookup.php
+++ b/src/HierarchyLookup.php
@@ -4,11 +4,11 @@ namespace SMW;
 
 use InvalidArgumentException;
 use Iterator;
-use Onoi\Cache\Cache;
 use Psr\Log\LoggerAwareTrait;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -39,7 +39,7 @@ class HierarchyLookup {
 
 	private Store $store;
 
-	private Cache $cache;
+	private BagOStuff $cache;
 
 	private array $inMemoryCache = [];
 
@@ -58,7 +58,7 @@ class HierarchyLookup {
 	/**
 	 * @since 2.3
 	 */
-	public function __construct( Store $store, Cache $cache ) {
+	public function __construct( Store $store, BagOStuff $cache ) {
 		$this->store = $store;
 		$this->cache = $cache;
 	}
@@ -237,7 +237,7 @@ class HierarchyLookup {
 		$reqCacheUpdate = false;
 		$hierarchyMembers = [];
 
-		$hierarchyCache = $this->cache->fetch( $cacheKey );
+		$hierarchyCache = $this->cache->get( $cacheKey );
 		if ( !$hierarchyCache ) {
 			$hierarchyCache = [];
 		}
@@ -283,7 +283,7 @@ class HierarchyLookup {
 		}
 
 		if ( $reqCacheUpdate ) {
-			$this->cache->save( $cacheKey, $hierarchyCache, $this->cacheTTL );
+			$this->cache->set( $cacheKey, $hierarchyCache, $this->cacheTTL );
 		}
 
 		return $hierarchyList[$key];

--- a/src/Maintenance/DuplicateEntitiesDisposer.php
+++ b/src/Maintenance/DuplicateEntitiesDisposer.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Maintenance;
 
-use Onoi\Cache\Cache;
 use Onoi\MessageReporter\MessageReporterAwareTrait;
 use SMW\DataItems\DataItem;
 use SMW\MediaWiki\Api\Tasks\Task;
@@ -12,6 +11,7 @@ use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Utils\CliMsgFormatter;
 use Traversable;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -28,7 +28,7 @@ class DuplicateEntitiesDisposer {
 	 */
 	public function __construct(
 		private Store $store,
-		private ?Cache $cache = null,
+		private ?BagOStuff $cache = null,
 	) {
 	}
 

--- a/src/Maintenance/MaintenanceFactory.php
+++ b/src/Maintenance/MaintenanceFactory.php
@@ -127,7 +127,7 @@ class MaintenanceFactory {
 	public function newDuplicateEntitiesDisposer( Store $store, $reporterCallback = null ): DuplicateEntitiesDisposer {
 		$duplicateEntitiesDisposer = new DuplicateEntitiesDisposer(
 			$store,
-			ApplicationFactory::getInstance()->getCache()
+			ApplicationFactory::getInstance()->getObjectCache()
 		);
 
 		$duplicateEntitiesDisposer->setMessageReporter(

--- a/src/SQLStore/EntityStore/CachingSemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/CachingSemanticDataLookup.php
@@ -2,8 +2,6 @@
 
 namespace SMW\SQLStore\EntityStore;
 
-use Onoi\Cache\Cache;
-use Onoi\Cache\NullCache;
 use Psr\Log\LoggerAwareTrait;
 use RuntimeException;
 use SMW\DataItems\DataItem;
@@ -47,11 +45,7 @@ class CachingSemanticDataLookup {
 	 */
 	public function __construct(
 		private SemanticDataLookup $semanticDataLookup,
-		private ?Cache $cache = null,
 	) {
-		if ( $this->cache === null ) {
-			$this->cache = new NullCache();
-		}
 	}
 
 	/**

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -833,8 +833,7 @@ class SQLStoreFactory {
 		);
 
 		$cachingSemanticDataLookup = new CachingSemanticDataLookup(
-			$semanticDataLookup,
-			ApplicationFactory::getInstance()->getCache()
+			$semanticDataLookup
 		);
 
 		return $cachingSemanticDataLookup;

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -820,7 +820,7 @@ return [
 
 		$hierarchyLookup = new HierarchyLookup(
 			$servicesFactory->getStore(),
-			$servicesFactory->getCache()
+			$servicesFactory->getObjectCache()
 		);
 
 		$hierarchyLookup->setLogger(

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -994,7 +994,7 @@ class ServicesFactory {
 
 		$hierarchyLookup = new HierarchyLookup(
 			$store ?? $this->getStore(),
-			$this->getCache( $cacheType )
+			$this->getObjectCache( $cacheType )
 		);
 
 		$hierarchyLookup->setLogger(
@@ -1183,15 +1183,14 @@ class ServicesFactory {
 			return $this->testOverrides['ResultCache'];
 		}
 
-		$cacheFactory = $this->getCacheFactory();
 		$settings = $this->getSettings();
 
 		$cacheType = $cacheType === null ? $settings->get( 'smwgQueryResultCacheType' ) : $cacheType;
 
-		// Explicitly use the CACHE_DB to access a SqlBagOstuff instance
+		// Explicitly use the CACHE_DB to access a SqlBagOStuff instance
 		// for a bit more persistence
 		$cacheStats = new CacheStats(
-			$cacheFactory->newMediaWikiCache( CACHE_DB ),
+			$this->getObjectCache( CACHE_DB ),
 			ResultCache::STATSD_ID
 		);
 
@@ -1238,11 +1237,9 @@ class ServicesFactory {
 			return $this->testOverrides['Stats'];
 		}
 
-		$cacheFactory = $this->getCacheFactory();
-
-		// Explicitly use the DB to access a SqlBagOstuff instance
+		// Explicitly use the DB to access a SqlBagOStuff instance
 		return new Stats(
-			$cacheFactory->newMediaWikiCache( CACHE_DB ),
+			$this->getObjectCache( CACHE_DB ),
 			$id
 		);
 	}

--- a/src/Utils/Stats.php
+++ b/src/Utils/Stats.php
@@ -2,8 +2,8 @@
 
 namespace SMW\Utils;
 
-use Onoi\Cache\Cache;
 use SMW\Services\ServicesFactory as ApplicationFactory;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * Collect statistics in a provisional schema-free storage that depends on the
@@ -55,7 +55,7 @@ class Stats {
 	 * @since 2.5
 	 */
 	public function __construct(
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 		private $id,
 	) {
 		$this->initRecord();
@@ -90,7 +90,7 @@ class Stats {
 	 * @return array
 	 */
 	public function getStats(): array {
-		$stats = $this->cache->fetch( $this->makeCacheKey( $this->id ) );
+		$stats = $this->cache->get( $this->makeCacheKey( $this->id ) );
 		if ( $stats === false ) {
 			return [];
 		}
@@ -158,7 +158,7 @@ class Stats {
 			return;
 		}
 
-		$container = $this->cache->fetch( $this->makeCacheKey( $this->id ) );
+		$container = $this->cache->get( $this->makeCacheKey( $this->id ) );
 
 		if ( $container === false || $container === null ) {
 			$container = [];
@@ -190,7 +190,7 @@ class Stats {
 			$container[$key] = $value;
 		}
 
-		$this->cache->save( $this->makeCacheKey( $this->id ), $container );
+		$this->cache->set( $this->makeCacheKey( $this->id ), $container );
 		$this->stats = [];
 	}
 

--- a/tests/phpunit/Unit/Elastic/Connection/LockManagerTest.php
+++ b/tests/phpunit/Unit/Elastic/Connection/LockManagerTest.php
@@ -2,9 +2,9 @@
 
 namespace SMW\Tests\Unit\Elastic\Connection;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\Elastic\Connection\LockManager;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\Elastic\Connection\LockManager
@@ -20,7 +20,7 @@ class LockManagerTest extends TestCase {
 	private $cache;
 
 	protected function setUp(): void {
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -34,7 +34,7 @@ class LockManagerTest extends TestCase {
 
 	public function testHasMaintenanceLock() {
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->with( $this->stringContains( 'smw:elastic:57cb773ae7a82c8c8aae12fa8f8d7abd' ) )
 			->willReturn( true );
 
@@ -47,7 +47,7 @@ class LockManagerTest extends TestCase {
 
 	public function testSetMaintenanceLock() {
 		$this->cache->expects( $this->once() )
-			->method( 'save' )
+			->method( 'set' )
 			->with( $this->stringContains( 'smw:elastic:57cb773ae7a82c8c8aae12fa8f8d7abd' ) );
 
 		$instance = new LockManager(
@@ -59,7 +59,7 @@ class LockManagerTest extends TestCase {
 
 	public function testSetLock() {
 		$this->cache->expects( $this->once() )
-			->method( 'save' )
+			->method( 'set' )
 			->with(
 				$this->anything(),
 				2 );
@@ -73,7 +73,7 @@ class LockManagerTest extends TestCase {
 
 	public function testHasLock() {
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( '123' );
 
 		$instance = new LockManager(
@@ -87,7 +87,7 @@ class LockManagerTest extends TestCase {
 
 	public function testGetLock() {
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( 2 );
 
 		$instance = new LockManager(

--- a/tests/phpunit/Unit/HierarchyLookupTest.php
+++ b/tests/phpunit/Unit/HierarchyLookupTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Unit;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
@@ -10,6 +9,7 @@ use SMW\HierarchyLookup;
 use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\HierarchyLookup
@@ -33,7 +33,7 @@ class HierarchyLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -83,7 +83,7 @@ class HierarchyLookupTest extends TestCase {
 			->method( 'getPropertySubjects' )
 			->willReturn( [] );
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -124,7 +124,7 @@ class HierarchyLookupTest extends TestCase {
 				$this->anything() )
 			->willReturn( $expected );
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -170,11 +170,11 @@ class HierarchyLookupTest extends TestCase {
 			} );
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( false );
 
 		$this->cache->expects( $this->once() )
-			->method( 'save' )
+			->method( 'set' )
 			->with(
 				$this->stringContains( ':smw:hierarchy:2d440b72499319439ab5f466701f13fa' ),
 				$this->anything() );
@@ -205,11 +205,11 @@ class HierarchyLookupTest extends TestCase {
 		];
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( [ 'Foo' => [ 'Bar', 'Foobar' ] ] );
 
 		$this->cache->expects( $this->never() )
-			->method( 'save' );
+			->method( 'set' );
 
 		$instance = new HierarchyLookup(
 			$this->store,
@@ -255,11 +255,11 @@ class HierarchyLookupTest extends TestCase {
 			} );
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( false );
 
 		$this->cache->expects( $this->once() )
-			->method( 'save' )
+			->method( 'set' )
 			->with(
 				$this->stringContains( ':smw:hierarchy:78c9d3ed63c959981731afeef22cc8e9' ),
 				$this->anything() );
@@ -308,11 +308,11 @@ class HierarchyLookupTest extends TestCase {
 			} );
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( false );
 
 		$this->cache->expects( $this->once() )
-			->method( 'save' )
+			->method( 'set' )
 			->with(
 				$this->stringContains( ':smw:hierarchy:c61e6ee84187efaafbb31878af471432' ),
 				$this->anything() );
@@ -343,11 +343,11 @@ class HierarchyLookupTest extends TestCase {
 		];
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( [ 'Foo' => [ 'Bar', 'Foobar' ] ] );
 
 		$this->cache->expects( $this->never() )
-			->method( 'save' );
+			->method( 'set' );
 
 		$instance = new HierarchyLookup(
 			$this->store,
@@ -396,7 +396,7 @@ class HierarchyLookupTest extends TestCase {
 				$this->anything() )
 			->willReturn( $expected );
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -434,7 +434,7 @@ class HierarchyLookupTest extends TestCase {
 				$this->anything() )
 			->willReturn( $expected );
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -458,13 +458,12 @@ class HierarchyLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$cache->expects( $this->never() )
-			->method( 'contains' )
-			->willReturn( false );
+			->method( 'get' );
 
 		$instance = new HierarchyLookup( $store, $cache );
 		$instance->setSubpropertyDepth( 0 );
@@ -479,13 +478,12 @@ class HierarchyLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$cache->expects( $this->never() )
-			->method( 'contains' )
-			->willReturn( false );
+			->method( 'get' );
 
 		$instance = new HierarchyLookup( $store, $cache );
 		$instance->setSubcategoryDepth( 0 );

--- a/tests/phpunit/Unit/Maintenance/DuplicateEntitiesDisposerTest.php
+++ b/tests/phpunit/Unit/Maintenance/DuplicateEntitiesDisposerTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Unit\Maintenance;
 
-use Onoi\Cache\Cache;
 use Onoi\MessageReporter\MessageReporter;
 use PHPUnit\Framework\TestCase;
 use SMW\Maintenance\DuplicateEntitiesDisposer;
@@ -13,6 +12,7 @@ use SMW\SQLStore\SQLStore;
 use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use stdClass;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\Maintenance\DuplicateEntitiesDisposer
@@ -55,7 +55,7 @@ class DuplicateEntitiesDisposerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}

--- a/tests/phpunit/Unit/Query/Cache/CacheStatsTest.php
+++ b/tests/phpunit/Unit/Query/Cache/CacheStatsTest.php
@@ -2,9 +2,9 @@
 
 namespace SMW\Tests\Unit\Query\Cache;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\Query\Cache\CacheStats;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\Query\Cache\CacheStats
@@ -20,7 +20,7 @@ class CacheStatsTest extends TestCase {
 	private $cache;
 
 	protected function setUp(): void {
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -40,7 +40,7 @@ class CacheStatsTest extends TestCase {
 		];
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( $container );
 
 		$instance = new CacheStats(
@@ -61,7 +61,7 @@ class CacheStatsTest extends TestCase {
 
 	public function testGetStatsEmpty() {
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( false );
 
 		$instance = new CacheStats(

--- a/tests/phpunit/Utils/StatsTest.php
+++ b/tests/phpunit/Utils/StatsTest.php
@@ -2,9 +2,9 @@
 
 namespace SMW\Tests\Utils;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\Utils\Stats;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\Utils\Stats
@@ -20,7 +20,7 @@ class StatsTest extends TestCase {
 	private $cache;
 
 	protected function setUp(): void {
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -38,11 +38,11 @@ class StatsTest extends TestCase {
 		];
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( $container );
 
 		$this->cache->expects( $this->once() )
-			->method( 'save' )
+			->method( 'set' )
 			->with(
 				$this->anything(),
 				[ 'Foo.bar' => 11 ] );
@@ -58,7 +58,7 @@ class StatsTest extends TestCase {
 
 	public function testSet() {
 		$this->cache->expects( $this->once() )
-			->method( 'save' )
+			->method( 'set' )
 			->with(
 				$this->anything(),
 				[ 'Foo.bar' => 10 ] );
@@ -78,11 +78,11 @@ class StatsTest extends TestCase {
 		];
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( $container );
 
 		$this->cache->expects( $this->once() )
-			->method( 'save' )
+			->method( 'set' )
 			->with(
 				$this->anything(),
 				[ 'Foo.bar' => 7.5 ] );
@@ -108,7 +108,7 @@ class StatsTest extends TestCase {
 		];
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( $container );
 
 		$instance = new Stats(
@@ -134,7 +134,7 @@ class StatsTest extends TestCase {
 		];
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( $container );
 
 		$instance = new Stats(
@@ -161,7 +161,7 @@ class StatsTest extends TestCase {
 		];
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( $container );
 
 		$instance = new Stats(


### PR DESCRIPTION
## What

Continues removing the `onoi/cache` dependency by moving more leaf cache consumers onto MediaWiki core `BagOStuff`, building on the `ServicesFactory::getObjectCache()` resolver added earlier.

## Changes

- Convert `LockManager`, `CachingTermsLookup`, `HierarchyLookup`, `Stats` (and the `CacheStats` subclass it backs), and `DuplicateEntitiesDisposer` from the `Onoi\Cache\Cache` interface to `BagOStuff`. Their construction sites resolve the cache through `ServicesFactory::getObjectCache()`; the `Stats` and `CacheStats` callers pass `CACHE_DB` through for the DB-backed store. Cache reads and writes use `get` and `set`.
- Remove the dead, never-read cache parameter from `CachingSemanticDataLookup`.
- Migrate the affected unit tests to inject a `BagOStuff` mock.

## Scope

The shared `SMW.Cache` service stays on the existing composite cache, which `EntityCache` and the remaining consumers still require. This converts only the leaves that resolve their own cache through a factory; the API modules, the `ChangeDiff` write-path cluster, and the entity-store pool caches are left for follow-ups.

## Behaviour notes

- The three Elastic/hierarchy leaves previously resolved a two-tier composite (an in-process L1 over the persistent store) and now receive the bare persistent `BagOStuff`. The persistent backing store is unchanged (same `$smwgMainCacheType`), so cross-process visibility, including the Elasticsearch maintenance lock, is preserved; only per-request memoization of repeated reads is dropped, and `HierarchyLookup` / `CachingTermsLookup` keep their own in-object memo arrays.
- `BagOStuff::get()` returns `false` on a miss, matching each converted consumer's existing miss check; none of these consumers stores a legitimately falsy value, so there is no falsy-as-absent change.