### PR TITLE
SemanticDataLookup: skip untabled properties in getTableUsageInfo

### DIFF
--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -102,10 +102,16 @@ class SemanticDataLookup {
 		$state = [];
 
 		foreach ( $semanticData->getProperties() as $property ) {
-			// findPropertyTableID() returns '' (not null) when a property has no
-			// dedicated table; coerce defensively so a null is never used as an
-			// array offset, which is deprecated as of PHP 8.4.
-			$state[$this->store->findPropertyTableID( $property ) ?? ''] = true;
+			$tableId = $this->store->findPropertyTableID( $property );
+
+			// null = not stored in any property table (e.g. sortkeys);
+			// '' = no dedicated table / unregistered type. Neither is a real
+			// table id, so skip rather than fabricate a $state[''] bucket.
+			if ( $tableId === null || $tableId === '' ) {
+				continue;
+			}
+
+			$state[$tableId] = true;
 		}
 
 		return $state;

--- a/src/SQLStore/PropertyTableInfoFetcher.php
+++ b/src/SQLStore/PropertyTableInfoFetcher.php
@@ -143,7 +143,7 @@ class PropertyTableInfoFetcher {
 	 *
 	 * @param Property $property
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public function findTableIdForProperty( Property $property ) {
 		if ( $this->fixedPropertyTableIds === null ) {

--- a/src/SQLStore/SQLStore.php
+++ b/src/SQLStore/SQLStore.php
@@ -573,7 +573,7 @@ class SQLStore extends Store {
 	 *
 	 * @param Property $property
 	 *
-	 * @return string
+	 * @return string|null
 	 */
 	public function findPropertyTableID( Property $property ) {
 		return $this->getPropertyTableInfoFetcher()->findTableIdForProperty( $property );

--- a/tests/phpunit/Unit/SQLStore/EntityStore/SemanticDataLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/SemanticDataLookupTest.php
@@ -147,6 +147,88 @@ class SemanticDataLookupTest extends TestCase {
 		);
 	}
 
+	public function testGetTableUsageInfoSkipsSortkeyProperty() {
+		$property = new Property( '_SKEY' );
+
+		$this->store->expects( $this->once() )
+			->method( 'findPropertyTableID' )
+			->with( $property )
+			->willReturn( null );
+
+		$semanticData = $this->getMockBuilder( SemanticData::class )
+			->setConstructorArgs( [ WikiPage::newFromText( 'Foo' ) ] )
+			->getMock();
+
+		$semanticData->expects( $this->any() )
+			->method( 'getProperties' )
+			->willReturn( [ $property ] );
+
+		$instance = new SemanticDataLookup(
+			$this->store
+		);
+
+		// _SKEY is never stored in a property table; findPropertyTableID()
+		// returns null for it, so it must not appear in the usage set.
+		$this->assertSame(
+			[],
+			$instance->getTableUsageInfo( $semanticData )
+		);
+	}
+
+	public function testGetTableUsageInfoSkipsPropertyWithoutDedicatedTable() {
+		$property = new Property( 'Foo' );
+
+		$this->store->expects( $this->once() )
+			->method( 'findPropertyTableID' )
+			->with( $property )
+			->willReturn( '' );
+
+		$semanticData = $this->getMockBuilder( SemanticData::class )
+			->setConstructorArgs( [ WikiPage::newFromText( 'Foo' ) ] )
+			->getMock();
+
+		$semanticData->expects( $this->any() )
+			->method( 'getProperties' )
+			->willReturn( [ $property ] );
+
+		$instance = new SemanticDataLookup(
+			$this->store
+		);
+
+		$this->assertSame(
+			[],
+			$instance->getTableUsageInfo( $semanticData )
+		);
+	}
+
+	public function testGetTableUsageInfoKeepsRealTableWhenSentinelPropertyPresent() {
+		$tabled = new Property( 'Foo' );
+		$sortkey = new Property( '_SKEY' );
+
+		$this->store->method( 'findPropertyTableID' )
+			->willReturnCallback( static function ( Property $property ) {
+				return $property->getKey() === 'Foo' ? '__bar__' : null;
+			} );
+
+		$semanticData = $this->getMockBuilder( SemanticData::class )
+			->setConstructorArgs( [ WikiPage::newFromText( 'Foo' ) ] )
+			->getMock();
+
+		$semanticData->expects( $this->any() )
+			->method( 'getProperties' )
+			->willReturn( [ $tabled, $sortkey ] );
+
+		$instance = new SemanticDataLookup(
+			$this->store
+		);
+
+		// A real table id is retained even when a sentinel property is skipped.
+		$this->assertSame(
+			[ '__bar__' => true ],
+			$instance->getTableUsageInfo( $semanticData )
+		);
+	}
+
 	public function testNewRequestOptions_NULL() {
 		$property = new Property( 'Foo' );
 


### PR DESCRIPTION
## Problem

PR #6962 silenced a PHP 8.4 "Using null as an array offset" deprecation in `SemanticDataLookup::getTableUsageInfo()` by coercing the offending value with `?? ''`. That value comes from `findPropertyTableID()`, which returns:

- a real property-table id for most properties,
- `''` for a property whose data-item type has no default table, and
- `null` for `_SKEY` (the sortkey), a deliberate sentinel set in `PropertyTableDefinitionBuilder` meaning "this property is never stored in any property table".

Coercing the `null` to `''` removed the deprecation but fabricated a meaningless `$state['']` entry and collapsed two semantically distinct "no table" signals into one. It also left the docblocks claiming `@return string` even though the methods can genuinely return `null`.

## Change

- `getTableUsageInfo()` now skips properties that have no property table (`null` or `''`) instead of using the value as an array key, matching how the sibling `PropertyTableRowMapper::mapToRows()` already handles sortkeys. The returned set is built only from real table ids.
- Correct the `@return string` docblock on `SQLStore::findPropertyTableID()` and `PropertyTableInfoFetcher::findTableIdForProperty()` to `@return string|null`, documenting the long-standing `_SKEY` behaviour.
- Add unit tests for the sortkey (`null`) case, the no-dedicated-table (`''`) case, and a mixed case where a real id is retained while a sentinel property is skipped.

The `_SKEY => null` sentinel is intentionally kept: it is the signal that lets the sibling mapper distinguish "never store this property" from "no dedicated table, use the data-item default". A native `?string` return type is deliberately not added. Several callers guard `''` but not `null`, so tightening the type would require auditing all of them; widening only the docblock is the accurate, low-risk step.

## Behaviour

Behaviour-preserving. The only consumer of `getTableUsageInfo()` is `CachingSemanticDataLookup`, which stores the result and later checks `isset( $state[$id][$tableName] )` using concrete property-table names. The empty-string key the previous code produced was never read, so dropping it changes nothing observable.
