### PR TITLE
Migrate the entity-ID cache tests off Onoi\Cache\Cache to InMemoryLruCache

### DIFF
--- a/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/EntityIdFinderTest.php
@@ -2,8 +2,8 @@
 
 namespace SMW\Tests\Unit\SQLStore\EntityStore;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
+use SMW\Cache\InMemoryLruCache;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\EntityIdFinder;
@@ -36,9 +36,10 @@ class EntityIdFinderTest extends TestCase {
 	protected function setUp(): void {
 		$this->testEnvironment = new TestEnvironment();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
-			->disableOriginalConstructor()
-			->getMock();
+		// A real in-process cache rather than a mock: IdCacheManager::get()
+		// hands it back, but EntityIdFinder routes through getId()/setCache()
+		// here, so the cache is never exercised directly by these tests.
+		$this->cache = new InMemoryLruCache();
 
 		$this->idCacheManager = $this->getMockBuilder( IdCacheManager::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdEntityFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdEntityFinderTest.php
@@ -2,8 +2,8 @@
 
 namespace SMW\Tests\Unit\SQLStore\EntityStore;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
+use SMW\Cache\InMemoryLruCache;
 use SMW\DataItems\WikiPage;
 use SMW\IteratorFactory;
 use SMW\MediaWiki\Connection\Database;
@@ -37,9 +37,9 @@ class IdEntityFinderTest extends TestCase {
 	protected function setUp(): void {
 		$this->testEnvironment = new TestEnvironment();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
-			->disableOriginalConstructor()
-			->getMock();
+		// A real in-process cache rather than a mock: getDataItemById()
+		// round-trips through it, so behaviour is asserted on the cached state.
+		$this->cache = new InMemoryLruCache();
 
 		$this->idCacheManager = $this->getMockBuilder( IdCacheManager::class )
 			->disableOriginalConstructor()
@@ -85,16 +85,7 @@ class IdEntityFinderTest extends TestCase {
 		$row->smw_sort = '';
 		$row->smw_hash = 'x99w';
 
-		$this->cache->expects( $this->once() )
-			->method( 'save' )
-			->with(
-				42,
-				$this->anything() );
-
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
-			->willReturn( false );
-
+		// The cache starts empty, so the lookup misses and reads from the table.
 		$whereConditions = [];
 		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
@@ -108,18 +99,24 @@ class IdEntityFinderTest extends TestCase {
 			$this->idCacheManager
 		);
 
+		$dataItem = $instance->getDataItemById( 42 );
+
 		$this->assertInstanceOf(
 			WikiPage::class,
-			$instance->getDataItemById( 42 )
+			$dataItem
 		);
 
 		$this->assertContains( [ 'smw_id' => 42 ], $whereConditions );
+
+		// The freshly fetched row is written back into the cache under its id.
+		$this->assertSame( $dataItem, $this->cache->fetch( '42' ) );
 	}
 
 	public function testGetDataItemForCachedId() {
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
-			->willReturn( new WikiPage( 'Foo', NS_MAIN ) );
+		$cached = new WikiPage( 'Foo', NS_MAIN );
+
+		// Pre-populate the cache so the lookup is served without a table read.
+		$this->cache->save( '42', $cached );
 
 		$this->connection->expects( $this->never() )
 			->method( 'newSelectQueryBuilder' );
@@ -130,8 +127,8 @@ class IdEntityFinderTest extends TestCase {
 			$this->idCacheManager
 		);
 
-		$this->assertInstanceOf(
-			WikiPage::class,
+		$this->assertSame(
+			$cached,
 			$instance->getDataItemById( 42 )
 		);
 	}
@@ -152,10 +149,7 @@ class IdEntityFinderTest extends TestCase {
 		$row->smw_sort = 'BAR';
 		$row->smw_hash = 'x99w';
 
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
-			->willReturn( false );
-
+		// The cache starts empty, so the lookup misses and reads from the table.
 		$whereConditions = [];
 		$qb = $this->createMockSelectQueryBuilder( [ $row ], $whereConditions );
 
@@ -178,10 +172,7 @@ class IdEntityFinderTest extends TestCase {
 	}
 
 	public function testNullForUnknownId() {
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
-			->willReturn( false );
-
+		// The cache starts empty, so the lookup misses and reads from the table.
 		$qb = $this->createMockSelectQueryBuilder( [] );
 
 		$this->connection->expects( $this->once() )

--- a/tests/phpunit/Unit/SQLStore/EntityStore/SequenceMapFinderTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/SequenceMapFinderTest.php
@@ -2,8 +2,8 @@
 
 namespace SMW\Tests\Unit\SQLStore\EntityStore;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
+use SMW\Cache\InMemoryLruCache;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\EntityStore\SequenceMapFinder;
@@ -30,9 +30,9 @@ class SequenceMapFinderTest extends TestCase {
 	private Database $connection;
 
 	protected function setUp(): void {
-		$this->cache = $this->getMockBuilder( Cache::class )
-			->disableOriginalConstructor()
-			->getMock();
+		// A real in-process cache rather than a mock: the methods under test
+		// round-trip through it, so behaviour is asserted on the cached state.
+		$this->cache = new InMemoryLruCache();
 
 		$this->idCacheManager = $this->getMockBuilder( IdCacheManager::class )
 			->disableOriginalConstructor()
@@ -93,10 +93,7 @@ class SequenceMapFinderTest extends TestCase {
 			'smw_seqmap' => $map
 		];
 
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
-			->willReturn( false );
-
+		// An empty cache forces the database read path (a natural miss).
 		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ] );
 
 		$this->connection->expects( $this->once() )
@@ -116,6 +113,9 @@ class SequenceMapFinderTest extends TestCase {
 			[ 'Foo' ],
 			$instance->findMapById( 1001 )
 		);
+
+		// The resolved map is written back to the cache.
+		$this->assertSame( [ 'Foo' ], $this->cache->fetch( '1001' ) );
 	}
 
 	public function testPrefetchSequenceMap() {
@@ -125,9 +125,6 @@ class SequenceMapFinderTest extends TestCase {
 			'smw_id' => 1001,
 			'smw_seqmap' => $map
 		];
-
-		$this->cache->expects( $this->atLeastOnce() )
-			->method( 'save' );
 
 		$whereConditions = [];
 		$capturedSelects = [];
@@ -150,6 +147,11 @@ class SequenceMapFinderTest extends TestCase {
 
 		$this->assertContains( [ 'smw_id', 'smw_seqmap' ], $capturedSelects );
 		$this->assertContains( [ 'smw_id' => [ 42, 1001 ] ], $whereConditions );
+
+		// The matched row is cached under its id, and the leftover id (with no
+		// matching row) is cached as an empty map to avoid individual SELECTs.
+		$this->assertSame( [ 'Foo' ], $this->cache->fetch( '1001' ) );
+		$this->assertSame( [], $this->cache->fetch( '42' ) );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/Lookup/RedirectTargetLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/RedirectTargetLookupTest.php
@@ -2,8 +2,8 @@
 
 namespace SMW\Tests\Unit\SQLStore\Lookup;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
+use SMW\Cache\InMemoryLruCache;
 use SMW\DataItems\WikiPage;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\IdCacheManager;
@@ -47,9 +47,9 @@ class RedirectTargetLookupTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
-			->disableOriginalConstructor()
-			->getMock();
+		// A real in-process cache rather than a mock: the methods under test
+		// round-trip through it, so behaviour is asserted on the cached state.
+		$this->cache = new InMemoryLruCache();
 	}
 
 	public function testCanConstruct() {
@@ -72,26 +72,24 @@ class RedirectTargetLookupTest extends TestCase {
 			->method( 'get' )
 			->willReturn( $this->cache );
 
-		$this->cache->expects( $this->exactly( 2 ) )
-			->method( 'save' )
-			->willReturnCallback( function ( $key, $value ) {
-				static $calls = [];
-				$calls[] = [ $key, $value ];
-				if ( count( $calls ) === 1 ) {
-					$this->assertEquals( sha1( json_encode( [ 'Foo', 0, '', '' ] ), true ), $key );
-					$this->assertEquals( 'Bar#0##', $value );
-				} elseif ( count( $calls ) === 2 ) {
-					$this->assertEquals( sha1( json_encode( [ 'Bar', 0, '', '' ] ), true ), $key );
-					$this->assertEquals( 'Foo#0##', $value );
-				}
-			} );
-
 		$instance = new RedirectTargetLookup(
 			$this->store,
 			$this->idCacheManager
 		);
 
 		$instance->prepareCache( [ 42 => 'Foo#0##' ] );
+
+		// Two saves: target->source and source->target, both landing in the
+		// shared cache returned by IdCacheManager::get().
+		$this->assertSame( 2, $this->cache->getStats()['count'] );
+		$this->assertSame(
+			'Bar#0##',
+			$this->cache->fetch( sha1( json_encode( [ 'Foo', 0, '', '' ] ), true ) )
+		);
+		$this->assertSame(
+			'Foo#0##',
+			$this->cache->fetch( sha1( json_encode( [ 'Bar', 0, '', '' ] ), true ) )
+		);
 	}
 
 	public function testPrepareCache_FromInstance() {
@@ -107,26 +105,24 @@ class RedirectTargetLookupTest extends TestCase {
 			->method( 'get' )
 			->willReturn( $this->cache );
 
-		$this->cache->expects( $this->exactly( 2 ) )
-			->method( 'save' )
-			->willReturnCallback( function ( $key, $value ) {
-				static $calls = [];
-				$calls[] = [ $key, $value ];
-				if ( count( $calls ) === 1 ) {
-					$this->assertEquals( sha1( json_encode( [ 'Foo', 0, '', '' ] ), true ), $key );
-					$this->assertEquals( 'Bar#0##', $value );
-				} elseif ( count( $calls ) === 2 ) {
-					$this->assertEquals( sha1( json_encode( [ 'Bar', 0, '', '' ] ), true ), $key );
-					$this->assertEquals( 'Foo#0##', $value );
-				}
-			} );
-
 		$instance = new RedirectTargetLookup(
 			$this->store,
 			$this->idCacheManager
 		);
 
 		$instance->prepareCache( [ 42 => WikiPage::newFromText( 'Foo' ) ] );
+
+		// Two saves: target->source and source->target, both landing in the
+		// shared cache returned by IdCacheManager::get().
+		$this->assertSame( 2, $this->cache->getStats()['count'] );
+		$this->assertSame(
+			'Bar#0##',
+			$this->cache->fetch( sha1( json_encode( [ 'Foo', 0, '', '' ] ), true ) )
+		);
+		$this->assertSame(
+			'Foo#0##',
+			$this->cache->fetch( sha1( json_encode( [ 'Bar', 0, '', '' ] ), true ) )
+		);
 	}
 
 	public function testFindRedirectSource() {
@@ -138,10 +134,8 @@ class RedirectTargetLookupTest extends TestCase {
 			->with( IdCacheManager::REDIRECT_SOURCE )
 			->willReturn( $this->cache );
 
-		$this->cache->expects( $this->atLeastOnce() )
-			->method( 'fetch' )
-			->with( sha1( json_encode( [ 'Foo', 0, '', '' ] ), true ) )
-			->willReturn( 'Bar#0##' );
+		// A pre-populated cache entry drives the CACHE_ONLY hit path.
+		$this->cache->save( sha1( json_encode( [ 'Foo', 0, '', '' ] ), true ), 'Bar#0##' );
 
 		$instance = new RedirectTargetLookup(
 			$this->store,

--- a/tests/phpunit/Unit/SQLStore/PropertyTable/PropertyTableHashesTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTable/PropertyTableHashesTest.php
@@ -2,8 +2,8 @@
 
 namespace SMW\Tests\Unit\SQLStore\PropertyTable;
 
-use Onoi\Cache\Cache;
 use PHPUnit\Framework\TestCase;
+use SMW\Cache\InMemoryLruCache;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\EntityStore\IdCacheManager;
 use SMW\SQLStore\PropertyTable\PropertyTableHashes;
@@ -37,9 +37,9 @@ class PropertyTableHashesTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->cache = $this->getMockBuilder( Cache::class )
-			->disableOriginalConstructor()
-			->getMock();
+		// A real in-process cache rather than a mock: the methods under test
+		// round-trip through it, so behaviour is asserted on the cached state.
+		$this->cache = new InMemoryLruCache();
 	}
 
 	public function testCanConstruct() {
@@ -50,9 +50,6 @@ class PropertyTableHashesTest extends TestCase {
 	}
 
 	public function testSetPropertyTableHashes() {
-		$this->cache->expects( $this->once() )
-			->method( 'save' );
-
 		$this->idCacheManager->expects( $this->once() )
 			->method( 'get' )
 			->willReturn( $this->cache );
@@ -77,13 +74,6 @@ class PropertyTableHashesTest extends TestCase {
 	}
 
 	public function testGetPropertyTableHashes() {
-		$this->cache->expects( $this->once() )
-			->method( 'save' );
-
-		$this->cache->expects( $this->once() )
-			->method( 'fetch' )
-			->willReturn( false );
-
 		$this->idCacheManager->expects( $this->once() )
 			->method( 'get' )
 			->willReturn( $this->cache );
@@ -108,6 +98,7 @@ class PropertyTableHashesTest extends TestCase {
 			$this->idCacheManager
 		);
 
+		// An empty cache forces the database read path.
 		$this->assertEquals(
 			[ 'foo' ],
 			$instance->getPropertyTableHashesById( 42 )
@@ -117,12 +108,6 @@ class PropertyTableHashesTest extends TestCase {
 	}
 
 	public function testSetPropertyTableHashesCache() {
-		$this->cache->expects( $this->once() )
-			->method( 'save' )
-			->with(
-				42,
-				[ 'foo' ] );
-
 		$this->idCacheManager->expects( $this->once() )
 			->method( 'get' )
 			->willReturn( $this->cache );
@@ -133,12 +118,13 @@ class PropertyTableHashesTest extends TestCase {
 		);
 
 		$instance->setPropertyTableHashesCache( 42, 'a:1:{i:0;s:3:"foo";}' );
+
+		$this->assertSame( [ 'foo' ], $this->cache->fetch( '42' ) );
 	}
 
 	public function testSetPropertyTableHashesCache_Zero() {
 		$this->idCacheManager->expects( $this->never() )
-			->method( 'get' )
-			->willReturn( $this->cache );
+			->method( 'get' );
 
 		$instance = new PropertyTableHashes(
 			$this->connection,
@@ -153,18 +139,14 @@ class PropertyTableHashesTest extends TestCase {
 			->method( 'get' )
 			->willReturn( $this->cache );
 
-		$this->cache->expects( $this->once() )
-			->method( 'save' )
-			->with(
-				42,
-				[] );
-
 		$instance = new PropertyTableHashes(
 			$this->connection,
 			$this->idCacheManager
 		);
 
 		$instance->clearPropertyTableHashCacheById( 42 );
+
+		$this->assertSame( [], $this->cache->fetch( '42' ) );
 	}
 
 }


### PR DESCRIPTION
Part of the 7.0.0 removal of the `onoi/cache` dependency.

These SQLStore unit tests mocked `Onoi\Cache\Cache` purely as a stand-in for the cache that `IdCacheManager::get()` returns. The real type is the `final` `SMW\Cache\InMemoryLruCache`, which cannot be mocked, so ahead of dropping `onoi/cache` the tests now use a real `InMemoryLruCache` and assert on cached state rather than `fetch`/`save` call counts.

`InMemoryLruCache` is a cheap, deterministic in-process collaborator, so a real instance is preferable to a mock here: the tests verify the caching outcome instead of the interaction. State-based assertions are also more robust to refactoring than the call-count expectations they replace.

Several assertions are tightened in passing:

- exact cached instances instead of `instanceof` (the entity lookup returns the same object it cached),
- exact keys and values for the redirect-source and sequence-map entries (replacing a brittle `willReturnCallback` static counter),
- the negative-cache entry for ids with no matching row.

No production code changes; the dependency itself is dropped in a later step once its remaining composite plumbing is gone.