### PR TITLE
Replace internal wgMonthNames with mediawiki.language.months in JS

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -228,6 +228,7 @@ Adds MediaWiki 1.45 support (see [Compatibility](#compatibility)).
 * PHPUnit test suite reorganized into `Unit/` and `Integration/` directories
 * Numerous static analysis (phan) errors fixed
 * Migrated `Special:Browse`'s search form from the deprecated `mediawiki.ui` ResourceLoader modules to Codex CSS-only components, ahead of `mediawiki.ui`'s removal in MediaWiki 1.46 ([#6476](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6476))
+* Migrated client-side date rendering off MediaWiki's internal `wgMonthNames` JavaScript config variable to the `mediawiki.language.months` module ([#3851](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/3851))
 * CI updated: added MediaWiki 1.45 to the test matrix, added cancellation of in-progress runs on new pushes, removed Travis CI leftovers
 
 ## Upgrading

--- a/extension.json
+++ b/extension.json
@@ -599,6 +599,7 @@
 				"tests/qunit/smw/query/ext.smw.query.test.js"
 			],
 			"dependencies": [
+				"mediawiki.language.months",
 				"ext.smw",
 				"ext.smw.tooltip",
 				"ext.smw.query",
@@ -830,6 +831,7 @@
 				"mediawiki.Title",
 				"mediawiki.storage",
 				"mediawiki.util",
+				"mediawiki.language.months",
 				"ext.smw",
 				"ext.smw.query"
 			]

--- a/res/smw/data/ext.smw.dataItem.time.js
+++ b/res/smw/data/ext.smw.dataItem.time.js
@@ -99,15 +99,11 @@
 	};
 
 	/**
-	 * Map wgMonthNames and create an indexed array
-	 *
+	 * Zero-indexed array of localised month names in the user interface
+	 * language, provided by the mediawiki.language.months module (declared
+	 * as a dependency of the ext.smw.api module).
 	 */
-	var monthNames = [];
-	$.map ( mw.config.get( 'wgMonthNames' ), function( index ) {
-		if( index !== '' ) {
-			monthNames.push( index );
-		}
-	} );
+	var monthNames = mw.language.months.names;
 
 	/**
 	 * Constructor

--- a/tests/qunit/smw/data/ext.smw.data.test.js
+++ b/tests/qunit/smw/data/ext.smw.data.test.js
@@ -182,12 +182,7 @@
 		assert.expect( 4 );
 
 		// Use as helper to fetch language dep. month name
-		var monthNames = [];
-		$.map ( mw.config.get( 'wgMonthNames' ), function( value ) {
-			if( value !== '' ){
-				monthNames.push( value );
-			}
-		} );
+		var monthNames = mw.language.months.names;
 
 		// Testing indirect via the smw.Api otherwise the whole JSON parsing
 		// needs to be copied

--- a/tests/qunit/smw/data/ext.smw.dataItem.time.test.js
+++ b/tests/qunit/smw/data/ext.smw.dataItem.time.test.js
@@ -116,12 +116,7 @@
 		var result;
 
 		// Use as helper to fetch language dep. month name
-		var monthNames = [];
-		$.map ( mw.config.get( 'wgMonthNames' ), function( index ) {
-			if( index !== '' ){
-				monthNames.push( index );
-			}
-		} );
+		var monthNames = mw.language.months.names;
 
 		result = new smw.dataItem.time( '1362200400' );
 		assert.equal( result.getMediaWikiDate(), '2 ' + monthNames[2] + ' 2013 05:00:00', pass + 'returned a MW date and time formatted string' );


### PR DESCRIPTION
## What

The client-side date formatter `smw.dataItem.time` read month names from `mw.config.get( 'wgMonthNames' )`. In MediaWiki 1.43 that config variable is internal to MediaWiki core: it lives in `OutputPage`'s "Internal variables for MediaWiki core" block, separate from the supported config variables intended for extensions and gadgets. This change sources the month names from the `mediawiki.language.months` ResourceLoader module (`mw.language.months.names`), which is the supported replacement.

## Changes

* `res/smw/data/ext.smw.dataItem.time.js`: read `mw.language.months.names` instead of `mw.config.get( 'wgMonthNames' )`. That array is already zero-indexed, so the loop that stripped the empty leading slot from `wgMonthNames` is removed. Indexing by `Date.getUTCMonth()` is unchanged.
* `extension.json`: declare `mediawiki.language.months` as a dependency of the `ext.smw.api` module (which bundles the formatter) and of the `ext.smw.tests` QUnit module (whose specs reference `mw.language.months.names` directly).
* The QUnit specs that derived their expected month names from `wgMonthNames` now read from the same source as the production code.
* Release note under Internal improvements.

## Behavior

`wgMonthNames` is built from the page content language, whereas `mediawiki.language.months` is built from the user interface language. On a monolingual wiki, and wherever a reader's interface language is the content language, output is unchanged. On a multilingual wiki where a reader's interface language differs from the page content language, month names in JavaScript-rendered query result dates now follow the interface language. This matches SMW's server-side date formatting, where `TimeValueFormatter::getMediaWikiDate` formats with the user language by default.

Closes #3851