### PR TITLE
Fix date sorting in result tables under '.'-as-group-separator locales (#6830)

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -118,6 +118,7 @@ Adds MediaWiki 1.45 support (see [Compatibility](#compatibility)).
 * Fixed `update.php` failing with "Data too long for column 'smw_hash'" on wikis with more than 200,000 entities. The pre-upgrade hex-to-binary conversion now always runs as a single server-side `UPDATE`, regardless of row count. Setting `$smwgIgnoreUpgradeKeyCheck = true` now also lets maintenance scripts run when the schema is in an intermediate state, providing a documented escape hatch for stalled upgrades. ([#6715](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6715))
 * Removing `userlang` or `dateformat` from `$smwgSetParserCacheKeys` now correctly stops SMW from adding that key to the parser cache key. Previously a removed key was still added through a different mechanism.
 * Fixed dependency tracking for pages embedding multiple `#ask` queries that share conditions but request different printouts. Changes to a printout-only property now correctly invalidate the embedding page's cached query results.
+* Fixed date columns in the `table` and `broadtable` result formats not sorting chronologically under locales that use `.` as a digit-group separator, such as German ([#6830](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6830))
 
 ### Configuration changes
 

--- a/src/Query/ResultPrinters/TableResultPrinter.php
+++ b/src/Query/ResultPrinters/TableResultPrinter.php
@@ -6,6 +6,7 @@ use MediaWiki\Html\Html;
 use SMW\DataItems\Blob;
 use SMW\DataItems\WikiPage;
 use SMW\DataValues\DataValue;
+use SMW\DataValues\TimeValue;
 use SMW\Localizer\Message;
 use SMW\Query\PrintRequest;
 use SMW\Query\QueryResult;
@@ -24,6 +25,14 @@ use SMW\Utils\HtmlTable;
  * @author mwjames
  */
 class TableResultPrinter extends ResultPrinter {
+
+	/**
+	 * Scaling factor used to turn the Julian Day date sort key into a
+	 * decimal-free integer for `data-sort-value`. It matches the seven decimal
+	 * places that JulianDay::format() keeps, so the integer is exact and
+	 * preserves the original ordering. See #6830.
+	 */
+	private const DATE_SORT_FACTOR = 10000000;
 
 	private ?HtmlTable $htmlTable = null;
 
@@ -275,12 +284,24 @@ class TableResultPrinter extends ResultPrinter {
 				$attributes['class'] = "$columnClass smwtype$dataValueType";
 			}
 
+			// Dates expose their sort key as a Julian Day float (e.g. "2440618.5").
+			// MediaWiki's locale-aware tablesorter treats the "." as a group
+			// separator under locales such as German, strips it, and so sorts the
+			// column by the number of fractional digits rather than chronologically
+			// (#6830). Emit a decimal-free, locale-proof integer that preserves the
+			// exact ordering of the Julian Day sort key instead.
+			$sortValue = $sortKey;
+
+			if ( $dataValues[0] instanceof TimeValue && is_numeric( $sortKey ) ) {
+				$sortValue = (string)(int)round( (float)$sortKey * self::DATE_SORT_FACTOR );
+			}
+
 			if ( is_numeric( $sortKey ) ) {
-				$attributes['data-sort-value'] = $sortKey;
+				$attributes['data-sort-value'] = $sortValue;
 			}
 
 			if ( $this->isDataTable && $sortKey !== '' ) {
-				$attributes['data-order'] = $sortKey;
+				$attributes['data-order'] = $sortValue;
 			}
 
 			$alignment = trim( $printRequest->getParameter( 'align' ) );

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0210.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0210.json
@@ -34,10 +34,10 @@
 			"subject": "Example/P0210/Q1",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype&#95;wpg\">Example/P0210/1#_6c0c58959b4717205b4c1b2c3b0e3e84</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2440618.5\">1 February 1970</td>",
-					"<td class=\"smwtype&#95;wpg\">Example/P0210/1#_999d559e938eeaee07f5f52de53638e9</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2445001.5\">1 February 1982</td>",
-					"<td class=\"smwtype&#95;wpg\">Example/P0210/1#_f42111f2b6af198c265ef2d8330b6a13</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2449384.5\">1 February 1994</td>",
-					"<td class=\"smwtype&#95;wpg\">Example/P0210/1#_bdfba16fe62b82d1eadcb21054d8452b</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2453767.5\">1 February 2006</td>"
+					"<td class=\"smwtype&#95;wpg\">Example/P0210/1#_6c0c58959b4717205b4c1b2c3b0e3e84</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24406185000000\">1 February 1970</td>",
+					"<td class=\"smwtype&#95;wpg\">Example/P0210/1#_999d559e938eeaee07f5f52de53638e9</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24450015000000\">1 February 1982</td>",
+					"<td class=\"smwtype&#95;wpg\">Example/P0210/1#_f42111f2b6af198c265ef2d8330b6a13</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24493845000000\">1 February 1994</td>",
+					"<td class=\"smwtype&#95;wpg\">Example/P0210/1#_bdfba16fe62b82d1eadcb21054d8452b</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24537675000000\">1 February 2006</td>"
 				]
 			}
 		},
@@ -47,9 +47,9 @@
 			"subject": "Example/P0210/Q.2",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype&#95;wpg\">Example/P0210/2#_6af7f30c51558500a93d03f795738a61</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2440618.5\">1 February 1970</td>",
-					"<td class=\"smwtype&#95;wpg\">Example/P0210/2#_6c8f1e0c1ab31ea31cfbc3d4fa44a173</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2440677.5\">1 April 1970</td>",
-					"<td class=\"smwtype&#95;wpg\">Example/P0210/2#_dc90c230beae622cd7e0d87ea1a93b78</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2440646.5\">1 March 1970</td>"
+					"<td class=\"smwtype&#95;wpg\">Example/P0210/2#_6af7f30c51558500a93d03f795738a61</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24406185000000\">1 February 1970</td>",
+					"<td class=\"smwtype&#95;wpg\">Example/P0210/2#_6c8f1e0c1ab31ea31cfbc3d4fa44a173</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24406775000000\">1 April 1970</td>",
+					"<td class=\"smwtype&#95;wpg\">Example/P0210/2#_dc90c230beae622cd7e0d87ea1a93b78</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24406465000000\">1 March 1970</td>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0413.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0413.json
@@ -208,10 +208,10 @@
 			"subject": "Example/P0413/1a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451585.9166782\">11 February 2000 10:00:01</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451585.9166782\">2000-02-11T10:00:01</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2451585.9166782\">2000-02-11T10:00:01</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2451585.9166782\">10:00, 11 February 2000</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515859166782\">11 February 2000 10:00:01</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515859166782\">2000-02-11T10:00:01</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24515859166782\">2000-02-11T10:00:01</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24515859166782\">10:00, 11 February 2000</td>"
 				]
 			}
 		},
@@ -245,10 +245,10 @@
 			"subject": "Example/P0413/2a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451585.5\">11 February 2000</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451585.5\">2000-02-11</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2451585.5\">2000-02-11</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2451585.5\">11 February 2000</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515855000000\">11 February 2000</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515855000000\">2000-02-11</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24515855000000\">2000-02-11</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24515855000000\">11 February 2000</td>"
 				]
 			}
 		},
