### PR TITLE
Fix FacetedSearch hiding a single result row (#6260)

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -96,6 +96,7 @@ Adds MediaWiki 1.45 support (see [Compatibility](#compatibility)).
 
 ### Bug fixes
 
+* Fixed `Special:FacetedSearch` not showing the result row when a query returns a single result ([#6260](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6260))
 * Fixed a fatal error on `Special:Search` when `$wgSearchType` is set to `SMWSearch` ([#6915](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6915))
 * Fixed a stray trailing space in `'edit '` that caused the edit-protection check in `ParserAfterTidy::process()` to silently match no pages since the migration off the deprecated `Title::isProtected()` API. With the typo removed, edit-protected pages once again trigger continued post-parse processing, matching the behaviour before that migration.
 * Fixed incorrect timezone offset for negative half-hour timezones (e.g., Newfoundland `-3:30`): the 30-minute component was always added positively, producing `-2.5` instead of `-3.5` ([#6478](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6478))

--- a/res/smw/special/smw.special.facetedsearch.css
+++ b/res/smw/special/smw.special.facetedsearch.css
@@ -765,10 +765,17 @@
 /**
  * Result output
  */
-.smwtable-clean.broadtable thead th,
-.dataTable thead th {
+.smwtable-clean.broadtable thead th {
 	position: sticky;
 	top: 50px;
+	background-color: #fff;
+	border-bottom: 1px solid #ddd;
+}
+
+/* DataTables forces position:relative on sortable headers, which defeats
+   position:sticky here; a top offset would then push the header down over the
+   result rows and hide them (issue #6260). Keep these headers in normal flow. */
+.dataTable thead th {
 	background-color: #fff;
 	border-bottom: 1px solid #ddd;
 }
@@ -820,9 +827,10 @@
 		margin-bottom: 5px;
 	}
 
-	/* We need some extra space no this this option have been folded */
-	.smwtable-clean.broadtable thead th,
-	.dataTable thead th {
+	/* We need some extra space now this option has been folded. Only the plain
+	   sticky broadtable header needs the larger offset; DataTable headers are
+	   not sticky (issue #6260). */
+	.smwtable-clean.broadtable thead th {
 		top: 79px;
 	}
 


### PR DESCRIPTION

<img width="1280" height="850" alt="6260-after-fix" src="https://github.com/user-attachments/assets/63d29a80-f150-4d30-a1f1-10e1b7fc74e9" />


## Problem

On `Special:FacetedSearch`, a query that returns a single result renders the result invisible: the column header shows but the lone data row appears as blank space. The row only becomes visible by shrinking the window. Fixes #6260.

## Cause

The result-table header rule sets `position: sticky; top: 50px` on `.dataTable thead th`. DataTables sets `position: relative` on sortable header cells with a more specific selector (`table.dataTable thead > tr > th.dt-orderable-*`), so `position: sticky` never applies. The orphaned `top: 50px` then shifts the now relatively positioned header 50px downward, and because the header is positioned and has a white background it paints over the row beneath it. With a single result the only row is fully covered. With many rows only the first row is affected, so it usually goes unnoticed. The `@media (max-width: 1020px)` block re-applies the same offset as `top: 79px`, so the issue also occurs at narrow widths.

This regressed in 5.0.0 with the DataTables 2.1.6 upgrade (#5720), which introduced the `position: relative` rule on sortable headers.

## Fix

Remove the sticky offset from the `.dataTable` header branch so these headers stay in normal flow, in both the base rule and the 1020px media query. The plain `.smwtable-clean.broadtable` branch is unchanged.

Restoring a genuinely sticky header is intentionally not attempted. Raising specificity makes `position: sticky` compute correctly, but it still does not produce a working sticky header, because the result table sits inside an `overflow: auto` ancestor (for example `.mw-body` on some skins) that traps sticky positioning. A reliable sticky header would require the DataTables FixedHeader extension, which is out of scope for this fix.

## Testing

Verified on a single-result FacetedSearch page. Before: the header overlaps the row by about 28px and the row is hidden. After: the header sits above the row with no overlap and the row is fully visible.
