### PR TITLE
onoi/cache removal: convert the Api cache consumers to BagOStuff

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -453,7 +453,7 @@
 		},
 		"smwbrowse": {
 			"class": "SMW\\MediaWiki\\Api\\Browse",
-			"services": [ "SMW.Store", "SMW.Settings", "SMW.Cache", "TitleFactory" ]
+			"services": [ "SMW.Store", "SMW.Settings", "SMW.ObjectCache", "TitleFactory" ]
 		},
 		"ask": {
 			"class": "SMW\\MediaWiki\\Api\\Ask",

--- a/src/MediaWiki/Api/Browse.php
+++ b/src/MediaWiki/Api/Browse.php
@@ -5,7 +5,6 @@ namespace SMW\MediaWiki\Api;
 use MediaWiki\Api\ApiBase;
 use MediaWiki\Api\ApiMain;
 use MediaWiki\Title\TitleFactory;
-use Onoi\Cache\Cache;
 use SMW\Exception\JSONParseException;
 use SMW\Exception\ParameterNotFoundException;
 use SMW\Exception\RedirectTargetUnresolvableException;
@@ -21,6 +20,7 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Settings;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
+use Wikimedia\ObjectCache\BagOStuff;
 use Wikimedia\ParamValidator\ParamValidator;
 
 /**
@@ -41,7 +41,7 @@ class Browse extends ApiBase {
 		string $action,
 		private readonly Store $store,
 		private readonly Settings $settings,
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 		private readonly TitleFactory $titleFactory
 	) {
 		parent::__construct( $main, $action );

--- a/src/MediaWiki/Api/Browse/CachingLookup.php
+++ b/src/MediaWiki/Api/Browse/CachingLookup.php
@@ -2,9 +2,9 @@
 
 namespace SMW\MediaWiki\Api\Browse;
 
-use Onoi\Cache\Cache;
 use SMW\Store;
 use SMW\Utils\Timer;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -28,7 +28,7 @@ class CachingLookup {
 	 * @since 3.0
 	 */
 	public function __construct(
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 		private readonly Lookup $lookup,
 	) {
 		$this->cacheTTL = self::CACHE_TTL;
@@ -62,7 +62,7 @@ class CachingLookup {
 		);
 
 		if ( $this->cacheTTL !== false ) {
-			$res = $this->cache->fetch( $hash );
+			$res = $this->cache->get( $hash );
 			if ( $res !== false ) {
 				$res['meta']['isFromCache'] = true;
 				$res['meta']['queryTime'] = Timer::getElapsedTime( __METHOD__, 5 );
@@ -75,7 +75,7 @@ class CachingLookup {
 		);
 
 		if ( $this->cacheTTL !== false ) {
-			$this->cache->save( $hash, $res, $this->cacheTTL );
+			$this->cache->set( $hash, $res, $this->cacheTTL );
 		}
 
 		$res['meta']['isFromCache'] = false;

--- a/src/MediaWiki/Api/TaskFactory.php
+++ b/src/MediaWiki/Api/TaskFactory.php
@@ -4,7 +4,6 @@ namespace SMW\MediaWiki\Api;
 
 use MediaWiki\HookContainer\HookContainer;
 use MediaWiki\User\User;
-use Onoi\Cache\Cache;
 use RuntimeException;
 use SMW\Indicator\EntityExaminerIndicatorsFactory;
 use SMW\MediaWiki\Api\Tasks\CheckQueryTask;
@@ -20,6 +19,7 @@ use SMW\MediaWiki\JobQueue;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Settings;
 use SMW\Store;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -44,7 +44,7 @@ class TaskFactory {
 	public function __construct(
 		private readonly Store $store,
 		private readonly JobQueue $jobQueue,
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 		private readonly Settings $settings,
 		private readonly JobFactory $jobFactory,
 		private readonly HookContainer $hookContainer

--- a/src/MediaWiki/Api/Tasks/DuplicateLookupTask.php
+++ b/src/MediaWiki/Api/Tasks/DuplicateLookupTask.php
@@ -3,8 +3,8 @@
 namespace SMW\MediaWiki\Api\Tasks;
 
 use Iterator;
-use Onoi\Cache\Cache;
 use SMW\Store;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -21,7 +21,7 @@ class DuplicateLookupTask extends Task {
 	 */
 	public function __construct(
 		private readonly Store $store,
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 	) {
 	}
 
@@ -45,7 +45,7 @@ class DuplicateLookupTask extends Task {
 		$key = self::makeCacheKey( 'duplicate-lookup' );
 
 		// Guard against repeated API calls (or fuzzing)
-		$result = $this->cache->fetch( $key );
+		$result = $this->cache->get( $key );
 		if ( $result !== false && $cacheTTL !== false ) {
 			return $result + [ 'isFromCache' => true ];
 		}
@@ -63,7 +63,7 @@ class DuplicateLookupTask extends Task {
 			'time'  => date( 'Y-m-d H:i:s' )
 		];
 
-		$this->cache->save( $key, $result, $cacheTTL );
+		$this->cache->set( $key, $result, $cacheTTL );
 
 		return $result;
 	}

--- a/src/MediaWiki/Api/Tasks/TableStatisticsTask.php
+++ b/src/MediaWiki/Api/Tasks/TableStatisticsTask.php
@@ -2,8 +2,8 @@
 
 namespace SMW\MediaWiki\Api\Tasks;
 
-use Onoi\Cache\Cache;
 use SMW\Store;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -22,7 +22,7 @@ class TableStatisticsTask extends Task {
 	 */
 	public function __construct(
 		private readonly Store $store,
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 	) {
 	}
 
@@ -47,7 +47,7 @@ class TableStatisticsTask extends Task {
 
 		// Guard against repeated API calls (or fuzzing)
 		if ( $cacheTTL !== false ) {
-			$result = $this->cache->fetch( $key );
+			$result = $this->cache->get( $key );
 			if ( $result !== false ) {
 				return $result + [ 'isFromCache' => true, 'cacheTTL' => $cacheTTL ];
 			}
@@ -60,7 +60,7 @@ class TableStatisticsTask extends Task {
 			'time' => date( 'Y-m-d H:i:s' )
 		];
 
-		$this->cache->save( $key, $result, $cacheTTL );
+		$this->cache->set( $key, $result, $cacheTTL );
 
 		return $result;
 	}

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -67,6 +67,7 @@ use SMW\SQLStore\QueryDependencyLinksStoreFactory;
 use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
 use SMW\Store;
 use SMW\StoreFactory;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * Service wiring for SMW. Registered via `extension.json`'s
@@ -172,6 +173,13 @@ return [
 		// that need a non-default cache type still go through
 		// CacheFactory::newMediaWikiCompositeCache() directly.
 		return ( new CacheFactory() )->newMediaWikiCompositeCache();
+	},
+
+	'SMW.ObjectCache' => static function ( MediaWikiServices $services ): BagOStuff {
+		// MediaWiki-native BagOStuff for consumers migrated off the Onoi cache.
+		// Resolved through ServicesFactory so it shares the same backing store
+		// (the configured $smwgMainCacheType) as the SMW.Cache composite.
+		return ServicesFactory::getInstance()->getObjectCache();
 	},
 
 	'SMW.EntityCache' => static function ( MediaWikiServices $services ): EntityCache {
@@ -416,7 +424,7 @@ return [
 		return new TaskFactory(
 			$servicesFactory->getStore(),
 			$servicesFactory->getJobQueue(),
-			$servicesFactory->getCache(),
+			$servicesFactory->getObjectCache(),
 			$servicesFactory->getSettings(),
 			$servicesFactory->getJobFactory(),
 			$services->getHookContainer()

--- a/tests/phpunit/Unit/MediaWiki/Api/Browse/CachingLookupTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Browse/CachingLookupTest.php
@@ -2,10 +2,10 @@
 
 namespace SMW\Tests\Unit\MediaWiki\Api\Browse;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Api\Browse\CachingLookup;
 use SMW\MediaWiki\Api\Browse\Lookup;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\MediaWiki\Api\Browse\CachingLookup
@@ -19,7 +19,7 @@ use SMW\MediaWiki\Api\Browse\Lookup;
 class CachingLookupTest extends TestCase {
 
 	public function testCanConstruct() {
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -36,16 +36,16 @@ class CachingLookupTest extends TestCase {
 	public function testLookupWithoutCache() {
 		$cacheTTL = 42;
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$cache->expects( $this->atLeastOnce() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( false );
 
 		$cache->expects( $this->atLeastOnce() )
-			->method( 'save' )
+			->method( 'set' )
 			->with(
 				$this->anything(),
 				$this->anything(),
@@ -73,16 +73,16 @@ class CachingLookupTest extends TestCase {
 	}
 
 	public function testLookupWithCache() {
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$cache->expects( $this->atLeastOnce() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( [] );
 
 		$cache->expects( $this->never() )
-			->method( 'save' );
+			->method( 'set' );
 
 		$lookup = $this->getMockBuilder( Lookup::class )
 			->disableOriginalConstructor()
@@ -103,15 +103,15 @@ class CachingLookupTest extends TestCase {
 	}
 
 	public function testLookupWithCacheBeingDisabled() {
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$cache->expects( $this->never() )
-			->method( 'fetch' );
+			->method( 'get' );
 
 		$cache->expects( $this->never() )
-			->method( 'save' );
+			->method( 'set' );
 
 		$lookup = $this->getMockBuilder( Lookup::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Api/BrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/BrowseTest.php
@@ -3,7 +3,6 @@
 namespace SMW\Tests\Unit\MediaWiki\Api;
 
 use MediaWiki\Title\TitleFactory;
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
@@ -15,6 +14,7 @@ use SMW\SQLStore\Lookup\ProximityPropertyValueLookup;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
+use Wikimedia\ObjectCache\BagOStuff;
 use Wikimedia\Rdbms\FakeResultWrapper;
 
 /**
@@ -74,7 +74,7 @@ class BrowseTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -106,12 +106,12 @@ class BrowseTest extends TestCase {
 			->method( 'getSMWPropertyID' )
 			->willReturn( false );
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$cache->expects( $this->atLeastOnce() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( false );
 
 		$resultWrapper = $this->getMockBuilder( FakeResultWrapper::class )
@@ -204,7 +204,7 @@ class BrowseTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/Api/TaskFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/TaskFactoryTest.php
@@ -3,7 +3,6 @@
 namespace SMW\Tests\Unit\MediaWiki\Api;
 
 use MediaWiki\HookContainer\HookContainer;
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Api\TaskFactory;
 use SMW\MediaWiki\Api\Tasks\Task;
@@ -12,6 +11,7 @@ use SMW\MediaWiki\JobQueue;
 use SMW\Settings;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\MediaWiki\Api\TaskFactory
@@ -91,7 +91,7 @@ class TaskFactoryTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 

--- a/tests/phpunit/Unit/MediaWiki/Api/TaskTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/TaskTest.php
@@ -4,7 +4,6 @@ namespace SMW\Tests\Unit\MediaWiki\Api;
 
 use MediaWiki\HookContainer\HookContainer;
 use MediaWiki\Title\Title;
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Api\Task;
 use SMW\MediaWiki\Api\TaskFactory;
@@ -18,6 +17,7 @@ use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\MediaWiki\Api\Task
@@ -94,16 +94,16 @@ class TaskTest extends TestCase {
 	}
 
 	public function testDupLookupTask() {
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( false );
 
 		$cache->expects( $this->once() )
-			->method( 'save' );
+			->method( 'set' );
 
 		$entityTable = $this->getMockBuilder( EntityIdManager::class )
 			->disableOriginalConstructor()
@@ -259,7 +259,7 @@ class TaskTest extends TestCase {
 	private function newRealTaskFactory(
 		?Store $store = null,
 		?JobQueue $jobQueue = null,
-		?Cache $cache = null,
+		?BagOStuff $cache = null,
 		?JobFactory $jobFactory = null
 	): TaskFactory {
 		if ( $store === null ) {
@@ -275,7 +275,7 @@ class TaskTest extends TestCase {
 		}
 
 		if ( $cache === null ) {
-			$cache = $this->getMockBuilder( Cache::class )
+			$cache = $this->getMockBuilder( BagOStuff::class )
 				->disableOriginalConstructor()
 				->getMock();
 		}

--- a/tests/phpunit/Unit/MediaWiki/Api/Tasks/DuplicateLookupTaskTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Tasks/DuplicateLookupTaskTest.php
@@ -2,13 +2,13 @@
 
 namespace SMW\Tests\Unit\MediaWiki\Api\Tasks;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Api\Tasks\DuplicateLookupTask;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\MediaWiki\Api\Tasks\DuplicateLookupTask
@@ -34,7 +34,7 @@ class DuplicateLookupTaskTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -54,16 +54,16 @@ class DuplicateLookupTaskTest extends TestCase {
 	}
 
 	public function testProcess() {
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( false );
 
 		$this->cache->expects( $this->once() )
-			->method( 'save' );
+			->method( 'set' );
 
 		$entityTable = $this->getMockBuilder( EntityIdManager::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/MediaWiki/Api/Tasks/TableStatisticsTaskTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Api/Tasks/TableStatisticsTaskTest.php
@@ -2,12 +2,12 @@
 
 namespace SMW\Tests\Unit\MediaWiki\Api\Tasks;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Api\Tasks\TableStatisticsTask;
 use SMW\SQLStore\Lookup\TableStatisticsLookup;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\MediaWiki\Api\Tasks\TableStatisticsTask
@@ -34,7 +34,7 @@ class TableStatisticsTaskTest extends TestCase {
 			->setMethods( [ 'service' ] )
 			->getMockForAbstractClass();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 	}
@@ -63,16 +63,16 @@ class TableStatisticsTaskTest extends TestCase {
 			->with( 'TableStatisticsLookup' )
 			->willReturn( $tableStatisticsLookup );
 
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( false );
 
 		$this->cache->expects( $this->once() )
-			->method( 'save' );
+			->method( 'set' );
 
 		$instance = new TableStatisticsTask(
 			$this->store,


### PR DESCRIPTION
## What

Continues removing the `onoi/cache` dependency by moving the Api/Browse cache consumers onto MediaWiki core `BagOStuff`.

## Changes

- Add a new `SMW.ObjectCache` service: the global `BagOStuff` resolver (via `ServicesFactory::getObjectCache()`) for modules wired through `extension.json`, sharing the same backing store as the existing `SMW.Cache` composite.
- Point the `smwbrowse` API module (`extension.json`) and the `SMW.TaskFactory` service at `SMW.ObjectCache`.
- Convert `Browse`, `CachingLookup`, `TaskFactory`, `DuplicateLookupTask`, and `TableStatisticsTask` from the `Onoi\Cache\Cache` interface to `BagOStuff`. Cache reads and writes use `get` and `set`; `TableStatisticsTask`'s domain `getStats()` (on the statistics lookup, not the cache) is untouched.
- Migrate the affected unit tests to a `BagOStuff` mock.

## Scope

The shared `SMW.Cache` service stays on the existing composite cache, which `EntityCache` and the remaining consumers still require. The `ChangeDiff` write-path cluster, the persistent `contains()` sites, and the entity-store pool caches are left for follow-ups.