### PR TITLE
Add SMW\Cache\InMemoryLruCache adapter over MapCacheLRU

### DIFF
--- a/src/Cache/InMemoryLruCache.php
+++ b/src/Cache/InMemoryLruCache.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace SMW\Cache;
+
+use MapCacheLRU;
+
+/**
+ * Request-scoped, bounded in-process LRU cache backed by MediaWiki core's
+ * {@link MapCacheLRU}. It reproduces the small surface SMW's in-process pool
+ * caches rely on (the methods of the former `Onoi\Cache\FixedInMemoryLruCache`:
+ * `fetch`/`contains`/`save`/`delete` plus `getStats`) without depending on
+ * onoi/cache.
+ *
+ * This is deliberately a concrete, final adapter rather than a general cache
+ * interface: it exposes only the methods its pool consumers call, is never
+ * backed by a persistent or cross-request store, and synthesises the
+ * occupancy/hit counters that `MapCacheLRU` does not track. `fetch()` returns
+ * the `false` miss-sentinel and `contains()` maps to `MapCacheLRU::has()`, so
+ * the pool consumer call sites keep working unchanged.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ *
+ * @author mwjames
+ */
+final class InMemoryLruCache {
+
+	private MapCacheLRU $cache;
+	private int $inserts = 0;
+	private int $deletes = 0;
+	private int $hits = 0;
+	private int $misses = 0;
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function __construct( int $maxCacheCount = 500 ) {
+		$this->cache = new MapCacheLRU( $maxCacheCount );
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param string $key
+	 *
+	 * @return mixed The cached value, or `false` when the key is absent.
+	 */
+	public function fetch( $key ) {
+		if ( $this->cache->has( $key ) ) {
+			$this->hits++;
+			return $this->cache->get( $key );
+		}
+
+		$this->misses++;
+		return false;
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param string $key
+	 */
+	public function contains( $key ): bool {
+		return $this->cache->has( $key );
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 * @param int $ttl Accepted for call-shape compatibility with the former
+	 *  Onoi cache; the in-process LRU bounds entries by count, not time, so the
+	 *  value is ignored.
+	 */
+	public function save( $key, $value, $ttl = 0 ): void {
+		$this->inserts++;
+		$this->cache->set( $key, $value );
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param string $key
+	 *
+	 * @return bool Whether an entry was present and removed.
+	 */
+	public function delete( $key ): bool {
+		if ( !$this->cache->has( $key ) ) {
+			return false;
+		}
+
+		$this->deletes++;
+		$this->cache->clear( [ $key ] );
+		return true;
+	}
+
+	/**
+	 * Occupancy and hit/miss counters in the shape the former
+	 * `FixedInMemoryLruCache` exposed, consumed by
+	 * `InMemoryPoolCache::getStats()` and `rebuildData --report-poolcache`.
+	 *
+	 * @since 7.0.0
+	 */
+	public function getStats(): array {
+		return [
+			'inserts' => $this->inserts,
+			'deletes' => $this->deletes,
+			'max' => $this->cache->getMaxSize(),
+			'count' => count( $this->cache->getAllKeys() ),
+			'hits' => $this->hits,
+			'misses' => $this->misses,
+		];
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getName(): string {
+		return self::class;
+	}
+
+}

--- a/tests/phpunit/Unit/Cache/InMemoryLruCacheTest.php
+++ b/tests/phpunit/Unit/Cache/InMemoryLruCacheTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace SMW\Tests\Unit\Cache;
+
+use PHPUnit\Framework\TestCase;
+use SMW\Cache\InMemoryLruCache;
+
+/**
+ * @covers \SMW\Cache\InMemoryLruCache
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ *
+ * @author mwjames
+ */
+class InMemoryLruCacheTest extends TestCase {
+
+	public function testCanConstruct() {
+		$this->assertInstanceOf(
+			InMemoryLruCache::class,
+			new InMemoryLruCache()
+		);
+	}
+
+	public function testSaveFetchContainsDelete() {
+		$instance = new InMemoryLruCache();
+
+		$this->assertFalse( $instance->contains( 'k' ) );
+		$this->assertFalse( $instance->fetch( 'k' ) );
+
+		$instance->save( 'k', 'v' );
+
+		$this->assertTrue( $instance->contains( 'k' ) );
+		$this->assertSame( 'v', $instance->fetch( 'k' ) );
+
+		$this->assertTrue( $instance->delete( 'k' ) );
+
+		$this->assertFalse( $instance->contains( 'k' ) );
+		$this->assertFalse( $instance->fetch( 'k' ) );
+	}
+
+	public function testFetchReturnsFalseSentinelOnMiss() {
+		$instance = new InMemoryLruCache();
+
+		// The false sentinel is what the negative-cache consumers rely on.
+		$this->assertFalse( $instance->fetch( 'absent' ) );
+	}
+
+	public function testDeleteReturnsFalseWhenAbsent() {
+		$instance = new InMemoryLruCache();
+
+		$this->assertFalse( $instance->delete( 'absent' ) );
+	}
+
+	public function testSaveAcceptsAndIgnoresTtlArgument() {
+		$instance = new InMemoryLruCache();
+
+		$instance->save( 'k', 'v', 3600 );
+
+		$this->assertSame( 'v', $instance->fetch( 'k' ) );
+	}
+
+	public function testStoresFalsyValuesDistinctFromMiss() {
+		$instance = new InMemoryLruCache();
+
+		// A stored 0 is a hit; the value round-trips even though it is falsy.
+		$instance->save( 'zero', 0 );
+
+		$this->assertTrue( $instance->contains( 'zero' ) );
+		$this->assertSame( 0, $instance->fetch( 'zero' ) );
+	}
+
+	public function testGetStatsShapeAndCounters() {
+		$instance = new InMemoryLruCache( 10 );
+
+		$instance->save( 'k', 'v' );
+		$instance->fetch( 'k' );
+		$instance->fetch( 'miss' );
+		// Overwriting an existing key is still counted as an insert.
+		$instance->save( 'k', 'v2' );
+		$instance->delete( 'k' );
+		// Deleting an absent key does not increment the delete counter.
+		$instance->delete( 'k' );
+
+		$this->assertSame(
+			[
+				'inserts' => 2,
+				'deletes' => 1,
+				'max' => 10,
+				'count' => 0,
+				'hits' => 1,
+				'misses' => 1,
+			],
+			$instance->getStats()
+		);
+	}
+
+	public function testEvictsLeastRecentlyUsedBeyondCapacity() {
+		$instance = new InMemoryLruCache( 2 );
+
+		$instance->save( 'a', '1' );
+		$instance->save( 'b', '2' );
+		$instance->save( 'c', '3' );
+
+		// Capacity is 2, so the oldest entry is evicted and the count is capped.
+		$this->assertFalse( $instance->contains( 'a' ) );
+		$this->assertTrue( $instance->contains( 'b' ) );
+		$this->assertTrue( $instance->contains( 'c' ) );
+		$this->assertSame( 2, $instance->getStats()['count'] );
+		$this->assertSame( 2, $instance->getStats()['max'] );
+	}
+
+	public function testGetName() {
+		$this->assertSame(
+			InMemoryLruCache::class,
+			( new InMemoryLruCache() )->getName()
+		);
+	}
+
+}


### PR DESCRIPTION
## What

Adds `SMW\Cache\InMemoryLruCache`, a concrete final in-process LRU cache backed by MediaWiki core's `MapCacheLRU`. This is the substrate that SMW's in-process pool caches will move onto, replacing `Onoi\Cache\FixedInMemoryLruCache` as part of removing the `onoi/cache` dependency.

## Why this shape

`MapCacheLRU` is not a drop-in for `FixedInMemoryLruCache`: `get()` returns `null` (not `false`) on a miss, single-key removal is `clear()` (returning void, not a bool), `set()` has no TTL, and it tracks no hit/miss/occupancy counters. The adapter bridges those gaps so the pool consumer call sites do not change when the pool registry swaps its mint in a follow-up change:

- `fetch()` returns the `false` miss-sentinel and counts hits/misses.
- `contains()` maps to `MapCacheLRU::has()`.
- `save()` accepts a TTL argument for call-shape compatibility but ignores it, since the in-process LRU bounds by count, not time.
- `delete()` returns whether an entry was present and removed.
- `getStats()` synthesises the `inserts`/`deletes`/`max`/`count`/`hits`/`misses` array shape consumed by `InMemoryPoolCache::getStats()` and `rebuildData --report-poolcache`.

It is deliberately a concrete, final class rather than a general cache interface: it exposes only the methods its pool consumers call, is request-scoped, and is never backed by a persistent or cross-request store (no `BagOStuff`, no WAN).

## Tests

A characterization test pins the store/retrieve/delete round-trips, the `false` miss-sentinel, falsy-value storage distinct from a miss, the `getStats()` shape and counter semantics, and LRU eviction at capacity.

Additive only; no existing code is rewired in this change. The pool registry swap onto this adapter is a separate follow-up.