### PR TITLE
Fix PHP 8.2 dynamic property deprecation for pre-7.0 cached data items

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -130,6 +130,7 @@ Adds MediaWiki 1.45 support (see [Compatibility](#compatibility)).
 * Fixed dependency tracking for pages embedding multiple `#ask` queries that share conditions but request different printouts. Changes to a printout-only property now correctly invalidate the embedding page's cached query results.
 * Fixed date columns in the `table` and `broadtable` result formats not sorting chronologically under locales that use `.` as a digit-group separator, such as German ([#6830](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6830))
 * Local time in `#ask` / `#show` output (`#LOCL#TO`) is now converted to each viewer's time zone in the browser. Previously it was rendered server-side and shared through the parser cache, so every viewer saw the time zone of whoever first populated the cache. Without JavaScript the wiki's local time is shown. The non-functional per-user parser-cache key (`localTime`) registered by the previous mechanism has been removed. ([#6820](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6820))
+* Fixed PHP 8.2 dynamic property deprecation warnings when reading data items from caches written by a pre-7.0 version ([#6965](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6965))
 
 ### Configuration changes
 

--- a/src/DataItems/DataItem.php
+++ b/src/DataItems/DataItem.php
@@ -2,6 +2,7 @@
 
 namespace SMW\DataItems;
 
+use AllowDynamicProperties;
 use InvalidArgumentException;
 use MediaWiki\Json\JsonDeserializable;
 use MediaWiki\Json\JsonDeserializer;
@@ -29,10 +30,25 @@ use SMW\Options;
  * property values may be influences by settings made for their property. This
  * aspect, however, is not part of the data item API.
  *
+ * Data items are routinely PHP-serialized into the object cache, both directly
+ * (property specifications via EntityCache) and as part of cached query results
+ * (QueryResultStore, which intentionally keeps pre-7.0 entries readable). Cache
+ * blobs written before this hierarchy moved into the SMW\DataItems namespace
+ * (#6453) encode the inherited private `$options` property under the old
+ * declaring-class mangle (`SMWDataItem`). Unserializing such a blob can no
+ * longer match that name to the renamed property and would otherwise create a
+ * dynamic property, which PHP 8.2 reports as a deprecation (#6965). Because the
+ * data items are shared across all of these caches, the tolerance belongs on
+ * the data item itself: AllowDynamicProperties keeps the legacy entries readable
+ * without the warning (the stray value is ignored by the declared accessors).
+ * This allowance is transitional and may be removed once upgrading directly from
+ * a pre-7.0 release is no longer supported.
+ *
  * @since 1.6
  *
  * @ingroup DataItems
  */
+#[AllowDynamicProperties]
 abstract class DataItem implements JsonDeserializable {
 
 	/// Data item ID that can be used to indicate that no data item class is appropriate

--- a/tests/phpunit/Unit/DataItems/CommonDataItemTest.php
+++ b/tests/phpunit/Unit/DataItems/CommonDataItemTest.php
@@ -4,6 +4,8 @@ namespace SMW\Tests\Unit\DataItems;
 
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\DataItem;
+use SMW\DataItems\Uri;
+use SMW\DataItems\WikiPage;
 
 /**
  * @covers \SMW\DataItems\DataItem
@@ -37,6 +39,68 @@ class CommonDataItemTest extends TestCase {
 		$this->assertCount(
 			2,
 			array_unique( $items )
+		);
+	}
+
+	/**
+	 * Cache blobs written before the data item classes moved into the
+	 * SMW\DataItems namespace (#6453) encode the inherited private
+	 * DataItem::$options under the old declaring-class mangle. Unserializing
+	 * such a blob must not create a dynamic `options` property, which PHP 8.2
+	 * reports as a deprecation (#6965).
+	 *
+	 * @dataProvider legacyCacheBlobProvider
+	 */
+	public function testUnserializeLegacyCacheBlobDoesNotCreateDynamicProperty( DataItem $dataItem, string $legacyClass ) {
+		$legacyBlob = $this->rewriteToLegacyNamespace( serialize( $dataItem ), get_class( $dataItem ), $legacyClass );
+
+		$deprecations = [];
+		set_error_handler(
+			static function ( $errno, $errstr ) use ( &$deprecations ) {
+				if ( str_contains( $errstr, 'dynamic property' ) ) {
+					$deprecations[] = $errstr;
+				}
+				return true;
+			},
+			E_ALL
+		);
+
+		try {
+			$restored = unserialize( $legacyBlob );
+		} finally {
+			restore_error_handler();
+		}
+
+		$this->assertInstanceOf( get_class( $dataItem ), $restored );
+		$this->assertSame( [], $deprecations );
+	}
+
+	public function legacyCacheBlobProvider() {
+		return [
+			'Uri written as SMWDIUri' => [ new Uri( 'http', 'example.org', '', '' ), 'SMWDIUri' ],
+			'WikiPage written as SMW\DIWikiPage' => [ new WikiPage( 'Example', NS_MAIN ), 'SMW\DIWikiPage' ],
+		];
+	}
+
+	/**
+	 * Rewrites a current data item serialization into the byte form a pre-#6453
+	 * blob would have: the outer class name and the inherited private
+	 * DataItem::$options mangle both keyed to the old global SMWDataItem name.
+	 */
+	private function rewriteToLegacyNamespace( string $blob, string $currentClass, string $legacyClass ): string {
+		$blob = str_replace(
+			'O:' . strlen( $currentClass ) . ':"' . $currentClass . '"',
+			'O:' . strlen( $legacyClass ) . ':"' . $legacyClass . '"',
+			$blob
+		);
+
+		$current = "\0" . DataItem::class . "\0options";
+		$legacy = "\0" . 'SMWDataItem' . "\0options";
+
+		return str_replace(
+			's:' . strlen( $current ) . ':"' . $current . '"',
+			's:' . strlen( $legacy ) . ':"' . $legacy . '"',
+			$blob
 		);
 	}
 


### PR DESCRIPTION
## Problem

On PHP 8.2, reading data items from caches populated by a pre-7.0 version produces repeated deprecation notices:

```
Deprecated: Creation of dynamic property SMW\DataItems\Uri::$options is deprecated in .../MediumSpecificBagOStuff.php
Deprecated: Creation of dynamic property SMW\DataItems\WikiPage::$options is deprecated in .../MediumSpecificBagOStuff.php
```

## Cause

The base `DataItem` class declares `private ?Options $options`. PHP encodes a private property in a serialized blob under a name mangled with its declaring class. The data item classes moved from the global `SMWDataItem` / `SMWDIUri` names into the `SMW\DataItems\` namespace in #6453. A cache blob written before that move carries the `$options` key mangled to the old class name (`SMWDataItem`). When such a blob is unserialized under the renamed class, the old key no longer matches the declared property, so PHP creates a dynamic `options` property and reports it as deprecated.

Data items reach more than one cache this way: property specifications via `EntityCache` (the path shown in the report, where `BagOStuff` performs the unserialize), and cached query results via `QueryResultStore`, which intentionally keeps pre-7.0 entries readable.

## Fix

Mark the `DataItem` base class with `#[AllowDynamicProperties]`, which is inherited by every data item subclass. Because the data items are shared across all of those caches, placing the tolerance on the data item itself keeps each legacy entry readable without the warning; the stray value is ignored by the declared accessors, and fresh entries are written in the current format. This mirrors how MediaWiki core marks `Parser`, `User`, and `EditPage` for legacy-serialization tolerance.

The allowance is transitional: it can be removed once upgrading directly from a pre-7.0 release is no longer supported, at which point no pre-7.0 cache blobs can exist. A cache-version bump was considered instead, but it would have to be applied per cache and would contradict `QueryResultStore`'s deliberate cross-version readability, while still not guarding against future class moves.

A regression test reconstructs a pre-7.0 blob (old class name plus the old `$options` mangle) for both a `Uri` and a `WikiPage` and asserts that unserializing it raises no dynamic-property deprecation.

## Note on the third reported warning

The report also lists `OutputPage::$smwmagicwords`. This is not reproducible on current `master`: SMW stores magic words exclusively through `ParserOutput::setExtensionData( 'smwmagicwords', ... )`, and no code path assigns that property on `OutputPage`. Driving the real output pipeline on a factbox page (which populates the `smwmagicwords` extension data) produces no such property and no deprecation. The output-object dynamic-property write for magic words was removed long ago, and MediaWiki only began reporting dynamic-property writes on `OutputPage` in 1.43; the warning appears to come from a build predating the removal. No SMW change is needed for it.

Resolves #6965
