### PR TITLE
Document logger wrapper removal in 7.0 migration guide

### DIFF
--- a/docs/migration/7.0.md
+++ b/docs/migration/7.0.md
@@ -215,3 +215,7 @@ The following long-deprecated functions and methods were removed. Use the listed
 * `TaskHandler::isEnabledFeature()` — use `hasFeature()` (deprecated since 3.1)
 * `Property::setPropertyTypeId()` — use `setPropertyValueType()` (deprecated since 3.0)
 * `Property::findPropertyTypeId()` — use `findPropertyValueType()` (deprecated since 3.0)
+
+### Removed internal APIs
+
+* `ServicesFactory::getMediaWikiLogger()` and the `SMW\Utils\Logger` wrapper — use `MediaWiki\Logger\LoggerFactory::getInstance( $channel )` directly


### PR DESCRIPTION
## What

Adds a short *Removed internal logger wrapper* subsection to the 7.0 developer migration guide (`docs/migration/7.0.md`).

## Why

`RELEASE-NOTES-7.0.0.md` records the removal of the internal `SMW\Utils\Logger` wrapper and `ServicesFactory::getMediaWikiLogger()`, and the release notes explicitly point extension authors to the migration guide "for the removed and changed APIs." The migration guide, however, omitted this particular removal — so a developer following that pointer wouldn't find it.

This is not a hypothetical gap: a first-party ecosystem extension (SemanticExtraSpecialProperties) called `ServicesFactory::getInstance()->getMediaWikiLogger( 'sesp' )` and hit a fatal `Call to undefined method` on every install against SMW 7.0. The migration is trivial and unambiguous, so it's worth a one-line mapping in the guide.

## Note on placement

`getMediaWikiLogger()` was an internal method removed in-cycle, **not** a long-deprecated public API, so it does not belong in the *Removed long-deprecated methods* list. It gets its own correctly-scoped subsection that states it was internal and gives the direct `LoggerFactory::getInstance( $channel )` replacement.