@@ -282,10 +282,10 @@
 			"subject": "Example/P0413/3a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451544.5\">2000</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451544.5\">2000-01-01</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2451544.5\">2000-01-01</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2451544.5\">2000</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515445000000\">2000</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515445000000\">2000-01-01</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24515445000000\">2000-01-01</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24515445000000\">2000</td>"
 				]
 			}
 		},
@@ -319,10 +319,10 @@
 			"subject": "Example/P0413/4a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451586.4166782\">11 February 2000 22:00:01</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451586.4166782\">2000-02-11T22:00:01</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2451586.4166782\">2000-02-11T22:00:01</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2451586.4166782\">22:00, 11 February 2000</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515864166782\">11 February 2000 22:00:01</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515864166782\">2000-02-11T22:00:01</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24515864166782\">2000-02-11T22:00:01</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24515864166782\">22:00, 11 February 2000</td>"
 				]
 			}
 		},
@@ -356,10 +356,10 @@
 			"subject": "Example/P0413/5a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451586.4166782\">11 February 2000 22:00:01</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451586.4166782\">2000-02-11T22:00:01</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2451586.4166782\">2000-02-11T22:00:01</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2451586.4166782\">22:00, 11 February 2000</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515864166782\">11 February 2000 22:00:01</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515864166782\">2000-02-11T22:00:01</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24515864166782\">2000-02-11T22:00:01</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24515864166782\">22:00, 11 February 2000</td>"
 				]
 			}
 		},
@@ -393,10 +393,10 @@
 			"subject": "Example/P0413/6a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451586.4166782\">11 February 2000 22:00:01</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451586.4166782\">2000-02-11T22:00:01</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2451586.4166782\">2000-02-11T22:00:01</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2451586.4166782\">22:00, 11 February 2000</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515864166782\">11 February 2000 22:00:01</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515864166782\">2000-02-11T22:00:01</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24515864166782\">2000-02-11T22:00:01</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24515864166782\">22:00, 11 February 2000</td>"
 				]
 			}
 		},
