### PR TITLE
Rename the BlobStore factory to QueryResultStore and tidy cache cruft

### DIFF
--- a/docs/migration/7.0.md
+++ b/docs/migration/7.0.md
@@ -219,3 +219,9 @@ The following long-deprecated functions and methods were removed. Use the listed
 ### Removed internal APIs
 
 * `ServicesFactory::getMediaWikiLogger()` and the `SMW\Utils\Logger` wrapper — use `MediaWiki\Logger\LoggerFactory::getInstance( $channel )` directly
+* **Cache services moved to MediaWiki primitives** (the bundled `onoi/cache` and `onoi/blob-store` dependencies are gone):
+  * `ServicesFactory::getCache()` and the `SMW.Cache` service are removed — use `ServicesFactory::getObjectCache()` (or the `SMW.ObjectCache` service), which returns a `Wikimedia\ObjectCache\BagOStuff` over `$smwgMainCacheType`.
+  * `CacheFactory::newFixedInMemoryCache()`, `newNullCache()`, `newMediaWikiCache()`, `newMediaWikiCompositeCache()`, and `newCacheByType()` are removed — use MediaWiki's `Wikimedia\ObjectCache\BagOStuff` / `MapCacheLRU`, or the in-tree `SMW\Cache\InMemoryLruCache`, directly.
+  * `ServicesFactory::newBlobStore()` and `CacheFactory::newBlobStore()` are renamed to `newQueryResultStore()`, and the `'BlobStore'` service route is now `'QueryResultStore'` (they construct a `SMW\Query\Cache\QueryResultStore`).
+  * `CacheFactory::getPurgeCacheKey()` is removed — build the key with `smwfCacheKey( SMW\MediaWiki\Hooks\ArticlePurge::CACHE_NAMESPACE, $articleId )`.
+  * `SMW\InMemoryPoolCache::__construct()` no longer takes a `CacheFactory` argument — resolve the pool via `InMemoryPoolCache::getInstance()`.

