### PR TITLE
Catch PHP errors in rebuildData so --ignore-exceptions can skip them

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -99,6 +99,7 @@ Adds MediaWiki 1.45 support (see [Compatibility](#compatibility)).
 
 * Fixed `Special:FacetedSearch` not showing the result row when a query returns a single result ([#6260](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6260))
 * Fixed a fatal error on `Special:Search` when `$wgSearchType` is set to `SMWSearch` ([#6915](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6915))
+* `rebuildData.php --ignore-exceptions` now also skips and logs PHP errors (such as a `TypeError` raised while parsing a single page), so one un-parseable page no longer aborts the whole rebuild ([#6218](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6218))
 * Fixed a stray trailing space in `'edit '` that caused the edit-protection check in `ParserAfterTidy::process()` to silently match no pages since the migration off the deprecated `Title::isProtected()` API. With the typo removed, edit-protected pages once again trigger continued post-parse processing, matching the behaviour before that migration.
 * Fixed incorrect timezone offset for negative half-hour timezones (e.g., Newfoundland `-3:30`): the 30-minute component was always added positively, producing `-2.5` instead of `-3.5` ([#6478](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6478))
 * Fixed CSV export producing malformed output when values contain the delimiter character ([#6343](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6343))

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -101,7 +101,7 @@ class rebuildData extends Maintenance {
 		$this->addOption( 'force-update', 'Force an update even when an associated revision is known', false );
 		$this->addOption( 'revision-mode', 'Skip entities where its associated revision matches the latests referenced revision of an associated page', false );
 
-		$this->addOption( 'ignore-exceptions', 'Ignore exceptions and log exception to a file', false );
+		$this->addOption( 'ignore-exceptions', 'Ignore exceptions and errors (e.g. a parser TypeError on a single page) and log them to a file instead of aborting the run', false );
 		$this->addOption( 'exception-log', 'Exception log file location (e.g. /tmp/logs/)', false, true );
 		$this->addOption( 'with-maintenance-log', 'Add log entry to `Special:Log` about the maintenance run.', false );
 

--- a/src/Maintenance/DataRebuilder.php
+++ b/src/Maintenance/DataRebuilder.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Maintenance;
 
-use Exception;
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
@@ -16,6 +15,7 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\Rebuilder\Rebuilder;
 use SMW\Store;
 use SMW\Utils\CliMsgFormatter;
+use Throwable;
 
 /**
  * Is part of the `rebuildData.php` maintenance script to rebuild existing data
@@ -440,8 +440,16 @@ class DataRebuilder {
 
 			try {
 				$this->entityRebuildDispatcher->rebuild( $id );
-			} catch ( Exception $e ) {
+			} catch ( Throwable $e ) {
 				$this->exceptionFileLogger->recordException( $id, $e );
+
+				// Rebuilder::rebuild() advances $id only via next_position() at
+				// the very end, after running its jobs; when a job throws that
+				// step is skipped and $id keeps pointing at the failing entity.
+				// Advance past it (the dispatch range is fixed to 1 in
+				// rebuildAll()) so the run continues instead of reprocessing the
+				// same id indefinitely.
+				$id++;
 			}
 		}
 

--- a/src/Maintenance/DistinctEntityDataRebuilder.php
+++ b/src/Maintenance/DistinctEntityDataRebuilder.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Maintenance;
 
-use Exception;
 use MediaWiki\Title\Title;
 use MediaWiki\Title\TitleFactory;
 use Onoi\MessageReporter\MessageReporter;
@@ -16,6 +15,7 @@ use SMW\Query\QueryProcessor;
 use SMW\Query\QueryResult;
 use SMW\Store;
 use SMW\Utils\CliMsgFormatter;
+use Throwable;
 
 /**
  * @license GPL-2.0-or-later
@@ -167,9 +167,12 @@ class DistinctEntityDataRebuilder {
 			return $updatejob->run();
 		}
 
+		// doRebuild() iterates a fixed list of pages, so a caught error simply
+		// lets that foreach continue with the next page; no position
+		// advancement is needed here (unlike DataRebuilder::doUpdateById()).
 		try {
 			$updatejob->run();
-		} catch ( Exception $e ) {
+		} catch ( Throwable $e ) {
 			$this->exceptionFileLogger->recordException( $page->getPrefixedDBkey(), $e );
 		}
 	}

--- a/src/Maintenance/ExceptionFileLogger.php
+++ b/src/Maintenance/ExceptionFileLogger.php
@@ -3,10 +3,10 @@
 namespace SMW\Maintenance;
 
 use DateTimeZone;
-use Exception;
 use SMW\MediaWiki\ExtendedDateTime;
 use SMW\Options;
 use SMW\Utils\File;
+use Throwable;
 
 /**
  * @private
@@ -70,7 +70,7 @@ class ExceptionFileLogger {
 	/**
 	 * @since 2.4
 	 */
-	public function recordException( int|string $id, Exception $exception ): void {
+	public function recordException( int|string $id, Throwable $exception ): void {
 		$this->exceptionCount++;
 
 		$this->exceptionLogMessages[$id] = [

--- a/tests/phpunit/Unit/Maintenance/DataRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/DataRebuilderTest.php
@@ -21,6 +21,7 @@ use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
+use TypeError;
 
 /**
  * @covers \SMW\Maintenance\DataRebuilder
@@ -436,6 +437,85 @@ class DataRebuilderTest extends TestCase {
 			3,
 			$instance->getRebuildCount()
 		);
+	}
+
+	/**
+	 * @depends testCanConstruct
+	 */
+	public function testRebuildAllWithIgnoreExceptionsContinuesPastError() {
+		$seenIds = [];
+
+		$rebuilder = $this->getMockBuilder( Rebuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Mirror Rebuilder::rebuild() throwing from a job before next_position()
+		// runs: the id is left unadvanced when the call throws. A PHP Error
+		// (TypeError) is used because that is what escapes a catch ( Exception )
+		// and aborts the whole rebuild (#6218). The safety net stops the loop
+		// after far more iterations than the [1,3] range needs, so a regression
+		// that fails to advance the id fails the assertion below instead of
+		// looping forever.
+		$rebuilder->expects( $this->any() )
+			->method( 'rebuild' )
+			->willReturnCallback( static function ( &$id ) use ( &$seenIds ) {
+				$seenIds[] = $id;
+
+				if ( count( $seenIds ) > 20 ) {
+					$id = -1;
+					return 1;
+				}
+
+				throw new TypeError( 'Return value must be of type string, array returned' );
+			} );
+
+		$rebuilder->expects( $this->any() )
+			->method( 'getMaxId' )
+			->willReturn( 1000 );
+
+		$rebuilder->expects( $this->any() )
+			->method( 'getDispatchedEntities' )
+			->willReturn( [] );
+
+		$store = $this->getMockBuilder( Store::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'refreshData' ] )
+			->getMockForAbstractClass();
+
+		$store->expects( $this->once() )
+			->method( 'refreshData' )
+			->willReturn( $rebuilder );
+
+		$store->setConnectionManager( $this->connectionManager );
+
+		$titleFactory = $this->getMockBuilder( TitleFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$exceptionLogDir = sys_get_temp_dir() . '/smw-6218-' . uniqid();
+		mkdir( $exceptionLogDir );
+
+		$instance = new DataRebuilder( $store, $titleFactory, $this->jobFactory );
+
+		$instance->setOptions( new Options( [
+			's' => 1,
+			'e' => 3,
+			'ignore-exceptions' => true,
+			'exception-log' => $exceptionLogDir
+		] ) );
+
+		try {
+			$this->assertTrue( $instance->rebuild() );
+
+			// Each failing id in the [1,3] range is visited exactly once and the
+			// run advances past it, proving the loop does not reprocess the same
+			// id forever.
+			$this->assertSame( [ 1, 2, 3 ], $seenIds );
+			$this->assertSame( 3, $instance->getExceptionCount() );
+		} finally {
+			array_map( 'unlink', glob( "$exceptionLogDir/*" ) ?: [] );
+			rmdir( $exceptionLogDir );
+		}
 	}
 
 	/**

--- a/tests/phpunit/Unit/Maintenance/DistinctEntityDataRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/DistinctEntityDataRebuilderTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\Connection\ConnectionManager;
 use SMW\DataItems\WikiPage;
 use SMW\Maintenance\DistinctEntityDataRebuilder;
+use SMW\Maintenance\ExceptionFileLogger;
 use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\Jobs\UpdateJob;
@@ -17,6 +18,7 @@ use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use stdClass;
+use TypeError;
 
 /**
  * @covers \SMW\Maintenance\DistinctEntityDataRebuilder
@@ -279,6 +281,70 @@ class DistinctEntityDataRebuilderTest extends TestCase {
 
 		$this->assertEquals(
 			3,
+			$instance->getRebuildCount()
+		);
+	}
+
+	public function testRebuildSelectedPagesWithIgnoreExceptionsContinuesPastError() {
+		// A PHP Error (TypeError) escapes a catch ( Exception ) and would abort
+		// the rebuild of the remaining selected pages (#6218).
+		$updateJob = $this->getMockBuilder( UpdateJob::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$updateJob->method( 'run' )
+			->willReturnCallback( static function () {
+				throw new TypeError( 'Return value must be of type string, array returned' );
+			} );
+
+		$jobFactory = $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$jobFactory->method( 'newUpdateJob' )
+			->willReturn( $updateJob );
+
+		$exceptionFileLogger = $this->getMockBuilder( ExceptionFileLogger::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$exceptionFileLogger->expects( $this->exactly( 2 ) )
+			->method( 'recordException' );
+
+		$store = $this->getMockBuilder( Store::class )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$mwTitleFactory = MediaWikiServices::getInstance()->getTitleFactory();
+
+		$titleFactory = $this->getMockBuilder( TitleFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$titleFactory->method( 'newFromText' )
+			->willReturnCallback( static function ( $title ) use ( $mwTitleFactory ) {
+				return $mwTitleFactory->newFromText( $title );
+			} );
+
+		$instance = new DistinctEntityDataRebuilder(
+			$store,
+			$titleFactory,
+			$jobFactory
+		);
+
+		$instance->setExceptionFileLogger( $exceptionFileLogger );
+
+		$instance->setOptions( new Options( [
+			'page' => 'Main page|Some other page',
+			'ignore-exceptions' => true
+		] ) );
+
+		$this->assertTrue(
+			$instance->doRebuild()
+		);
+
+		$this->assertEquals(
+			2,
 			$instance->getRebuildCount()
 		);
 	}

--- a/tests/phpunit/Unit/Maintenance/Jobs/ExceptionFileLoggerTest.php
+++ b/tests/phpunit/Unit/Maintenance/Jobs/ExceptionFileLoggerTest.php
@@ -7,6 +7,7 @@ use PHPUnit\Framework\TestCase;
 use SMW\Maintenance\ExceptionFileLogger;
 use SMW\Options;
 use SMW\Utils\File;
+use TypeError;
 
 /**
  * @covers \SMW\Maintenance\ExceptionFileLogger
@@ -71,6 +72,23 @@ class ExceptionFileLoggerTest extends TestCase {
 		);
 
 		$instance->doWrite();
+	}
+
+	public function testRecordExceptionAcceptsThrowableError() {
+		$instance = new ExceptionFileLogger( 'foo', $this->file );
+
+		// A PHP Error (here TypeError) is a Throwable but not an Exception.
+		// rebuildData.php must be able to log these, e.g. a parser tag hook
+		// declaring a string return type but returning an array (#6218).
+		$instance->recordException(
+			'Foo',
+			new TypeError( 'Bar' )
+		);
+
+		$this->assertSame(
+			1,
+			$instance->getExceptionCount()
+		);
 	}
 
 }


### PR DESCRIPTION
## Problem

`rebuildData.php --ignore-exceptions` is meant to log a problematic page and keep going, but it only caught `Exception`. A PHP `Error` (for example a `TypeError` raised while parsing a single page) is not an `Exception`, so it escaped the handler and aborted the entire rebuild.

This surfaced as a fatal during `rebuildData.php` (#6218):

```
TypeError: MediaWiki\Parser\CoreTagHooks::gallery(): Return value must be of type string, array returned
```

The `TypeError` originates in MediaWiki core: `CoreTagHooks::gallery()` is declared to return `string`, while the parser framework (`Parser::extensionSubstitution`) supports tag hooks returning an array `[ $output, 'markerType' => ... ]` (as a custom gallery mode or an `onAfterParserFetchFileAndTitle` handler can produce). SMW only triggers a normal parse during the rebuild, so it cannot change that return type, but it should not let one un-parseable page abort the whole run when the operator has opted into `--ignore-exceptions`.

## Change

- Widen the exception handling in `DataRebuilder`, `DistinctEntityDataRebuilder`, and the parameter of `ExceptionFileLogger::recordException()` from `Exception` to `Throwable`, so `--ignore-exceptions` also catches and logs PHP errors, not just exceptions.
- `DataRebuilder::doUpdateById()` advances `$id` in the catch. `Rebuilder::rebuild()` moves `$id` forward only via `next_position()`, after running its jobs; when a job throws, that step is skipped and `$id` keeps pointing at the failing entity, so a widened catch alone would reprocess the same `$id` indefinitely. The dispatch range is fixed to 1 in `rebuildAll()`, the only caller of `doUpdateById()`. The fixed page list iterated by `DistinctEntityDataRebuilder` needs no such advance.

The default rebuild (without the flag) still fails on such an error, by design: silently skipping un-parseable pages would drop their semantic data without notice. `--ignore-exceptions` remains the opt-in to skip and log the affected page so it can be investigated.

## Tests

Added unit coverage for a PHP `Error` thrown during rebuild under `--ignore-exceptions`: the run completes instead of aborting, each failing id is visited once and the run advances past it, and the error is recorded. The page-selection rebuild path and the logger accepting a `Throwable` are covered too.

Fixes #6218