@@ -430,10 +430,10 @@
 			"subject": "Example/P0413/7a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451586.3333449\">11 February 2000 20:00:01</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451586.3333449\">2000-02-11T20:00:01</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2451586.3333449\">2000-02-11T20:00:01</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2451586.3333449\">20:00, 11 February 2000</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515863333449\">11 February 2000 20:00:01</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515863333449\">2000-02-11T20:00:01</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24515863333449\">2000-02-11T20:00:01</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24515863333449\">20:00, 11 February 2000</td>"
 				]
 			}
 		},
@@ -467,10 +467,10 @@
 			"subject": "Example/P0413/8a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451576.5\">2 February 2000</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451576.5\">2000-02-02</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2451576.5\">2000-02-02</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2451576.5\">2 February 2000</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515765000000\">2 February 2000</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515765000000\">2000-02-02</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24515765000000\">2000-02-02</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24515765000000\">2 February 2000</td>"
 				]
 			}
 		},
@@ -504,10 +504,10 @@
 			"subject": "Example/P0413/9a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451577.5\">3 February 2000</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451577.5\">2000-02-03</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2451577.5\">2000-02-03</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2451577.5\">3 February 2000</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515775000000\">3 February 2000</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515775000000\">2000-02-03</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24515775000000\">2000-02-03</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24515775000000\">3 February 2000</td>"
 				]
 			}
 		},
@@ -541,10 +541,10 @@
 			"subject": "Example/P0413/10a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451577.5\">3 February 2000</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451577.5\">2000-02-03</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2451577.5\">2000-02-03</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2451577.5\">3 February 2000</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515775000000\">3 February 2000</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515775000000\">2000-02-03</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24515775000000\">2000-02-03</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24515775000000\">3 February 2000</td>"
 				]
 			}
 		},
@@ -584,12 +584,12 @@
 			"subject": "Example/P0413/11a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"1611848.5\">1 January 300 BC <sup>JL</sup></td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"1611848.5\">28 December 301 BC</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"1611848.5\">--301-12-28</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"1611848.5\">--301-12-28</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"1611848.5\">28 December 0000</td>",
-					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"1611848.5\">1611848.5</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"16118485000000\">1 January 300 BC <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"16118485000000\">28 December 301 BC</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"16118485000000\">--301-12-28</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"16118485000000\">--301-12-28</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"16118485000000\">28 December 0000</td>",
+					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"16118485000000\">1611848.5</td>"
 				]
 			}
 		},
@@ -623,12 +623,12 @@
 			"subject": "Example/P0413/13a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451598.5\">11 February 2000 <sup>JL</sup></td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451598.5\">2000-02-24</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2451598.5\">2000-02-24</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2451598.5\">24 February 2000</td>",
-					"<td class=\"JL-Date smwtype&#95;dat\" data-sort-value=\"2451598.5\">11 February 2000 <sup>JL</sup></td>",
-					"<td class=\"GR-Date smwtype&#95;dat\" data-sort-value=\"2451598.5\">24 February 2000</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515985000000\">11 February 2000 <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515985000000\">2000-02-24</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24515985000000\">2000-02-24</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24515985000000\">24 February 2000</td>",
+					"<td class=\"JL-Date smwtype&#95;dat\" data-sort-value=\"24515985000000\">11 February 2000 <sup>JL</sup></td>",
+					"<td class=\"GR-Date smwtype&#95;dat\" data-sort-value=\"24515985000000\">24 February 2000</td>"
 				]
 			}
 		},
@@ -662,12 +662,12 @@
 			"subject": "Example/P0413/14a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2266042.5\">2 February 1492 <sup>JL</sup></td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2266042.5\">1492-02-11</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2266042.5\">1492-02-11</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2266042.5\">11 February 1492</td>",
-					"<td class=\"JL-Date smwtype&#95;dat\" data-sort-value=\"2266042.5\">2 February 1492 <sup>JL</sup></td>",
-					"<td class=\"GR-Date smwtype&#95;dat\" data-sort-value=\"2266042.5\">11 February 1492</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"22660425000000\">2 February 1492 <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"22660425000000\">1492-02-11</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"22660425000000\">1492-02-11</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"22660425000000\">11 February 1492</td>",
+					"<td class=\"JL-Date smwtype&#95;dat\" data-sort-value=\"22660425000000\">2 February 1492 <sup>JL</sup></td>",
+					"<td class=\"GR-Date smwtype&#95;dat\" data-sort-value=\"22660425000000\">11 February 1492</td>"
 				]
 			}
 		},
