### PR TITLE
Split CI into separate static-analysis, test, and coverage jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,67 +11,139 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+env:
+  PHP_EXTENSIONS: pcntl
+
 jobs:
-  build:
-
+  # Static analysis. phpcs, phan and minus-x are version-independent: phan
+  # targets PHP 8.1 via .phan/config.php and the phpcs ruleset has no
+  # PHPCompatibility/testVersion, so the full set (composer analyze:ci) runs
+  # once on the primary version. parallel-lint parses with the host PHP, so it
+  # IS version-dependent and runs on every supported PHP version (lint only on
+  # the non-primary legs).
+  static-analysis:
+    name: Static analysis (MW ${{ matrix.mw }}, PHP ${{ matrix.php }}, ${{ matrix.db }})
     runs-on: ubuntu-latest
-    continue-on-error: ${{ matrix.experimental }}
-
     strategy:
+      fail-fast: false
       matrix:
         include:
-          - mediawiki_version: '1.43'
-            php_version: 8.2
-            database_type: mysql
-            database_image: "mariadb:11.2"
-            coverage: true
-            experimental: false
-          - mediawiki_version: '1.43'
-            php_version: 8.2
-            database_type: mysql
-            database_image: "mariadb:11.2"
-            coverage: false
-            experimental: false
-          - mediawiki_version: '1.44'
-            php_version: 8.3
-            database_type: mysql
-            database_image: "mariadb:11.8"
-            coverage: false
-            experimental: false
-          - mediawiki_version: '1.45'
-            php_version: 8.4
-            database_type: mysql
-            database_image: "mariadb:11.8"
-            coverage: false
-            experimental: false
-
+          - { mw: '1.43', php: 8.2, db: "mariadb:11.2", full: true }
+          - { mw: '1.44', php: 8.3, db: "mariadb:11.8", full: false }
+          - { mw: '1.45', php: 8.4, db: "mariadb:11.8", full: false }
     env:
-      MW_VERSION: ${{ matrix.mediawiki_version }}
-      PHP_VERSION: ${{ matrix.php_version }}
-      DB_TYPE: ${{ matrix.database_type }}
-      DB_IMAGE: ${{ matrix.database_image }}
-      PHP_EXTENSIONS: pcntl
-
+      MW_VERSION: ${{ matrix.mw }}
+      PHP_VERSION: ${{ matrix.php }}
+      DB_TYPE: mysql
+      DB_IMAGE: ${{ matrix.db }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: recursive
-                   
+
       - name: Update submodules
         run: git submodule update --init --remote
 
-      - name: Run tests
-        run: make ci
-        if: matrix.coverage == false
+      - name: Build image and install MediaWiki
+        run: make install
+
+      - name: Run static analysis
+        run: |
+          set -e
+          CID=$(docker ps -q \
+            --filter "label=com.docker.compose.project=semanticmediawiki-mysql" \
+            --filter "label=com.docker.compose.service=wiki")
+          if [ -z "$CID" ]; then echo "wiki container not found"; exit 1; fi
+          if [ "${{ matrix.full }}" = "true" ]; then
+            docker exec -w /var/www/html/extensions/SemanticMediaWiki "$CID" composer analyze:ci
+          else
+            docker exec -w /var/www/html/extensions/SemanticMediaWiki "$CID" composer lint
+          fi
+
+  # Unit and integration tests per PHP/MediaWiki version. Unit and integration
+  # run as SEPARATE phpunit invocations: MediaWikiUnitTestCase does not restore
+  # globals, so sharing a process leaves config drift that fails integration
+  # assertions (e.g. ConfigDefaultsParityTest). The integration suite runs as
+  # one unit; it has inter-test ordering dependencies (fulltext index state,
+  # query-result cache) that make splitting it by directory unsafe.
+  tests:
+    name: Test (MW ${{ matrix.mw }}, PHP ${{ matrix.php }}, ${{ matrix.db }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { mw: '1.43', php: 8.2, db: "mariadb:11.2" }
+          - { mw: '1.44', php: 8.3, db: "mariadb:11.8" }
+          - { mw: '1.45', php: 8.4, db: "mariadb:11.8" }
+    env:
+      MW_VERSION: ${{ matrix.mw }}
+      PHP_VERSION: ${{ matrix.php }}
+      DB_TYPE: mysql
+      DB_IMAGE: ${{ matrix.db }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Update submodules
+        run: git submodule update --init --remote
+
+      - name: Build image and install MediaWiki
+        run: make install
+
+      - name: Run unit tests
+        run: make composer-phpunit COMPOSER_PARAMS='-- --testsuite semantic-mediawiki-unit --fail-on-empty-test-suite'
+
+      - name: Run integration tests
+        run: make composer-phpunit COMPOSER_PARAMS='-- --testsuite semantic-mediawiki-check,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure --fail-on-empty-test-suite'
+
+  # Coverage is unchanged: same suite, same Xdebug instrumentation, codecov
+  # upload. It is not on the fast-feedback path (the test jobs report pass/fail
+  # well before coverage finishes).
+  coverage:
+    name: Coverage (MW 1.43, PHP 8.2, mariadb:11.2)
+    runs-on: ubuntu-latest
+    env:
+      MW_VERSION: '1.43'
+      PHP_VERSION: 8.2
+      DB_TYPE: mysql
+      DB_IMAGE: "mariadb:11.2"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Update submodules
+        run: git submodule update --init --remote
 
       - name: Run tests with coverage
         run: make ci-coverage COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-unit,semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
-        if: matrix.coverage == true
 
       - name: Upload code coverage
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/php/coverage.xml
-        if: matrix.coverage == true
+
+  # Single fixed-name gate so branch protection does not have to list every
+  # matrix leg (which would need updating on each version change). Require only
+  # "CI success" as a status check on master. Drop `coverage` from `needs` if
+  # merges should gate on the fast feedback path only.
+  ci-success:
+    name: CI success
+    runs-on: ubuntu-latest
+    needs: [ static-analysis, tests, coverage ]
+    if: ${{ always() }}
+    steps:
+      - name: Verify all jobs succeeded
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: |
+          echo "One or more CI jobs did not succeed:"
+          echo "  static-analysis: ${{ needs.static-analysis.result }}"
+          echo "  tests:           ${{ needs.tests.result }}"
+          echo "  coverage:        ${{ needs.coverage.result }}"
+          exit 1

--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,12 @@
 			"@lint",
 			"@phpcs"
 		],
+		"analyze:ci": [
+			"@lint",
+			"@phpcs",
+			"@minus-x",
+			"@phan"
+		],
 		"fix": [
 			"@phpcs-fix"
 		],


### PR DESCRIPTION
## Why

The single matrixed `build` job ran the full `composer test` (lint, phpcs, minus-x, phan, unit, integration) on every PHP/MediaWiki version leg. The static analysis therefore ran on all three legs and only surfaced after the slow integration suite, so a lint or phan error took the full run to appear.

## What changed

The one job becomes four:

- **`static-analysis`** runs phpcs, minus-x and phan once via a new `composer analyze:ci` script. These are version-independent (phan targets PHP 8.1 via `.phan/config.php`; the phpcs ruleset has no `PHPCompatibility`/`testVersion`). `parallel-lint` parses with the host PHP, so it runs on every supported PHP version (lint-only on the non-primary legs).
- **`tests`** runs unit and integration per version, as two separate phpunit invocations. They must not share a process: `MediaWikiUnitTestCase` does not restore globals, so running unit before integration leaves config drift that fails integration assertions.
- **`coverage`** is unchanged.
- **`ci-success`** is a small aggregate job that succeeds only when the others do, giving a single stable status-check name.

`--fail-on-empty-test-suite` is set on the test invocations so a mistyped suite name fails instead of passing green.

The integration suite still runs as one unit. It has inter-test ordering dependencies (fulltext index state and the query-result cache) that make splitting it by directory unsafe, so this change does not attempt that.

## Effect

Static analysis fails in a few minutes instead of being buried mid-run, and no longer runs on every version leg. The integration suite is unchanged, so per-version test feedback drops by roughly the analysis time it no longer carries.

## Action required for maintainers

The job names change, so any branch-protection rule on `master` that requires the old `build (...)` status checks must be updated to require `CI success` instead (and the old contexts removed). Otherwise pull requests will wait on status checks that no longer report.