### PR TITLE
Fix 7.0 migration table to string options and DeprecationNotices version

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -352,7 +352,7 @@ notices" panel. Extensions populate this array (keyed by section name) to
 inform administrators about settings or features planned for removal or
 already removed in the running version.
 
-**Since:** 7.0.0
+**Since:** 3.2.0
 **Default:** `[]`
 
 ## $smwgDetectOutdatedData

--- a/docs/migration/7.0.md
+++ b/docs/migration/7.0.md
@@ -44,24 +44,24 @@ The runtime shim that rewrote settings deprecated in SMW 3.1 and 3.2 to their re
 
 | Removed setting | Use instead |
 |---|---|
-| `$smwgEnabledInTextAnnotationParserStrictMode` | `$smwgParserFeatures` (`SMW_PARSER_STRICT` bit) |
-| `$smwgInlineErrors` | `$smwgParserFeatures` (`SMW_PARSER_INL_ERROR` bit) |
-| `$smwgShowHiddenCategories` | `$smwgParserFeatures` (`SMW_PARSER_HID_CATS` bit) |
-| `$smwgLinksInValues` | `$smwgParserFeatures` (`SMW_PARSER_LINV` bit) |
-| `$smwgFactboxUseCache` | `$smwgFactboxFeatures` (`SMW_FACTBOX_CACHE` bit) |
-| `$smwgFactboxCacheRefreshOnPurge` | `$smwgFactboxFeatures` (`SMW_FACTBOX_PURGE_REFRESH` bit) |
-| `$smwgUseCategoryRedirect` | `$smwgCategoryFeatures` (`SMW_CAT_REDIRECT` bit) |
-| `$smwgCategoriesAsInstances` | `$smwgCategoryFeatures` (`SMW_CAT_INSTANCE` bit) |
-| `$smwgUseCategoryHierarchy` | `$smwgCategoryFeatures` (`SMW_CAT_HIERARCHY` bit) |
-| `$smwgQSortingSupport` | `$smwgQSortFeatures` (`SMW_QSORT` bit) |
-| `$smwgQRandSortingSupport` | `$smwgQSortFeatures` (`SMW_QSORT_RANDOM` bit) |
-| `$smwgToolboxBrowseLink` | `$smwgBrowseFeatures` (`SMW_BROWSE_TLINK` bit) |
-| `$smwgBrowseShowInverse` | `$smwgBrowseFeatures` (`SMW_BROWSE_SHOW_INVERSE` bit) |
-| `$smwgBrowseShowAll` | `$smwgBrowseFeatures` (`SMW_BROWSE_SHOW_INCOMING` bit) |
-| `$smwgBrowseByApi` | `$smwgBrowseFeatures` (`SMW_BROWSE_USE_API` bit) |
-| `$smwgAdminRefreshStore` | `$smwgAdminFeatures` (`SMW_ADM_REFRESH` bit) |
-| `$smwgQueryProfiler['smwgQueryDurationEnabled']` | `$smwgQueryProfiler` (`SMW_QPRFL_DUR` bit) |
-| `$smwgQueryProfiler['smwgQueryParametersEnabled']` | `$smwgQueryProfiler` (`SMW_QPRFL_PARAMS` bit) |
+| `$smwgEnabledInTextAnnotationParserStrictMode` | `$smwgParserFeatures` (option `'strict'`) |
+| `$smwgInlineErrors` | `$smwgParserFeatures` (option `'inline-errors'`) |
+| `$smwgShowHiddenCategories` | `$smwgParserFeatures` (option `'hidden-categories'`) |
+| `$smwgLinksInValues` | `$smwgParserFeatures` (option `'links-in-values'`) |
+| `$smwgFactboxUseCache` | `$smwgFactboxFeatures` (option `'cache'`) |
+| `$smwgFactboxCacheRefreshOnPurge` | `$smwgFactboxFeatures` (option `'purge-refresh'`) |
+| `$smwgUseCategoryRedirect` | `$smwgCategoryFeatures` (option `'redirect'`) |
+| `$smwgCategoriesAsInstances` | `$smwgCategoryFeatures` (option `'instance'`) |
+| `$smwgUseCategoryHierarchy` | `$smwgCategoryFeatures` (option `'hierarchy'`) |
+| `$smwgQSortingSupport` | `$smwgQSortFeatures` (option `'sort'`) |
+| `$smwgQRandSortingSupport` | `$smwgQSortFeatures` (option `'random'`) |
+| `$smwgToolboxBrowseLink` | `$smwgBrowseFeatures` (option `'toolbox-link'`) |
+| `$smwgBrowseShowInverse` | `$smwgBrowseFeatures` (option `'show-inverse'`) |
+| `$smwgBrowseShowAll` | `$smwgBrowseFeatures` (option `'show-incoming'`) |
+| `$smwgBrowseByApi` | `$smwgBrowseFeatures` (option `'use-api'`) |
+| `$smwgAdminRefreshStore` | `$smwgAdminFeatures` (option `'refresh'`) |
+| `$smwgQueryProfiler['smwgQueryDurationEnabled']` | `$smwgQueryProfiler` (option `'duration'`) |
+| `$smwgQueryProfiler['smwgQueryParametersEnabled']` | `$smwgQueryProfiler` (option `'parameters'`) |
 | `$smwgCacheType` | `$smwgMainCacheType` |
 | `$smwgImportFileDir` | `$smwgImportFileDirs` |
 | `$smwgDeclarationProperties` | `$smwgChangePropagationWatchlist` |


### PR DESCRIPTION
## Summary

Two small corrections to the 7.0 release documentation.

- `docs/migration/7.0.md`: the "Removed legacy settings" table's *Use instead* column referenced the deprecated `SMW_*` constant bits (e.g. `$smwgParserFeatures` with `SMW_PARSER_STRICT`). Since 7.0.0 documents the string-array form, the affected rows now reference the string option instead (e.g. `$smwgParserFeatures` with `'strict'`), so the guide no longer recommends the constant form it tells users to migrate away from.
- `docs/config.md`: the `$smwgDeprecationNotices` entry was listed as *Since 7.0.0*; it was introduced in 3.2.0 (#4418). Corrected.

Documentation only; no code or behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)