@@ -701,12 +701,12 @@
 			"subject": "Example/P0413/15a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451585.9166667\">11 February 2000 10:00:00</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451585.9166667\">2000-02-11T10:00:00</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2451585.9166667\">2000-02-11T10:00:00</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2451585.9166667\">10:00, 11 February 2000</td>",
-					"<td class=\"JL-Date smwtype&#95;dat\" data-sort-value=\"2451585.9166667\">29 January 2000 10:00:00 <sup>JL</sup></td>",
-					"<td class=\"GR-Date smwtype&#95;dat\" data-sort-value=\"2451585.9166667\">11 February 2000 10:00:00</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515859166667\">11 February 2000 10:00:00</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515859166667\">2000-02-11T10:00:00</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24515859166667\">2000-02-11T10:00:00</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24515859166667\">10:00, 11 February 2000</td>",
+					"<td class=\"JL-Date smwtype&#95;dat\" data-sort-value=\"24515859166667\">29 January 2000 10:00:00 <sup>JL</sup></td>",
+					"<td class=\"GR-Date smwtype&#95;dat\" data-sort-value=\"24515859166667\">11 February 2000 10:00:00</td>"
 				]
 			}
 		},
@@ -740,10 +740,10 @@
 			"subject": "Example/P0413/16a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451596.5\">22 February 2000</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2451596.5\">2000-02-22</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2451596.5\">2000-02-22</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2451596.5\">22 February 2000</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515965000000\">22 February 2000</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24515965000000\">2000-02-22</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24515965000000\">2000-02-22</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24515965000000\">22 February 2000</td>"
 				]
 			}
 		},
@@ -783,10 +783,10 @@
 			"subject": "Example/P0413/17a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"-11001\">11000 BC</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"-11001\">--11000-01-01</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"-11001\">--11000-01-01</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"-11001\">0000</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"-110010000000\">11000 BC</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"-110010000000\">--11000-01-01</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"-110010000000\">--11000-01-01</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"-110010000000\">0000</td>"
 				]
 			}
 		},
@@ -820,11 +820,11 @@
 			"subject": "Example/P0413/18a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2488346.0804977\">4 October 2100 13:55:55</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2488346.0804977\">2100-10-04T13:55:55</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"2488346.0804977\">2100-10-04T13:55:55</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"2488346.0804977\">13:55, 4 October 2100</td>",
-					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"2488346.0804977\">2488346.0804977</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24883460804977\">4 October 2100 13:55:55</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24883460804977\">2100-10-04T13:55:55</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"24883460804977\">2100-10-04T13:55:55</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"24883460804977\">13:55, 4 October 2100</td>",
+					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"24883460804977\">2488346.0804977</td>"
 				]
 			}
 		},
@@ -858,11 +858,11 @@
 			"subject": "Example/P0413/19a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"4888346.5804977\">27 September 8671 01:55:55</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"4888346.5804977\">8671-09-27T01:55:55</td>",
-					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"4888346.5804977\">8671-09-27T01:55:55</td>",
-					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"4888346.5804977\">01:55, 27 September 8671</td>",
-					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"4888346.5804977\">4888346.5804977</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"48883465804977\">27 September 8671 01:55:55</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"48883465804977\">8671-09-27T01:55:55</td>",
+					"<td class=\"ISO-Date smwtype&#95;dat\" data-sort-value=\"48883465804977\">8671-09-27T01:55:55</td>",
+					"<td class=\"MW-Date smwtype&#95;dat\" data-sort-value=\"48883465804977\">01:55, 27 September 8671</td>",
+					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"48883465804977\">4888346.5804977</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0414.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0414.json
@@ -106,10 +106,10 @@
 			"subject": "Example/P0414/1a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2228431.9166782\">10:00:01.000000</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2228431.9166782\">1389/02/11 10:00 <sup>JL</sup></td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2228431.9166782\">1389/02/19 10:00</td>",
-					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"2228431.9166782\">2228431.9166782</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"22284319166782\">10:00:01.000000</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"22284319166782\">1389/02/11 10:00 <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"22284319166782\">1389/02/19 10:00</td>",
+					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"22284319166782\">2228431.9166782</td>"
 				]
 			}
 		},
@@ -143,8 +143,8 @@
 			"subject": "Example/P0414/2a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"-100001\">--100000-01-01</td>",
