### PR TITLE
Test a MariaDB LTS spread and bump action majors

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,9 +28,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { mw: '1.43', php: 8.2, db: "mariadb:11.2", full: true }
+          - { mw: '1.43', php: 8.2, db: "mariadb:10.11", full: true }
           - { mw: '1.44', php: 8.3, db: "mariadb:11.8", full: false }
-          - { mw: '1.45', php: 8.4, db: "mariadb:11.8", full: false }
+          - { mw: '1.45', php: 8.4, db: "mariadb:12.3", full: false }
     env:
       MW_VERSION: ${{ matrix.mw }}
       PHP_VERSION: ${{ matrix.php }}
@@ -38,7 +38,7 @@ jobs:
       DB_IMAGE: ${{ matrix.db }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -74,9 +74,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { mw: '1.43', php: 8.2, db: "mariadb:11.2" }
+          - { mw: '1.43', php: 8.2, db: "mariadb:10.11" }
           - { mw: '1.44', php: 8.3, db: "mariadb:11.8" }
-          - { mw: '1.45', php: 8.4, db: "mariadb:11.8" }
+          - { mw: '1.45', php: 8.4, db: "mariadb:12.3" }
     env:
       MW_VERSION: ${{ matrix.mw }}
       PHP_VERSION: ${{ matrix.php }}
@@ -84,7 +84,7 @@ jobs:
       DB_IMAGE: ${{ matrix.db }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -104,16 +104,16 @@ jobs:
   # upload. It is not on the fast-feedback path (the test jobs report pass/fail
   # well before coverage finishes).
   coverage:
-    name: Coverage (MW 1.43, PHP 8.2, mariadb:11.2)
+    name: Coverage (MW 1.43, PHP 8.2, mariadb:11.4)
     runs-on: ubuntu-latest
     env:
       MW_VERSION: '1.43'
       PHP_VERSION: 8.2
       DB_TYPE: mysql
-      DB_IMAGE: "mariadb:11.2"
+      DB_IMAGE: "mariadb:11.4"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -124,7 +124,7 @@ jobs:
         run: make ci-coverage COMPOSER_PARAMS="-- --testsuite semantic-mediawiki-unit,semantic-mediawiki-check,semantic-mediawiki-data-model,semantic-mediawiki-integration,semantic-mediawiki-import,semantic-mediawiki-structure"
 
       - name: Upload code coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/php/coverage.xml

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -179,7 +179,7 @@ class Database {
 	}
 
 	/**
-	 * @see IDatabase::buildIntegerCast
+	 * @see ISQLPlatform::buildIntegerCast
 	 *
 	 * @since 7.0.0
 	 */

--- a/src/MediaWiki/Connection/Database.php
+++ b/src/MediaWiki/Connection/Database.php
@@ -179,6 +179,15 @@ class Database {
 	}
 
 	/**
+	 * @see IDatabase::buildIntegerCast
+	 *
+	 * @since 7.0.0
+	 */
+	public function buildIntegerCast( string $field ): string {
+		return $this->connRef->getConnection( 'read' )->buildIntegerCast( $field );
+	}
+
+	/**
 	 * @see IDatabase::tableName
 	 *
 	 * @since 1.9

--- a/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
+++ b/src/SQLStore/QueryEngine/HierarchyTempTableBuilder.php
@@ -162,13 +162,18 @@ class HierarchyTempTableBuilder {
 		$tablenameQb->execute();
 		$tmpnewQb->execute();
 
+		// MySQL rejects CAST( ... AS INTEGER ) and requires SIGNED, while SQLite
+		// and PostgreSQL want INTEGER; buildIntegerCast() emits the form matching
+		// the connection's platform.
+		$idCast = $db->buildIntegerCast( 's_id' );
+
 		for ( $i = 0; $i < $depth; $i++ ) {
 			// INSERT IGNORE INTO $tmpres (id)
-			//   SELECT CAST(s_id AS INTEGER) FROM $smwtable, $tmpnew WHERE o_id=id
+			//   SELECT <integer cast of s_id> FROM $smwtable, $tmpnew WHERE o_id=id
 			$db->insertSelect(
 				$tmpres,
 				[ $smwtable, $tmpnew ],
-				[ 'id' => 'CAST(s_id AS INTEGER)' ],
+				[ 'id' => $idCast ],
 				[ 'o_id=id' ],
 				__METHOD__,
 				[ 'IGNORE' ],


### PR DESCRIPTION
## Summary

Modernise the CI matrix and fix a non-portable integer cast.

- **Database spread.** Replace the EOL `mariadb:11.2` with a spread across supported MariaDB releases: `1.43` → `mariadb:10.11`, `1.44` → `mariadb:11.8`, `1.45` → `mariadb:12.3`, bracketing the oldest and newest LTS. The coverage leg runs on `mariadb:11.4`.
- **Bump action majors.** `actions/checkout@v4` → `@v6`, `codecov/codecov-action@v5` → `@v6`.
- **Portable integer cast.** `HierarchyTempTableBuilder` emitted `CAST(s_id AS INTEGER)`, which a genuine MySQL server rejects (it requires `SIGNED`). The statement runs against an SMW runtime temporary table, so it fails on MySQL in production for subproperty/subcategory hierarchy queries; MariaDB accepts `INTEGER`, which is why it went unnoticed. Switch to `IDatabase::buildIntegerCast()`, exposed on the connection wrapper, so the cast matches the connection's platform (`SIGNED` on MySQL/MariaDB, `INTEGER` on SQLite/PostgreSQL).

The job structure (`static-analysis` / `tests` / `coverage` / `ci-success`) and version dimensions are otherwise unchanged.