### PR TITLE
Add the SMW query-result store (QueryResultStore + QueryResultContainer)

### DIFF
--- a/src/Query/Cache/QueryResultContainer.php
+++ b/src/Query/Cache/QueryResultContainer.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace SMW\Query\Cache;
+
+/**
+ * Per-id value object for the durable query-result cache. It holds the cached
+ * result payload (`results`/`continue`/`count`/`excerpts`) plus the
+ * `@linkedList` set of dependent query ids that `QueryResultStore` enumerates
+ * to cascade-purge a subject and all queries embedded on it.
+ *
+ * This is the SMW-owned replacement for `Onoi\BlobStore\Container`. The array
+ * payload shape, including the `@linkedList` magic key, is preserved
+ * byte-for-byte so entries written by the former store round-trip unchanged.
+ *
+ * `get()` returns `false` (not `null`) for an absent key, matching the former
+ * container so callers can distinguish a stored falsy value from a miss.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ *
+ * @author mwjames
+ */
+class QueryResultContainer {
+
+	/**
+	 * Reserved payload key holding the dependent ids as a key set
+	 * (`[ $id => true ]`). Frozen: it appears verbatim in serialized cache
+	 * entries written by the former blob store.
+	 */
+	private const LINKED_LIST = '@linkedList';
+
+	private string $id;
+	private array $data;
+	private int $expiry = 0;
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param string $id
+	 * @param array $data
+	 */
+	public function __construct( string $id, array $data = [] ) {
+		$this->id = $id;
+		$this->data = $data;
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getId(): string {
+		return $this->id;
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getData(): array {
+		return $this->data;
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function getExpiry(): int {
+		return $this->expiry;
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param int $expiry
+	 */
+	public function setExpiryInSeconds( $expiry ): void {
+		$this->expiry = (int)$expiry;
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param string $key
+	 */
+	public function has( $key ): bool {
+		return isset( $this->data[$key] ) || array_key_exists( $key, $this->data );
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param string $key
+	 *
+	 * @return mixed The stored value, or `false` when the key is absent.
+	 */
+	public function get( $key ) {
+		return $this->has( $key ) ? $this->data[$key] : false;
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function set( $key, $value ): void {
+		$this->data[$key] = $value;
+	}
+
+	/**
+	 * Record a dependent id so that deleting this container also purges the
+	 * linked entry.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param string|int $hash
+	 */
+	public function addToLinkedList( $hash ): void {
+		if ( !isset( $this->data[self::LINKED_LIST] ) ) {
+			$this->data[self::LINKED_LIST] = [];
+		}
+
+		$this->data[self::LINKED_LIST][$hash] = true;
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @return array The dependent ids recorded via addToLinkedList().
+	 */
+	public function getLinkedList(): array {
+		return isset( $this->data[self::LINKED_LIST] )
+			? array_keys( $this->data[self::LINKED_LIST] )
+			: [];
+	}
+
+}

--- a/src/Query/Cache/QueryResultStore.php
+++ b/src/Query/Cache/QueryResultStore.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace SMW\Query\Cache;
+
+use MapCacheLRU;
+use Wikimedia\ObjectCache\BagOStuff;
+
+/**
+ * Durable store for cached query results, the SMW-owned replacement for
+ * `Onoi\BlobStore\BlobStore`.
+ *
+ * Two tiers: a request-scoped {@link MapCacheLRU} fast tier holding the raw
+ * (unserialized) payload to avoid repeated unserialization, over a
+ * cross-request {@link BagOStuff} slow tier that holds the serialized payload.
+ * A backend hit is promoted into the fast tier.
+ *
+ * The cache key (`{namespacePrefix}:{namespace}:{id}`) and the `serialize()`
+ * encoding are preserved byte-for-byte from the former blob store so entries it
+ * wrote remain readable. `delete()` reimplements the enumerable `@linkedList`
+ * bulk-purge: it reads the container, hard-deletes every linked id and then the
+ * anchor (N+1 true deletes), never a WAN tombstone/check-key, because SMW
+ * invalidates query results by precise deletion.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ *
+ * @author mwjames
+ */
+class QueryResultStore {
+
+	private string $namespace;
+	private BagOStuff $cache;
+	private MapCacheLRU $internalCache;
+	private string $namespacePrefix = 'blobstore';
+	private bool $usageState = true;
+	private int $expiry = 0;
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param string $namespace
+	 * @param BagOStuff $cache Cross-request slow tier.
+	 * @param MapCacheLRU|null $internalCache Request-scoped fast tier.
+	 */
+	public function __construct( string $namespace, BagOStuff $cache, ?MapCacheLRU $internalCache = null ) {
+		$this->namespace = $namespace;
+		$this->cache = $cache;
+		$this->internalCache = $internalCache ?? new MapCacheLRU( 500 );
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param string $namespacePrefix
+	 */
+	public function setNamespacePrefix( $namespacePrefix ): void {
+		$this->namespacePrefix = $namespacePrefix;
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param int $expiry
+	 */
+	public function setExpiryInSeconds( $expiry ): void {
+		$this->expiry = (int)$expiry;
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param bool $usageState
+	 */
+	public function setUsageState( $usageState ): void {
+		$this->usageState = (bool)$usageState;
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function canUse(): bool {
+		return $this->usageState;
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param string $id
+	 */
+	public function exists( $id ): bool {
+		return $this->cache->get( $this->getKey( $id ) ) !== false;
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param string $id
+	 */
+	public function read( $id ): QueryResultContainer {
+		$key = $this->getKey( $id );
+
+		if ( $this->internalCache->has( $key ) ) {
+			$data = $this->internalCache->get( $key );
+		} else {
+			$blob = $this->cache->get( $key );
+
+			if ( $blob !== false ) {
+				$data = unserialize( $blob );
+				$this->internalCache->set( $key, $data );
+			} else {
+				$data = [];
+			}
+		}
+
+		$container = new QueryResultContainer( $key, (array)$data );
+		$container->setExpiryInSeconds( $this->expiry );
+
+		return $container;
+	}
+
+	/**
+	 * @since 7.0.0
+	 */
+	public function save( QueryResultContainer $container ): void {
+		// The container id is already the composite key (assigned by read()).
+		$this->internalCache->set( $container->getId(), $container->getData() );
+
+		$this->cache->set(
+			$container->getId(),
+			serialize( $container->getData() ),
+			$container->getExpiry()
+		);
+	}
+
+	/**
+	 * @since 7.0.0
+	 *
+	 * @param string $id
+	 */
+	public function delete( $id ): void {
+		$container = $this->read( $id );
+
+		foreach ( $container->getLinkedList() as $lid ) {
+			$this->cache->delete( $this->getKey( $lid ) );
+		}
+
+		$this->cache->delete( $this->getKey( $id ) );
+		$this->internalCache->clear( [ $this->getKey( $id ) ] );
+	}
+
+	private function getKey( $id ): string {
+		return $this->namespacePrefix . ':' . $this->namespace . ':' . $id;
+	}
+
+}

--- a/src/Query/Cache/QueryResultStore.php
+++ b/src/Query/Cache/QueryResultStore.php
@@ -18,8 +18,8 @@ use Wikimedia\ObjectCache\BagOStuff;
  * encoding are preserved byte-for-byte from the former blob store so entries it
  * wrote remain readable. `delete()` reimplements the enumerable `@linkedList`
  * bulk-purge: it reads the container, hard-deletes every linked id and then the
- * anchor (N+1 true deletes), never a WAN tombstone/check-key, because SMW
- * invalidates query results by precise deletion.
+ * anchor from both tiers (N+1 true deletes), never a WAN tombstone/check-key,
+ * because SMW invalidates query results by precise deletion.
  *
  * @license GPL-2.0-or-later
  * @since 7.0.0
@@ -139,13 +139,21 @@ class QueryResultStore {
 	 */
 	public function delete( $id ): void {
 		$container = $this->read( $id );
+		$keys = [];
 
 		foreach ( $container->getLinkedList() as $lid ) {
-			$this->cache->delete( $this->getKey( $lid ) );
+			$linkedKey = $this->getKey( $lid );
+			$this->cache->delete( $linkedKey );
+			$keys[] = $linkedKey;
 		}
 
-		$this->cache->delete( $this->getKey( $id ) );
-		$this->internalCache->clear( [ $this->getKey( $id ) ] );
+		$anchorKey = $this->getKey( $id );
+		$this->cache->delete( $anchorKey );
+		$keys[] = $anchorKey;
+
+		// Evict the anchor and every linked id from the fast tier as well, so a
+		// later read in the same request cannot return a stale promoted entry.
+		$this->internalCache->clear( $keys );
 	}
 
 	private function getKey( $id ): string {

--- a/tests/phpunit/Unit/Query/Cache/QueryResultContainerTest.php
+++ b/tests/phpunit/Unit/Query/Cache/QueryResultContainerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace SMW\Tests\Unit\Query\Cache;
+
+use PHPUnit\Framework\TestCase;
+use SMW\Query\Cache\QueryResultContainer;
+
+/**
+ * @covers \SMW\Query\Cache\QueryResultContainer
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ *
+ * @author mwjames
+ */
+class QueryResultContainerTest extends TestCase {
+
+	public function testGetIdAndData() {
+		$instance = new QueryResultContainer( 'mw:smw:query:store:abc', [ 'count' => 3 ] );
+
+		$this->assertSame( 'mw:smw:query:store:abc', $instance->getId() );
+		$this->assertSame( [ 'count' => 3 ], $instance->getData() );
+	}
+
+	public function testGetReturnsFalseOnAbsentKey() {
+		$instance = new QueryResultContainer( 'id' );
+
+		// The false sentinel distinguishes a miss from a stored falsy value.
+		$this->assertFalse( $instance->get( 'results' ) );
+	}
+
+	public function testHas() {
+		$instance = new QueryResultContainer( 'id', [ 'results' => [], 'continue' => false, 'nothing' => null ] );
+
+		$this->assertTrue( $instance->has( 'results' ) );
+		// A stored null is still "present" (array_key_exists, not isset).
+		$this->assertTrue( $instance->has( 'nothing' ) );
+		$this->assertFalse( $instance->has( 'absent' ) );
+	}
+
+	public function testSetAndGet() {
+		$instance = new QueryResultContainer( 'id' );
+
+		$instance->set( 'count', 0 );
+		$instance->set( 'continue', false );
+
+		// Stored falsy values round-trip as themselves, not as the miss sentinel.
+		$this->assertSame( 0, $instance->get( 'count' ) );
+		$this->assertFalse( $instance->get( 'continue' ) );
+		$this->assertTrue( $instance->has( 'count' ) );
+	}
+
+	public function testExpiryCastsToInt() {
+		$instance = new QueryResultContainer( 'id' );
+
+		$this->assertSame( 0, $instance->getExpiry() );
+
+		$instance->setExpiryInSeconds( '3600' );
+
+		$this->assertSame( 3600, $instance->getExpiry() );
+	}
+
+	public function testLinkedList() {
+		$instance = new QueryResultContainer( 'id' );
+
+		// Empty by default.
+		$this->assertSame( [], $instance->getLinkedList() );
+
+		$instance->addToLinkedList( 'q1' );
+		$instance->addToLinkedList( 'q2' );
+		// Re-adding the same id is idempotent (key set).
+		$instance->addToLinkedList( 'q1' );
+
+		$this->assertSame( [ 'q1', 'q2' ], $instance->getLinkedList() );
+	}
+
+	public function testLinkedListUsesFrozenMagicKeyInPayload() {
+		$instance = new QueryResultContainer( 'id' );
+		$instance->addToLinkedList( 'q1' );
+
+		// The dependent-id set is stored under the frozen '@linkedList' key so
+		// it survives the serialize() round-trip the store performs.
+		$this->assertSame(
+			[ '@linkedList' => [ 'q1' => true ] ],
+			$instance->getData()
+		);
+	}
+
+	public function testReadsLinkedListWrittenByTheFormerStore() {
+		// A payload as the former Onoi container serialized it.
+		$instance = new QueryResultContainer( 'id', [ '@linkedList' => [ 'a42b' => true ] ] );
+
+		$this->assertSame( [ 'a42b' ], $instance->getLinkedList() );
+	}
+
+}

--- a/tests/phpunit/Unit/Query/Cache/QueryResultStoreTest.php
+++ b/tests/phpunit/Unit/Query/Cache/QueryResultStoreTest.php
@@ -119,6 +119,32 @@ class QueryResultStoreTest extends TestCase {
 		$this->assertFalse( $store->exists( 'dep' ) );
 	}
 
+	public function testDeleteEvictsLinkedEntryFromFastTier() {
+		// One store instance keeps its request-scoped fast tier across the calls.
+		$store = $this->newStore();
+
+		$main = $store->read( 'main' );
+		$main->addToLinkedList( 'dep' );
+		$store->save( $main );
+
+		$dep = $store->read( 'dep' );
+		$dep->set( 'results', [ 'D' ] );
+		$store->save( $dep );
+
+		// Promote 'dep' into the fast tier, mirroring an embedded query that was
+		// already rendered earlier in the same request.
+		$this->assertSame( [ 'D' ], $store->read( 'dep' )->get( 'results' ) );
+
+		// Deleting the anchor must cascade-evict 'dep' from the fast tier too,
+		// not only the durable backend, or this later read returns stale data.
+		$store->delete( 'main' );
+
+		$this->assertFalse(
+			$store->read( 'dep' )->get( 'results' ),
+			'a linked entry must be evicted from the fast tier on cascade delete'
+		);
+	}
+
 	public function testCanUseReflectsUsageState() {
 		$store = $this->newStore();
 		$this->assertTrue( $store->canUse() );

--- a/tests/phpunit/Unit/Query/Cache/QueryResultStoreTest.php
+++ b/tests/phpunit/Unit/Query/Cache/QueryResultStoreTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace SMW\Tests\Unit\Query\Cache;
+
+use MapCacheLRU;
+use PHPUnit\Framework\TestCase;
+use SMW\Query\Cache\QueryResultContainer;
+use SMW\Query\Cache\QueryResultStore;
+use Wikimedia\ObjectCache\HashBagOStuff;
+
+/**
+ * @covers \SMW\Query\Cache\QueryResultStore
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.0.0
+ *
+ * @author mwjames
+ */
+class QueryResultStoreTest extends TestCase {
+
+	private function newStore( ?HashBagOStuff $cache = null ): QueryResultStore {
+		$store = new QueryResultStore( 'smw:query:store', $cache ?? new HashBagOStuff(), new MapCacheLRU( 500 ) );
+		$store->setNamespacePrefix( 'mw' );
+
+		return $store;
+	}
+
+	public function testCanConstruct() {
+		$this->assertInstanceOf(
+			QueryResultStore::class,
+			$this->newStore()
+		);
+	}
+
+	public function testReadMissReturnsEmptyContainer() {
+		$container = $this->newStore()->read( 'absent' );
+
+		$this->assertInstanceOf( QueryResultContainer::class, $container );
+		$this->assertFalse( $container->get( 'results' ) );
+	}
+
+	public function testSaveReadRoundTrip() {
+		$store = $this->newStore();
+
+		$container = $store->read( 'q1' );
+		$container->set( 'results', [ 'Foo#0' ] );
+		$container->set( 'count', 1 );
+		$store->save( $container );
+
+		$read = $store->read( 'q1' );
+
+		$this->assertSame( [ 'Foo#0' ], $read->get( 'results' ) );
+		$this->assertSame( 1, $read->get( 'count' ) );
+	}
+
+	public function testReadFromBackendUnserializes() {
+		$cache = new HashBagOStuff();
+
+		// Writer store saves; reader store shares the backend but has its own
+		// (empty) fast tier, so the read goes through the serialize round-trip.
+		$writer = $this->newStore( $cache );
+		$container = $writer->read( 'q1' );
+		$container->set( 'results', [ 'Bar#0' ] );
+		$writer->save( $container );
+
+		$reader = $this->newStore( $cache );
+
+		$this->assertSame( [ 'Bar#0' ], $reader->read( 'q1' )->get( 'results' ) );
+	}
+
+	public function testExists() {
+		$store = $this->newStore();
+
+		$this->assertFalse( $store->exists( 'q1' ) );
+
+		$container = $store->read( 'q1' );
+		$container->set( 'results', [ 'Foo#0' ] );
+		$store->save( $container );
+
+		$this->assertTrue( $store->exists( 'q1' ) );
+	}
+
+	public function testKeyFormatIsFrozen() {
+		$cache = new HashBagOStuff();
+		$store = $this->newStore( $cache );
+
+		$container = $store->read( 'abc' );
+		$container->set( 'results', [ 'Foo#0' ] );
+		$store->save( $container );
+
+		// {namespacePrefix}:{namespace}:{id}
+		$this->assertNotFalse(
+			$cache->get( 'mw:smw:query:store:abc' ),
+			'the durable entry must be stored under the frozen key format'
+		);
+	}
+
+	public function testDeleteCascadesLinkedList() {
+		$store = $this->newStore();
+
+		// An embedded query 'dep' is linked to its subject container 'main'.
+		$main = $store->read( 'main' );
+		$main->set( 'results', [ 'M' ] );
+		$main->addToLinkedList( 'dep' );
+		$store->save( $main );
+
+		$dep = $store->read( 'dep' );
+		$dep->set( 'results', [ 'D' ] );
+		$store->save( $dep );
+
+		$this->assertTrue( $store->exists( 'main' ) );
+		$this->assertTrue( $store->exists( 'dep' ) );
+
+		$store->delete( 'main' );
+
+		// Both the anchor and every linked entry are purged.
+		$this->assertFalse( $store->exists( 'main' ) );
+		$this->assertFalse( $store->exists( 'dep' ) );
+	}
+
+	public function testCanUseReflectsUsageState() {
+		$store = $this->newStore();
+		$this->assertTrue( $store->canUse() );
+
+		$store->setUsageState( false );
+		$this->assertFalse( $store->canUse() );
+	}
+
+}


### PR DESCRIPTION
## What

Introduces the SMW-owned classes that will replace `onoi/blob-store` as the durable query-result cache: `SMW\Query\Cache\QueryResultStore` and `SMW\Query\Cache\QueryResultContainer`. Additive only; nothing consumes them yet (`ResultCache` is rerouted onto them in a follow-up).

## QueryResultContainer

The per-id value object (port of `Onoi\BlobStore\Container`). It holds the cached result payload (`results`/`continue`/`count`/`excerpts`) plus the `@linkedList` set of dependent query ids that the store enumerates to cascade-purge a subject and the queries embedded on it.

- The array payload shape, including the `@linkedList` magic key, is preserved byte-for-byte, so entries written by the former store round-trip unchanged.
- `get()` returns the `false` miss-sentinel (not `null`) for an absent key.
- The three former container methods with no production callers (`append`, `delete`, `isEmpty`) are not ported.

## QueryResultStore

The durable store (port of `Onoi\BlobStore\BlobStore`) over a `Wikimedia\ObjectCache\BagOStuff` slow tier and a `MapCacheLRU(500)` request-scoped fast tier.

- The cache key (`{namespacePrefix}:{namespace}:{id}`) and the `serialize()`/`unserialize()` encoding are preserved byte-for-byte, so existing cached entries remain readable.
- A backend hit is promoted into the fast tier (raw, unserialized) to avoid repeated unserialization.
- `delete()` reimplements the enumerable `@linkedList` bulk-purge as N+1 true deletes (every linked id, then the anchor) — never a WAN tombstone or check-key, because SMW invalidates query results by precise deletion.
- The no-op `drop()` and the `getStats()` aggregate have no `ResultCache` callers and are not ported.

Both classes are intentionally not `final`, since `ResultCacheTest` mocks the store and the container.

## Tests

Characterization tests pin the container's `false`-on-absent contract and the frozen `@linkedList` key-set, and the store's save/read round-trip, the cross-request `unserialize` path (a second store sharing the backend), `exists()`, the frozen key format, and the N+1 `@linkedList` cascade delete.