### PR TITLE
Swap the in-process pool substrate to SMW\Cache\InMemoryLruCache

### DIFF
--- a/src/Cache/InMemoryLruCache.php
+++ b/src/Cache/InMemoryLruCache.php
@@ -33,9 +33,14 @@ final class InMemoryLruCache {
 
 	/**
 	 * @since 7.0.0
+	 *
+	 * @param int|string $maxCacheCount Cast to int to match the tolerance of
+	 *  the former Onoi cache, which accepted string pool sizes from config. A
+	 *  non-positive size is clamped to 1, since MapCacheLRU requires a positive
+	 *  capacity where the former cache treated a 0 size as "hold nothing".
 	 */
-	public function __construct( int $maxCacheCount = 500 ) {
-		$this->cache = new MapCacheLRU( $maxCacheCount );
+	public function __construct( $maxCacheCount = 500 ) {
+		$this->cache = new MapCacheLRU( max( 1, (int)$maxCacheCount ) );
 	}
 
 	/**

--- a/src/Exporter/ResourceBuilders/PropertyValueResourceBuilder.php
+++ b/src/Exporter/ResourceBuilders/PropertyValueResourceBuilder.php
@@ -2,7 +2,7 @@
 
 namespace SMW\Exporter\ResourceBuilders;
 
-use Onoi\Cache\Cache;
+use SMW\Cache\InMemoryLruCache;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Property;
 use SMW\Export\ExpData;
@@ -23,7 +23,7 @@ class PropertyValueResourceBuilder implements ResourceBuilder {
 
 	protected ?Exporter $exporter;
 
-	private Cache $inMemoryPoolCache;
+	private InMemoryLruCache $inMemoryPoolCache;
 
 	/**
 	 * @since 2.5

--- a/src/InMemoryPoolCache.php
+++ b/src/InMemoryPoolCache.php
@@ -2,7 +2,7 @@
 
 namespace SMW;
 
-use Onoi\Cache\Cache;
+use SMW\Cache\InMemoryLruCache;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Utils\StatsFormatter;
 
@@ -97,11 +97,11 @@ class InMemoryPoolCache {
 	 * @param string $poolCacheId
 	 * @param int $cacheSize
 	 *
-	 * @return Cache
+	 * @return InMemoryLruCache
 	 */
 	public function getPoolCacheById( $poolCacheId, $cacheSize = 500 ) {
 		if ( !isset( $this->poolCacheList[$poolCacheId] ) ) {
-			$this->poolCacheList[$poolCacheId] = $this->cacheFactory->newFixedInMemoryCache( $cacheSize );
+			$this->poolCacheList[$poolCacheId] = new InMemoryLruCache( $cacheSize );
 		}
 
 		return $this->poolCacheList[$poolCacheId];

--- a/src/Localizer/Message.php
+++ b/src/Localizer/Message.php
@@ -4,7 +4,7 @@ namespace SMW\Localizer;
 
 use Closure;
 use MediaWiki\Language\Language;
-use Onoi\Cache\Cache;
+use SMW\Cache\InMemoryLruCache;
 use SMW\InMemoryPoolCache;
 use Wikimedia\Message\MessageSpecifier;
 
@@ -22,7 +22,7 @@ use Wikimedia\Message\MessageSpecifier;
  */
 class Message {
 
-	private static ?Cache $messageCache = null;
+	private static ?InMemoryLruCache $messageCache = null;
 
 	/**
 	 * PoolCache ID
@@ -68,7 +68,7 @@ class Message {
 	/**
 	 * @since 2.4
 	 */
-	public static function getCache(): Cache {
+	public static function getCache(): InMemoryLruCache {
 		if ( self::$messageCache === null ) {
 			self::$messageCache = InMemoryPoolCache::getInstance()->getPoolCacheById( self::POOLCACHE_ID, 1000 );
 		}

--- a/src/Query/Cache/ResultCache.php
+++ b/src/Query/Cache/ResultCache.php
@@ -4,10 +4,10 @@ namespace SMW\Query\Cache;
 
 use Onoi\BlobStore\BlobStore;
 use Onoi\BlobStore\Container;
-use Onoi\Cache\Cache;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
+use SMW\Cache\InMemoryLruCache;
 use SMW\DataItems\WikiPage;
 use SMW\Query\Excerpts;
 use SMW\Query\Query;
@@ -81,7 +81,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 	 * back-end, yet queries with the same signature may have been retrieved
 	 * already therefore allow to recall the result from tempCache.
 	 *
-	 * @var Cache
+	 * @var InMemoryLruCache
 	 */
 	private $tempCache;
 

--- a/src/SPARQLStore/TurtleTriplesBuilder.php
+++ b/src/SPARQLStore/TurtleTriplesBuilder.php
@@ -3,7 +3,7 @@
 namespace SMW\SPARQLStore;
 
 use LogicException;
-use Onoi\Cache\Cache;
+use SMW\Cache\InMemoryLruCache;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\Export\ExpData;
@@ -49,7 +49,7 @@ class TurtleTriplesBuilder {
 	 */
 	public function __construct(
 		private readonly RepositoryRedirectLookup $repositoryRedirectLookup,
-		private readonly ?Cache $cache = null,
+		private readonly ?InMemoryLruCache $cache = null,
 	) {
 	}
 

--- a/src/SQLStore/EntityStore/InstrumentedCache.php
+++ b/src/SQLStore/EntityStore/InstrumentedCache.php
@@ -3,12 +3,13 @@
 namespace SMW\SQLStore\EntityStore;
 
 use Onoi\Cache\Cache;
+use SMW\Cache\InMemoryLruCache;
 use Wikimedia\Stats\StatsFactory;
 
 /**
  * Decorator that emits per-event hit/miss counters and a current-size gauge to
- * a `StatsFactory` for an underlying `Cache` instance. Used to instrument the
- * request-scoped LRU pools backing entity ID lookups so operators can see
+ * a `StatsFactory` for an underlying in-process LRU cache. Used to instrument
+ * the request-scoped pools backing entity ID lookups so operators can see
  * cache effectiveness in their existing metrics tooling.
  *
  * @license GPL-2.0-or-later
@@ -17,7 +18,7 @@ use Wikimedia\Stats\StatsFactory;
 class InstrumentedCache implements Cache {
 
 	public function __construct(
-		private readonly Cache $inner,
+		private readonly InMemoryLruCache $inner,
 		private readonly StatsFactory $statsFactory,
 		private readonly string $pool,
 	) {
@@ -44,9 +45,9 @@ class InstrumentedCache implements Cache {
 	}
 
 	public function save( $id, $data, $ttl = 0 ) {
-		$result = $this->inner->save( $id, $data, $ttl );
+		$this->inner->save( $id, $data, $ttl );
 		$this->updateSizeGauge();
-		return $result;
+		return null;
 	}
 
 	public function delete( $id ) {

--- a/src/SQLStore/RedirectStore.php
+++ b/src/SQLStore/RedirectStore.php
@@ -4,7 +4,7 @@ namespace SMW\SQLStore;
 
 use MediaWiki\JobQueue\JobFactory;
 use MediaWiki\Title\TitleFactory;
-use Onoi\Cache\Cache;
+use SMW\Cache\InMemoryLruCache;
 use SMW\InMemoryPoolCache;
 use SMW\Listener\ChangeListener\ChangeRecord;
 use SMW\MediaWiki\Job;
@@ -33,7 +33,7 @@ class RedirectStore {
 		private readonly Store $store,
 		private readonly TitleFactory $titleFactory,
 		private readonly JobFactory $jobFactory,
-		private ?Cache $cache = null,
+		private ?InMemoryLruCache $cache = null,
 	) {
 		if ( $this->cache === null ) {
 			$this->cache = InMemoryPoolCache::getInstance()->getPoolCacheById( 'sql.store.redirect.infostore' );

--- a/tests/phpunit/Unit/Cache/InMemoryLruCacheTest.php
+++ b/tests/phpunit/Unit/Cache/InMemoryLruCacheTest.php
@@ -23,6 +23,30 @@ class InMemoryLruCacheTest extends TestCase {
 		);
 	}
 
+	/**
+	 * The former Onoi cache cast its size argument to int and tolerated a 0
+	 * (or empty-string) size from config without erroring; the adapter keeps
+	 * that tolerance over MapCacheLRU, which requires a positive capacity.
+	 *
+	 * @dataProvider degenerateSizeProvider
+	 */
+	public function testConstructsWithDegenerateOrStringSize( $size ) {
+		$instance = new InMemoryLruCache( $size );
+
+		$instance->save( 'k', 'v' );
+
+		$this->assertInstanceOf( InMemoryLruCache::class, $instance );
+	}
+
+	public function degenerateSizeProvider() {
+		return [
+			'empty string' => [ '' ],
+			'numeric string' => [ '1000' ],
+			'zero' => [ 0 ],
+			'negative' => [ -5 ],
+		];
+	}
+
 	public function testSaveFetchContainsDelete() {
 		$instance = new InMemoryLruCache();
 

--- a/tests/phpunit/Unit/InMemoryPoolCacheTest.php
+++ b/tests/phpunit/Unit/InMemoryPoolCacheTest.php
@@ -2,8 +2,8 @@
 
 namespace SMW\Tests\Unit;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
+use SMW\Cache\InMemoryLruCache;
 use SMW\CacheFactory;
 use SMW\InMemoryPoolCache;
 
@@ -43,7 +43,7 @@ class InMemoryPoolCacheTest extends TestCase {
 		$instance = InMemoryPoolCache::getInstance();
 
 		$this->assertInstanceOf(
-			Cache::class,
+			InMemoryLruCache::class,
 			$instance->getPoolCacheById( 'Foo' )
 		);
 

--- a/tests/phpunit/Unit/SQLStore/RedirectStoreTest.php
+++ b/tests/phpunit/Unit/SQLStore/RedirectStoreTest.php
@@ -5,7 +5,6 @@ namespace SMW\Tests\Unit\SQLStore;
 use MediaWiki\JobQueue\JobFactory;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use SMW\Connection\ConnectionManager;
 use SMW\InMemoryPoolCache;
@@ -38,7 +37,6 @@ class RedirectStoreTest extends TestCase {
 
 	private $store;
 	private Database $connection;
-	private $cache;
 	private $testEnvironment;
 	private $connectionManager;
 	private TitleFactory $titleFactory;
@@ -46,10 +44,6 @@ class RedirectStoreTest extends TestCase {
 
 	protected function setUp(): void {
 		$this->testEnvironment = new TestEnvironment();
-
-		$this->cache = $this->getMockBuilder( Cache::class )
-			->disableOriginalConstructor()
-			->getMock();
 
 		$this->connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()


### PR DESCRIPTION
## What

Continues removing the `onoi/cache` dependency. Points SMW's in-process pool caches at `SMW\Cache\InMemoryLruCache` (the `MapCacheLRU`-backed adapter added previously) instead of `Onoi\Cache\FixedInMemoryLruCache`.

## How

`InMemoryPoolCache::getPoolCacheById()` now mints an `InMemoryLruCache`. Because the adapter exposes the same `fetch`/`contains`/`save`/`delete`/`getStats` surface with the `false` miss-sentinel, the pool consumers keep their call sites. The consumers that hold a pool cache in a typed slot are retyped from `Onoi\Cache\Cache` to `InMemoryLruCache`:

- `InstrumentedCache::$inner`
- `Message::$messageCache` (and the `getCache()` return type)
- `PropertyValueResourceBuilder::$inMemoryPoolCache`
- `TurtleTriplesBuilder` and `RedirectStore` constructor parameters
- `ResultCache::$tempCache` (its blob-store tier stays on Onoi for now)

The three inline-resolver consumers (`RepositoryRedirectLookup`, `ExpResourceMapper`, `TurtleSerializer`) hold the pool cache in an untyped local, so they are unchanged.

Two compatibility adjustments the swap surfaced:

- The adapter constructor casts its size argument to int and clamps a non-positive size to 1. Config can pass string pool sizes, and `MapCacheLRU` requires a positive capacity where the former cache cast to int and treated a 0 size as hold-nothing.
- `InstrumentedCache::save()` no longer assigns the now-void inner return; it returns `null` to keep satisfying the `Onoi\Cache\Cache` interface it still implements.

`InMemoryPoolCache` keeps its `CacheFactory` constructor dependency for now; removing it is a separate change.

## Tests

The existing pool-consumer tests (`InMemoryPoolCacheTest`, `RedirectStoreTest`, `MessageTest`) exercise the swapped substrate, including the `getStats()` hit/miss counters; `InMemoryPoolCacheTest` asserts the pool returns an `InMemoryLruCache`, and `RedirectStoreTest` drops a dead cache mock. The adapter's degenerate-size tolerance gains an explicit test. The `getStats()` reporting path (`rebuildData --report-poolcache`) was exercised against the new substrate and returns the same shape.