### PR TITLE
Fix job queue watchlist popup and visibility (#6075)

### DIFF
--- a/res/smw/util/ext.smw.tooltip.tippy.js
+++ b/res/smw/util/ext.smw.tooltip.tippy.js
@@ -262,7 +262,18 @@
 		};
 
 		options.target = target;
-		tippy.delegate( context, options );
+
+		// An empty target means the tooltip is bound directly to the context
+		// element (the show() path, e.g. the personal bar job queue watchlist or
+		// Special:Ask info icons). tippy.delegate() expects a non-empty child
+		// selector and runs context.closest( '' ) on hover, which throws and
+		// silently prevents the tooltip from ever appearing. Bind directly in
+		// that case and reserve tippy.delegate() for genuine child delegation.
+		if ( target === '' ) {
+			tippy( context, options );
+		} else {
+			tippy.delegate( context, options );
+		}
 	};
 
 	/**

--- a/src/MediaWiki/Hooks/SkinTemplateNavigationUniversal.php
+++ b/src/MediaWiki/Hooks/SkinTemplateNavigationUniversal.php
@@ -28,9 +28,13 @@ class SkinTemplateNavigationUniversal implements SkinTemplateNavigation__Univers
 	 */
 	// phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps
 	public function onSkinTemplateNavigation__Universal( $sktemplate, &$links ): void {
-		if ( isset( $links['user-interface-preferences'] ) ) {
+		// Add the job queue watchlist to the notifications menu. It renders
+		// inline next to the user links in modern skins (e.g. Vector 2022) and
+		// merges into the personal tools in legacy skins, so the indicator stays
+		// visible at a glance rather than being hidden inside a dropdown.
+		if ( isset( $links['notifications'] ) ) {
 			$this->personalUrls->onPersonalUrls(
-				$links['user-interface-preferences'],
+				$links['notifications'],
 				$sktemplate->getTitle(),
 				$sktemplate
 			);

--- a/tests/phpunit/Unit/MediaWiki/Hooks/SkinTemplateNavigationUniversalTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/SkinTemplateNavigationUniversalTest.php
@@ -86,4 +86,42 @@ class SkinTemplateNavigationUniversalTest extends TestCase {
 		$this->assertArrayHasKey( 'purge', $links['actions'] );
 	}
 
+	public function testJobQueueWatchlistIsDelegatedToNotificationsMenu() {
+		$title = $this->createMock( Title::class );
+
+		$user = $this->createMock( User::class );
+		$user->method( 'isAllowed' )->willReturn( false );
+
+		$skinTemplate = $this->createMock( SkinTemplate::class );
+		$skinTemplate->method( 'getUser' )->willReturn( $user );
+		$skinTemplate->method( 'getTitle' )->willReturn( $title );
+
+		$personalUrls = $this->createMock( PersonalUrls::class );
+		$personalUrls->expects( $this->once() )
+			->method( 'onPersonalUrls' )
+			->with( [], $title, $skinTemplate );
+
+		$links = [ 'notifications' => [] ];
+
+		$instance = new SkinTemplateNavigationUniversal( $personalUrls );
+		$instance->onSkinTemplateNavigation__Universal( $skinTemplate, $links );
+	}
+
+	public function testJobQueueWatchlistIsSkippedWithoutNotificationsMenu() {
+		$user = $this->createMock( User::class );
+		$user->method( 'isAllowed' )->willReturn( false );
+
+		$skinTemplate = $this->createMock( SkinTemplate::class );
+		$skinTemplate->method( 'getUser' )->willReturn( $user );
+
+		$personalUrls = $this->createMock( PersonalUrls::class );
+		$personalUrls->expects( $this->never() )
+			->method( 'onPersonalUrls' );
+
+		$links = [];
+
+		$instance = new SkinTemplateNavigationUniversal( $personalUrls );
+		$instance->onSkinTemplateNavigation__Universal( $skinTemplate, $links );
+	}
+
 }


### PR DESCRIPTION

<img width="1406" height="632" alt="image" src="https://github.com/user-attachments/assets/1f445784-b675-4439-878c-4277a2262dfd" />


## Problem

The job queue watchlist personal bar item (gated by `$smwgJobQueueWatchlist` + the SMW curator right + the "Show the job queue watchlist in my personal bar" preference) no longer shows its popup on hover, as reported in #6075. There are two separate defects:

1. **Popup never appears.** The shared tooltip `show()` path attaches a tooltip directly to a single element by passing an empty `target` to `initFromContext()`. The Tippy 4 to 6 upgrade converted every `tippy( context, options )` call to `tippy.delegate( context, options )`. `tippy.delegate()` treats `target` as a child selector and runs `context.closest( target )` on hover; with an empty target this throws a `selector is empty` error, so no tooltip is ever created. The same `show()` path is used by the Special:Ask info icons and property page value tooltips, which were broken in the same way.

2. **Indicator hidden in modern skins.** Since the move to the `SkinTemplateNavigation::Universal` hook, the item was added to the `user-interface-preferences` menu, and the "insert before watchlist" logic no longer had an anchor (the `watchlist` entry lives in a different bucket).

## Fix

- Tooltip: in `initFromContext()`, bind directly with `tippy()` when `target` is empty and reserve `tippy.delegate()` for genuine child delegation.
- Placement: add the item to the `notifications` menu. It renders inline beside the user links in modern skins (e.g. Vector 2022) and merges into the personal tools in legacy skins, so the indicator stays visible at a glance.

## Testing

- Verified in a browser (Vector 2022 and MonoBook) that the indicator is visible inline and the popup appears on hover with the queue counts, with no console errors.
- Confirmed the in-text annotation tooltips (`.smw-highlighter` delegation) still work.
- Added unit coverage for the notifications-menu delegation.

Fixes #6075
