### PR TITLE
Remove the Onoi\Cache\Cache interface from the entity-ID cache tier

### DIFF
--- a/src/Cache/InMemoryLruCache.php
+++ b/src/Cache/InMemoryLruCache.php
@@ -118,11 +118,4 @@ final class InMemoryLruCache {
 		];
 	}
 
-	/**
-	 * @since 7.0.0
-	 */
-	public function getName(): string {
-		return self::class;
-	}
-
 }

--- a/src/SQLStore/EntityStore/IdCacheManager.php
+++ b/src/SQLStore/EntityStore/IdCacheManager.php
@@ -2,8 +2,8 @@
 
 namespace SMW\SQLStore\EntityStore;
 
-use Onoi\Cache\Cache;
 use RuntimeException;
+use SMW\Cache\InMemoryLruCache;
 use SMW\DataItems\WikiPage;
 
 /**
@@ -59,7 +59,7 @@ class IdCacheManager {
 	 *
 	 * @param string $key
 	 *
-	 * @return Cache
+	 * @return InstrumentedCache|InMemoryLruCache
 	 */
 	public function get( $key ) {
 		if ( !isset( $this->caches[$key] ) ) {

--- a/src/SQLStore/EntityStore/InstrumentedCache.php
+++ b/src/SQLStore/EntityStore/InstrumentedCache.php
@@ -2,7 +2,6 @@
 
 namespace SMW\SQLStore\EntityStore;
 
-use Onoi\Cache\Cache;
 use SMW\Cache\InMemoryLruCache;
 use Wikimedia\Stats\StatsFactory;
 
@@ -15,7 +14,7 @@ use Wikimedia\Stats\StatsFactory;
  * @license GPL-2.0-or-later
  * @since 7.0.0
  */
-class InstrumentedCache implements Cache {
+class InstrumentedCache {
 
 	public function __construct(
 		private readonly InMemoryLruCache $inner,
@@ -44,10 +43,9 @@ class InstrumentedCache implements Cache {
 		return $this->inner->contains( $id );
 	}
 
-	public function save( $id, $data, $ttl = 0 ) {
+	public function save( $id, $data, $ttl = 0 ): void {
 		$this->inner->save( $id, $data, $ttl );
 		$this->updateSizeGauge();
-		return null;
 	}
 
 	public function delete( $id ) {
@@ -58,10 +56,6 @@ class InstrumentedCache implements Cache {
 
 	public function getStats() {
 		return $this->inner->getStats();
-	}
-
-	public function getName() {
-		return $this->inner->getName();
 	}
 
 	private function updateSizeGauge(): void {

--- a/tests/phpunit/Unit/Cache/InMemoryLruCacheTest.php
+++ b/tests/phpunit/Unit/Cache/InMemoryLruCacheTest.php
@@ -135,11 +135,4 @@ class InMemoryLruCacheTest extends TestCase {
 		$this->assertSame( 2, $instance->getStats()['max'] );
 	}
 
-	public function testGetName() {
-		$this->assertSame(
-			InMemoryLruCache::class,
-			( new InMemoryLruCache() )->getName()
-		);
-	}
-
 }

--- a/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
@@ -4,9 +4,8 @@ namespace SMW\Tests\Unit\SQLStore;
 
 use MediaWiki\JobQueue\JobFactory;
 use MediaWiki\Title\TitleFactory;
-use Onoi\Cache\Cache;
-use Onoi\Cache\FixedInMemoryLruCache;
 use PHPUnit\Framework\TestCase;
+use SMW\Cache\InMemoryLruCache;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Connection\Database;
@@ -61,16 +60,14 @@ class EntityIdManagerTest extends TestCase {
 	protected function setUp(): void {
 		$idCacheManager = new IdCacheManager(
 			[
-				'entity.id' => new FixedInMemoryLruCache(),
-				'entity.sort' => new FixedInMemoryLruCache(),
-				'entity.lookup' => new FixedInMemoryLruCache(),
-				'propertytable.hash' => new FixedInMemoryLruCache()
+				'entity.id' => new InMemoryLruCache(),
+				'entity.sort' => new InMemoryLruCache(),
+				'entity.lookup' => new InMemoryLruCache(),
+				'propertytable.hash' => new InMemoryLruCache()
 			]
 		);
 
-		$this->cache = $this->getMockBuilder( Cache::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->cache = new InMemoryLruCache();
 
 		$propertyStatisticsStore = $this->getMockBuilder( PropertyStatisticsStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/EntityStore/AuxiliaryFieldsTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/AuxiliaryFieldsTest.php
@@ -2,9 +2,8 @@
 
 namespace SMW\Tests\Unit\SQLStore\EntityStore;
 
-use Onoi\Cache\Cache;
-use Onoi\Cache\FixedInMemoryLruCache;
 use PHPUnit\Framework\TestCase;
+use SMW\Cache\InMemoryLruCache;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\AuxiliaryFields;
@@ -30,7 +29,7 @@ class AuxiliaryFieldsTest extends TestCase {
 
 	private $connection;
 	private $idCacheManager;
-	private Cache $cache;
+	private InMemoryLruCache $cache;
 
 	protected function setUp(): void {
 		$this->connection = $this->getMockBuilder( Database::class )
@@ -41,7 +40,7 @@ class AuxiliaryFieldsTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->cache = new FixedInMemoryLruCache();
+		$this->cache = new InMemoryLruCache();
 	}
 
 	public function testCanConstruct() {

--- a/tests/phpunit/Unit/SQLStore/EntityStore/CacheWarmerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/CacheWarmerTest.php
@@ -2,8 +2,8 @@
 
 namespace SMW\Tests\Unit\SQLStore\EntityStore;
 
-use Onoi\Cache\FixedInMemoryLruCache;
 use PHPUnit\Framework\TestCase;
+use SMW\Cache\InMemoryLruCache;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DisplayTitleFinder;
@@ -41,7 +41,7 @@ class CacheWarmerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->cache = new FixedInMemoryLruCache();
+		$this->cache = new InMemoryLruCache();
 
 		$this->linkBatch = $this->getMockBuilder( LinkBatch::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdCacheManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdCacheManagerTest.php
@@ -2,9 +2,8 @@
 
 namespace SMW\Tests\Unit\SQLStore\EntityStore;
 
-use Onoi\Cache\Cache;
-use Onoi\Cache\FixedInMemoryLruCache;
 use PHPUnit\Framework\TestCase;
+use SMW\Cache\InMemoryLruCache;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\SQLStore\EntityStore\IdCacheManager;
@@ -24,10 +23,10 @@ class IdCacheManagerTest extends TestCase {
 
 	protected function setUp(): void {
 		$this->caches = [
-			'entity.id' => new FixedInMemoryLruCache(),
-			'entity.sort' => new FixedInMemoryLruCache(),
-			'entity.lookup' => new FixedInMemoryLruCache(),
-			'propertytable.hash' => new FixedInMemoryLruCache()
+			'entity.id' => new InMemoryLruCache(),
+			'entity.sort' => new InMemoryLruCache(),
+			'entity.lookup' => new InMemoryLruCache(),
+			'propertytable.hash' => new InMemoryLruCache()
 		];
 	}
 
@@ -140,7 +139,7 @@ class IdCacheManagerTest extends TestCase {
 		$instance = new IdCacheManager( $this->caches );
 
 		$this->assertInstanceOf(
-			FixedInMemoryLruCache::class,
+			InMemoryLruCache::class,
 			$instance->get( 'entity.sort' )
 		);
 	}
@@ -229,20 +228,21 @@ class IdCacheManagerTest extends TestCase {
 	}
 
 	public function testDeleteCacheById() {
-		$cache = $this->getMockBuilder( Cache::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$cache->expects( $this->once() )
-			->method( 'delete' )
-			->with( IdCacheManager::computeSha1( [ 'foo', 0, '', '' ] ) );
-
-		$this->caches['entity.id'] = $cache;
-
 		$instance = new IdCacheManager( $this->caches );
 		$instance->setCache( 'foo', 0, '', '', '42', 'bar' );
 
+		$key = IdCacheManager::computeSha1( [ 'foo', 0, '', '' ] );
+		$this->assertNotFalse(
+			$this->caches['entity.id']->fetch( $key ),
+			'precondition: the id is cached under entity.id'
+		);
+
 		$instance->deleteCacheById( 42 );
+
+		$this->assertFalse(
+			$this->caches['entity.id']->fetch( $key ),
+			'deleteCacheById removes the entity.id entry'
+		);
 	}
 
 	public function testSetCacheOnTitleWithSpace_ThrowsException() {


### PR DESCRIPTION
## What

Continues removing the `onoi/cache` dependency. Drops the last `Onoi\Cache\Cache` references from SMW's in-process entity-ID cache tier, now that `InMemoryPoolCache::getPoolCacheById()` already mints `SMW\Cache\InMemoryLruCache`.

## How

- `InstrumentedCache` no longer `implements Onoi\Cache\Cache`; it decorates an `InMemoryLruCache` directly (it is constructed only in `SQLStoreFactory::newIdCacheManager` and held in `IdCacheManager`'s untyped cache array, so nothing relied on the interface type). Its `save()` is now `: void`, and the unused `getName()` delegate is removed.
- `IdCacheManager` drops the Onoi import; `get()`'s `@return` becomes the concrete `InstrumentedCache|InMemoryLruCache` union it actually returns (an `InstrumentedCache` in production, a raw `InMemoryLruCache` in tests). Every `get()` caller invokes only `fetch`/`save`/`contains`, which both arms provide.
- `InMemoryLruCache::getName()` is removed; its only caller was `InstrumentedCache::getName()`.

## Tests

The `IdCacheManager`-family tests build `InMemoryLruCache` instead of the former Onoi cache. `testDeleteCacheById` is reworked from a mocked `delete()` expectation to a real-cache outcome assertion (seed the id, delete by id, assert the entity.id entry is gone), which exercises the full id-to-key resolution rather than stubbing it out. `EntityIdManager`'s cache collaborator (returned by `IdCacheManager::get()`) becomes a real `InMemoryLruCache`.

Scope is the entity-ID cache tier only; other `onoi/cache` consumers are handled separately.