### PR TITLE
onoi/cache removal: convert the ChangeDiff write-path cache consumers to BagOStuff

### DIFF
--- a/src/MediaWiki/PostProcHandlerFactory.php
+++ b/src/MediaWiki/PostProcHandlerFactory.php
@@ -3,9 +3,9 @@
 namespace SMW\MediaWiki;
 
 use MediaWiki\Parser\ParserOutput;
-use Onoi\Cache\Cache;
 use SMW\PostProcHandler;
 use SMW\Settings;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * Produces a {@link PostProcHandler} for the `OutputPageParserOutput` hook.
@@ -22,7 +22,7 @@ class PostProcHandlerFactory {
 	 * @since 7.0.0
 	 */
 	public function __construct(
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 		private readonly Settings $settings,
 	) {
 	}

--- a/src/PostProcHandler.php
+++ b/src/PostProcHandler.php
@@ -7,10 +7,10 @@ use MediaWiki\Html\Html;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Request\WebRequest;
 use MediaWiki\Title\Title;
-use Onoi\Cache\Cache;
 use SMW\DataItems\WikiPage;
 use SMW\Query\Query;
 use SMW\SQLStore\ChangeOp\ChangeDiff;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * Some updates need to be handled in via post processing,
@@ -51,7 +51,7 @@ class PostProcHandler {
 
 	private ParserOutput $parserOutput;
 
-	private Cache $cache;
+	private BagOStuff $cache;
 
 	private array $options = [];
 
@@ -59,9 +59,9 @@ class PostProcHandler {
 	 * @since 3.0
 	 *
 	 * @param ParserOutput $parserOutput
-	 * @param Cache $cache
+	 * @param BagOStuff $cache
 	 */
-	public function __construct( ParserOutput $parserOutput, Cache $cache ) {
+	public function __construct( ParserOutput $parserOutput, BagOStuff $cache ) {
 		$this->parserOutput = $parserOutput;
 		$this->cache = $cache;
 	}

--- a/src/SQLStore/ChangeOp/ChangeDiff.php
+++ b/src/SQLStore/ChangeOp/ChangeDiff.php
@@ -2,9 +2,9 @@
 
 namespace SMW\SQLStore\ChangeOp;
 
-use Onoi\Cache\Cache;
 use SMW\DataItems\WikiPage;
 use SMW\Utils\HmacSerializer;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -205,31 +205,31 @@ class ChangeDiff {
 	/**
 	 * @since 3.0
 	 *
-	 * @param Cache $cache
+	 * @param BagOStuff $cache
 	 */
-	public function save( Cache $cache ): void {
+	public function save( BagOStuff $cache ): void {
 		$key = smwfCacheKey(
 			self::CACHE_NAMESPACE,
 			$this->subject->getHash()
 		);
 
 		// Keep it a week
-		$cache->save( $key, HmacSerializer::compress( $this ), self::CACHE_TTL );
+		$cache->set( $key, HmacSerializer::compress( $this ), self::CACHE_TTL );
 	}
 
 	/**
 	 * @since 3.0
 	 *
-	 * @param Cache $cache
+	 * @param BagOStuff $cache
 	 * @param WikiPage $subject
 	 */
-	public static function fetch( Cache $cache, WikiPage $subject ) {
+	public static function fetch( BagOStuff $cache, WikiPage $subject ) {
 		$key = smwfCacheKey(
 			self::CACHE_NAMESPACE,
 			$subject->getHash()
 		);
 
-		$diff = $cache->fetch( $key );
+		$diff = $cache->get( $key );
 		if ( $diff !== false ) {
 			return HmacSerializer::uncompress( $diff );
 		}

--- a/src/SQLStore/QueryEngine/Fulltext/TextChangeUpdater.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextChangeUpdater.php
@@ -2,7 +2,6 @@
 
 namespace SMW\SQLStore\QueryEngine\Fulltext;
 
-use Onoi\Cache\Cache;
 use Psr\Log\LoggerAwareTrait;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Connection\Database;
@@ -11,6 +10,7 @@ use SMW\SQLStore\ChangeOp\ChangeDiff;
 use SMW\SQLStore\ChangeOp\ChangeOp;
 use SMW\SQLStore\ChangeOp\TableChangeOp;
 use SMW\Utils\Timer;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -36,7 +36,7 @@ class TextChangeUpdater {
 	 */
 	public function __construct(
 		private readonly Database $connection,
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 		private readonly SearchTableUpdater $searchTableUpdater,
 		private readonly JobFactory $jobFactory,
 	) {

--- a/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
+++ b/src/SQLStore/QueryEngine/FulltextSearchTableFactory.php
@@ -130,7 +130,7 @@ class FulltextSearchTableFactory {
 
 		$textChangeUpdater = new TextChangeUpdater(
 			$store->getConnection( 'mw.db' ),
-			$applicationFactory->getCache(),
+			$applicationFactory->getObjectCache(),
 			$this->newSearchTableUpdater( $store ),
 			$applicationFactory->newJobFactory()
 		);

--- a/src/SQLStore/SQLStoreUpdater.php
+++ b/src/SQLStore/SQLStoreUpdater.php
@@ -246,7 +246,7 @@ class SQLStoreUpdater {
 		// Store the diff in cache so any post processing has a chance to find
 		// what entities and values were changed
 		$changeDiff = $changeOp->newChangeDiff();
-		$changeDiff->save( ApplicationFactory::getInstance()->getCache() );
+		$changeDiff->save( ApplicationFactory::getInstance()->getObjectCache() );
 
 		$status = new Status(
 			[

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -733,7 +733,7 @@ return [
 		$servicesFactory = ServicesFactory::getInstance();
 
 		return new PostProcHandlerFactory(
-			$servicesFactory->getCache(),
+			$servicesFactory->getObjectCache(),
 			$servicesFactory->getSettings()
 		);
 	},

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -1658,7 +1658,7 @@ class ServicesFactory {
 
 		$postProcHandler = new PostProcHandler(
 			$parserOutput,
-			$this->getCache()
+			$this->getObjectCache()
 		);
 
 		$postProcHandler->setOptions(

--- a/tests/phpunit/Unit/MediaWiki/PostProcHandlerFactoryTest.php
+++ b/tests/phpunit/Unit/MediaWiki/PostProcHandlerFactoryTest.php
@@ -3,11 +3,11 @@
 namespace SMW\Tests\Unit\MediaWiki;
 
 use MediaWiki\Parser\ParserOutput;
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\PostProcHandlerFactory;
 use SMW\PostProcHandler;
 use SMW\Settings;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\MediaWiki\PostProcHandlerFactory
@@ -18,13 +18,13 @@ use SMW\Settings;
  */
 class PostProcHandlerFactoryTest extends TestCase {
 
-	private Cache $cache;
+	private $cache;
 	private Settings $settings;
 
 	protected function setUp(): void {
 		parent::setUp();
 
-		$this->cache = $this->createMock( Cache::class );
+		$this->cache = $this->createMock( BagOStuff::class );
 		$this->settings = $this->createMock( Settings::class );
 	}
 

--- a/tests/phpunit/Unit/PostProcHandlerTest.php
+++ b/tests/phpunit/Unit/PostProcHandlerTest.php
@@ -5,7 +5,6 @@ namespace SMW\Tests\Unit;
 use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Request\WebRequest;
 use MediaWiki\Title\Title;
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\DependencyValidator;
@@ -18,6 +17,7 @@ use SMW\SQLStore\ChangeOp\ChangeDiff;
 use SMW\SQLStore\ChangeOp\FieldChangeOp;
 use SMW\SQLStore\ChangeOp\TableChangeOp;
 use SMW\SQLStore\QueryDependency\DependencyLinksValidator;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\PostProcHandler
@@ -38,7 +38,7 @@ class PostProcHandlerTest extends TestCase {
 
 		$this->parserOutput = $this->createMock( ParserOutput::class );
 
-		$this->cache = $this->createMock( Cache::class );
+		$this->cache = $this->createMock( BagOStuff::class );
 	}
 
 	public function testCanConstruct() {
@@ -87,7 +87,7 @@ class PostProcHandlerTest extends TestCase {
 
 	public function testGetHtml_CheckQuery() {
 		$this->cache->expects( $this->atLeastOnce() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( true );
 
 		$this->parserOutput->expects( $this->exactly( 2 ) )
@@ -141,7 +141,7 @@ class PostProcHandlerTest extends TestCase {
 	public function testGetHtml_DifferentExtensionData() {
 		// inverse testing - Mocking the data to ensure that the html has DifferentExtensionData
 		$this->cache->expects( $this->atLeastOnce() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( true );
 
 		$this->parserOutput->expects( $this->exactly( 2 ) )
@@ -305,7 +305,7 @@ class PostProcHandlerTest extends TestCase {
 		);
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( $changeDiff->serialize() );
 
 		$this->parserOutput->expects( $this->once() )

--- a/tests/phpunit/Unit/SQLStore/ChangeOp/ChangeDiffTest.php
+++ b/tests/phpunit/Unit/SQLStore/ChangeOp/ChangeDiffTest.php
@@ -2,12 +2,12 @@
 
 namespace SMW\Tests\Unit\SQLStore\ChangeOp;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\ChangeOp\ChangeDiff;
 use SMW\SQLStore\ChangeOp\TableChangeOp;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\SQLStore\ChangeOp\ChangeDiff
@@ -76,7 +76,7 @@ class ChangeDiffTest extends TestCase {
 	}
 
 	public function testSave() {
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -92,7 +92,7 @@ class ChangeDiffTest extends TestCase {
 		);
 
 		$cache->expects( $this->once() )
-			->method( 'save' )
+			->method( 'set' )
 			->with(
 				$this->stringContains( ChangeDiff::CACHE_NAMESPACE ),
 				$instance->serialize() );
@@ -103,7 +103,7 @@ class ChangeDiffTest extends TestCase {
 	public function testFetch() {
 		$subject = WikiPage::newFromText( 'Foo' );
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -119,7 +119,7 @@ class ChangeDiffTest extends TestCase {
 		);
 
 		$cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( $instance->serialize() );
 
 		$this->assertEquals(
@@ -162,7 +162,7 @@ class ChangeDiffTest extends TestCase {
 
 	public function FetchFromCache() {
 		$changeDiff = ChangeDiff::fetch(
-			ApplicationFactory::getInstance()->getCache(),
+			ApplicationFactory::getInstance()->getObjectCache(),
 			WikiPage::newFromText( 'DifferentSort' )
 		);
 

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextChangeUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextChangeUpdaterTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Unit\SQLStore\QueryEngine\Fulltext;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItemFactory;
 use SMW\MediaWiki\Connection\Database;
@@ -14,6 +13,7 @@ use SMW\SQLStore\QueryEngine\Fulltext\SearchTable;
 use SMW\SQLStore\QueryEngine\Fulltext\SearchTableUpdater;
 use SMW\SQLStore\QueryEngine\Fulltext\TextChangeUpdater;
 use SMW\Tests\TestEnvironment;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\SQLStore\QueryEngine\Fulltext\TextChangeUpdater
@@ -46,7 +46,7 @@ class TextChangeUpdaterTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 


### PR DESCRIPTION
## What

Continues removing the `onoi/cache` dependency by moving the `ChangeDiff` change-propagation write path onto MediaWiki core `BagOStuff`.

## Changes

- Retype `ChangeDiff::fetch()` and `ChangeDiff::save()` (which take the cache as a parameter) from `Onoi\Cache\Cache` to `BagOStuff`; their internal cache reads and writes become `get` and `set`.
- Convert the consumers that supply that cache: `PostProcHandler`, `PostProcHandlerFactory`, and `TextChangeUpdater`.
- Repoint their construction sites to `getObjectCache()`: the `SMW.PostProcHandlerFactory` service, `ServicesFactory::newPostProcHandler()`, `FulltextSearchTableFactory::newTextChangeUpdater()`, and the `SQLStoreUpdater` change-diff save.
- Migrate the affected unit tests to a `BagOStuff` mock.

## Scope

The shared `SMW.Cache` service stays on the existing composite cache, which `EntityCache` and the remaining consumers still require. The two persistent `contains()` sites (`CachedListLookup`, `JsonContentsFileReader`) and `IndexerRecoveryJob` are the final follow-up.

## Behaviour notes

- These consumers use the cache as a cross-request handoff (write during the store update, read during post-processing or a later job), so dropping the previous in-process L1 tier is a no-op for this access pattern; the persistent backing store is unchanged (same `$smwgMainCacheType`).
- `BagOStuff::get()` returns `false` on a miss, matching the existing `ChangeDiff::fetch()` miss check; `set()` preserves the previous `save()` key/value/ttl argument order.