### PR TITLE
Convert the purge hooks off onoi/cache to MediaWiki BagOStuff

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -95,7 +95,7 @@
 			"class": "SMW\\MediaWiki\\Hooks\\ParserAfterTidy",
 			"services": [
 				"SMW.NamespaceExaminer",
-				"SMW.Cache",
+				"SMW.ObjectCache",
 				"SMW.ApplicationFactory",
 				"HookContainer",
 				"SMW.Settings",
@@ -201,7 +201,7 @@
 			"class": "SMW\\MediaWiki\\Hooks\\ArticlePurge",
 			"services": [
 				"SMW.Store",
-				"SMW.Cache",
+				"SMW.ObjectCache",
 				"SMW.Settings",
 				"SMW.EventDispatcher"
 			]

--- a/src/MediaWiki/Hooks/ArticlePurge.php
+++ b/src/MediaWiki/Hooks/ArticlePurge.php
@@ -4,12 +4,12 @@ namespace SMW\MediaWiki\Hooks;
 
 use MediaWiki\Page\Hook\ArticlePurgeHook;
 use MediaWiki\Title\Title;
-use Onoi\Cache\Cache;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\EventDispatcher\EventDispatcher;
 use SMW\Settings;
 use SMW\Store;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * A function hook being executed before running "&action=purge"
@@ -33,7 +33,7 @@ class ArticlePurge implements ArticlePurgeHook {
 	 */
 	public function __construct(
 		private readonly Store $store,
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 		private readonly Settings $settings,
 		private readonly EventDispatcher $eventDispatcher,
 	) {
@@ -47,7 +47,7 @@ class ArticlePurge implements ArticlePurgeHook {
 		$articleID = $title->getArticleID();
 
 		if ( $articleID > 0 ) {
-			$this->cache->save(
+			$this->cache->set(
 				smwfCacheKey( self::CACHE_NAMESPACE, $articleID ),
 				$this->settings->get( 'smwgAutoRefreshOnPurge' )
 			);

--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -7,7 +7,6 @@ use MediaWiki\HookContainer\HookContainer;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\ParserOutputLinkTypes;
 use MediaWiki\Permissions\RestrictionStore;
-use Onoi\Cache\Cache;
 use Psr\Log\LoggerInterface;
 use SMW\DataModel\SemanticData;
 use SMW\NamespaceExaminer;
@@ -16,6 +15,7 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Settings;
 use SMW\Site;
 use WeakMap;
+use Wikimedia\ObjectCache\BagOStuff;
 
 /**
  * Hook: ParserAfterTidy to add some final processing to the
@@ -53,7 +53,7 @@ class ParserAfterTidy implements ParserAfterTidyHook {
 	 */
 	public function __construct(
 		private readonly NamespaceExaminer $namespaceExaminer,
-		private readonly Cache $cache,
+		private readonly BagOStuff $cache,
 		private readonly ApplicationFactory $servicesFactory,
 		private readonly HookContainer $hookContainer,
 		private readonly Settings $settings,
@@ -223,7 +223,7 @@ class ParserAfterTidy implements ParserAfterTidyHook {
 		// through the annotation and update process as part of a programtic
 		// purge request.
 		// @see SemanticApprovedRevs#2
-		if ( $this->cache->fetch( $key ) !== false ) {
+		if ( $this->cache->get( $key ) !== false ) {
 			return true;
 		}
 
@@ -333,7 +333,7 @@ class ParserAfterTidy implements ParserAfterTidyHook {
 
 		$key = smwfCacheKey( ArticlePurge::CACHE_NAMESPACE, $title->getArticleID() );
 
-		if ( $this->cache->contains( $key ) && $this->cache->fetch( $key ) ) {
+		if ( $this->cache->get( $key ) ) {
 			$this->cache->delete( $key );
 			$this->cache->delete( smwfCacheKey( self::CACHE_NAMESPACE, $title->getPrefixedDBKey() ) );
 

--- a/tests/phpunit/Integration/MediaWiki/MediaWikiIntegrationForRegisteredHookTest.php
+++ b/tests/phpunit/Integration/MediaWiki/MediaWikiIntegrationForRegisteredHookTest.php
@@ -67,19 +67,11 @@ class MediaWikiIntegrationForRegisteredHookTest extends SMWIntegrationTestCase {
 
 	public function testPagePurge() {
 		$cacheFactory = $this->applicationFactory->newCacheFactory();
-		$cache = $cacheFactory->newFixedInMemoryCache();
 
-		$this->applicationFactory->registerObject( 'Cache', $cache );
-
-		// reseatDeclarativeHandlers() in setUp() already built ArticlePurge
-		// with the default Cache. Reset the cached SMW.Cache MediaWikiServices
-		// entry and reseat so the next ObjectFactory pass resolves the
-		// test's fixed-memory cache via the service wiring's hasTestOverride
-		// branch.
-		MediaWikiServices::getInstance()->resetServiceForTesting( 'SMW.Cache' );
-		( new SMWDeclarativeHookReseater(
-			MediaWikiServices::getInstance()->getHookContainer()
-		) )->reseatDeclarativeHandlers();
+		// ArticlePurge writes the purge marker through SMW.ObjectCache, i.e.
+		// ServicesFactory::getObjectCache(); read it back from that same
+		// instance rather than an injected Cache override.
+		$cache = $this->applicationFactory->getObjectCache();
 
 		$this->title = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __METHOD__ );
 
@@ -96,7 +88,7 @@ class MediaWikiIntegrationForRegisteredHookTest extends SMWIntegrationTestCase {
 			->doPurge();
 
 		$this->assertTrue(
-			$cache->fetch( $key )
+			$cache->get( $key )
 		);
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
@@ -11,6 +11,7 @@ use SMW\Settings;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockTitle;
+use Wikimedia\ObjectCache\HashBagOStuff;
 use WikiPage;
 
 /**
@@ -40,7 +41,7 @@ class ArticlePurgeTest extends TestCase {
 
 		$this->testEnvironment = new TestEnvironment( $settings );
 
-		$this->cache = $this->applicationFactory->newCacheFactory()->newFixedInMemoryCache();
+		$this->cache = new HashBagOStuff();
 
 		$this->eventDispatcher = $this->getMockBuilder( EventDispatcher::class )
 			->disableOriginalConstructor()
@@ -83,12 +84,12 @@ class ArticlePurgeTest extends TestCase {
 
 		$this->assertEquals(
 			$expected['autorefreshPreProcess'],
-			$this->cache->fetch( $purgeCacheKey ),
+			$this->cache->get( $purgeCacheKey ),
 			'Asserts the autorefresh cache status before processing'
 		);
 
 		// Travis 210.5, 305.3
-		$travis = $this->cache->fetch( $factboxCacheKey );
+		$travis = $this->cache->get( $factboxCacheKey );
 		$travisText = json_encode( $travis );
 		$this->assertEquals(
 			$expected['factboxPreProcess'],
@@ -97,7 +98,7 @@ class ArticlePurgeTest extends TestCase {
 		);
 
 		$this->assertFalse(
-			$this->cache->fetch( $purgeCacheKey ),
+			$this->cache->get( $purgeCacheKey ),
 			'Asserts that before processing ...'
 		);
 
@@ -110,13 +111,13 @@ class ArticlePurgeTest extends TestCase {
 
 		$this->assertEquals(
 			$expected['autorefreshPostProcess'],
-			$this->cache->fetch( $purgeCacheKey ),
+			$this->cache->get( $purgeCacheKey ),
 			'Asserts the autorefresh cache status after processing'
 		);
 
 		$this->assertEquals(
 			$expected['factboxPostProcess'],
-			$this->cache->fetch( $factboxCacheKey ),
+			$this->cache->get( $factboxCacheKey ),
 			'Asserts the factbox cache status after processing'
 		);
 	}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -11,7 +11,6 @@ use MediaWiki\Permissions\RestrictionStore;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Title\Title;
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use RuntimeException;
@@ -27,6 +26,7 @@ use SMW\Store;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\MockTitle;
 use Throwable;
+use Wikimedia\ObjectCache\BagOStuff;
 use WikiPage;
 
 /**
@@ -88,7 +88,7 @@ class ParserAfterTidyTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
+		$this->cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -122,7 +122,7 @@ class ParserAfterTidyTest extends TestCase {
 		$prop->setValue( $parser, true );
 	}
 
-	private function newInstance( ?Cache $cache = null, ?Settings $settings = null ): ParserAfterTidy {
+	private function newInstance( ?BagOStuff $cache = null, ?Settings $settings = null ): ParserAfterTidy {
 		return new ParserAfterTidy(
 			$this->namespaceExaminer,
 			$cache ?? $this->cache,
@@ -171,22 +171,17 @@ class ParserAfterTidyTest extends TestCase {
 		$instance->onParserAfterTidy( $this->parser, $text );
 	}
 
-	private function newMockCache( $id, $containsStatus, $fetchStatus ) {
+	private function newMockCache( $id, $getStatus ) {
 		$key = $this->applicationFactory->newCacheFactory()->getPurgeCacheKey( $id );
 
-		$cache = $this->getMockBuilder( Cache::class )
+		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$cache->expects( $this->any() )
-			->method( 'contains' )
+			->method( 'get' )
 			->with( $key )
-			->willReturn( $containsStatus );
-
-		$cache->expects( $this->any() )
-			->method( 'fetch' )
-			->with( $key )
-			->willReturn( $fetchStatus );
+			->willReturn( $getStatus );
 
 		return $cache;
 	}
@@ -219,7 +214,6 @@ class ParserAfterTidyTest extends TestCase {
 
 		$cache = $this->newMockCache(
 			$parameters['title']->getArticleID(),
-			$parameters['cache-contains'],
 			$parameters['cache-fetch']
 		);
 
@@ -258,7 +252,7 @@ class ParserAfterTidyTest extends TestCase {
 			->willReturn( [] );
 
 		$this->cache->expects( $this->any() )
-			->method( 'fetch' )
+			->method( 'get' )
 			->with( $this->stringContains( "smw:parseraftertidy" ) )
 			->willReturn( true );
 
@@ -590,8 +584,8 @@ class ParserAfterTidyTest extends TestCase {
 
 		// Cache key set as if `?action=purge` had fired, so checkPurgeRequest
 		// reaches `updateStore` (which then triggers our throwing store).
-		$cache = $this->applicationFactory->getCache();
-		$cache->save(
+		$cache = $this->applicationFactory->getObjectCache();
+		$cache->set(
 			smwfCacheKey(
 				ArticlePurge::CACHE_NAMESPACE,
 				$title->getArticleID()
@@ -670,7 +664,6 @@ class ParserAfterTidyTest extends TestCase {
 			[
 				'store'    => $store,
 				'title'    => $title,
-				'cache-contains' => true,
 				'cache-fetch'    => true,
 				'data-status' => true
 			]
@@ -699,7 +692,6 @@ class ParserAfterTidyTest extends TestCase {
 			[
 				'store'    => $store,
 				'title'    => $title,
-				'cache-contains' => false,
 				'cache-fetch'    => false,
 				'data-status' => true
 			]
@@ -728,7 +720,6 @@ class ParserAfterTidyTest extends TestCase {
 			[
 				'store'    => $store,
 				'title'    => $title,
-				'cache-contains' => false,
 				'cache-fetch'    => false,
 				'data-status' => true
 			]
@@ -769,7 +760,6 @@ class ParserAfterTidyTest extends TestCase {
 				'store'    => $store,
 				'title'    => $title,
 				'revision' => $revision,
-				'cache-contains' => true,
 				'cache-fetch'    => true,
 				'data-status' => true
 			]
@@ -802,7 +792,6 @@ class ParserAfterTidyTest extends TestCase {
 			[
 				'store'    => $store,
 				'title'    => $title,
-				'cache-contains' => true,
 				'cache-fetch'    => false,
 				'data-status' => true
 			]
@@ -827,7 +816,6 @@ class ParserAfterTidyTest extends TestCase {
 			[
 				'store'    => $store,
 				'title'    => $title,
-				'cache-contains' => true,
 				'cache-fetch'    => true,
 				'data-status' => false,
 				'displaytitle' => 'Foo'


### PR DESCRIPTION
Part of the 7.0.0 removal of the `onoi/cache` dependency.

`ArticlePurge` and `ParserAfterTidy` used the shared `SMW.Cache` composite only to exchange a short-lived purge marker. This injects `SMW.ObjectCache` (a bare `Wikimedia\ObjectCache\BagOStuff` over the same `$smwgMainCacheType`) into both hooks and types them against `BagOStuff`.

### Conversion

- `save()` becomes `set()`, `fetch()` becomes `get()`, `delete()` is unchanged.
- `checkPurgeRequest()`'s `contains( $k ) && fetch( $k )` collapses to a single truthy `get( $k )`: `BagOStuff` has no `contains()`, and the marker is only acted upon when its stored value is truthy, so the two are equivalent for every value the hook writes (including the `smwgAutoRefreshOnPurge === false` case, which stores `false`).
- Both `extension.json` HookHandler specs flip `SMW.Cache` to `SMW.ObjectCache`.

### Behaviour

The purge marker bridges separate requests (the purge action writes it; a later parse reads it), so it always relied on the configured persistent cache, never on the composite's per-request in-memory front, which could not survive a request boundary. Dropping that front leaves the marker's behaviour unchanged for every cache type.

### Verification

`composer analyze` and `composer phan` are clean, and the `ArticlePurge` and `ParserAfterTidy` unit tests pass. A live `?action=purge` with `forcelinkupdate` against a development wiki exercises the full write-then-read handshake without error.