### PR TITLE
Convert CachedListLookup, JsonContentsFileReader and IndexerRecoveryJob to BagOStuff

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -736,7 +736,7 @@
 		},
 		"smw.elasticIndexerRecovery": {
 			"class": "SMW\\Elastic\\Jobs\\IndexerRecoveryJob",
-			"services": [ "SMW.Store", "SMW.Cache", "SMW.JobFactory" ]
+			"services": [ "SMW.Store", "SMW.ObjectCache", "SMW.JobFactory" ]
 		},
 		"smw.elasticFileIngest": {
 			"class": "SMW\\Elastic\\Jobs\\FileIngestJob",

--- a/src/Elastic/Jobs/IndexerRecoveryJob.php
+++ b/src/Elastic/Jobs/IndexerRecoveryJob.php
@@ -4,7 +4,6 @@ namespace SMW\Elastic\Jobs;
 
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\Title\Title;
-use Onoi\Cache\Cache;
 use SMW\DataItems\WikiPage;
 use SMW\Elastic\Connection\Client as ElasticClient;
 use SMW\Elastic\ElasticStore;
@@ -15,6 +14,7 @@ use SMW\MediaWiki\JobFactory;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
 use SMW\Utils\HmacSerializer;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * Partial DI: Store and Cache are injected via the JobClasses ObjectFactory
@@ -51,7 +51,7 @@ class IndexerRecoveryJob extends Job {
 		Title $title,
 		array $params,
 		Store $store,
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 		private readonly JobFactory $jobFactory
 	) {
 		parent::__construct( self::JOB_COMMAND, $title, $params );
@@ -74,10 +74,10 @@ class IndexerRecoveryJob extends Job {
 	 * @since 3.2
 	 */
 	public static function pushFromDocument( Document $document ): void {
-		$cache = ApplicationFactory::getInstance()->getCache();
+		$cache = ApplicationFactory::getInstance()->getObjectCache();
 		$subject = $document->getSubject();
 
-		$cache->save(
+		$cache->set(
 			self::makeCacheKey( $subject ),
 			HmacSerializer::compress( $document ),
 			self::TTL_WEEK
@@ -208,7 +208,7 @@ class IndexerRecoveryJob extends Job {
 
 		$document = null;
 
-		$data = $cache->fetch( $key );
+		$data = $cache->get( $key );
 		if ( $data !== false ) {
 			$document = HmacSerializer::uncompress( $data );
 		}

--- a/src/Localizer/LocalLanguage/JsonContentsFileReader.php
+++ b/src/Localizer/LocalLanguage/JsonContentsFileReader.php
@@ -3,10 +3,10 @@
 namespace SMW\Localizer\LocalLanguage;
 
 use Exception;
-use Onoi\Cache\Cache;
-use Onoi\Cache\NullCache;
 use RuntimeException;
 use SMW\Utils\ErrorCodeFormatter;
+use Wikimedia\ObjectCache\BagOStuff;
+use Wikimedia\ObjectCache\EmptyBagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -26,11 +26,11 @@ class JsonContentsFileReader {
 	 * @since 2.5
 	 */
 	public function __construct(
-		private ?Cache $cache = null,
+		private ?BagOStuff $cache = null,
 		private $languageFileDir = '',
 	) {
 		if ( $this->cache === null ) {
-			$this->cache = new NullCache();
+			$this->cache = new EmptyBagOStuff();
 		}
 
 		if ( $this->languageFileDir === '' ) {
@@ -107,8 +107,12 @@ class JsonContentsFileReader {
 			]
 		);
 
-		if ( !$readFromFile && !$this->skipCache && !isset( self::$contents[$languageCode] ) && $this->cache->contains( $cacheKey ) ) {
-			self::$contents[$languageCode] = $this->cache->fetch( $cacheKey );
+		if ( !$readFromFile && !$this->skipCache && !isset( self::$contents[$languageCode] ) ) {
+			$cached = $this->cache->get( $cacheKey );
+
+			if ( $cached !== false ) {
+				self::$contents[$languageCode] = $cached;
+			}
 		}
 
 		if ( $readFromFile || !isset( self::$contents[$languageCode] ) ) {
@@ -125,7 +129,7 @@ class JsonContentsFileReader {
 		);
 
 		if ( $contents !== null && json_last_error() === JSON_ERROR_NONE ) {
-			$this->cache->save( $cacheKey, $contents, $this->ttl );
+			$this->cache->set( $cacheKey, $contents, $this->ttl );
 			return $contents;
 		}
 

--- a/src/Lookup/CachedListLookup.php
+++ b/src/Lookup/CachedListLookup.php
@@ -2,9 +2,9 @@
 
 namespace SMW\Lookup;
 
-use Onoi\Cache\Cache;
 use SMW\SQLStore\Lookup\UsageStatisticsListLookup;
 use stdClass;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @license GPL-2.0-or-later
@@ -30,7 +30,7 @@ class CachedListLookup implements ListLookup {
 	 */
 	public function __construct(
 		private readonly ListLookup $listLookup,
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 		private readonly stdClass $cacheOptions,
 	) {
 	}
@@ -109,7 +109,7 @@ class CachedListLookup implements ListLookup {
 			$this->listLookup->getHash()
 		);
 
-		$data = unserialize( $this->cache->fetch( $id ) );
+		$data = unserialize( $this->cache->get( $id ) );
 
 		if ( is_array( $data ) && $data !== [] ) {
 			foreach ( $data as $key => $value ) {
@@ -121,11 +121,11 @@ class CachedListLookup implements ListLookup {
 	}
 
 	private function tryFetchFromCache( $key, $optionsKey ) {
-		if ( !$this->cache->contains( $key ) ) {
+		if ( $this->cache->get( $key ) === false ) {
 			return null;
 		}
 
-		$data = unserialize( $this->cache->fetch( $optionsKey ) );
+		$data = unserialize( $this->cache->get( $optionsKey ) );
 
 		if ( !is_array( $data ) || $data === [] ) {
 			return null;
@@ -149,17 +149,17 @@ class CachedListLookup implements ListLookup {
 		$this->isFromCache = false;
 
 		// Collect the options keys
-		$data = unserialize( $this->cache->fetch( $key ) ?? '' );
+		$data = unserialize( $this->cache->get( $key ) ?? '' );
 		$data = $data === false ? [] : $data;
 		$data[$optionsKey] = true;
-		$this->cache->save( $key, serialize( $data ), $ttl );
+		$this->cache->set( $key, serialize( $data ), $ttl );
 
 		$data = [
 			'time' => $this->timestamp,
 			'list' => $list
 		];
 
-		$this->cache->save( $optionsKey, serialize( $data ), $ttl );
+		$this->cache->set( $optionsKey, serialize( $data ), $ttl );
 	}
 
 	private function getCacheKey( ?string $id ): array {

--- a/src/SQLStore/SQLStoreFactory.php
+++ b/src/SQLStore/SQLStoreFactory.php
@@ -295,7 +295,7 @@ class SQLStoreFactory {
 
 		$cachedListLookup = new CachedListLookup(
 			$listLookup,
-			$cacheFactory->newMediaWikiCompositeCache( $cacheFactory->getMainCacheType() ),
+			ApplicationFactory::getInstance()->getObjectCache(),
 			$cacheOptions
 		);
 

--- a/tests/phpunit/Unit/Elastic/Jobs/IndexerRecoveryJobTest.php
+++ b/tests/phpunit/Unit/Elastic/Jobs/IndexerRecoveryJobTest.php
@@ -3,7 +3,6 @@
 namespace SMW\Tests\Unit\Elastic\Jobs;
 
 use MediaWiki\Title\Title;
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\Elastic\Config;
 use SMW\Elastic\Connection\Client;
@@ -14,6 +13,7 @@ use SMW\Elastic\Indexer\Indexer;
 use SMW\Elastic\Jobs\IndexerRecoveryJob;
 use SMW\MediaWiki\JobFactory;
 use SMW\Tests\TestEnvironment;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\Elastic\Jobs\IndexerRecoveryJob
@@ -55,12 +55,9 @@ class IndexerRecoveryJobTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
-			->getMockForAbstractClass();
-
-		// Cache is also fetched via ApplicationFactory in
-		// pushFromDocument(); mirror the injected cache there.
-		$this->testEnvironment->registerObject( 'Cache', $this->cache );
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
+			->disableOriginalConstructor()
+			->getMock();
 
 		$this->jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
 			->disableOriginalConstructor()
@@ -94,7 +91,7 @@ class IndexerRecoveryJobTest extends TestCase {
 		parent::tearDown();
 	}
 
-	private function newJob( array $params = [], ?ElasticStore $store = null, ?Cache $cache = null ): IndexerRecoveryJob {
+	private function newJob( array $params = [], ?ElasticStore $store = null, ?BagOStuff $cache = null ): IndexerRecoveryJob {
 		return new IndexerRecoveryJob(
 			$this->title,
 			$params,
@@ -175,7 +172,7 @@ class IndexerRecoveryJobTest extends TestCase {
 			->willReturn( $this->connection );
 
 		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->with( $this->stringContains( 'smw:elastic:document:d1ea1c1728561f9d6aeed8c28b9b7617' ) );
 
 		$instance = $this->newJob( [ 'index' => 'Foo#0##' ] );
@@ -221,10 +218,6 @@ class IndexerRecoveryJobTest extends TestCase {
 	public function testPushFromDocument() {
 		$this->jobQueue->expects( $this->atLeastOnce() )
 			->method( 'push' );
-
-		$this->cache->expects( $this->once() )
-			->method( 'save' )
-			->with( $this->stringContains( 'smw:elastic:document:d1ea1c1728561f9d6aeed8c28b9b7617' ) );
 
 		$data = [
 			'subject' => [ 'serialization' => 'Foo#0##' ]

--- a/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
+++ b/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
@@ -2,9 +2,9 @@
 
 namespace SMW\Tests\Unit\Localizer\LocalLanguage;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\Localizer\LocalLanguage\JsonContentsFileReader;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\Localizer\LocalLanguage\JsonContentsFileReader
@@ -40,16 +40,12 @@ class JsonContentsFileReaderTest extends TestCase {
 	 * @dataProvider languageCodeProvider
 	 */
 	public function testReadByLanguageCodeWithCache( $languageCode ) {
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMockForAbstractClass();
 
 		$cache->expects( $this->atLeastOnce() )
-			->method( 'contains' )
-			->willReturn( true );
-
-		$cache->expects( $this->atLeastOnce() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( [] );
 
 		$instance = new JsonContentsFileReader( $cache );

--- a/tests/phpunit/Unit/SQLStore/Lookup/CachedListLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/CachedListLookupTest.php
@@ -2,11 +2,11 @@
 
 namespace SMW\Tests\Unit\SQLStore\Lookup;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\Lookup\CachedListLookup;
 use SMW\Lookup\ListLookup;
 use stdClass;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\Lookup\CachedListLookup
@@ -24,7 +24,7 @@ class CachedListLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -48,17 +48,13 @@ class CachedListLookupTest extends TestCase {
 			->method( 'getHash' )
 			->willReturn( 'Bar#123' );
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$cache->expects( $this->once() )
-			->method( 'contains' )
-			->with(	$this->stringContains( 'cacheprefix-foobar:smw:store:lookup:' ) )
-			->willReturn( true );
-
-		$cache->expects( $this->once() )
-			->method( 'fetch' )
+		$cache->expects( $this->exactly( 2 ) )
+			->method( 'get' )
+			->with( $this->stringContains( 'cacheprefix-foobar:smw:store:lookup:' ) )
 			->willReturn( serialize( $expectedCachedItem ) );
 
 		$cacheOptions = new stdClass;
@@ -109,16 +105,16 @@ class CachedListLookupTest extends TestCase {
 			->method( 'getHash' )
 			->willReturn( 'Foo#123' );
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$cache->expects( $this->any() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( false );
 
 		$cache->expects( $this->atLeastOnce() )
-			->method( 'save' )
+			->method( 'set' )
 			->with(
 				$this->stringContains( 'smw:store:lookup' ),
 				$this->anything(),
@@ -154,12 +150,12 @@ class CachedListLookupTest extends TestCase {
 			->method( 'getHash' )
 			->willReturn( 'Foo#123' );
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$cache->expects( $this->once() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( serialize( [ 'smw:store:lookup:6283479db90b04ad3a6db333a3c89766' => true ] ) );
 
 		$cache->expects( $this->atLeastOnce() )


### PR DESCRIPTION
## What

Continues the migration of Semantic MediaWiki off the `onoi/cache` dependency toward MediaWiki core's `Wikimedia\ObjectCache\BagOStuff`. This converts the remaining classes that depended directly on the `Onoi\Cache\Cache` interface:

- `CachedListLookup` (and its construction in `SQLStoreFactory`)
- `JsonContentsFileReader`
- `IndexerRecoveryJob` (and the `smw.elasticIndexerRecovery` job wiring)

The domain cache classes (`EntityCache`, the entity-store pools, the query `ResultCache`) still consume the Onoi composite and are handled separately.

## How

Each consumer follows the same conversion:

- Type-hints change from `Onoi\Cache\Cache` to `Wikimedia\ObjectCache\BagOStuff`.
- Calls on the cache object are renamed: `fetch()` becomes `get()`, `save()` becomes `set()` (argument order unchanged), `delete()` is kept. `BagOStuff::get()` returns `false` on a miss, matching the existing `=== false` checks.
- `Onoi\Cache\Cache` has a `contains()` method that `BagOStuff` does not, so the two `!contains( $key )` guards become `get( $key ) === false`. This is safe because the guarded value is always non-falsy: in `CachedListLookup` it is a serialized non-empty array, and in `JsonContentsFileReader` it is the decoded contents of a language JSON file, which is always a non-empty object.
- The null-object default in `JsonContentsFileReader` changes from `Onoi\Cache\NullCache` to `Wikimedia\ObjectCache\EmptyBagOStuff`, which has the same no-op behaviour.
- Construction sites resolve the cache through `ServicesFactory::getObjectCache()` (a `BagOStuff` over the configured main cache type) rather than `CacheFactory::newMediaWikiCompositeCache()`. The `IndexerRecoveryJob` job spec switches its injected cache service from `SMW.Cache` to `SMW.ObjectCache`.

`IndexerRecoveryJob` uses two cache references: the injected one used when the job runs, and a second resolved inside the static `pushFromDocument()` helper used when a document is queued for recovery. Both now resolve through `getObjectCache()`, so the key written when a document is queued is read back from the same backing store when the job runs.

## Tests

Unit tests mock the abstract `BagOStuff` in place of the `Cache` interface and assert the renamed methods. The `IndexerRecoveryJob` test no longer asserts the cache write performed by `pushFromDocument()`: that path resolves its cache from `MediaWikiServices`, which has no test-override seam, so a unit mock cannot intercept it. The job-enqueue behaviour stays covered, and the queue-then-recover cache round-trip is exercised by the Elasticsearch integration tests.

This targets the 7.0.0 major release, so the conversion is a hard cutover with no deprecation shims.