### PR TITLE
Fix SMWSearch fatal on Special:Search and re-enable its test

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -94,6 +94,7 @@ Adds MediaWiki 1.45 support (see [Compatibility](#compatibility)).
 
 ### Bug fixes
 
+* Fixed a fatal error on `Special:Search` when `$wgSearchType` is set to `SMWSearch` ([#6915](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6915))
 * Fixed a stray trailing space in `'edit '` that caused the edit-protection check in `ParserAfterTidy::process()` to silently match no pages since the migration off the deprecated `Title::isProtected()` API. With the typo removed, edit-protected pages once again trigger continued post-parse processing, matching the behaviour before that migration.
 * Fixed incorrect timezone offset for negative half-hour timezones (e.g., Newfoundland `-3:30`): the 30-minute component was always added positively, producing `-2.5` instead of `-3.5` ([#6478](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6478))
 * Fixed CSV export producing malformed output when values contain the delimiter character ([#6343](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6343))

--- a/src/MediaWiki/Search/ExtendedSearchEngine.php
+++ b/src/MediaWiki/Search/ExtendedSearchEngine.php
@@ -4,6 +4,7 @@ namespace SMW\MediaWiki\Search;
 
 use SearchEngine;
 use SMW\Formatters\InfoLink;
+use Wikimedia\Rdbms\IConnectionProvider;
 
 /**
  * Facade to the MediaWiki `SearchEngine` which doesn't allow any factory
@@ -25,7 +26,7 @@ class ExtendedSearchEngine extends SearchEngine {
 	 *
 	 * @since 3.1
 	 */
-	public function __construct( $connection = null ) {
+	public function __construct( ?IConnectionProvider $connection = null ) {
 		// It is common practice to avoid construction work in the constructor
 		// but we are unable to define a factory or callable and this is the only
 		// place to create an instance.

--- a/src/MediaWiki/Search/SearchEngineFactory.php
+++ b/src/MediaWiki/Search/SearchEngineFactory.php
@@ -9,6 +9,7 @@ use SMW\MediaWiki\Search\Exception\SearchDatabaseInvalidTypeException;
 use SMW\MediaWiki\Search\Exception\SearchEngineInvalidTypeException;
 use SMW\MediaWiki\Search\ProfileForm\ProfileForm;
 use SMW\Services\ServicesFactory as ApplicationFactory;
+use Wikimedia\Rdbms\IConnectionProvider;
 
 /**
  * @license GPL-2.0-or-later
@@ -21,19 +22,14 @@ class SearchEngineFactory {
 	/**
 	 * @since 3.1
 	 *
-	 * @param mixed $connection Either IConnectionProvider (MW 1.41+) or IDatabase (MW 1.40)
-	 *
-	 * @return SearchEngine
 	 * @throws SearchEngineInvalidTypeException
 	 */
-	public function newFallbackSearchEngine( $connection = null ) {
+	public function newFallbackSearchEngine( ?IConnectionProvider $connection = null ): SearchEngine {
 		$applicationFactory = ApplicationFactory::getInstance();
 		$settings = $applicationFactory->getSettings();
 
 		if ( $connection === null ) {
-			// For MW 1.41+, getConnectionManager()->getConnection() returns IConnectionProvider
-			// For MW 1.40, it returns IDatabase
-			$connection = $applicationFactory->getConnectionManager()->getConnection( DB_REPLICA );
+			$connection = MediaWikiServices::getInstance()->getConnectionProvider();
 		}
 
 		$dbLoadBalancer = MediaWikiServices::getInstance()->getDBLoadBalancerFactory();

--- a/tests/phpunit/Integration/JSONScript/TestCases/special-search-0001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/special-search-0001.json
@@ -60,9 +60,6 @@
 		}
 	},
 	"meta": {
-		"skip-on": {
-			"mediawiki": [ ">1.40.x", "Check connection provider, should be IProviderConnection for MW 1.41+."]
-		},
 		"version": "2",
 		"is-incomplete": false,
 		"debug": false

--- a/tests/phpunit/JSONScriptServicesTestCaseRunner.php
+++ b/tests/phpunit/JSONScriptServicesTestCaseRunner.php
@@ -373,6 +373,16 @@ abstract class JSONScriptServicesTestCaseRunner extends JSONScriptTestCaseRunner
 			return;
 		}
 
+		// A test case may set `wgSearchType` (e.g. to `SMWSearch`) via the
+		// settings block, which TestConfig applies as a $GLOBALS write. MediaWiki's
+		// SearchEngineConfig copies `wgSearchType` into a ServiceOptions snapshot at
+		// construction, so a value snapshotted earlier in the run (the test bootstrap
+		// defaults it to SearchEngineDummy) would otherwise mask the override. Reset
+		// the config and the factory that consumes it so Special:Search resolves the
+		// configured engine instead of the stale default.
+		$this->testEnvironment->resetMediaWikiService( 'SearchEngineConfig' );
+		$this->testEnvironment->resetMediaWikiService( 'SearchEngineFactory' );
+
 		$specialPageTestCaseProcessor = new SpecialPageTestCaseProcessor(
 			$this->getStore(),
 			$this->validatorFactory->newStringValidator()


### PR DESCRIPTION
## Problem

With `$wgSearchType` set to `SMWSearch`, loading `Special:Search` fails with a fatal `TypeError`:

```
getDefaultSearchEngineTypeForDB(): Argument #1 ($dbProvider) must be of type
Wikimedia\Rdbms\IConnectionProvider, Wikimedia\Rdbms\DBConnRef given
```

`SearchEngineFactory::newFallbackSearchEngine()` resolved its connection through `ConnectionManager::getConnection( DB_REPLICA )`, which returns a `DBConnRef` (an `IDatabase`), and passed it to `getDefaultSearchEngineTypeForDB()`. That method requires an `IConnectionProvider`, matching MediaWiki core's `SearchEngineFactory::getSearchEngineClass( IConnectionProvider )`, so the no-connection path always threw on supported MediaWiki versions. The unit tests did not catch it because they always pass an `IConnectionProvider` explicitly and never exercise that production path.

Reported in #6915.

## Fix

Resolve the connection from `MediaWikiServices::getConnectionProvider()` (an `IConnectionProvider`) in the no-argument branch of `newFallbackSearchEngine()`, and type the parameter `?IConnectionProvider` there and on `ExtendedSearchEngine::__construct()`.

## Test

The `special-search-0001` JSONScript test that exercises this path was skipped on MediaWiki `>1.40.x`, so it no longer ran on any supported version. It is re-enabled here.

Re-enabling alone was not sufficient: the test sets `wgSearchType` through a `$GLOBALS` write, but MediaWiki's `SearchEngineConfig` copies `wgSearchType` into a `ServiceOptions` snapshot at construction (and the PHPUnit bootstrap defaults it to `SearchEngineDummy`), so the override was ignored and the engine stayed a dummy. `doRunSpecialTests` now resets `SearchEngineConfig` and `SearchEngineFactory` so `Special:Search` resolves the configured engine, mirroring the existing service resets used for language overrides.

A bug-fix entry is added to the 7.0.0 release notes; the fatal is present in released 6.0.x on its supported MediaWiki versions, so it is a user-facing fix.