### PR TITLE
Convert ChangePropagationDispatchJob to MediaWiki BagOStuff

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -716,7 +716,7 @@
 			"class": "SMW\\MediaWiki\\Jobs\\ChangePropagationDispatchJob",
 			"services": [
 				"SMW.Store",
-				"SMW.Cache",
+				"SMW.ObjectCache",
 				"SMW.PropertySpecificationLookup",
 				"SMW.IteratorFactory",
 				"SMW.JobFactory"

--- a/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
@@ -4,7 +4,6 @@ namespace SMW\MediaWiki\Jobs;
 
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\Title\Title;
-use Onoi\Cache\Cache;
 use Psr\Log\LoggerInterface;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
@@ -16,6 +15,7 @@ use SMW\Property\SpecificationLookup as PropertySpecificationLookup;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\Lookup\ChangePropagationEntityLookup;
 use SMW\Store;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * `ChangePropagationDispatchJob` dispatches update jobs via `ChangePropagationUpdateJob`
@@ -89,7 +89,7 @@ class ChangePropagationDispatchJob extends Job {
 		Title $title,
 		array $params,
 		Store $store,
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 		private readonly PropertySpecificationLookup $propertySpecificationLookup,
 		private readonly IteratorFactory $iteratorFactory,
 		private readonly JobFactory $jobFactory
@@ -144,7 +144,7 @@ class ChangePropagationDispatchJob extends Job {
 			return;
 		}
 
-		ApplicationFactory::getInstance()->getCache()->delete(
+		ApplicationFactory::getInstance()->getObjectCache()->delete(
 			smwfCacheKey(
 				self::CACHE_NAMESPACE,
 				$subject->getHash()
@@ -180,7 +180,7 @@ class ChangePropagationDispatchJob extends Job {
 			$subject->getHash()
 		);
 
-		return $applicationFactory->getCache()->fetch( $key ) > 0;
+		return $applicationFactory->getObjectCache()->get( $key ) > 0;
 	}
 
 	/**
@@ -217,7 +217,7 @@ class ChangePropagationDispatchJob extends Job {
 				$subject->getHash()
 			);
 
-			$count = $applicationFactory->getCache()->fetch( $key );
+			$count = $applicationFactory->getObjectCache()->get( $key );
 		}
 
 		return $count;
@@ -350,9 +350,9 @@ class ChangePropagationDispatchJob extends Job {
 
 		// SemanticData hasn't been updated, re-enter the cycle to ensure that
 		// the update of the property took place
-		if ( $this->cache->fetch( $key ) === false ) {
+		if ( $this->cache->get( $key ) === false ) {
 
-			$this->cache->save( $key, 1, 60 * 60 * 24 );
+			$this->cache->set( $key, 1, 60 * 60 * 24 );
 			$params = $this->params;
 
 			$changePropagationDispatchJob = $this->jobFactory->newChangePropagationDispatchJob(
@@ -478,7 +478,12 @@ class ChangePropagationDispatchJob extends Job {
 		//
 		// The marker will be removed after running the ChangePropagationUpdateJob
 		// on the same subject.
-		$this->cache->save(
+		//
+		// $count is always >= 1 here (the dispatched subject is always counted),
+		// so the marker value is never 0. That invariant is what keeps the
+		// `get( $key ) === false` absence check below behaviour-preserving: a 0
+		// marker would read back as a present 0, not as absent.
+		$this->cache->set(
 			smwfCacheKey( self::CACHE_NAMESPACE, $subject->getHash() ),
 			$count,
 			60 * 60 * 24

--- a/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
@@ -3,7 +3,6 @@
 namespace SMW\Tests\Unit\MediaWiki\Jobs;
 
 use MediaWiki\Title\Title;
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use ReflectionClass;
 use SMW\DataItems\WikiPage;
@@ -14,9 +13,11 @@ use SMW\MediaWiki\Jobs\ChangePropagationDispatchJob;
 use SMW\MediaWiki\Jobs\ChangePropagationUpdateJob;
 use SMW\MediaWiki\Jobs\UpdateJob;
 use SMW\Property\SpecificationLookup as PropertySpecificationLookup;
+use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\PropertyTableInfoFetcher;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\TestEnvironment;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * @covers \SMW\MediaWiki\Jobs\ChangePropagationDispatchJob
@@ -45,8 +46,10 @@ class ChangePropagationDispatchJobTest extends TestCase {
 		parent::tearDown();
 	}
 
-	private function newCache(): Cache {
-		return $this->getMockBuilder( Cache::class )->getMockForAbstractClass();
+	private function newCache(): BagOStuff {
+		return $this->getMockBuilder( BagOStuff::class )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	private function newPropertySpecificationLookup(): PropertySpecificationLookup {
@@ -75,7 +78,7 @@ class ChangePropagationDispatchJobTest extends TestCase {
 		Title $title,
 		array $params = [],
 		?SQLStore $store = null,
-		?Cache $cache = null,
+		?BagOStuff $cache = null,
 		?PropertySpecificationLookup $propertySpecificationLookup = null,
 		?IteratorFactory $iteratorFactory = null,
 		?JobFactory $jobFactory = null
@@ -105,42 +108,33 @@ class ChangePropagationDispatchJobTest extends TestCase {
 	public function testCleanUp() {
 		$subject = WikiPage::newFromText( __METHOD__, SMW_NS_PROPERTY );
 
-		$cache = $this->getMockBuilder( Cache::class )
-			->getMockForAbstractClass();
-
-		$cache->expects( $this->once() )
-			->method( 'delete' );
-
-		$this->testEnvironment->registerObject( 'Cache', $cache );
+		// cleanUp() resolves its cache from the global service, which has no
+		// test-override seam, so exercise it against the real object cache.
+		$cache = ApplicationFactory::getInstance()->getObjectCache();
+		$key = smwfCacheKey( ChangePropagationDispatchJob::CACHE_NAMESPACE, $subject->getHash() );
+		$cache->set( $key, 1 );
 
 		ChangePropagationDispatchJob::cleanUp( $subject );
+
+		$this->assertFalse( $cache->get( $key ) );
 	}
 
 	public function testHasPendingJobs() {
-		$subject = WikiPage::newFromText( 'Foo' );
+		$subject = WikiPage::newFromText( 'ChangePropPending' );
 
-		$jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
-
-		$cache = $this->getMockBuilder( Cache::class )
-			->getMockForAbstractClass();
-
-		$cache->expects( $this->once() )
-			->method( 'fetch' )
-			->willReturn( 42 );
-
-		$this->testEnvironment->registerObject( 'Cache', $cache );
+		$cache = ApplicationFactory::getInstance()->getObjectCache();
+		$key = smwfCacheKey( ChangePropagationDispatchJob::CACHE_NAMESPACE, $subject->getHash() );
+		$cache->set( $key, 42 );
 
 		$this->assertTrue(
 			ChangePropagationDispatchJob::hasPendingJobs( $subject )
 		);
+
+		$cache->delete( $key );
 	}
 
 	public function testGetPendingJobsCount() {
-		$subject = WikiPage::newFromText( 'Foo' );
+		$subject = WikiPage::newFromText( 'ChangePropCount' );
 
 		$jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
 			->disableOriginalConstructor()
@@ -148,19 +142,18 @@ class ChangePropagationDispatchJobTest extends TestCase {
 
 		$this->testEnvironment->registerObject( 'JobQueue', $jobQueue );
 
-		$cache = $this->getMockBuilder( Cache::class )
-			->getMockForAbstractClass();
-
-		$cache->expects( $this->atLeastOnce() )
-			->method( 'fetch' )
-			->willReturn( 42 );
-
-		$this->testEnvironment->registerObject( 'Cache', $cache );
+		// With no queued jobs, getPendingJobsCount() falls back to the cache
+		// marker, which is resolved from the unmockable global object cache.
+		$cache = ApplicationFactory::getInstance()->getObjectCache();
+		$key = smwfCacheKey( ChangePropagationDispatchJob::CACHE_NAMESPACE, $subject->getHash() );
+		$cache->set( $key, 42 );
 
 		$this->assertSame(
 			42,
 			ChangePropagationDispatchJob::getPendingJobsCount( $subject )
 		);
+
+		$cache->delete( $key );
 	}
 
 	public function testFindAndDispatchOnNonPropertyEntity() {
@@ -347,12 +340,13 @@ class ChangePropagationDispatchJobTest extends TestCase {
 		// path to apply.
 		$subject = WikiPage::newFromText( 'Foo', SMW_NS_PROPERTY );
 
-		$cache = $this->getMockBuilder( Cache::class )
-			->getMockForAbstractClass();
+		$cache = $this->getMockBuilder( BagOStuff::class )
+			->disableOriginalConstructor()
+			->getMock();
 
 		// Return a non-false value so dispatchFromData() passes the cache check.
 		$cache->expects( $this->any() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->willReturn( 3 );
 
 		$updateJob = $this->getMockBuilder( ChangePropagationUpdateJob::class )


### PR DESCRIPTION
## What

Continues removing the `onoi/cache` dependency. Converts `ChangePropagationDispatchJob` from `Onoi\Cache\Cache` to MediaWiki core's `Wikimedia\ObjectCache\BagOStuff`. The job uses a short-lived cache marker (`smw:chgprop:<subjectHash>`, 24h TTL) to track in-flight change-propagation jobs.

## How

- The injected marker cache flips its JobClasses service from `SMW.Cache` to `SMW.ObjectCache`, and the static helpers (`cleanUp`, `hasPendingJobs`, `getPendingJobsCount`) resolve the cache through `getObjectCache()`. Both paths resolve to the same `BagOStuff` over the configured main cache type, so a marker written by one is read by the other.
- `fetch()` becomes `get()`, `save()` becomes `set()`, and `delete()` is kept. The value checks are unchanged: the marker is always a positive integer, so `get( $key ) > 0` and `get( $key ) === false` carry the same meaning as before (a present `0` and an absent key both fail `> 0`, and the stored value is never `false`). No sentinel is needed. A comment at the write site records the always-positive invariant, since that is what keeps the absence check behaviour-preserving.

## Tests

The three static-helper tests previously intercepted the cache via `registerObject('Cache', …)`. Because `getObjectCache()` resolves from `MediaWikiServices` and has no test-override seam, they are rewritten to exercise the real object cache: seed a marker, run the helper, and assert the resulting state. The remaining tests inject a `BagOStuff` mock directly.

The marker is produced and consumed only by this job, so nothing else reads it through the former cache.