### PR TITLE
SemanticDataLookup: avoid using null as an array offset

### DIFF
--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -102,7 +102,10 @@ class SemanticDataLookup {
 		$state = [];
 
 		foreach ( $semanticData->getProperties() as $property ) {
-			$state[$this->store->findPropertyTableID( $property )] = true;
+			// findPropertyTableID() returns '' (not null) when a property has no
+			// dedicated table; coerce defensively so a null is never used as an
+			// array offset, which is deprecated as of PHP 8.4.
+			$state[$this->store->findPropertyTableID( $property ) ?? ''] = true;
 		}
 
 		return $state;


### PR DESCRIPTION
## Problem

`SemanticDataLookup::getTableUsageInfo()` builds a set of property-table ids:

```php
foreach ( $semanticData->getProperties() as $property ) {
    $state[$this->store->findPropertyTableID( $property )] = true;
}
```

`findPropertyTableID()` can return `null` (the fixed-property path in `PropertyTableInfoFetcher::findTableIdForProperty()` may yield `null`, even though `findTableIdForDataItemTypeId()` is documented to return `''` for "no table"). Using that `null` as an array offset emits `Using null as an array offset is deprecated, use an empty string instead` on PHP 8.4+.

This runs in the page-save indexing path (`LinksUpdateComplete` → `DataUpdater` → `SQLStoreUpdater` → `getTableUsageInfo`), so under a test harness that escalates deprecations to errors it fails for essentially any semantic page. It surfaced in a downstream extension's CI on MediaWiki master / PHP 8.5.

## Fix

Coerce the table id to `''` explicitly:

```php
$state[$this->store->findPropertyTableID( $property ) ?? ''] = true;
```

This is behaviour-preserving — PHP already coerced the `null` to `''`, which is the documented "no table" value — it just makes the coercion explicit so no deprecation is raised. The downstream map is consulted via `isset( $state[$id][$tableName] )`, so an empty-string key is as harmless as it was before.

A deeper fix would be to make `findPropertyTableID()` honour its `''` contract at the source, but that touches more call sites; this keeps the change minimal and local to where the deprecation fires.