### PR TITLE
Drop the onoi/blob-store dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,7 +49,6 @@
 		"serialization/serialization": "~4.0",
 		"jeroen/message-reporter": "~1.0",
 		"onoi/cache": "~1.2",
-		"onoi/blob-store": "~1.2",
 		"jeroen/file-fetcher": "^6|^5|^4.4",
 		"wikimedia/textcat": "^2|^1.1"
 	},

--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -152,6 +152,7 @@ Adds MediaWiki 1.45 support (see [Compatibility](#compatibility)).
 * Removed the `mediawiki/parser-hooks` dependency.
 * Removed `psr/log` from `composer.json`. Extensions that relied on SMW pulling in `psr/log` transitively must declare it in their own `composer.json`.
 * Removed the `mediawiki/callback-container` (`onoi/callback-container`) Composer dependency. The internal DI layer now uses MediaWiki's `Wikimedia\Services\ServiceContainer` directly ([#6428](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6428)).
+* Removed the `onoi/blob-store` Composer dependency. SMW's durable query-result cache now uses the in-tree `SMW\Query\Cache\QueryResultStore` and `QueryResultContainer` over MediaWiki's `Wikimedia\ObjectCache\BagOStuff`, with the cache key format and payload encoding preserved so existing entries round-trip unchanged. This was internal infrastructure and never part of the public API.
 * Removed the `@private` internal class `SMW\Services\SharedServicesContainer` and the internal wiring files `src/Services/mediawiki.php`, `src/Services/events.php`, and `src/Services/cache.php`. These were never part of the public API ([#6428](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6428)).
 * Removed the root `DefaultSettings.php` shim (deprecated since 4.0.0). Use `$GLOBALS['smwgFoo']` or `SMW\Settings::getInstance()->get('smwgFoo')` instead.
 * Removed `Defines.php`.

--- a/src/Query/Cache/QueryResultContainer.php
+++ b/src/Query/Cache/QueryResultContainer.php
@@ -8,9 +8,10 @@ namespace SMW\Query\Cache;
  * `@linkedList` set of dependent query ids that `QueryResultStore` enumerates
  * to cascade-purge a subject and all queries embedded on it.
  *
- * This is the SMW-owned replacement for `Onoi\BlobStore\Container`. The array
- * payload shape, including the `@linkedList` magic key, is preserved
- * byte-for-byte so entries written by the former store round-trip unchanged.
+ * This is the SMW-owned replacement for the container value object from the
+ * former bundled `onoi/blob-store`. The array payload shape, including the
+ * `@linkedList` magic key, is preserved byte-for-byte so entries written by the
+ * former store round-trip unchanged.
  *
  * `get()` returns `false` (not `null`) for an absent key, matching the former
  * container so callers can distinguish a stored falsy value from a miss.

--- a/src/Query/Cache/QueryResultStore.php
+++ b/src/Query/Cache/QueryResultStore.php
@@ -6,8 +6,8 @@ use MapCacheLRU;
 use Wikimedia\ObjectCache\BagOStuff;
 
 /**
- * Durable store for cached query results, the SMW-owned replacement for
- * `Onoi\BlobStore\BlobStore`.
+ * Durable store for cached query results, the SMW-owned replacement for the
+ * former bundled `onoi/blob-store`.
  *
  * Two tiers: a request-scoped {@link MapCacheLRU} fast tier holding the raw
  * (unserialized) payload to avoid repeated unserialization, over a


### PR DESCRIPTION
Part of the 7.0.0 removal of bundled Onoi libraries.

The durable query-result cache moved to the in-tree `SMW\Query\Cache\QueryResultStore` and `QueryResultContainer` over MediaWiki's `Wikimedia\ObjectCache\BagOStuff`, so `onoi/blob-store` no longer has any consumers in the codebase.

- Removes `onoi/blob-store` from `composer.json`.
- Rewords the two `QueryResultStore`/`QueryResultContainer` docblocks that named the former classes.
- Records the removal under Removed / Dependencies and autoloading in the 7.0.0 release notes.

No behaviour change: the cache key format and payload encoding were preserved when the replacement classes landed, so existing entries round-trip unchanged.

### Verification

`composer validate` passes and a repo-wide search confirms no remaining references to the dependency. `composer analyze` and `composer phan` are clean and the `QueryResultStore`, `QueryResultContainer`, and `ResultCache` tests pass. CI performs the authoritative dependency resolution without the package.