### PR TITLE
Remove the orphaned ServicesFactory::getLogger() accessor

### DIFF
--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -596,12 +596,6 @@ return [
 	},
 
 	'SMW.Logger' => static function ( MediaWikiServices $services ): LoggerInterface {
-		$servicesFactory = ServicesFactory::getInstance();
-
-		if ( $servicesFactory->hasTestOverride( 'Logger' ) ) {
-			return $servicesFactory->getLogger();
-		}
-
 		return LoggerFactory::getInstance( 'smw' );
 	},
 

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -12,7 +12,6 @@ use MediaWiki\Parser\ParserOutput;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\Title\Title;
 use MediaWiki\User\User;
-use Psr\Log\LoggerInterface;
 use RuntimeException;
 use SMW\CacheFactory;
 use SMW\Connection\ConnectionManager;
@@ -328,7 +327,6 @@ class ServicesFactory {
 			'ContentParserFactory' => fn () => $this->getContentParserFactory(),
 			'ParserDataFactory' => fn () => $this->getParserDataFactory(),
 			'PageUpdaterFactory' => fn () => $this->getPageUpdaterFactory(),
-			'Logger' => fn () => $this->getLogger(),
 			'MwCollaboratorFactory' => fn () => $this->getMwCollaboratorFactory(),
 			'NamespaceExaminer' => fn () => $this->getNamespaceExaminer(),
 			'DataValueServiceFactory' => fn () => $this->getDataValueServiceFactory(),
@@ -671,17 +669,6 @@ class ServicesFactory {
 		}
 
 		return MediaWikiServices::getInstance()->getService( 'SMW.PageUpdaterFactory' );
-	}
-
-	/**
-	 * @since 7.0.0
-	 */
-	public function getLogger(): LoggerInterface {
-		if ( array_key_exists( 'Logger', $this->testOverrides ) ) {
-			return $this->testOverrides['Logger'];
-		}
-
-		return MediaWikiServices::getInstance()->getService( 'SMW.Logger' );
 	}
 
 	/**


### PR DESCRIPTION
## What

Removes `ServicesFactory::getLogger()`, its `'Logger'` `singleton()` / `create()` dispatch-table entry, and the now-unused `Psr\Log\LoggerInterface` import. The `SMW.Logger` service closure in `ServiceWiring.php` is simplified to resolve `LoggerFactory::getInstance( 'smw' )` directly.

## Why

`getLogger()` and the `SMW.Logger` service were both introduced earlier in the 7.0.0 development cycle (both `@since 7.0.0`, unreleased) to support logger injection. The accessor backed a test-override seam for the `SMW.Logger` service, but it has no remaining callers: production code resolves its PSR-3 logger via `LoggerFactory::getInstance( 'smw' )` directly, and no test registers a `'Logger'` override. With no caller, the `hasTestOverride( 'Logger' )` branch inside the `SMW.Logger` closure was dead and the dispatch-table entry was unreachable.

## Scope note

The `SMW.Logger` service itself is kept. It is load-bearing, injected into several components (hook handlers and a job) through `extension.json` `services` arrays. Only the dead accessor, the dispatch entry, and the override branch are removed. In production the closure already returned `LoggerFactory::getInstance( 'smw' )`, so resolution of `SMW.Logger` is unchanged for every consumer.

## Verification

- `composer analyze` (lint + PHPCS): clean
- `composer phan`: clean
- `composer phpunit --testsuite=semantic-mediawiki-unit`: green
- Resolving `SMW.Logger` from the live service container returns a `Psr\Log\LoggerInterface`, matching the previous non-override behaviour
