### PR TITLE
Reroute the query-result cache off onoi/blob-store

### DIFF
--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -5,10 +5,10 @@ namespace SMW;
 use MediaWiki\Title\Title;
 use MediaWiki\WikiMap\WikiMap;
 use ObjectCache;
-use Onoi\BlobStore\BlobStore;
 use Onoi\Cache\Cache;
 use Onoi\Cache\CacheFactory as OnoiCacheFactory;
 use RuntimeException;
+use SMW\Query\Cache\QueryResultStore;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use stdClass;
 
@@ -152,7 +152,7 @@ class CacheFactory {
 	 * @param string|int|null $cacheType
 	 * @param int $cacheLifetime
 	 *
-	 * @return BlobStore
+	 * @return QueryResultStore
 	 */
 	public function newBlobStore( $namespace, $cacheType = null, $cacheLifetime = 0 ) {
 		return ApplicationFactory::getInstance()->create( 'BlobStore', $namespace, $cacheType, $cacheLifetime );

--- a/src/Query/Cache/ResultCache.php
+++ b/src/Query/Cache/ResultCache.php
@@ -2,8 +2,6 @@
 
 namespace SMW\Query\Cache;
 
-use Onoi\BlobStore\BlobStore;
-use Onoi\BlobStore\Container;
 use Psr\Log\LoggerAwareInterface;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
@@ -101,7 +99,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 	public function __construct(
 		private readonly Store $store,
 		private readonly QueryFactory $queryFactory,
-		private readonly BlobStore $blobStore,
+		private readonly QueryResultStore $blobStore,
 		private readonly CacheStats $cacheStats,
 	) {
 		$this->tempCache = ApplicationFactory::getInstance()->getInMemoryPoolCache()->getPoolCacheById( self::POOLCACHE_ID );
@@ -385,7 +383,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 		$deferredTransactionalUpdate->pushUpdate();
 	}
 
-	private function doCacheQueryResult( QueryResult $queryResult, string $queryId, Container $container, Query $query ): QueryResult {
+	private function doCacheQueryResult( QueryResult $queryResult, string $queryId, QueryResultContainer $container, Query $query ): QueryResult {
 		$results = [];
 
 		// Keep the simple string representation to avoid unnecessary data cruft

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -3,6 +3,7 @@
 namespace SMW\Services;
 
 use JobQueueGroup;
+use MapCacheLRU;
 use MediaWiki\Language\Language;
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
@@ -11,7 +12,6 @@ use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\Title\Title;
 use MediaWiki\User\User;
-use Onoi\BlobStore\BlobStore;
 use Onoi\Cache\Cache;
 use Onoi\Cache\CacheFactory as OnoiCacheFactory;
 use Onoi\Cache\FixedInMemoryLruCache;
@@ -78,6 +78,7 @@ use SMW\PropertyLabelFinder;
 use SMW\Protection\EditProtectionUpdater;
 use SMW\Protection\ProtectionValidator;
 use SMW\Query\Cache\CacheStats;
+use SMW\Query\Cache\QueryResultStore;
 use SMW\Query\Cache\ResultCache;
 use SMW\Query\Processor\ParamListProcessor;
 use SMW\Query\Processor\QueryCreator;
@@ -1160,16 +1161,17 @@ class ServicesFactory {
 	/**
 	 * @since 7.0.0
 	 */
-	public function newBlobStore( $namespace, $cacheType = null, $ttl = 0 ): BlobStore {
+	public function newBlobStore( $namespace, $cacheType = null, $ttl = 0 ): QueryResultStore {
 		if ( array_key_exists( 'BlobStore', $this->testOverrides ) ) {
 			return $this->testOverrides['BlobStore'];
 		}
 
 		$cacheFactory = $this->getCacheFactory();
 
-		$blobStore = new BlobStore(
+		$blobStore = new QueryResultStore(
 			$namespace,
-			$cacheFactory->newMediaWikiCompositeCache( $cacheType )
+			$this->getObjectCache( $cacheType ),
+			new MapCacheLRU( 500 )
 		);
 
 		$blobStore->setNamespacePrefix(

--- a/tests/phpunit/Unit/CacheFactoryTest.php
+++ b/tests/phpunit/Unit/CacheFactoryTest.php
@@ -3,12 +3,12 @@
 namespace SMW\Tests\Unit;
 
 use MediaWiki\Title\Title;
-use Onoi\BlobStore\BlobStore;
 use Onoi\Cache\Cache;
 use Onoi\Cache\NullCache;
 use PHPUnit\Framework\TestCase;
 use SMW\CacheFactory;
 use SMW\MediaWiki\Hooks\ArticlePurge;
+use SMW\Query\Cache\QueryResultStore;
 
 /**
  * @covers \SMW\CacheFactory
@@ -162,7 +162,7 @@ class CacheFactoryTest extends TestCase {
 		$instance = new CacheFactory( 'hash' );
 
 		$this->assertInstanceOf(
-			BlobStore::class,
+			QueryResultStore::class,
 			$instance->newBlobStore( 'foo', CACHE_NONE )
 		);
 	}

--- a/tests/phpunit/Unit/Query/Cache/ResultCacheTest.php
+++ b/tests/phpunit/Unit/Query/Cache/ResultCacheTest.php
@@ -2,11 +2,11 @@
 
 namespace SMW\Tests\Unit\Query\Cache;
 
-use Onoi\BlobStore\BlobStore;
-use Onoi\BlobStore\Container;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\WikiPage;
 use SMW\Query\Cache\CacheStats;
+use SMW\Query\Cache\QueryResultContainer;
+use SMW\Query\Cache\QueryResultStore;
 use SMW\Query\Cache\ResultCache;
 use SMW\Query\Query;
 use SMW\QueryEngine;
@@ -27,7 +27,7 @@ class ResultCacheTest extends TestCase {
 	private $store;
 	private $queryFactory;
 	private $blobStore;
-	private Container $container;
+	private QueryResultContainer $container;
 	private $cacheStats;
 
 	protected function setUp(): void {
@@ -39,7 +39,7 @@ class ResultCacheTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->blobStore = $this->getMockBuilder( BlobStore::class )
+		$this->blobStore = $this->getMockBuilder( QueryResultStore::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -47,7 +47,7 @@ class ResultCacheTest extends TestCase {
 			->method( 'canUse' )
 			->willReturn( true );
 
-		$this->container = $this->getMockBuilder( Container::class )
+		$this->container = $this->getMockBuilder( QueryResultContainer::class )
 			->disableOriginalConstructor()
 			->getMock();
 


### PR DESCRIPTION
Part of the 7.0.0 removal of the `onoi/blob-store` dependency.

Points the query-result cache consumer (`ResultCache`) and the factory that mints its store (`ServicesFactory::newBlobStore`) at the SMW-owned `QueryResultStore`/`QueryResultContainer` added in #6924, in place of `Onoi\BlobStore\BlobStore`/`Container`.

### Behaviour preservation

- `ResultCache` changes are type hints only; every call on the store (`canUse`/`read`/`exists`/`delete`/`save`) and on the container (`has`/`get`/`set`/`addToLinkedList`/`setExpiryInSeconds`) exists with the same signature on the new classes.
- The factory builds the store over `getObjectCache( $cacheType )`, which resolves to the same `BagOStuff` the former `newMediaWikiCompositeCache( $cacheType )` path used (same `null` and `CACHE_NONE` mapping), plus an explicit `MapCacheLRU( 500 )` request-scoped fast tier. The namespace prefix, expiry and usage-state setup are unchanged.
- The cache key format and `serialize()` encoding are preserved, so existing entries round-trip unchanged.

The `newBlobStore` method name and `'BlobStore'` service route are kept for now to keep the diff focused; the rename is a follow-up.

### Verification

`composer analyze` and `composer phan` are clean, and the `ResultCache` and `CacheFactory` unit tests pass. A `CACHE_DB`-backed round-trip additionally exercises a save, a cross-request read served from the persistent tier, and the `@linkedList` cascade purge that removes a dependent entry alongside its anchor.

Stacked on #6924; that should be reviewed and merged first.