### PR TITLE
Use temporary tables for integration tests to fix lock-wait timeouts

### DIFF
--- a/tests/phpunit/SMWIntegrationTestCase.php
+++ b/tests/phpunit/SMWIntegrationTestCase.php
@@ -36,11 +36,6 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 
 		// Load default settings specific to SMW
 		TestEnvironment::loadDefaultSettings( [ 'smwgQEqualitySupport' ] );
-
-		// Don't use temporary tables to avoid "Error: 1137 Can't reopen table" on mysql.
-		// Must be set before maybeSetupDB() reads this flag.
-		// https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/80/commits/565061cd0b9ccabe521f0382938d013a599e4673
-		static::setCliArg( 'use-normal-tables', true );
 	}
 
 	/**
@@ -129,21 +124,6 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 		if ( $this->testEnvironment !== null ) {
 			$this->testEnvironment->tearDown();
 		}
-
-		// Before MediaWiki's own teardown truncates the test tables, make sure no
-		// database connection still holds an open transaction or session-level
-		// lock that could block the TRUNCATE and surface as a "Lock wait timeout"
-		// (1205). The truncation runs in MediaWikiIntegrationTestCase's @after
-		// hook, after this method returns, so the cleanup must happen here.
-		//
-		// commitPrimaryChanges() commits pending primary writes (for example the
-		// transactions left open by page deletions in flushPages) and flushes
-		// replica snapshots. flushPrimarySessions() additionally releases any
-		// lingering named or table locks on the primary connections, which
-		// commitPrimaryChanges() does not do.
-		$lbFactory = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();
-		$lbFactory->commitPrimaryChanges( __METHOD__ );
-		$lbFactory->flushPrimarySessions( __METHOD__ );
 
 		parent::tearDown();
 	}


### PR DESCRIPTION
## Problem

Integration tests intermittently fail in CI with:

```
Wikimedia\Rdbms\DBQueryError: Error 1205: Lock wait timeout exceeded
Function: MediaWikiIntegrationTestCase::truncateTables
Query: TRUNCATE TABLE `unittest_smw_...`
```

The failing test and truncated table vary from run to run; the only constant is that a `TRUNCATE` issued during teardown waits the full `innodb_lock_wait_timeout` and then errors. This has appeared sporadically for months.

## Root cause

`SMWIntegrationTestCase` forced normal (non-temporary) tables, so MediaWiki does not wrap each test in a transaction and teardown empties the shared test tables with `TRUNCATE`. When another database connection still holds an open transaction touching one of those tables, the `TRUNCATE` blocks and times out.

Two previous fixes added connection flushes to `tearDown()` (`commitPrimaryChanges` in #6387, `flushPrimarySessions` in #6935). Both operate on the primary/writer connections only and do not reach SMW's read-role connection, whose lingering snapshot is what blocks the `TRUNCATE`, so the flake survived both.

## Fix

Remove the `use-normal-tables` flag so MediaWiki uses its default temporary-table isolation. Temporary tables are connection-local and are dropped with the session rather than truncated, which removes the cross-connection `TRUNCATE` entirely and with it the lock-wait timeout. The now-unnecessary teardown flushes are removed as well.

## On the historical 1137 reason

The flag was added in 2014 (PR #80) to work around "Error 1137 Can't reopen table" on MySQL. That limitation no longer reproduces on the MariaDB versions CI runs: the full SMW integration suite passes with temporary tables, with no 1137 and no lock-wait timeout.

## Validation

The full integration suite was run locally with temporary tables: all tests pass, with no errors, no failures, no 1137, and no lock-wait timeout, identical to the baseline run with normal tables. Because the lock-wait timeout is an intermittent race, CI across the full matrix is the real long-term confirmation; this change removes the mechanism that causes the timeout rather than mitigating the symptom.