### PR TITLE
Rename the `<section>` parser tag to `<smwsection>`

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -2113,7 +2113,7 @@ continue to work without a deprecation notice. The mapping is:
 
 ## $smwgSupportSectionTag
 
-When `true`, enables `<section>…</section>` tag support.
+When `true`, enables `<smwsection>…</smwsection>` tag support.
 
 **Since:** 3.0
 **Default:** `true`

--- a/docs/migration/7.0.md
+++ b/docs/migration/7.0.md
@@ -81,6 +81,12 @@ The runtime shim that rewrote settings deprecated in SMW 3.1 and 3.2 to their re
 | `$smwgCacheUsage['smwgUnusedPropertiesCacheExpiry']` | `$smwgCacheUsage['special.unusedproperties']` |
 | `$smwgCacheUsage['smwgWantedPropertiesCacheExpiry']` | `$smwgCacheUsage['special.wantedproperties']` |
 
+### Renamed `<section>` parser tag
+
+SMW's `<section>` parser tag is renamed to `<smwsection>` so it no longer collides with the `<section>` tag registered by extensions such as [LabeledSectionTransclusion](https://www.mediawiki.org/wiki/Extension:Labeled_Section_Transclusion). The rendered output is unchanged (still an HTML `<section class="smw-property-specification">` element), so styling and property-page tabs are unaffected; only the wikitext tag name changes.
+
+Saved pages are not migrated automatically. Update any page (typically in the `Property:` namespace) that wraps content in `<section>...</section>` for SMW, replacing the tags with `<smwsection>...</smwsection>`. The `$smwgSupportSectionTag` setting still controls whether SMW registers its tag; with the collision resolved, most wikis no longer need to disable it.
+
 ## Developers
 
 ### Removed job aliases

--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -69,6 +69,8 @@ Adds MediaWiki 1.45 support (see [Compatibility](#compatibility)).
 
   Note: `enableSemantics()` itself still exists but is deprecated as a no-op (see Deprecated).
 
+* **SMW's `<section>` parser tag renamed to `<smwsection>`.** The tag that marks up property-page specification content is now `<smwsection>…</smwsection>`, so it no longer collides with the `<section>` tag registered by extensions such as [LabeledSectionTransclusion](https://www.mediawiki.org/wiki/Extension:Labeled_Section_Transclusion). The rendered output is unchanged (still an HTML `<section class="smw-property-specification">` element), so styling and property-page tabs behave exactly as before; only the wikitext you type changes. Saved pages are not migrated automatically: update any page (typically in the `Property:` namespace) that uses `<section>` for SMW by replacing the opening and closing tags with `<smwsection>` and `</smwsection>`. The `$smwgSupportSectionTag` setting still controls whether SMW registers its tag, and most wikis no longer need to disable it. ([#5687](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5687))
+
 ### New features and enhancements
 
 * The `smw-admin` right is now granted to the `sysop` group by default, so wiki administrators can reach `Special:SemanticMediaWiki` out of the box without first joining the `smwadministrator` group. The `smwadministrator` group is retained for installs that want SMW administration to be a separate role; revoke the new default with `$wgGroupPermissions['sysop']['smw-admin'] = false;` in `LocalSettings.php`.

--- a/extension.json
+++ b/extension.json
@@ -1885,7 +1885,7 @@
 		},
 		"SupportSectionTag": {
 			"value": true,
-			"description": "When `true`, enables `<section>…</section>` tag support."
+			"description": "When `true`, enables `<smwsection>…</smwsection>` tag support."
 		},
 		"Translate": {
 			"value": false,

--- a/src/MediaWiki/Hooks/ParserFirstCallInit.php
+++ b/src/MediaWiki/Hooks/ParserFirstCallInit.php
@@ -87,7 +87,7 @@ class ParserFirstCallInit implements ParserFirstCallInitHook {
 			return $parser->recursiveTagParse( $resultText, $frame );
 		} );
 
-		// Support for <section> ... </section>
+		// Support for <smwsection> ... </smwsection>
 		SectionTag::register(
 			$parser,
 			$this->settings->get( 'smwgSupportSectionTag' )

--- a/src/ParserFunctions/SectionTag.php
+++ b/src/ParserFunctions/SectionTag.php
@@ -7,7 +7,7 @@ use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 
 /**
- * To support the generation of <section> ... </section>
+ * To support the generation of <smwsection> ... </smwsection>
  *
  * @license GPL-2.0-or-later
  * @since 3.0
@@ -38,7 +38,7 @@ class SectionTag {
 			return false;
 		}
 
-		$parser->setHook( 'section', static function ( ?string $input, array $args, Parser $parser, PPFrame $frame ) {
+		$parser->setHook( 'smwsection', static function ( ?string $input, array $args, Parser $parser, PPFrame $frame ) {
 			return ( new self( $parser, $frame ) )->parse( $input, $args );
 		} );
 

--- a/tests/phpunit/Unit/ParserFunctions/SectionTagTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/SectionTagTest.php
@@ -40,7 +40,8 @@ class SectionTagTest extends TestCase {
 
 	public function testRegister_Enabled() {
 		$this->parser->expects( $this->once() )
-			->method( 'setHook' );
+			->method( 'setHook' )
+			->with( 'smwsection', $this->anything() );
 
 		$this->assertTrue(
 			SectionTag::register( $this->parser )


### PR DESCRIPTION
## Summary

SMW registers a `<section>` wikitext parser tag that collides with the `<section>` tag registered by extensions such as [LabeledSectionTransclusion](https://www.mediawiki.org/wiki/Extension:Labeled_Section_Transclusion). MediaWiki's `Parser::setHook` is last-wins, so whichever extension runs its `ParserFirstCallInit` hook last silently overwrites the other's `<section>` handler. The `$smwgSupportSectionTag` flag was added only as an escape hatch to let admins disable SMW's tag in this situation.

This renames SMW's tag to `<smwsection>` so SMW and LabeledSectionTransclusion can both provide their feature without colliding.

Resolves #5687.

## What changes

- The wikitext tag SMW registers is now `<smwsection>` instead of `<section>`.
- The rendered output is unchanged: the tag still produces an HTML `<section class="smw-property-specification">` element, so the property-page specification extraction and the associated CSS are untouched. Only the wikitext tag name changes.
- `$smwgSupportSectionTag` is kept as a registration toggle. With the collision resolved, most wikis no longer need to disable it, so its description is updated to match.
- No backward-compatibility alias is registered: keeping the old `<section>` tag alongside the new one would re-introduce the collision this removes.

## Breaking change

Wikis that use `<section>...</section>` in wikitext (typically on `Property:` pages) to produce SMW's specification block must update those pages to `<smwsection>...</smwsection>`. Saved pages are not migrated automatically; after upgrade the old markup falls through to another extension's `<section>` handler if one is installed, or renders as literal text otherwise.

This is documented under "Action required when upgrading" in the 7.0.0 release notes and in the migration guide.

## Testing

`SectionTagTest::testRegister_Enabled` now pins the registered tag name to `smwsection`; previously no test asserted the tag name, so a rename would have passed silently.