-					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"-100001\">-34802824.5</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"-1000010000000\">--100000-01-01</td>",
+					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"-1000010000000\">-34802824.5</td>"
 				]
 			}
 		},
@@ -178,9 +178,9 @@
 			"subject": "Example/P0414/3a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2415750.5\">1902</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2415750.5\">1902/01/01</td>",
-					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"2415750.5\">2415750.5</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24157505000000\">1902</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24157505000000\">1902/01/01</td>",
+					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"24157505000000\">2415750.5</td>"
 				]
 			}
 		},
@@ -214,9 +214,9 @@
 			"subject": "Example/P0414/4a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2159657.0023727\">1200 <sup>JL</sup></td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2159657.0023727\">1200/10/26 <sup>JL</sup></td>",
-					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"2159657.0023727\">2159657.0023727</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"21596570023727\">1200 <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"21596570023727\">1200/10/26 <sup>JL</sup></td>",
+					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"21596570023727\">2159657.0023727</td>"
 				]
 			}
 		},
@@ -250,8 +250,8 @@
 			"subject": "Example/P0414/5a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"-100001\">--100000-01-01</td>",
-					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"-100001\">-34802824.5</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"-1000010000000\">--100000-01-01</td>",
+					"<td class=\"JD smwtype&#95;dat\" data-sort-value=\"-1000010000000\">-34802824.5</td>"
 				]
 			}
 		},
@@ -285,9 +285,9 @@
 			"subject": "Example/P0414/6a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2415750.5\">AD 1902</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2415750.5\">1902</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2415750.5\">1902/01/01</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24157505000000\">AD 1902</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24157505000000\">1902</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24157505000000\">1902/01/01</td>"
 				]
 			}
 		},
@@ -345,8 +345,8 @@
 			"subject": "Example/P0414/8a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2455203.20625\">6 January 2010 16:57:00</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2455203.20625\">2010年01月06日 16:57</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24552032062500\">6 January 2010 16:57:00</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24552032062500\">2010年01月06日 16:57</td>"
 				]
 			}
 		},
@@ -356,8 +356,8 @@
 			"subject": "Example/P0414/9a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2455203.20625\">6 January 2010 16:57:00</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2455203.20625\">2010年01月06日 16:57</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24552032062500\">6 January 2010 16:57:00</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24552032062500\">2010年01月06日 16:57</td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0420.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0420.json
@@ -62,9 +62,9 @@
 			"subject": "Example/P0420/1a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2336583.5\">21 March 1685 <sup>JL</sup></td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2336583.5\">31 March 1685</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2336583.5\">21 March 1685 <sup>JL</sup></td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"23365835000000\">21 March 1685 <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"23365835000000\">31 March 1685</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"23365835000000\">21 March 1685 <sup>JL</sup></td>"
 				]
 			}
 		},
@@ -74,9 +74,9 @@
 			"subject": "Example/P0420/2a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2336583.5\">21 March 1685 <sup>JL</sup></td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2336583.5\">31 March 1685</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2336583.5\">21 March 1685 <sup>JL</sup></td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"23365835000000\">21 March 1685 <sup>JL</sup></td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"23365835000000\">31 March 1685</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"23365835000000\">21 March 1685 <sup>JL</sup></td>"
 				]
 			}
 		},
@@ -86,9 +86,9 @@
 			"subject": "Example/P0420/3a",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2336573.5\">21 March 1685</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2336573.5\">21 March 1685</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2336573.5\">11 March 1685 <sup>JL</sup></td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"23365735000000\">21 March 1685</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"23365735000000\">21 March 1685</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"23365735000000\">11 March 1685 <sup>JL</sup></td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0422.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0422.json
@@ -77,9 +77,9 @@
 			"subject": "Example/P0422/Q/2/1",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0422/2#_eda78f1641edf981597b59b79f9a8c1f</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2321884.5\">1645</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype&#95;wpg\">Example/P0422/2#_23b1a59a99dd05132dabb6cf45cb40b3</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2423420.5\">January 1923</td></tr>",
-					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0422/2#_f9a370d40ebd98e67c2b884fc09c7f9d</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2436965.5\">February 1960</td></tr>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0422/2#_eda78f1641edf981597b59b79f9a8c1f</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"23218845000000\">1645</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype&#95;wpg\">Example/P0422/2#_23b1a59a99dd05132dabb6cf45cb40b3</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24234205000000\">January 1923</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0422/2#_f9a370d40ebd98e67c2b884fc09c7f9d</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24369655000000\">February 1960</td></tr>"
 				]
 			}
 		},
