### PR TITLE
Drop the onoi/cache dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,6 @@
 		"param-processor/param-processor": "~1.13",
 		"serialization/serialization": "~4.0",
 		"jeroen/message-reporter": "~1.0",
-		"onoi/cache": "~1.2",
 		"jeroen/file-fetcher": "^6|^5|^4.4",
 		"wikimedia/textcat": "^2|^1.1"
 	},

--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -30,7 +30,7 @@ Adds MediaWiki 1.45 support (see [Compatibility](#compatibility)).
 
 **Built on MediaWiki core.**
 
-* [Bundled third-party libraries dropped](#removed) in favor of MediaWiki core services (`Onoi\Tesa`, `Onoi\HttpRequest`, `onoi/callback-container`), and a large batch of long-deprecated APIs removed. Extension authors: see the [migration guide](../migration/7.0.md).
+* [Bundled third-party libraries dropped](#removed) in favor of MediaWiki core services (`Onoi\Tesa`, `Onoi\HttpRequest`, `onoi/callback-container`, `onoi/cache`, `onoi/blob-store`), and a large batch of long-deprecated APIs removed. Extension authors: see the [migration guide](../migration/7.0.md).
 
 ## For users and administrators
 
@@ -153,6 +153,7 @@ Adds MediaWiki 1.45 support (see [Compatibility](#compatibility)).
 * Removed `psr/log` from `composer.json`. Extensions that relied on SMW pulling in `psr/log` transitively must declare it in their own `composer.json`.
 * Removed the `mediawiki/callback-container` (`onoi/callback-container`) Composer dependency. The internal DI layer now uses MediaWiki's `Wikimedia\Services\ServiceContainer` directly ([#6428](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6428)).
 * Removed the `onoi/blob-store` Composer dependency. SMW's durable query-result cache now uses the in-tree `SMW\Query\Cache\QueryResultStore` and `QueryResultContainer` over MediaWiki's `Wikimedia\ObjectCache\BagOStuff`, with the cache key format and payload encoding preserved so existing entries round-trip unchanged. This was internal infrastructure and never part of the public API.
+* Removed the `onoi/cache` Composer dependency. SMW's caches now use MediaWiki-native primitives directly: `Wikimedia\ObjectCache\BagOStuff` over the configured `$smwgMainCacheType`, and the in-tree `SMW\Cache\InMemoryLruCache` (over `MapCacheLRU`) for the in-process pool caches. The `SMW.Cache` composite service, `ServicesFactory::getCache()`, and `CacheFactory`'s Onoi cache-minting methods are gone. This was internal infrastructure and never part of the public API.
 * Removed the `@private` internal class `SMW\Services\SharedServicesContainer` and the internal wiring files `src/Services/mediawiki.php`, `src/Services/events.php`, and `src/Services/cache.php`. These were never part of the public API ([#6428](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6428)).
 * Removed the root `DefaultSettings.php` shim (deprecated since 4.0.0). Use `$GLOBALS['smwgFoo']` or `SMW\Settings::getInstance()->get('smwgFoo')` instead.
 * Removed `Defines.php`.

--- a/src/Cache/InMemoryLruCache.php
+++ b/src/Cache/InMemoryLruCache.php
@@ -7,9 +7,8 @@ use MapCacheLRU;
 /**
  * Request-scoped, bounded in-process LRU cache backed by MediaWiki core's
  * {@link MapCacheLRU}. It reproduces the small surface SMW's in-process pool
- * caches rely on (the methods of the former `Onoi\Cache\FixedInMemoryLruCache`:
- * `fetch`/`contains`/`save`/`delete` plus `getStats`) without depending on
- * onoi/cache.
+ * caches rely on (`fetch`/`contains`/`save`/`delete` plus `getStats`, the
+ * surface of the former bundled fixed-size in-memory cache).
  *
  * This is deliberately a concrete, final adapter rather than a general cache
  * interface: it exposes only the methods its pool consumers call, is never

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -4,9 +4,6 @@ namespace SMW;
 
 use MediaWiki\Title\Title;
 use MediaWiki\WikiMap\WikiMap;
-use ObjectCache;
-use Onoi\Cache\Cache;
-use Onoi\Cache\CacheFactory as OnoiCacheFactory;
 use RuntimeException;
 use SMW\Query\Cache\QueryResultStore;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -77,72 +74,6 @@ class CacheFactory {
 		}
 
 		return (object)$cacheOptions;
-	}
-
-	/**
-	 * @since 2.2
-	 *
-	 * @param int $cacheSize
-	 *
-	 * @return Cache
-	 */
-	public function newFixedInMemoryCache( $cacheSize = 500 ) {
-		return OnoiCacheFactory::getInstance()->newFixedInMemoryLruCache( $cacheSize );
-	}
-
-	/**
-	 * @since 2.2
-	 *
-	 * @return Cache
-	 */
-	public function newNullCache() {
-		return OnoiCacheFactory::getInstance()->newNullCache();
-	}
-
-	/**
-	 * @since 2.2
-	 *
-	 * @param int|string|null $mediaWikiCacheType
-	 *
-	 * @return Cache
-	 */
-	public function newMediaWikiCompositeCache( $mediaWikiCacheType = null ) {
-		$compositeCache = OnoiCacheFactory::getInstance()->newCompositeCache( [
-			$this->newFixedInMemoryCache( 500 ),
-			$this->newMediaWikiCache( $mediaWikiCacheType )
-		] );
-
-		return $compositeCache;
-	}
-
-	/**
-	 * @since 2.5
-	 *
-	 * @param int|string|null $mediaWikiCacheType
-	 *
-	 * @return Cache
-	 */
-	public function newMediaWikiCache( $mediaWikiCacheType = null ) {
-		$mediaWikiCache = ObjectCache::getInstance(
-			( $mediaWikiCacheType === null ? $this->getMainCacheType() : $mediaWikiCacheType )
-		);
-
-		return OnoiCacheFactory::getInstance()->newMediaWikiCache( $mediaWikiCache );
-	}
-
-	/**
-	 * @since 2.5
-	 *
-	 * @param int|null $cacheType
-	 *
-	 * @return Cache
-	 */
-	public function newCacheByType( $cacheType = null ) {
-		if ( $cacheType === CACHE_NONE || $cacheType === null ) {
-			return $this->newNullCache();
-		}
-
-		return $this->newMediaWikiCache( $cacheType );
 	}
 
 	/**

--- a/src/Localizer/LocalLanguage/LocalLanguage.php
+++ b/src/Localizer/LocalLanguage/LocalLanguage.php
@@ -42,8 +42,6 @@ class LocalLanguage {
 			return self::$instance;
 		}
 
-		// $cache = ApplicationFactory::getInstance()->getCache()
-
 		$jsonContentsFileReader = new JsonContentsFileReader();
 
 		self::$instance = new self(

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -3,7 +3,6 @@
 use MediaWiki\Logger\LoggerFactory;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\Parser;
-use Onoi\Cache\Cache;
 use Psr\Log\LoggerInterface;
 use SMW\CacheFactory;
 use SMW\Connection\ConnectionManager;
@@ -162,24 +161,9 @@ return [
 		return $instance;
 	},
 
-	'SMW.Cache' => static function ( MediaWikiServices $services ): Cache {
-		$servicesFactory = ServicesFactory::getInstance();
-
-		if ( $servicesFactory->hasTestOverride( 'Cache' ) ) {
-			return $servicesFactory->getCache();
-		}
-
-		// Mirror ServicesFactory::getCache() default-path behaviour: build a
-		// MediaWikiCompositeCache for the global $smwgMainCacheType. Callers
-		// that need a non-default cache type still go through
-		// CacheFactory::newMediaWikiCompositeCache() directly.
-		return ( new CacheFactory() )->newMediaWikiCompositeCache();
-	},
-
 	'SMW.ObjectCache' => static function ( MediaWikiServices $services ): BagOStuff {
-		// MediaWiki-native BagOStuff for consumers migrated off the Onoi cache.
-		// Resolved through ServicesFactory so it shares the same backing store
-		// (the configured $smwgMainCacheType) as the SMW.Cache composite.
+		// MediaWiki-native BagOStuff over the configured $smwgMainCacheType,
+		// resolved through ServicesFactory.
 		return ServicesFactory::getInstance()->getObjectCache();
 	},
 

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -12,9 +12,6 @@ use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\Title\Title;
 use MediaWiki\User\User;
-use Onoi\Cache\Cache;
-use Onoi\Cache\CacheFactory as OnoiCacheFactory;
-use Onoi\Cache\FixedInMemoryLruCache;
 use Psr\Log\LoggerInterface;
 use RuntimeException;
 use SMW\CacheFactory;
@@ -294,7 +291,6 @@ class ServicesFactory {
 			'Settings' => fn () => $this->getSettings(),
 			'EntityCache' => fn () => $this->getEntityCache(),
 			'JobQueue' => fn () => $this->getJobQueue(),
-			'Cache' => fn () => $this->getCache( ...$args ),
 			'JobQueueGroup' => fn () => $this->getJobQueueGroup(),
 			'PermissionManager' => fn () => $this->getPermissionManager(),
 			'RevisionGuard' => fn () => $this->getRevisionGuard(),
@@ -370,7 +366,6 @@ class ServicesFactory {
 			'DefaultSearchEngineTypeForDB' => fn () => $this->getDefaultSearchEngineTypeForDB( ...$args ),
 			// @phan-suppress-next-line PhanParamTooFewUnpack
 			'WikiPage' => fn () => $this->newWikiPage( ...$args ),
-			'FixedInMemoryLruCache' => fn () => $this->newFixedInMemoryLruCache( ...$args ),
 			'JobFactory' => fn () => $this->newJobFactory(),
 		];
 
@@ -744,32 +739,7 @@ class ServicesFactory {
 	}
 
 	/**
-	 * @since 2.0
-	 *
-	 * @return Cache
-	 */
-	public function getCache( $cacheType = null ) {
-		if ( array_key_exists( 'Cache', $this->testOverrides ) ) {
-			return $this->testOverrides['Cache'];
-		}
-
-		// SMW.Cache on the global container is the default-type cache.
-		// Non-default cache-type requests still build a fresh
-		// MediaWikiCompositeCache (callers depend on type-specific caches and
-		// the global registration only covers the default).
-		if ( $cacheType !== null ) {
-			return ( new CacheFactory() )->newMediaWikiCompositeCache( $cacheType );
-		}
-
-		return MediaWikiServices::getInstance()->getService( 'SMW.Cache' );
-	}
-
-	/**
 	 * Resolve a MediaWiki-native BagOStuff for the configured main cache type.
-	 *
-	 * Unlike getCache(), which returns the Onoi composite still consumed by
-	 * the remaining callers, this returns the bare BagOStuff that consumers
-	 * migrate onto as the onoi/cache dependency is removed.
 	 *
 	 * @since 7.0.0
 	 */
@@ -1303,13 +1273,6 @@ class ServicesFactory {
 	 */
 	public function newWikiPage( Title $title ) {
 		return $this->newPageCreator()->createPage( $title );
-	}
-
-	/**
-	 * @since 7.0.0
-	 */
-	public function newFixedInMemoryLruCache( int $cacheSize = 500 ): FixedInMemoryLruCache {
-		return OnoiCacheFactory::getInstance()->newFixedInMemoryLruCache( $cacheSize );
 	}
 
 	/**

--- a/tests/phpunit/Integration/Services/ServiceWiringTest.php
+++ b/tests/phpunit/Integration/Services/ServiceWiringTest.php
@@ -7,7 +7,6 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Request\FauxRequest;
 use MediaWiki\Title\Title;
 use MediaWikiIntegrationTestCase;
-use Onoi\Cache\Cache;
 use SMW\CacheFactory;
 use SMW\Connection\ConnectionManager;
 use SMW\ConstraintFactory;
@@ -118,7 +117,6 @@ class ServiceWiringTest extends MediaWikiIntegrationTestCase {
 		return [
 			[ 'SMW.Settings', Settings::class ],
 			[ 'SMW.Store', Store::class ],
-			[ 'SMW.Cache', Cache::class ],
 			[ 'SMW.EntityCache', EntityCache::class ],
 			[ 'SMW.JobQueue', JobQueue::class ],
 			[ 'SMW.LinkBatch', LinkBatch::class ],

--- a/tests/phpunit/SMWIntegrationTestCase.php
+++ b/tests/phpunit/SMWIntegrationTestCase.php
@@ -93,13 +93,10 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 	 * Initialize SMW test environment configuration.
 	 */
 	private function initializeTestEnvironment(): void {
-		$fixedInMemoryLruCache = ServicesFactory::getInstance()->create( 'FixedInMemoryLruCache' );
-
 		$this->testEnvironment = new TestEnvironment();
 		$this->testEnvironment->addConfiguration( 'smwgEnabledDeferredUpdate', false );
 		$this->testEnvironment->disableSoftwareChangeTags();
 		$this->testEnvironment->registerObject( 'Store', $this->getStore() );
-		$this->testEnvironment->registerObject( 'Cache', $fixedInMemoryLruCache );
 
 		PropertyRegistry::clear();
 

--- a/tests/phpunit/Unit/CacheFactoryTest.php
+++ b/tests/phpunit/Unit/CacheFactoryTest.php
@@ -3,8 +3,6 @@
 namespace SMW\Tests\Unit;
 
 use MediaWiki\Title\Title;
-use Onoi\Cache\Cache;
-use Onoi\Cache\NullCache;
 use PHPUnit\Framework\TestCase;
 use SMW\CacheFactory;
 use SMW\MediaWiki\Hooks\ArticlePurge;
@@ -101,61 +99,6 @@ class CacheFactoryTest extends TestCase {
 		$cacheOptions = $instance->newCacheOptions( [
 			'useCache' => true
 		] );
-	}
-
-	public function testCanConstructFixedInMemoryCache() {
-		$instance = new CacheFactory( 'hash' );
-
-		$this->assertInstanceOf(
-			Cache::class,
-			$instance->newFixedInMemoryCache()
-		);
-	}
-
-	public function testCanConstructNullCache() {
-		$instance = new CacheFactory( 'hash' );
-
-		$this->assertInstanceOf(
-			Cache::class,
-			$instance->newNullCache()
-		);
-	}
-
-	public function testCanConstructMediaWikiCompositeCache() {
-		$instance = new CacheFactory( 'hash' );
-
-		$this->assertInstanceOf(
-			Cache::class,
-			$instance->newMediaWikiCompositeCache( CACHE_NONE )
-		);
-
-		$this->assertInstanceOf(
-			Cache::class,
-			$instance->newMediaWikiCompositeCache( $instance->getMainCacheType() )
-		);
-	}
-
-	public function testCanConstructMediaWikiCache() {
-		$instance = new CacheFactory();
-
-		$this->assertInstanceOf(
-			Cache::class,
-			$instance->newMediaWikiCache( 'hash' )
-		);
-	}
-
-	public function testCanConstructCacheByType() {
-		$instance = new CacheFactory();
-
-		$this->assertInstanceOf(
-			NullCache::class,
-			$instance->newCacheByType( CACHE_NONE )
-		);
-
-		$this->assertInstanceOf(
-			Cache::class,
-			$instance->newCacheByType( 'hash' )
-		);
 	}
 
 	public function testCanConstructBlobStore() {


### PR DESCRIPTION
Part of the 7.0.0 removal of bundled Onoi libraries; this drops the last one, `onoi/cache`.

The purge hooks (now on `SMW.ObjectCache`), the query-result store, and the entity-ID cache tests (now using a real `InMemoryLruCache`) left the `SMW.Cache` Onoi composite with no remaining consumers. This removes the dead plumbing and the dependency:

- the `SMW.Cache` service, `ServicesFactory::getCache()`, and the `'Cache'` and `'FixedInMemoryLruCache'` object routes,
- `CacheFactory`'s Onoi cache-minting methods (`newFixedInMemoryCache`, `newNullCache`, `newMediaWikiCache`, `newMediaWikiCompositeCache`, `newCacheByType`),
- the `SMWIntegrationTestCase` `'Cache'` test-override scaffolding and the matching rows in `CacheFactoryTest` / `ServiceWiringTest`,
- `onoi/cache` from `composer.json`.

SMW's caches now use MediaWiki-native primitives throughout: `Wikimedia\ObjectCache\BagOStuff` over the configured `$smwgMainCacheType` (`SMW.ObjectCache`), and the in-tree `SMW\Cache\InMemoryLruCache` over `MapCacheLRU` for the in-process pool caches. With this and #6927, both Onoi cache-family packages are gone.

### Verification

`composer validate`, `composer analyze`, and `composer phan` are clean, with no remaining static or dynamic reference to any removed symbol and no service still depending on `SMW.Cache`. The `CacheFactory`, SQLStore, and Services unit suites pass, as do the `ServiceWiring` and registered-hook integration tests.