### PR TITLE
Fix intermittent lock-wait timeout in integration test teardown

### DIFF
--- a/tests/phpunit/SMWIntegrationTestCase.php
+++ b/tests/phpunit/SMWIntegrationTestCase.php
@@ -130,13 +130,20 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 			$this->testEnvironment->tearDown();
 		}
 
-		// Commit or rollback any open transactions from page deletions
-		// (flushPages) before MW's tearDown truncates tables. Without this,
-		// delete transactions can hold row locks that block TRUNCATE,
-		// causing "Lock wait timeout" errors.
-		MediaWikiServices::getInstance()
-			->getDBLoadBalancerFactory()
-			->commitPrimaryChanges( __METHOD__ );
+		// Before MediaWiki's own teardown truncates the test tables, make sure no
+		// database connection still holds an open transaction or session-level
+		// lock that could block the TRUNCATE and surface as a "Lock wait timeout"
+		// (1205). The truncation runs in MediaWikiIntegrationTestCase's @after
+		// hook, after this method returns, so the cleanup must happen here.
+		//
+		// commitPrimaryChanges() commits pending primary writes (for example the
+		// transactions left open by page deletions in flushPages) and flushes
+		// replica snapshots. flushPrimarySessions() additionally releases any
+		// lingering named or table locks on the primary connections, which
+		// commitPrimaryChanges() does not do.
+		$lbFactory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
+		$lbFactory->commitPrimaryChanges( __METHOD__ );
+		$lbFactory->flushPrimarySessions( __METHOD__ );
 
 		parent::tearDown();
 	}


### PR DESCRIPTION
Fixes #6387

## Problem

Integration tests intermittently fail in CI with:

```
Wikimedia\Rdbms\DBQueryError: Error 1205: Lock wait timeout exceeded; try restarting transaction
Function: MediaWikiIntegrationTestCase::truncateTables
Query: TRUNCATE TABLE `unittest_smw_...`
```

The failing test and the truncated table vary from run to run; the only constant is that a `TRUNCATE` issued during teardown waits the full `innodb_lock_wait_timeout` and then errors. This has appeared sporadically for months and has been hard to pin down because it does not reproduce reliably.

## Root cause

`SMWIntegrationTestCase` forces normal (non-temporary) tables, so MediaWiki does not wrap each test in a transaction and teardown depends on every database connection being flushed before the test tables are truncated.

`tearDown()` already calls `commitPrimaryChanges()`, which commits pending primary writes (such as the transactions left open by page deletions in `flushPages`) and flushes replica snapshots. It does not, however, release session-level state such as named locks or table locks held on the primary connections. When such a lock lingers, MediaWiki's table truncation in its `@after` teardown hook blocks on it and fails with error 1205.

## Fix

Add `flushPrimarySessions()` after the existing `commitPrimaryChanges()` so that no connection still holds a lingering named or table lock when the test tables are truncated. The call order matters: `commitPrimaryChanges()` first drains pending primary writes, which leaves the transaction round in the state `flushPrimarySessions()` requires.

## Validation

This change ran repeated full iterations of the integration suite locally with no errors and, in particular, no `DBTransactionError` from the new call, confirming it is safe in teardown. The intermittent timeout itself could not be reproduced locally even under an aggressively low lock-wait timeout and CPU starvation, so the effectiveness of the fix against the rare race is expected to be borne out by CI over time rather than demonstrated by a local reproduction.

## Scope note

This addresses lock-holding connections managed by the test's load balancer factory on the single-server topology used in CI. A read snapshot held on a physically separate replica server would be outside the scope of these calls, but that topology is not used by the integration tests.