@@ -89,9 +89,9 @@
 			"subject": "Example/P0422/Q/2/2",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0422/2#_f9a370d40ebd98e67c2b884fc09c7f9d</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2436965.5\">February 1960</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype&#95;wpg\">Example/P0422/2#_23b1a59a99dd05132dabb6cf45cb40b3</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2423420.5\">January 1923</td></tr>",
-					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0422/2#_eda78f1641edf981597b59b79f9a8c1f</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2321884.5\">1645</td></tr>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0422/2#_f9a370d40ebd98e67c2b884fc09c7f9d</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24369655000000\">February 1960</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype&#95;wpg\">Example/P0422/2#_23b1a59a99dd05132dabb6cf45cb40b3</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24234205000000\">January 1923</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0422/2#_eda78f1641edf981597b59b79f9a8c1f</td><td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"23218845000000\">1645</td></tr>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0423.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0423.json
@@ -85,8 +85,8 @@
 			"subject": "Example/P0423/Q1.1",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2435851.0034722\">12 January 1957 12:05:00</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2435851.0034722\">1957年1月12日 (土) 12:05</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24358510034722\">12 January 1957 12:05:00</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24358510034722\">1957年1月12日 (土) 12:05</td>"
 				]
 			}
 		},
@@ -96,8 +96,8 @@
 			"subject": "Example/P0423/Q1.2",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype&#95;dat\" data-sort-value=\"2435851.0034722\">12 January 1957 12:05:00</td>",
-					"<td class=\"smwtype&#95;dat\" data-sort-value=\"2435851.0034722\">1957年1月12日 (土) 12:05</td>"
+					"<td class=\"smwtype&#95;dat\" data-sort-value=\"24358510034722\">12 January 1957 12:05:00</td>",
+					"<td class=\"smwtype&#95;dat\" data-sort-value=\"24358510034722\">1957年1月12日 (土) 12:05</td>"
 				]
 			}
 		},
@@ -107,7 +107,7 @@
 			"subject": "Example/P0423/Q1.3",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2435851.0034722\">1957年1月12日 (土) 12:05:00</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24358510034722\">1957年1月12日 (土) 12:05:00</td>"
 				]
 			}
 		},

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0432.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0432.json
@@ -90,7 +90,7 @@
 			"assert-output": {
 				"to-contain": [
 					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0432/1</td>",
-					"<td class=\"Has-number-with-ref smwtype&#95;dat\" data-sort-value=\"2451544.5\">1 January 2000</td>",
+					"<td class=\"Has-number-with-ref smwtype&#95;dat\" data-sort-value=\"24515445000000\">1 January 2000</td>",
 					"<td class=\"Has-number-with-ref smwtype&#95;uri\"><a rel=\"nofollow\" class=\"external free\" href=\"http://example.org\">http://example.org</a></td>"
 				]
 			}
@@ -102,7 +102,7 @@
 			"assert-output": {
 				"to-contain": [
 					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0432/2#_7b5db4a4195b1843f9a25639c0d7ff5c</td>",
-					"<td class=\"Has-number-with-ref smwtype&#95;dat\" data-sort-value=\"2319299.5\">4 December 1637</td>",
+					"<td class=\"Has-number-with-ref smwtype&#95;dat\" data-sort-value=\"23192995000000\">4 December 1637</td>",
 					"<td class=\"Has-number-with-ref smwtype&#95;uri\"><a rel=\"nofollow\" class=\"external free\" href=\"http://example.org\">http://example.org</a></td>"
 				]
 			}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0434.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0434.json
@@ -86,7 +86,7 @@
 			"subject": "Example/P0434/Q1.2",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype&#95;wpg\">Example/P0434/1</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"2440587.5\">1 January 1970</td></tr></tbody></table>"
+					"<td class=\"smwtype&#95;wpg\">Example/P0434/1</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"24405875000000\">1 January 1970</td></tr></tbody></table>"
 				]
 			}
 		},
@@ -141,9 +141,9 @@
 			"subject": "Example/P0434/Q4.1",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_357f4a06073b86afc07cb0c6237b9f36</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"2415020.5\">1 January 1900</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_eb1c9a9f3a8ad677d7424e8d842b10dd</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"2451179.5\">1 January 1999</td></tr>",
