### PR TITLE
Drop the vestigial `dateformat` parser-cache key

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -1900,9 +1900,11 @@ injection container.
 
 ## $smwgSetParserCacheKeys
 
-Session keys added to the parser cache key, each causing additional cache
-fragmentation. Each listed key produces a separate cache entry per distinct
-value of that key.
+Controls whether the parser cache is fragmented by the viewer's interface
+language. The only recognized key is `userlang` (the default), which varies the
+cache for language-dependent output such as errors and localized tooltips. Set
+to `[]` to disable this; on a multilingual wiki that can serve such output in
+the wrong language.
 
 **Since:** 5.1
 **Default:** `["userlang"]`

--- a/src/ParserData.php
+++ b/src/ParserData.php
@@ -198,10 +198,11 @@ class ParserData {
 	 * @since 3.0
 	 */
 	public function addExtraParserKey( string $key ): void {
-		// Preference keys fragment the parser cache by a user preference and are
-		// opt-in via $smwgSetParserCacheKeys. Every other key (functional markers
-		// such as `smwq`, or keys added by other extensions) is always applied.
-		$configurableKeys = [ 'userlang', 'dateformat' ];
+		// `userlang` fragments the parser cache by the viewer's interface
+		// language and is opt-in via $smwgSetParserCacheKeys. Every other key
+		// (functional markers such as `smwq`, or keys added by other extensions)
+		// is always applied.
+		$configurableKeys = [ 'userlang' ];
 
 		if ( in_array( $key, $configurableKeys, true ) ) {
 			$keysToCache = ApplicationFactory::getInstance()->getSettings()->get( 'smwgSetParserCacheKeys' ) ?? [];

--- a/tests/phpunit/Unit/ParserDataTest.php
+++ b/tests/phpunit/Unit/ParserDataTest.php
@@ -563,30 +563,4 @@ class ParserDataTest extends TestCase {
 		$instance->addExtraParserKey( 'smwq' );
 	}
 
-	public function testAddExtraParserKeyForDisabledDateformatDoesNothing() {
-		$this->testEnvironment->withConfiguration( [ 'smwgSetParserCacheKeys' => [] ] );
-
-		$parserOptions = $this->getMockBuilder( ParserOptions::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$parserOptions->expects( $this->never() )
-			->method( 'addExtraKey' );
-
-		$title = $this->getMockBuilder( Title::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$parserOutput = $this->getMockBuilder( ParserOutput::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$parserOutput->expects( $this->never() )
-			->method( 'recordOption' );
-
-		$instance = new ParserData( $title, $parserOutput );
-		$instance->setParserOptions( $parserOptions );
-		$instance->addExtraParserKey( 'dateformat' );
-	}
-
 }


### PR DESCRIPTION
## Background

`$smwgSetParserCacheKeys` controls which user-preference keys Semantic MediaWiki adds to the parser cache key. As of 7.0 the only key it governs is `userlang`:

- `dateformat` was dropped from the default in #6819, because Semantic MediaWiki formats dates by language rather than by the per-user MediaWiki date-format preference, so fragmenting on it produced no benefit. That change also removed the only production call that passed `dateformat` to `ParserData::addExtraParserKey()`.
- #6948 made `userlang` fragmentation conditional on output that genuinely depends on the interface language.

This left `'dateformat'` in the configurable-key allowlist inside `ParserData::addExtraParserKey()`, gating a key that no production code emits, plus a unit test exercising that unreachable branch.

## Changes

- Remove `'dateformat'` from the configurable-key allowlist in `ParserData::addExtraParserKey()`. `userlang` is now the only key the setting governs.
- Delete `testAddExtraParserKeyForDisabledDateformatDoesNothing`, which covered the now-removed branch.
- Rewrite the `docs/config.md` entry to describe current behaviour: the setting gates per-language parser-cache fragmentation, only `userlang` is supported, and emptying the array disables that fragmentation, which on a multilingual wiki can cause language-dependent output (a localized error or tooltip) to be served in the interface language of whoever first populated the cache.

## Notes

No observable behaviour change for Semantic MediaWiki: no in-tree caller passes `dateformat` to `addExtraParserKey()`. `addExtraParserKey()` is public, so a hypothetical external caller passing `dateformat` would previously have had it gated by the setting and would now have it applied unconditionally, but no such caller exists in Semantic MediaWiki or any indexed extension.
