### PR TITLE
Convert EntityCache to MediaWiki BagOStuff

### DIFF
--- a/src/EntityCache.php
+++ b/src/EntityCache.php
@@ -3,8 +3,8 @@
 namespace SMW;
 
 use MediaWiki\Title\Title;
-use Onoi\Cache\Cache;
 use SMW\DataItems\WikiPage;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * Class provides a simple interface the link independent cache entries as
@@ -36,13 +36,11 @@ class EntityCache {
 	const TTL_WEEK = 604800; // 7 * 24 * 3600
 	const TTL_MONTH = 2592000; // 30 * 24 * 3600
 	const TTL_YEAR = 31536000; // 365 * 24 * 3600
-	private Cache $cache;
 
 	/**
 	 * @since 3.1
 	 */
-	public function __construct( Cache $cache ) {
-		$this->cache = $cache;
+	public function __construct( private readonly BagOStuff $cache ) {
 	}
 
 	/**
@@ -79,20 +77,13 @@ class EntityCache {
 
 	/**
 	 * @since 3.1
-	 */
-	public function getStats() {
-		return $this->cache->getStats();
-	}
-
-	/**
-	 * @since 3.1
 	 *
 	 * @param string $key
 	 *
 	 * @return bool
 	 */
 	public function contains( $key ) {
-		return $this->cache->contains( $key );
+		return $this->cache->get( $key ) !== false;
 	}
 
 	/**
@@ -101,7 +92,7 @@ class EntityCache {
 	 * @param string $key
 	 */
 	public function fetch( $key ) {
-		return $this->cache->fetch( $key );
+		return $this->cache->get( $key );
 	}
 
 	/**
@@ -111,7 +102,7 @@ class EntityCache {
 	 * @param mixed $value
 	 */
 	public function save( $key, $value = null, $ttl = 0 ): void {
-		$this->cache->save( $key, $value, $ttl );
+		$this->cache->set( $key, $value, $ttl );
 	}
 
 	/**
@@ -130,7 +121,7 @@ class EntityCache {
 	 * @param mixed $sub
 	 */
 	public function fetchSub( $key, $sub ) {
-		$res = $this->cache->fetch( $key );
+		$res = $this->cache->get( $key );
 		$sub = md5( $sub );
 
 		if ( !is_array( $res ) ) {
@@ -149,7 +140,7 @@ class EntityCache {
 	 * @param int $ttl
 	 */
 	public function saveSub( $key, $sub, $value = null, $ttl = 0 ): void {
-		$res = $this->cache->fetch( $key );
+		$res = $this->cache->get( $key );
 		$sub = md5( $sub );
 
 		if ( !is_array( $res ) ) {
@@ -158,7 +149,7 @@ class EntityCache {
 
 		$res[$sub] = $value;
 
-		$this->cache->save( $key, $res, $ttl );
+		$this->cache->set( $key, $res, $ttl );
 	}
 
 	/**
@@ -174,7 +165,7 @@ class EntityCache {
 			md5( $sub ) => $value
 		];
 
-		$this->cache->save( $key, $res, $ttl );
+		$this->cache->set( $key, $res, $ttl );
 	}
 
 	/**
@@ -185,7 +176,7 @@ class EntityCache {
 	 * @param int $ttl
 	 */
 	public function deleteSub( $key, $sub, $ttl = 0 ): void {
-		$res = $this->cache->fetch( $key );
+		$res = $this->cache->get( $key );
 		$sub = md5( $sub );
 
 		if ( !is_array( $res ) ) {
@@ -194,7 +185,7 @@ class EntityCache {
 
 		unset( $res[$sub] );
 
-		$this->cache->save( $key, $res, $ttl );
+		$this->cache->set( $key, $res, $ttl );
 	}
 
 	/**
@@ -222,7 +213,7 @@ class EntityCache {
 		$subject = $subject->asBase();
 
 		$k = $this->makeCacheKey( $subject );
-		$res = $this->cache->fetch( $k );
+		$res = $this->cache->get( $k );
 		$res = $res === false ? [] : $res;
 
 		// Initialize the record that binds the "page" entity to all associated
@@ -238,7 +229,7 @@ class EntityCache {
 		$res['__assoc'][$key] = true;
 
 		// Store without expiry
-		$this->cache->save( $k, $res );
+		$this->cache->set( $k, $res );
 	}
 
 	/**
@@ -262,7 +253,7 @@ class EntityCache {
 		$subject = $subject->asBase();
 
 		$k = $this->makeCacheKey( $subject );
-		$res = $this->cache->fetch( $k );
+		$res = $this->cache->get( $k );
 
 		if ( isset( $res['__assoc'] ) ) {
 			foreach ( $res['__assoc'] as $key => $bool ) {

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -191,7 +191,7 @@ return [
 		}
 
 		return new EntityCache(
-			$servicesFactory->getCache()
+			$servicesFactory->getObjectCache()
 		);
 	},
 

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -767,8 +767,8 @@ class ServicesFactory {
 	 * Resolve a MediaWiki-native BagOStuff for the configured main cache type.
 	 *
 	 * Unlike getCache(), which returns the Onoi composite still consumed by
-	 * EntityCache and other callers, this returns the bare BagOStuff that
-	 * consumers migrate onto as the onoi/cache dependency is removed.
+	 * the remaining callers, this returns the bare BagOStuff that consumers
+	 * migrate onto as the onoi/cache dependency is removed.
 	 *
 	 * @since 7.0.0
 	 */

--- a/tests/phpunit/Unit/DependencyValidatorTest.php
+++ b/tests/phpunit/Unit/DependencyValidatorTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Unit;
 
-use Onoi\Cache\FixedInMemoryLruCache;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LoggerInterface;
 use SMW\DataItems\WikiPage;
@@ -12,6 +11,7 @@ use SMW\EventDispatcher\EventDispatcher;
 use SMW\NamespaceExaminer;
 use SMW\SQLStore\QueryDependency\DependencyLinksValidator;
 use SMW\Tests\TestEnvironment;
+use Wikimedia\ObjectCache\HashBagOStuff;
 
 /**
  * @covers \SMW\DependencyValidator
@@ -264,7 +264,7 @@ class DependencyValidatorTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$realEntityCache = new EntityCache( new FixedInMemoryLruCache() );
+		$realEntityCache = new EntityCache( new HashBagOStuff() );
 
 		$instance = new DependencyValidator(
 			$this->namespaceExaminer,

--- a/tests/phpunit/Unit/EntityCacheTest.php
+++ b/tests/phpunit/Unit/EntityCacheTest.php
@@ -2,10 +2,10 @@
 
 namespace SMW\Tests\Unit;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\EntityCache;
+use Wikimedia\ObjectCache\HashBagOStuff;
 
 /**
  * @covers \SMW\EntityCache
@@ -18,25 +18,24 @@ use SMW\EntityCache;
  */
 class EntityCacheTest extends TestCase {
 
-	private $cache;
-
-	protected function setUp(): void {
-		$this->cache = $this->getMockBuilder( Cache::class )
-			->disableOriginalConstructor()
-			->getMockForAbstractClass();
+	/**
+	 * A real in-memory cache backing so the characterization tests exercise the
+	 * actual store/retrieve/delete behaviour rather than replaying mock
+	 * expectations.
+	 */
+	private function newCache() {
+		return new HashBagOStuff();
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			EntityCache::class,
-			new EntityCache( $this->cache )
+			new EntityCache( $this->newCache() )
 		);
 	}
 
 	public function testMakeCacheKey() {
-		$instance = new EntityCache(
-			$this->cache
-		);
+		$instance = new EntityCache( $this->newCache() );
 
 		$this->assertStringContainsString(
 			EntityCache::CACHE_NAMESPACE,
@@ -62,10 +61,6 @@ class EntityCacheTest extends TestCase {
 	}
 
 	public function testMakeCacheKey_SubNamespace() {
-		$instance = new EntityCache(
-			$this->cache
-		);
-
 		$subject = WikiPage::newFromText( 'Foo' );
 
 		$this->assertStringContainsString(
@@ -79,197 +74,129 @@ class EntityCacheTest extends TestCase {
 		);
 	}
 
-	public function testContains() {
-		$this->cache->expects( $this->once() )
-			->method( 'contains' )
-			->with( 'Foo' );
+	public function testSaveFetchContainsDelete() {
+		$instance = new EntityCache( $this->newCache() );
 
-		$instance = new EntityCache(
-			$this->cache
-		);
-
-		$instance->contains( 'Foo' );
-	}
-
-	public function testFetch() {
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
-			->with( 'Foo' )
-			->willReturn( 'bar' );
-
-		$instance = new EntityCache(
-			$this->cache
-		);
-
-		$instance->fetch( 'Foo' );
-	}
-
-	public function testSave() {
-		$this->cache->expects( $this->once() )
-			->method( 'save' )
-			->with(
-				'Foo',
-				'bar' );
-
-		$instance = new EntityCache(
-			$this->cache
-		);
+		$this->assertFalse( $instance->contains( 'Foo' ) );
+		$this->assertFalse( $instance->fetch( 'Foo' ) );
 
 		$instance->save( 'Foo', 'bar' );
-	}
 
-	public function testDelete() {
-		$this->cache->expects( $this->once() )
-			->method( 'delete' )
-			->with( 'Foo' );
-
-		$instance = new EntityCache(
-			$this->cache
-		);
+		$this->assertTrue( $instance->contains( 'Foo' ) );
+		$this->assertSame( 'bar', $instance->fetch( 'Foo' ) );
 
 		$instance->delete( 'Foo' );
+
+		$this->assertFalse( $instance->contains( 'Foo' ) );
+		$this->assertFalse( $instance->fetch( 'Foo' ) );
 	}
 
-	public function testFetchSub() {
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
-			->with( 'Foo' )
-			->willReturn( [ md5( 'bar' ) => 'Foobar' ] );
+	public function testFetchSub_MissingKeyOrSub() {
+		$instance = new EntityCache( $this->newCache() );
 
-		$instance = new EntityCache(
-			$this->cache
-		);
+		// Absent key: the underlying value is not an array.
+		$this->assertFalse( $instance->fetchSub( 'Foo', 'bar' ) );
 
-		$this->assertEquals(
-			'Foobar',
-			$instance->fetchSub( 'Foo', 'bar' )
-		);
+		$instance->save( 'Foo', [ md5( 'bar' ) => 'Foobar' ] );
+
+		// Present key, missing sub.
+		$this->assertFalse( $instance->fetchSub( 'Foo', 'missing' ) );
+
+		// Present key and sub.
+		$this->assertSame( 'Foobar', $instance->fetchSub( 'Foo', 'bar' ) );
 	}
 
-	public function tesSaveSub() {
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
-			->with( 'Foo' )
-			->willReturn( [ md5( 'bar' ) => 'Foobar' ] );
+	public function testSaveSub_MergesIntoExistingRecord() {
+		$instance = new EntityCache( $this->newCache() );
 
-		$this->cache->expects( $this->once() )
-			->method( 'save' )
-			->with(
-				'Foo',
-				[ md5( 'bar' ) => '123' ] );
+		$instance->saveSub( 'Foo', 'bar', '1' );
+		$instance->saveSub( 'Foo', 'baz', '2' );
 
-		$instance = new EntityCache(
-			$this->cache
-		);
-
-		$instance->saveSub( 'Foo', 'bar', '123' );
+		// Both subs coexist; the second save merges rather than replaces.
+		$this->assertSame( '1', $instance->fetchSub( 'Foo', 'bar' ) );
+		$this->assertSame( '2', $instance->fetchSub( 'Foo', 'baz' ) );
 	}
 
-	public function tesOverrideSub() {
-		$this->cache->expects( $this->once() )
-			->method( 'save' )
-			->with(
-				'Foo',
-				[ md5( 'bar' ) => '123' ] );
+	public function testOverrideSub_ReplacesWholeRecord() {
+		$instance = new EntityCache( $this->newCache() );
 
-		$instance = new EntityCache(
-			$this->cache
-		);
+		$instance->saveSub( 'Foo', 'bar', '1' );
+		$instance->overrideSub( 'Foo', 'baz', '2' );
 
-		$instance->overrideSub( 'Foo', 'bar', '123' );
+		// overrideSub discards any prior subs and keeps only the new one.
+		$this->assertFalse( $instance->fetchSub( 'Foo', 'bar' ) );
+		$this->assertSame( '2', $instance->fetchSub( 'Foo', 'baz' ) );
 	}
 
-	public function tesDeleteSub() {
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
-			->with( 'Foo' )
-			->willReturn( [ md5( 'bar' ) => 'Foobar', md5( 'foobar' ) => '123' ] );
+	public function testDeleteSub_RemovesOnlyTheNamedSub() {
+		$instance = new EntityCache( $this->newCache() );
 
-		$this->cache->expects( $this->once() )
-			->method( 'save' )
-			->with(
-				'Foo',
-				[ md5( 'foobar' ) => '123' ] );
-
-		$instance = new EntityCache(
-			$this->cache
-		);
+		$instance->saveSub( 'Foo', 'bar', '1' );
+		$instance->saveSub( 'Foo', 'baz', '2' );
 
 		$instance->deleteSub( 'Foo', 'bar' );
+
+		$this->assertFalse( $instance->fetchSub( 'Foo', 'bar' ) );
+		$this->assertSame( '2', $instance->fetchSub( 'Foo', 'baz' ) );
 	}
 
-	public function testAssociate() {
+	public function testAssociate_BuildsAnchorRecord() {
 		$subject = WikiPage::newFromText( 'Foo' );
+		$instance = new EntityCache( $this->newCache() );
 
-		$expected = [
-			md5( 'bar' ) => 'Foobar',
-			'__assoc' => [ 'Foo' => true ],
-			'__subject' => $subject->getHash()
-		];
+		$instance->associate( $subject, 'assocKey' );
 
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
-			->willReturn( [ md5( 'bar' ) => 'Foobar' ] );
+		$anchor = $instance->fetch( EntityCache::makeCacheKey( $subject ) );
 
-		$this->cache->expects( $this->once() )
-			->method( 'save' )
-			->with(
-				$this->stringContains( 'smw:entity:44ab375ee7ebac04b8e4471a70180dc5' ),
-				$expected );
-
-		$instance = new EntityCache(
-			$this->cache
-		);
-
-		$instance->associate( $subject, 'Foo' );
+		$this->assertSame( $subject->getHash(), $anchor['__subject'] );
+		$this->assertTrue( $anchor['__assoc']['assocKey'] );
 	}
 
-	public function testAssociate_NoValidSubject() {
-		$this->cache->expects( $this->never() )
-			->method( 'fetch' );
+	public function testAssociate_NoValidSubjectIsNoOp() {
+		$instance = new EntityCache( $this->newCache() );
 
-		$instance = new EntityCache(
-			$this->cache
+		$instance->associate( 'notASubject', 'assocKey' );
+
+		// No anchor record is created for a non-WikiPage subject.
+		$this->assertFalse(
+			$instance->contains( EntityCache::makeCacheKey( 'notASubject' ) )
 		);
-
-		$instance->associate( 'notASubject', 'Foo' );
 	}
 
-	public function testInvalidate() {
+	public function testInvalidate_DeletesAssociatesAndAnchorOnly() {
 		$subject = WikiPage::newFromText( 'Foo' );
+		$instance = new EntityCache( $this->newCache() );
 
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
-			->willReturn( [ md5( 'bar' ) => 'Foobar', '__assoc' => [ 'Foo' => true ] ] );
+		$assocKeyOne = $instance->makeCacheKey( 'assoc', 'one' );
+		$assocKeyTwo = $instance->makeCacheKey( 'assoc', 'two' );
+		$unrelatedKey = $instance->makeCacheKey( 'unrelated' );
 
-		$this->cache->expects( $this->exactly( 2 ) )
-			->method( 'delete' )
-			->willReturnCallback( function ( $key ) {
-				static $calls = [];
-				$calls[] = $key;
-				if ( count( $calls ) === 1 ) {
-					$this->assertStringContainsString( 'Foo', $key );
-				} elseif ( count( $calls ) === 2 ) {
-					$this->assertStringContainsString( 'smw:entity:44ab375ee7ebac04b8e4471a70180dc5', $key );
-				}
-			} );
+		$instance->save( $assocKeyOne, 'a' );
+		$instance->save( $assocKeyTwo, 'b' );
+		$instance->save( $unrelatedKey, 'u' );
+		$instance->associate( $subject, $assocKeyOne );
+		$instance->associate( $subject, $assocKeyTwo );
 
-		$instance = new EntityCache(
-			$this->cache
-		);
+		$anchorKey = EntityCache::makeCacheKey( $subject );
+		$this->assertTrue( $instance->contains( $anchorKey ) );
 
 		$instance->invalidate( $subject );
+
+		// Every associated key and the anchor are removed; an unrelated entry
+		// survives (the cascade deletes N associates + 1 anchor, no more).
+		$this->assertFalse( $instance->contains( $assocKeyOne ) );
+		$this->assertFalse( $instance->contains( $assocKeyTwo ) );
+		$this->assertFalse( $instance->contains( $anchorKey ) );
+		$this->assertTrue( $instance->contains( $unrelatedKey ) );
 	}
 
-	public function testInvalidate_NoValidSubject() {
-		$this->cache->expects( $this->never() )
-			->method( 'fetch' );
+	public function testInvalidate_NoValidSubjectIsNoOp() {
+		$instance = new EntityCache( $this->newCache() );
 
-		$instance = new EntityCache(
-			$this->cache
-		);
-
+		$instance->save( 'survivor', 'v' );
 		$instance->invalidate( 'notASubject' );
+
+		$this->assertTrue( $instance->contains( 'survivor' ) );
 	}
 
 }

--- a/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
+++ b/tests/phpunit/Unit/Factbox/CachedFactboxTest.php
@@ -18,6 +18,7 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockTitle;
+use Wikimedia\ObjectCache\HashBagOStuff;
 
 /**
  * @covers \SMW\Factbox\CachedFactbox
@@ -41,7 +42,7 @@ class CachedFactboxTest extends TestCase {
 		parent::setUp();
 
 		$this->testEnvironment = new TestEnvironment();
-		$this->memoryCache = ApplicationFactory::getInstance()->newCacheFactory()->newFixedInMemoryCache();
+		$this->memoryCache = new HashBagOStuff();
 
 		$this->testEnvironment->withConfiguration(
 			[


### PR DESCRIPTION
## What

Continues the migration off the `onoi/cache` dependency to MediaWiki core's `Wikimedia\ObjectCache\BagOStuff`. This converts `SMW\EntityCache`, the wrapper that links cache entries to a WikiPage so they can be invalidated together.

## How

- The injected delegate is retyped from `Onoi\Cache\Cache` to `Wikimedia\ObjectCache\BagOStuff`. Internal calls become `fetch()` to `get()` and `save()` to `set()` (argument order unchanged); `delete()` is kept. The two-argument `set()` in `associate()` relies on `BagOStuff::set()` treating a missing expiry as no expiry, matching the previous `save()` default.
- `contains()` keeps its public boolean signature; its body becomes `get( $key ) !== false`. This is safe at all three external callers, which store non-falsy values: `ProtectionValidator` stores `'yes'`/`'no'`, `DependencyValidator` stores a `saveSub`/`overrideSub` array, and `TableStatisticsTaskHandler` reads a non-empty statistics array.
- `getStats()` is removed; it had no callers, and `BagOStuff` does not expose it.
- The `SMW.EntityCache` service now injects `getObjectCache()` (a `BagOStuff` over the configured main cache type) instead of the shared Onoi composite from `getCache()`. EntityCache namespaces its own keys, so its entries stay separate from the consumers still on the composite.

## Behavioural note

EntityCache no longer shares a backing store with the Onoi composite returned by `getCache()`. Code that wrote through the composite and read back through EntityCache (or vice versa) would no longer see a single shared store. No such coupling exists in the current code; this is noted for completeness as the per-consumer migration proceeds.

## Tests

`EntityCacheTest` is rewritten to characterize behaviour against a real `HashBagOStuff` rather than replaying mock expectations: store/retrieve/contains/delete, the `*Sub` md5 packing (`saveSub` merges into the record, `overrideSub` replaces it), `associate` anchor construction, and the `invalidate` cascade (every associated key and the anchor are deleted while an unrelated entry survives). The rewrite also revives three tests that were silently skipped because of misspelled method names. Two further construction sites that passed an in-memory Onoi cache (`CachedFactboxTest`, `DependencyValidatorTest`) move to `HashBagOStuff`.

This targets the 7.0.0 major release, so the conversion is a hard cutover with no deprecation shims.