-					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_4bae31c0cd5bda46c3cf0245523a954a</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"2451544.5\">1 January 2000</td></tr>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_357f4a06073b86afc07cb0c6237b9f36</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"24150205000000\">1 January 1900</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_eb1c9a9f3a8ad677d7424e8d842b10dd</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"24511795000000\">1 January 1999</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_4bae31c0cd5bda46c3cf0245523a954a</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"24515445000000\">1 January 2000</td></tr>"
 				]
 			}
 		},
@@ -153,9 +153,9 @@
 			"subject": "Example/P0434/Q4.2",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_4bae31c0cd5bda46c3cf0245523a954a</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"2451544.5\">1 January 2000</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_eb1c9a9f3a8ad677d7424e8d842b10dd</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"2451179.5\">1 January 1999</td></tr>",
-					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_357f4a06073b86afc07cb0c6237b9f36</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"2415020.5\">1 January 1900</td></tr>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_4bae31c0cd5bda46c3cf0245523a954a</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"24515445000000\">1 January 2000</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_eb1c9a9f3a8ad677d7424e8d842b10dd</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"24511795000000\">1 January 1999</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_357f4a06073b86afc07cb0c6237b9f36</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"24150205000000\">1 January 1900</td></tr>"
 				]
 			}
 		},
@@ -165,9 +165,9 @@
 			"subject": "Example/P0434/Q4.3",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_357f4a06073b86afc07cb0c6237b9f36</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"2415020.5\">1 January 1900</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_eb1c9a9f3a8ad677d7424e8d842b10dd</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"2451179.5\">1 January 1999</td></tr>",
-					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_4bae31c0cd5bda46c3cf0245523a954a</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"2451544.5\">1 January 2000</td></tr>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_357f4a06073b86afc07cb0c6237b9f36</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"24150205000000\">1 January 1900</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_eb1c9a9f3a8ad677d7424e8d842b10dd</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"24511795000000\">1 January 1999</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_4bae31c0cd5bda46c3cf0245523a954a</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"24515445000000\">1 January 2000</td></tr>"
 				]
 			}
 		},