--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -166,6 +166,7 @@ Adds MediaWiki 1.45 support (see [Compatibility](#compatibility)).
 
 **Removed APIs:**
 
+* **Cache factory naming cleanup.** `ServicesFactory::newBlobStore()` and `CacheFactory::newBlobStore()` are renamed to `newQueryResultStore()`, and the `'BlobStore'` service route is now `'QueryResultStore'`, reflecting that they construct a `SMW\Query\Cache\QueryResultStore` (the former `onoi/blob-store` is gone). `CacheFactory::getPurgeCacheKey()` is removed; build the key with `smwfCacheKey( SMW\MediaWiki\Hooks\ArticlePurge::CACHE_NAMESPACE, $articleId )`. `SMW\InMemoryPoolCache`'s constructor no longer takes a `CacheFactory` argument. These were internal infrastructure.
 * **`browsebyproperty` and `browsebysubject` API modules removed.** Both were deprecated since 3.0. Use the `smwbrowse` API module (`action=smwbrowse`) instead.
 * **`SMW\MediaWiki\Api\PropertyListByApiRequest` removed.** This was an internal helper for the now-removed `browsebyproperty` module; no other code consumed it. External consumers should query the `smwbrowse` API module directly.
 * **`SMW\MediaWiki\Specials\SpecialPage` base class removed**, along with the legacy `SMW\SpecialPage` alias. All in-tree SMW special pages now extend MediaWiki core's `MediaWiki\SpecialPage\SpecialPage` directly and receive `Store` / `Settings` through their constructor (registered via `SpecialPages` ObjectFactory specs in `extension.json`). Third-party special pages that extended the SMW base class must extend MediaWiki core's `SpecialPage` and inject the services they need.

--- a/src/CacheFactory.php
+++ b/src/CacheFactory.php
@@ -2,7 +2,6 @@
 
 namespace SMW;
 
-use MediaWiki\Title\Title;
 use MediaWiki\WikiMap\WikiMap;
 use RuntimeException;
 use SMW\Query\Cache\QueryResultStore;
@@ -53,19 +52,6 @@ class CacheFactory {
 	/**
 	 * @since 2.2
 	 *
-	 * @param Title|int|string $key
-	 */
-	public static function getPurgeCacheKey( $key ): string {
-		if ( $key instanceof Title ) {
-			$key = $key->getArticleID();
-		}
-
-		return self::getCachePrefix() . ':smw:arc:' . md5( $key ?? '' );
-	}
-
-	/**
-	 * @since 2.2
-	 *
 	 * @throws RuntimeException
 	 */
 	public function newCacheOptions( array $cacheOptions ): stdClass {
@@ -77,7 +63,7 @@ class CacheFactory {
 	}
 
 	/**
-	 * @since 2.4
+	 * @since 7.0.0
 	 *
 	 * @param string $namespace
 	 * @param string|int|null $cacheType
@@ -85,8 +71,8 @@ class CacheFactory {
 	 *
 	 * @return QueryResultStore
 	 */
-	public function newBlobStore( $namespace, $cacheType = null, $cacheLifetime = 0 ) {
-		return ApplicationFactory::getInstance()->create( 'BlobStore', $namespace, $cacheType, $cacheLifetime );
+	public function newQueryResultStore( $namespace, $cacheType = null, $cacheLifetime = 0 ) {
+		return ApplicationFactory::getInstance()->create( 'QueryResultStore', $namespace, $cacheType, $cacheLifetime );
 	}
 
 }

--- a/src/InMemoryPoolCache.php
+++ b/src/InMemoryPoolCache.php
@@ -3,7 +3,6 @@
 namespace SMW;
 
 use SMW\Cache\InMemoryLruCache;
-use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Utils\StatsFormatter;
 
 /**
@@ -34,18 +33,7 @@ class InMemoryPoolCache {
 
 	private static ?InMemoryPoolCache $instance = null;
 
-	private CacheFactory $cacheFactory;
-
 	private array $poolCacheList = [];
-
-	/**
-	 * @since 2.3
-	 *
-	 * @param CacheFactory $cacheFactory
-	 */
-	public function __construct( CacheFactory $cacheFactory ) {
-		$this->cacheFactory = $cacheFactory;
-	}
 
 	/**
 	 * @since 2.3
@@ -54,7 +42,7 @@ class InMemoryPoolCache {
 	 */
 	public static function getInstance(): InMemoryPoolCache {
 		if ( self::$instance === null ) {
-			self::$instance = new self( ApplicationFactory::getInstance()->newCacheFactory() );
+			self::$instance = new self();
 		}
 
 		return self::$instance;

--- a/src/MediaWiki/Hooks/AfterQueryResultLookupComplete.php
+++ b/src/MediaWiki/Hooks/AfterQueryResultLookupComplete.php
@@ -35,7 +35,7 @@ class AfterQueryResultLookupComplete {
 		$queryDependencyLinksStore->updateDependencies( $result );
 
 		// `ResultCache` is resolved lazily rather than via the `services:`
-		// array because its `BlobStore` is built from `smwgQueryResultCacheType`
+		// array because its query-result store is built from `smwgQueryResultCacheType`
 		// at construction and `MediaWikiServices` caches the resolved instance.
 		// See `BeforeQueryResultLookupComplete` for the full rationale.
 		ApplicationFactory::getInstance()->singleton( 'ResultCache' )->recordStats();

--- a/src/MediaWiki/Hooks/BeforeQueryResultLookupComplete.php
+++ b/src/MediaWiki/Hooks/BeforeQueryResultLookupComplete.php
@@ -20,7 +20,7 @@ class BeforeQueryResultLookupComplete {
 	 */
 	public function onSMW__Store__BeforeQueryResultLookupComplete( $store, $query, &$result, $queryEngine ): bool {
 		// `ResultCache` cannot be injected through the declarative `services:`
-		// array because its `BlobStore` is constructed from
+		// array because its query-result store is constructed from
 		// `smwgQueryResultCacheType` at instantiation, and `MediaWikiServices`
 		// caches the resolved instance for the container's lifetime. JSONScript
 		// tests vary that setting per test case, so the cached instance would

--- a/src/Query/Cache/ResultCache.php
+++ b/src/Query/Cache/ResultCache.php
@@ -43,7 +43,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 	const VERSION = '1';
 
 	/**
-	 * Namespace occupied by the BlobStore
+	 * Namespace occupied by the query-result store
 	 */
 	const CACHE_NAMESPACE = 'smw:query:store';
 
@@ -99,7 +99,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 	public function __construct(
 		private readonly Store $store,
 		private readonly QueryFactory $queryFactory,
-		private readonly QueryResultStore $blobStore,
+		private readonly QueryResultStore $resultStore,
 		private readonly CacheStats $cacheStats,
 	) {
 		$this->tempCache = ApplicationFactory::getInstance()->getInMemoryPoolCache()->getPoolCacheById( self::POOLCACHE_ID );
@@ -154,7 +154,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 	 * @return bool
 	 */
 	public function isEnabled(): bool {
-		return $this->blobStore->canUse();
+		return $this->resultStore->canUse();
 	}
 
 	/**
@@ -200,7 +200,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 
 		$queryId = $this->getHashFrom( $query->getQueryId() );
 
-		$container = $this->blobStore->read(
+		$container = $this->resultStore->read(
 			$queryId
 		);
 
@@ -233,7 +233,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 	 * @param string $context
 	 */
 	public function invalidateCache( $items, $context = '' ): void {
-		if ( !$this->blobStore->canUse() ) {
+		if ( !$this->resultStore->canUse() ) {
 			return;
 		}
 
@@ -252,10 +252,10 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 			$id = $this->getHashFrom( $item );
 			$this->tempCache->delete( $id );
 
-			if ( $this->blobStore->exists( $id ) ) {
+			if ( $this->resultStore->exists( $id ) ) {
 				$recordStats = true;
 				$this->cacheStats->incr( 'deletes.on' . $context );
-				$this->blobStore->delete( $id );
+				$this->resultStore->delete( $id );
 			}
 		}
 
@@ -265,7 +265,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 	}
 
 	private function canUse( Query $query ): bool {
-		if ( !$this->enabledCache || !$this->blobStore->canUse() ) {
+		if ( !$this->enabledCache || !$this->resultStore->canUse() ) {
 			return false;
 		}
 
@@ -408,7 +408,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 			$hash = $contextPage->getHash();
 		}
 
-		$this->blobStore->save(
+		$this->resultStore->save(
 			$container
 		);
 
@@ -424,7 +424,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 	private function addToLinkedList( WikiPage $contextPage, string $queryId ): void {
 		// Ensure that without QueryDependencyLinksStore being enabled recorded
 		// subjects related to a query can be discoverable and purged separately
-		$container = $this->blobStore->read(
+		$container = $this->resultStore->read(
 			$this->getHashFrom( $contextPage )
 		);
 
@@ -432,7 +432,7 @@ class ResultCache implements QueryEngine, LoggerAwareInterface {
 		// with that subject allows for an immediate associated removal
 		$container->addToLinkedList( $queryId );
 
-		$this->blobStore->save(
+		$this->resultStore->save(
 			$container
 		);
 	}

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -352,7 +352,7 @@ class ServicesFactory {
 			// @phan-suppress-next-line PhanParamTooFewUnpack
 			'PostProcHandler' => fn () => $this->newPostProcHandler( ...$args ),
 			// @phan-suppress-next-line PhanParamTooFewUnpack
-			'BlobStore' => fn () => $this->newBlobStore( ...$args ),
+			'QueryResultStore' => fn () => $this->newQueryResultStore( ...$args ),
 			'ResultCache' => fn () => $this->getResultCache( ...$args ),
 			// @phan-suppress-next-line PhanParamTooFewUnpack
 			'Stats' => fn () => $this->newStats( ...$args ),
@@ -1131,32 +1131,32 @@ class ServicesFactory {
 	/**
 	 * @since 7.0.0
 	 */
-	public function newBlobStore( $namespace, $cacheType = null, $ttl = 0 ): QueryResultStore {
-		if ( array_key_exists( 'BlobStore', $this->testOverrides ) ) {
-			return $this->testOverrides['BlobStore'];
+	public function newQueryResultStore( $namespace, $cacheType = null, $ttl = 0 ): QueryResultStore {
+		if ( array_key_exists( 'QueryResultStore', $this->testOverrides ) ) {
+			return $this->testOverrides['QueryResultStore'];
 		}
 
 		$cacheFactory = $this->getCacheFactory();
 
-		$blobStore = new QueryResultStore(
+		$store = new QueryResultStore(
 			$namespace,
 			$this->getObjectCache( $cacheType ),
 			new MapCacheLRU( 500 )
 		);
 
-		$blobStore->setNamespacePrefix(
+		$store->setNamespacePrefix(
 			$cacheFactory->getCachePrefix()
 		);
 
-		$blobStore->setExpiryInSeconds(
+		$store->setExpiryInSeconds(
 			$ttl
 		);
 
-		$blobStore->setUsageState(
+		$store->setUsageState(
 			$cacheType !== CACHE_NONE && $cacheType !== false
 		);
 
-		return $blobStore;
+		return $store;
 	}
 
 	/**
@@ -1181,7 +1181,7 @@ class ServicesFactory {
 		$resultCache = new ResultCache(
 			$this->getStore(),
 			$this->getQueryFactory(),
-			$this->newBlobStore(
+			$this->newQueryResultStore(
 				ResultCache::CACHE_NAMESPACE,
 				$cacheType,
 				$settings->get( 'smwgQueryResultCacheLifetime' )

--- a/tests/phpunit/Integration/MediaWiki/MediaWikiIntegrationForRegisteredHookTest.php
+++ b/tests/phpunit/Integration/MediaWiki/MediaWikiIntegrationForRegisteredHookTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Integration\MediaWiki;
 use MediaWiki\Context\RequestContext;
 use MediaWiki\MediaWikiServices;
 use SMW\DataItems\WikiPage;
+use SMW\MediaWiki\Hooks\ArticlePurge;
 use SMW\ParserData;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Tests\SMWIntegrationTestCase;
@@ -66,8 +67,6 @@ class MediaWikiIntegrationForRegisteredHookTest extends SMWIntegrationTestCase {
 	}
 
 	public function testPagePurge() {
-		$cacheFactory = $this->applicationFactory->newCacheFactory();
-
 		// ArticlePurge writes the purge marker through SMW.ObjectCache, i.e.
 		// ServicesFactory::getObjectCache(); read it back from that same
 		// instance rather than an injected Cache override.
@@ -81,7 +80,7 @@ class MediaWikiIntegrationForRegisteredHookTest extends SMWIntegrationTestCase {
 			->createPage( $this->title )
 			->doEdit( '[[Has function hook test::page purge]]' );
 
-		$key = $cacheFactory->getPurgeCacheKey( $this->title->getArticleID() );
+		$key = smwfCacheKey( ArticlePurge::CACHE_NAMESPACE, $this->title->getArticleID() );
 
 		$pageCreator
 			->getPage()

--- a/tests/phpunit/Unit/CacheFactoryTest.php
+++ b/tests/phpunit/Unit/CacheFactoryTest.php
@@ -2,10 +2,8 @@
 
 namespace SMW\Tests\Unit;
 
-use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use SMW\CacheFactory;
-use SMW\MediaWiki\Hooks\ArticlePurge;
 use SMW\Query\Cache\QueryResultStore;
 
 /**
@@ -51,33 +49,6 @@ class CacheFactoryTest extends TestCase {
 		);
 	}
 
-	public function testGetPurgeCacheKey() {
-		$title = $this->getMockBuilder( Title::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$title->expects( $this->any() )
-			->method( 'getArticleID' )
-			->willReturn( 42 );
-
-		$instance = new CacheFactory( 'hash' );
-
-		$this->assertIsString(
-
-			$instance->getPurgeCacheKey( $title )
-		);
-
-		$this->assertSame(
-			smwfCacheKey( 'smw:arc', 42 ),
-			$instance->getPurgeCacheKey( $title )
-		);
-
-		$this->assertSame(
-			smwfCacheKey( ArticlePurge::CACHE_NAMESPACE, 42 ),
-			$instance->getPurgeCacheKey( $title )
-		);
-	}
-
 	public function testCanConstructCacheOptions() {
 		$instance = new CacheFactory( 'hash' );
 
@@ -101,12 +72,12 @@ class CacheFactoryTest extends TestCase {
 		] );
 	}
 
-	public function testCanConstructBlobStore() {
+	public function testCanConstructQueryResultStore() {
 		$instance = new CacheFactory( 'hash' );
 
 		$this->assertInstanceOf(
 			QueryResultStore::class,
-			$instance->newBlobStore( 'foo', CACHE_NONE )
+			$instance->newQueryResultStore( 'foo', CACHE_NONE )
 		);
 	}
 

--- a/tests/phpunit/Unit/InMemoryPoolCacheTest.php
+++ b/tests/phpunit/Unit/InMemoryPoolCacheTest.php
@@ -4,7 +4,6 @@ namespace SMW\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
 use SMW\Cache\InMemoryLruCache;
-use SMW\CacheFactory;
 use SMW\InMemoryPoolCache;
 
 /**
@@ -24,13 +23,9 @@ class InMemoryPoolCacheTest extends TestCase {
 	}
 
 	public function testCanConstruct() {
-		$cacheFactory = $this->getMockBuilder( CacheFactory::class )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->assertInstanceOf(
 			InMemoryPoolCache::class,
-			new InMemoryPoolCache( $cacheFactory )
+			new InMemoryPoolCache()
 		);
 
 		$this->assertInstanceOf(

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticlePurgeTest.php
@@ -78,9 +78,8 @@ class ArticlePurgeTest extends TestCase {
 
 		$instance = new ArticlePurge( $store, $this->cache, $settings, $this->eventDispatcher );
 
-		$cacheFactory = $this->applicationFactory->newCacheFactory();
 		$factboxCacheKey = CachedFactbox::makeCacheKey( $pageId );
-		$purgeCacheKey = $cacheFactory->getPurgeCacheKey( $pageId );
+		$purgeCacheKey = smwfCacheKey( ArticlePurge::CACHE_NAMESPACE, $pageId );
 
 		$this->assertEquals(
 			$expected['autorefreshPreProcess'],

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -172,7 +172,7 @@ class ParserAfterTidyTest extends TestCase {
 	}
 
 	private function newMockCache( $id, $getStatus ) {
-		$key = $this->applicationFactory->newCacheFactory()->getPurgeCacheKey( $id );
+		$key = smwfCacheKey( ArticlePurge::CACHE_NAMESPACE, $id );
 
 		$cache = $this->getMockBuilder( BagOStuff::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/Query/Cache/ResultCacheTest.php
+++ b/tests/phpunit/Unit/Query/Cache/ResultCacheTest.php
@@ -26,7 +26,7 @@ class ResultCacheTest extends TestCase {
 
 	private $store;
 	private $queryFactory;
-	private $blobStore;
+	private $resultStore;
 	private QueryResultContainer $container;
 	private $cacheStats;
 
@@ -39,11 +39,11 @@ class ResultCacheTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->blobStore = $this->getMockBuilder( QueryResultStore::class )
+		$this->resultStore = $this->getMockBuilder( QueryResultStore::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->blobStore
+		$this->resultStore
 			->method( 'canUse' )
 			->willReturn( true );
 
@@ -59,7 +59,7 @@ class ResultCacheTest extends TestCase {
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			ResultCache::class,
-			new ResultCache( $this->store, $this->queryFactory, $this->blobStore, $this->cacheStats )
+			new ResultCache( $this->store, $this->queryFactory, $this->resultStore, $this->cacheStats )
 		);
 	}
 
@@ -79,7 +79,7 @@ class ResultCacheTest extends TestCase {
 		$instance = new ResultCache(
 			$this->store,
 			$this->queryFactory,
-			$this->blobStore,
+			$this->resultStore,
 			$this->cacheStats
 		);
 
@@ -89,11 +89,11 @@ class ResultCacheTest extends TestCase {
 	}
 
 	public function testGetQueryResultFromTempCache() {
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'canUse' )
 			->willReturn( true );
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'read' )
 			->willReturn( $this->container );
 
@@ -124,7 +124,7 @@ class ResultCacheTest extends TestCase {
 		$instance = new ResultCache(
 			$this->store,
 			$this->queryFactory,
-			$this->blobStore,
+			$this->resultStore,
 			$this->cacheStats
 		);
 
@@ -137,21 +137,21 @@ class ResultCacheTest extends TestCase {
 	}
 
 	public function testPurgeCacheByQueryList() {
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'canUse' )
 			->willReturn( true );
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'exists' )
 			->willReturn( true );
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'delete' );
 
 		$instance = new ResultCache(
 			$this->store,
 			$this->queryFactory,
-			$this->blobStore,
+			$this->resultStore,
 			$this->cacheStats
 		);
 
@@ -159,10 +159,10 @@ class ResultCacheTest extends TestCase {
 	}
 
 	public function testNoCache() {
-		$this->blobStore->expects( $this->never() )
+		$this->resultStore->expects( $this->never() )
 			->method( 'read' );
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'canUse' )
 			->willReturn( true );
 
@@ -194,7 +194,7 @@ class ResultCacheTest extends TestCase {
 		$instance = new ResultCache(
 			$this->store,
 			$this->queryFactory,
-			$this->blobStore,
+			$this->resultStore,
 			$this->cacheStats
 		);
 
@@ -210,7 +210,7 @@ class ResultCacheTest extends TestCase {
 		$instance = new ResultCache(
 			$this->store,
 			$this->queryFactory,
-			$this->blobStore,
+			$this->resultStore,
 			$this->cacheStats
 		);
 
@@ -221,15 +221,15 @@ class ResultCacheTest extends TestCase {
 	public function testPurgeCacheBySubject() {
 		$subject = new WikiPage( 'Foo', NS_MAIN );
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'canUse' )
 			->willReturn( true );
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'exists' )
 			->willReturn( true );
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'delete' )
 			->with( '1d1e1d94a78b9476c8213a16febe2c9b' );
 
@@ -239,7 +239,7 @@ class ResultCacheTest extends TestCase {
 		$instance = new ResultCache(
 			$this->store,
 			$this->queryFactory,
-			$this->blobStore,
+			$this->resultStore,
 			$this->cacheStats
 		);
 
@@ -249,15 +249,15 @@ class ResultCacheTest extends TestCase {
 	public function testPurgeCacheBySubjectWithHasHMutation() {
 		$subject = new WikiPage( 'Foo', NS_MAIN );
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'canUse' )
 			->willReturn( true );
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'exists' )
 			->willReturn( true );
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'delete' )
 			->with( '1e5509cfde15f1f569db295e845ce997' );
 
@@ -267,7 +267,7 @@ class ResultCacheTest extends TestCase {
 		$instance = new ResultCache(
 			$this->store,
 			$this->queryFactory,
-			$this->blobStore,
+			$this->resultStore,
 			$this->cacheStats
 		);
 
@@ -287,15 +287,15 @@ class ResultCacheTest extends TestCase {
 		$subject->expects( $this->never() )
 			->method( 'asBase' );
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'canUse' )
 			->willReturn( true );
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'exists' )
 			->willReturn( true );
 
-		$this->blobStore->expects( $this->atLeastOnce() )
+		$this->resultStore->expects( $this->atLeastOnce() )
 			->method( 'delete' )
 			->with( 'dc63f8b4cab1bb1214979932b637cdec' );
 
@@ -305,7 +305,7 @@ class ResultCacheTest extends TestCase {
 		$instance = new ResultCache(
 			$this->store,
 			$this->queryFactory,
-			$this->blobStore,
+			$this->resultStore,
 			$this->cacheStats
 		);
 
@@ -319,7 +319,7 @@ class ResultCacheTest extends TestCase {
 		$instance = new ResultCache(
 			$this->store,
 			$this->queryFactory,
-			$this->blobStore,
+			$this->resultStore,
 			$this->cacheStats
 		);
 


### PR DESCRIPTION
Follows the 7.0.0 removal of the bundled Onoi cache libraries.

After the query-result-cache reroute, the "BlobStore"-named factory sites all construct a `SMW\Query\Cache\QueryResultStore`, so the name is residue. This renames them and tidies two pieces of now-dead cache cruft surfaced alongside.

### Rename

- `ServicesFactory::newBlobStore()` and `CacheFactory::newBlobStore()` become `newQueryResultStore()`.
- The `'BlobStore'` service route and `testOverrides['BlobStore']` key become `'QueryResultStore'`.
- `ResultCache`'s `$blobStore` property becomes `$resultStore`.
- Three cosmetic code comments.

The persisted `'blobstore'` cache-key prefix and the byte-for-byte key format are deliberately left untouched.

### Tidy

- `SMW\InMemoryPoolCache`'s constructor no longer takes a `CacheFactory` argument it never read (the class is a singleton via `getInstance()`).
- `CacheFactory::getPurgeCacheKey()` is removed (no production callers, redundant with `smwfCacheKey()`); the tests that used it to compute the expected purge-marker key now call `smwfCacheKey( ArticlePurge::CACHE_NAMESPACE, $id )` directly, which is the same path production uses.

Recorded in the 7.0.0 release notes and the migration guide.

### Verification

`composer analyze` and `composer phan` are clean, with no remaining reference to the renamed or removed symbols. The `ResultCache`, `CacheFactory`, `InMemoryPoolCache`, `ArticlePurge`, and `ParserAfterTidy` unit tests pass, as does the registered-hook integration test.