@@ -177,9 +177,9 @@
 			"subject": "Example/P0434/Q4.4",
 			"assert-output": {
 				"to-contain": [
-					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_4bae31c0cd5bda46c3cf0245523a954a</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"2451544.5\">1 January 2000</td></tr>",
-					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_eb1c9a9f3a8ad677d7424e8d842b10dd</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"2451179.5\">1 January 1999</td></tr>",
-					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_357f4a06073b86afc07cb0c6237b9f36</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"2415020.5\">1 January 1900</td></tr>"
+					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_4bae31c0cd5bda46c3cf0245523a954a</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"24515445000000\">1 January 2000</td></tr>",
+					"<tr data-row-number=\"2\" class=\"row-even\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_eb1c9a9f3a8ad677d7424e8d842b10dd</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"24511795000000\">1 January 1999</td></tr>",
+					"<tr data-row-number=\"3\" class=\"row-odd\"><td class=\"smwtype&#95;wpg\">Example/P0434/4#_357f4a06073b86afc07cb0c6237b9f36</td><td class=\"Date smwtype&#95;dat\" data-sort-value=\"24150205000000\">1 January 1900</td></tr>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0453.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0453.json
@@ -22,8 +22,8 @@
 			"subject": "Example/P0453/Q.1",
 			"assert-output": {
 				"to-contain": [
-					"<td class=\"smwtype&#95;dat\" data-sort-value=\"2440953.0416667\">1 January 1971 13:00:00</td>",
-					"<td class=\"smwtype&#95;dat\" data-sort-value=\"2440953.0416667\">15:00:00, 1 January 1971&#160;<sup title=\"ISO: 1971-01-01T13:00:00\">ᴸ</sup></td>"
+					"<td class=\"smwtype&#95;dat\" data-sort-value=\"24409530416667\">1 January 1971 13:00:00</td>",
+					"<td class=\"smwtype&#95;dat\" data-sort-value=\"24409530416667\">15:00:00, 1 January 1971&#160;<sup title=\"ISO: 1971-01-01T13:00:00\">ᴸ</sup></td>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0905.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0905.json
@@ -39,9 +39,9 @@
 			"subject": "Example/P0905/Q1",
 			"assert-output": {
 				"to-contain": [
-					"Assessment 1a</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"13\"",
-					"Assessment 1b</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"2453736.5\">2006</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"2\"",
-					"Assessment 1c</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"14\""
+					"Assessment 1a</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"24533715000000\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"13\"",
+					"Assessment 1b</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"24537365000000\">2006</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"2\"",
+					"Assessment 1c</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"24533715000000\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"14\""
 				]
 			}
 		},
@@ -51,11 +51,11 @@
 			"subject": "Example/P0905/Q2",
 			"assert-output": {
 				"to-contain": [
-					"Assessment 1c</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"14\""
+					"Assessment 1c</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"24533715000000\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"14\""
 				],
 				"not-contain": [
-					"Assessment 1a</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"13\"",
-					"Assessment 1b</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"2453736.5\">2006</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"2\""
+					"Assessment 1a</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"24533715000000\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"13\"",
+					"Assessment 1b</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"24537365000000\">2006</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"2\""
 				]
 			}
 		},
@@ -65,11 +65,11 @@
 			"subject": "Example/P0905/Q3",
 			"assert-output": {
 				"to-contain": [
-					"Assessment 1c</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"14\""
+					"Assessment 1c</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"24533715000000\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"14\""
 				],
 				"not-contain": [
-					"Assessment 1a</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"13\"",
-					"Assessment 1b</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"2453736.5\">2006</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"2\""
+					"Assessment 1a</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"24533715000000\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"13\"",
+					"Assessment 1b</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"24537365000000\">2006</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"2\""
 				]
 			}
 		},
@@ -79,11 +79,11 @@
 			"subject": "Example/P0905/Q4",
 			"assert-output": {
 				"to-contain": [
-					"Assessment 1b</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"2453736.5\">2006</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"2\""
+					"Assessment 1b</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"24537365000000\">2006</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"2\""
 				],
 				"not-contain": [
-					"Assessment 1a</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"13\"",
-					"Assessment 1c</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"2453371.5\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"14\""
+					"Assessment 1a</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"24533715000000\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"13\"",
+					"Assessment 1c</a></td><td class=\"Assessment-year smwtype&#95;dat\" data-sort-value=\"24533715000000\">2005</td><td class=\"Assessment-value smwtype&#95;num\" data-sort-value=\"14\""
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-1004.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-1004.json
@@ -28,9 +28,9 @@
 			"assert-output": {
 				"to-contain": [
 					"<td class=\"Modification-date smwtype&#95;dat\" data-sort-value=.*T.*</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2440587.5\">1 January 1970</td>",
-					"<td class=\"Has-date-2 smwtype&#95;dat\" data-sort-value=\"2451545.5\">2451545.5</td>",
-					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"2440587.5\">1970-01-01</td>"
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24405875000000\">1 January 1970</td>",
+					"<td class=\"Has-date-2 smwtype&#95;dat\" data-sort-value=\"24515455000000\">2451545.5</td>",
+					"<td class=\"Has-date smwtype&#95;dat\" data-sort-value=\"24405875000000\">1970-01-01</td>"
 				]
 			}
 		}


### PR DESCRIPTION
## Problem

Sorting a date column in a query result table (for example `Special:Ask` with `format=broadtable`) does not order the rows chronologically on wikis whose content language uses `.` as a digit-group separator, such as German. The column comes out scrambled. Reported in #6830.

## Cause

Date cells emit the date's Julian Day number as a decimal `data-sort-value`:

```html
<td class="... smwtype_dat" data-sort-value="2440618.5">1 February 1970</td>
```

MediaWiki core's `jquery.tablesorter` reads `data-sort-value`, detects the column as numeric, and runs each value through `formatDigit()`. Under a content language whose separator transform treats `.` as a group separator (German swaps `.` and `,`), `formatDigit` removes the `.` and parses the remaining digits as one integer: `2440618.5` becomes `24406185`, while `2228431.9166782` becomes `22284319166782`. The resulting magnitude depends on how many fractional digits the Julian Day has, so date-only values (one fractional digit) and date-and-time values (seven fractional digits) land in different ranges and chronological order is lost. Only the hidden sort key is affected; the visible cell text stays correct, which is why this is easy to miss. Under English (no separator transform) `formatDigit` behaves like `parseFloat`, so the Julian Day float sorts correctly there.

## Fix

`TableResultPrinter` now emits the date sort key as a decimal-free integer, the Julian Day scaled by `10^7` (matching the seven decimal places `JulianDay::format()` keeps). With no `.` in the value, `formatDigit` returns the same integer in every locale, and because the integer is monotonic with the Julian Day the ordering is preserved, including negative (BCE) sort keys. The change is gated to date (`TimeValue`) cells, so numeric and boolean columns are untouched, and the DataTables `data-order` attribute receives the same value for consistency.

The affected JSONScript date fixtures are regenerated to the integer form; non-date numeric fixtures are unchanged.

Adding a semantic `<time datetime>` element to date cells is a worthwhile follow-up and is intentionally left out of this change to keep it focused.
