### PR TITLE
SemanticDataLookup: cover the property value listing query for blob tables

### DIFF
--- a/src/SQLStore/EntityStore/DataItemHandlers/DIBlobHandler.php
+++ b/src/SQLStore/EntityStore/DataItemHandlers/DIBlobHandler.php
@@ -217,8 +217,12 @@ class DIBlobHandler extends DataItemHandler {
 	 * string length to 300-32 for LIKE/NLIKE queries.
 	 *
 	 * @since 3.0
+	 *
+	 * @since 7.0.0 exposed as public so callers can distinguish an inline
+	 * value (stored in `o_hash`) from a truncated long value (stored in
+	 * `o_blob`) by the length of `o_hash`.
 	 */
-	private function getMaxLength(): int {
+	public function getMaxLength(): int {
 		$length = 72;
 
 		if ( $this->hasFeature( SMW_FIELDT_CHAR_LONG ) ) {

--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -9,6 +9,7 @@ use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\DataModel\SequenceMap;
+use SMW\DataValues\KeywordValue;
 use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\RequestOptions;
 use SMW\SQLStore\Lookup\RedirectTargetLookup;
@@ -355,7 +356,156 @@ class SemanticDataLookup {
 			] );
 		}
 
+		// Fast path for listing the distinct values of a non-keyword blob
+		// property (e.g. Special:PageProperty). The generic DISTINCT over
+		// [ o_blob, o_hash ] cannot use the (p_id, o_hash) index because o_blob
+		// is a non-indexed MEDIUMBLOB, so a property with many subjects but few
+		// distinct values turns into a full partition scan that reads every
+		// blob body. For non-keyword blob values o_hash determines the value
+		// (it is the value when it fits inline; otherwise a truncated + md5 key
+		// mapping to exactly one o_blob), so the distinct set is found with a
+		// covering DISTINCT over o_hash and the rare long-value bodies fetched
+		// by an indexed point lookup. Keyword properties are excluded because
+		// their o_hash is a lossy (lowercased/transliterated) form of a still
+		// distinct o_blob, so dedup must remain on the [ o_blob, o_hash ] pair.
+		if ( !$isSubject
+			&& $propTable->getDIType() === DataItem::TYPE_BLOB
+			&& $dataItem->findPropertyValueType() !== KeywordValue::TYPE_ID
+		) {
+			return $this->fetchDistinctBlobValuesFromTable( $qb, $propTable, $id, $requestOptions );
+		}
+
 		return $this->fetchFromTable( $qb, $propTable, $isSubject, $requestOptions );
+	}
+
+	/**
+	 * Covering fast path for `fetchSemanticDataFromTable` when listing the
+	 * distinct values of a non-keyword blob property. See the call site for the
+	 * rationale.
+	 *
+	 * @return array<array{0: string|null, 1: string}> list of [ o_blob, o_hash ]
+	 *  pairs in the same shape `fetchFromTable` returns for the non-subject case
+	 */
+	private function fetchDistinctBlobValuesFromTable( SelectQueryBuilder $qb, PropertyTableDefinition $propTable, $id, ?RequestOptions $requestOptions ): array {
+		if ( $requestOptions === null ) {
+			$requestOptions = new RequestOptions();
+		}
+
+		$diHandler = $this->store->getDataItemHandlerForDIType( $propTable->getDIType() );
+		$maxLength = $diHandler->getMaxLength();
+
+		// o_hash is the value, sort and label field for a blob data item.
+		$valueField = 'o_hash';
+
+		// A string match (value search) and its sort apply to o_hash, mirroring
+		// the non-subject branch of fetchFromTable.
+		$explicitOrder = $requestOptions->getStringConditions() !== [] && $requestOptions->sort;
+
+		if ( $explicitOrder ) {
+			$sort = $requestOptions->ascending ? 'ASC' : 'DESC';
+			$requestOptions->setOption( 'ORDER BY', $valueField . " $sort" );
+		}
+
+		$conds = $this->store->getSQLConditions( $requestOptions, $valueField, $valueField, false );
+
+		if ( $conds !== '' ) {
+			$qb->andWhere( $conds );
+		}
+
+		// Covering DISTINCT over o_hash only.
+		$requestOptions->setOption( 'DISTINCT', true );
+		$opts = $this->store->getSQLOptions( $requestOptions, $valueField );
+
+		// Preserve a Postgres-specific `DISTINCT ON (...)` value as fetchFromTable does.
+		if ( isset( $opts['DISTINCT'] ) && is_string( $opts['DISTINCT'] ) ) {
+			$qb->option( 'DISTINCT', $opts['DISTINCT'] );
+			unset( $opts['DISTINCT'] );
+		}
+
+		if ( $requestOptions->exclude_limit ) {
+			unset( $opts['LIMIT'], $opts['OFFSET'] );
+		}
+
+		LegacyOptionsApplier::applyTo( $qb, $opts );
+
+		if (
+			$requestOptions->getOption( RequestOptions::CONDITION_CONSTRAINT_RESULT, false ) ||
+			$requestOptions->getOption( RequestOptions::CONDITION_CONSTRAINT, false ) ) {
+			if ( $requestOptions->sort ) {
+				$sort = $requestOptions->ascending ? 'ASC' : 'DESC';
+				$qb->orderBy( $valueField . " $sort" );
+			}
+		}
+
+		$qb->select( [ 'v1' => $valueField ] );
+
+		$hashes = [];
+		$res = $qb->caller( __METHOD__ )->fetchResultSet();
+
+		foreach ( $res as $row ) {
+			$hashes[$row->v1] = true;
+		}
+
+		$res->free();
+
+		// Reconstruct [ o_blob, o_hash ]. A value whose o_hash is shorter than
+		// the field length is stored inline (o_blob is NULL) and needs no
+		// lookup. Only an o_hash at (near) the field length can belong to a
+		// truncated long value: makeHash() keeps maxLength-32 bytes plus a
+		// 32-byte md5, and multibyte truncation can drop up to 3 bytes, so any
+		// o_hash within 3 bytes of the field length may have a stored body.
+		//
+		// This issues at most one indexed point lookup per distinct long value,
+		// i.e. bounded by the request limit, and none for the common case of
+		// inline values. The worst case (a property dominated by distinct long
+		// values) stays within the same order as the original single-statement
+		// scan it replaces, while the common many-subjects/few-values case
+		// avoids reading every blob body in the partition.
+		$threshold = $maxLength - 3;
+		$result = [];
+
+		foreach ( array_keys( $hashes ) as $hash ) {
+			$hash = (string)$hash;
+			$blob = null;
+
+			if ( strlen( $hash ) >= $threshold ) {
+				$blob = $this->fetchBlobByHash( $propTable, $id, $hash );
+			}
+
+			$result[] = [ $blob, $hash ];
+		}
+
+		// Mirror fetchFromTable: when no explicit ORDER BY was requested, apply
+		// a deterministic lexical order so a retrieved range is stable.
+		if ( !$explicitOrder ) {
+			sort( $result );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Point lookup for the o_blob body of a single (long) value, reached by the
+	 * (p_id, o_hash) index. Returns null when the value is stored inline.
+	 *
+	 * @return string|null
+	 */
+	private function fetchBlobByHash( PropertyTableDefinition $propTable, $id, string $hash ) {
+		$connection = $this->store->getConnection( 'mw.db' );
+
+		$qb = $connection->newSelectQueryBuilder()
+			->from( $propTable->getName() )
+			->select( 'o_blob' )
+			->where( [ 'o_hash' => $hash ] )
+			->limit( 1 );
+
+		if ( !$propTable->isFixedPropertyTable() ) {
+			$qb->andWhere( [ 'p_id' => $id ] );
+		}
+
+		$blob = $qb->caller( __METHOD__ )->fetchField();
+
+		return $blob === false ? null : $blob;
 	}
 
 	/**

--- a/tests/phpunit/Integration/JSONScript/TestCases/special-page-property-0002.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/special-page-property-0002.json
@@ -1,0 +1,51 @@
+{
+	"description": "Test output from `Special:PageProperty` listing the distinct values of a text property (`_txt`, covering fast path)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "SP0002 text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Example/SP0002/1",
+			"contents": "[[SP0002 text::AlphaSmoke]]"
+		},
+		{
+			"page": "Example/SP0002/2",
+			"contents": "[[SP0002 text::BetaSmoke]]"
+		},
+		{
+			"page": "Example/SP0002/3",
+			"contents": "[[SP0002 text::AlphaSmoke]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "#0 lists each distinct value once",
+			"special-page": {
+				"page": "PageProperty",
+				"query-parameters": "",
+				"request-parameters": {
+					"type": "SP0002 text"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<li>AlphaSmoke&#160;&#160;<span class=\"smwsearch\"><a href=\".*:SP0002-20text/AlphaSmoke\" title=\"AlphaSmoke\">+</a></span></li>",
+					"<li>BetaSmoke&#160;&#160;<span class=\"smwsearch\"><a href=\".*:SP0002-20text/BetaSmoke\" title=\"BetaSmoke\">+</a></span></li>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"wgLanguageCode": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/Query/SemanticDataLookupTest.php
+++ b/tests/phpunit/Integration/Query/SemanticDataLookupTest.php
@@ -192,4 +192,160 @@ class SemanticDataLookupTest extends SMWIntegrationTestCase {
 		);
 	}
 
+	public function testPropertyValueMatch_Txt_ShortValuesDistinctAcrossSubjects() {
+		$store = StoreFactory::getStore();
+
+		$property = new Property( 'SomeShortBlobValuesProperty' );
+		$property->setPropertyValueType( '_txt' );
+
+		// Several subjects sharing a small set of distinct short (<= 72 byte)
+		// values: the "few distinct values, many subjects" shape behind the
+		// slow Special:PageProperty value listing.
+		$values = [ 'alpha', 'beta', 'alpha', 'gamma', 'beta' ];
+
+		foreach ( $values as $i => $value ) {
+			$semanticData = $this->semanticDataFactory->newEmptySemanticData( 'ShortBlobSubject' . $i );
+			$this->subjectsToBeCleared[] = $semanticData->getSubject();
+			$semanticData->addPropertyObjectValue( $property, new Blob( $value ) );
+			$store->updateData( $semanticData );
+		}
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->setLimit( 10 );
+		$requestOptions->setOffset( 0 );
+
+		$results = $store->getPropertyValues( null, $property, $requestOptions );
+
+		$strings = array_map( static fn ( $di ) => $di->getString(), $results );
+		sort( $strings );
+
+		$this->assertEquals(
+			[ 'alpha', 'beta', 'gamma' ],
+			$strings
+		);
+	}
+
+	public function testPropertyValueMatch_Txt_LongValueIsReconstructed() {
+		$store = StoreFactory::getStore();
+
+		$property = new Property( 'SomeLongBlobValueProperty' );
+		$property->setPropertyValueType( '_txt' );
+
+		// > 72 bytes, so it is stored in o_blob with a truncated + hashed
+		// o_hash; the full value must still be reconstructed on read.
+		$longValue = str_repeat( 'abcdefghij', 12 );
+
+		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
+		$this->subjectsToBeCleared[] = $semanticData->getSubject();
+		$semanticData->addPropertyObjectValue( $property, new Blob( $longValue ) );
+		$store->updateData( $semanticData );
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->setLimit( 10 );
+
+		$results = $store->getPropertyValues( null, $property, $requestOptions );
+
+		$this->assertCount( 1, $results );
+		$this->assertSame( $longValue, end( $results )->getString() );
+	}
+
+	public function testPropertyValueMatch_Keyword_CaseVariantsRemainDistinct() {
+		$store = StoreFactory::getStore();
+
+		$property = new Property( 'SomeKeywordValuesProperty' );
+		$property->setPropertyValueType( '_keyw' );
+
+		// Keyword values normalise (lowercase, transliterate) to the same
+		// o_hash while keeping a distinct o_blob, so listing must preserve
+		// the case variants as distinct values.
+		$values = [ 'Foo', 'foo', 'FOO' ];
+
+		foreach ( $values as $i => $value ) {
+			$semanticData = $this->semanticDataFactory->newEmptySemanticData( 'KeywordSubject' . $i );
+			$this->subjectsToBeCleared[] = $semanticData->getSubject();
+
+			$dataValue = $this->dataValueFactory->newDataValueByProperty( $property, $value );
+			$semanticData->addPropertyObjectValue( $property, $dataValue->getDataItem() );
+			$store->updateData( $semanticData );
+		}
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->setLimit( 10 );
+
+		$results = $store->getPropertyValues( null, $property, $requestOptions );
+
+		$strings = array_map( static fn ( $di ) => $di->getString(), $results );
+		sort( $strings );
+
+		$this->assertEquals(
+			[ 'FOO', 'Foo', 'foo' ],
+			$strings
+		);
+	}
+
+	public function testPropertyValueMatch_Txt_MixedShortAndLongValues() {
+		$store = StoreFactory::getStore();
+
+		$property = new Property( 'SomeMixedBlobValuesProperty' );
+		$property->setPropertyValueType( '_txt' );
+
+		// A single property holding both inline (<= 72 byte, o_blob NULL) and
+		// long (> 72 byte, o_blob set) distinct values, so the reconstruction
+		// exercises the per-value blob fetch for some values but not others
+		// within one result set.
+		$short1 = 'cat';
+		$short2 = 'dog';
+		$long1 = str_repeat( 'long-value-one-', 8 );
+		$long2 = str_repeat( 'long-value-two-', 8 );
+
+		$values = [ $short1, $long1, $short2, $long2, $short1, $long1 ];
+
+		foreach ( $values as $i => $value ) {
+			$semanticData = $this->semanticDataFactory->newEmptySemanticData( 'MixedBlobSubject' . $i );
+			$this->subjectsToBeCleared[] = $semanticData->getSubject();
+			$semanticData->addPropertyObjectValue( $property, new Blob( $value ) );
+			$store->updateData( $semanticData );
+		}
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->setLimit( 10 );
+
+		$results = $store->getPropertyValues( null, $property, $requestOptions );
+
+		$strings = array_map( static fn ( $di ) => $di->getString(), $results );
+		sort( $strings );
+
+		$expected = [ $short1, $short2, $long1, $long2 ];
+		sort( $expected );
+
+		$this->assertEquals( $expected, $strings );
+	}
+
+	public function testPropertyValueMatch_Txt_LimitBoundsTheResultSet() {
+		$store = StoreFactory::getStore();
+
+		$property = new Property( 'SomeLimitedBlobValuesProperty' );
+		$property->setPropertyValueType( '_txt' );
+
+		$values = [ 'one', 'two', 'three', 'four', 'five' ];
+
+		foreach ( $values as $i => $value ) {
+			$semanticData = $this->semanticDataFactory->newEmptySemanticData( 'LimitedBlobSubject' . $i );
+			$this->subjectsToBeCleared[] = $semanticData->getSubject();
+			$semanticData->addPropertyObjectValue( $property, new Blob( $value ) );
+			$store->updateData( $semanticData );
+		}
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->setLimit( 2 );
+
+		$results = $store->getPropertyValues( null, $property, $requestOptions );
+
+		$this->assertCount( 2, $results );
+
+		foreach ( $results as $result ) {
+			$this->assertContains( $result->getString(), $values );
+		}
+	}
+
 }


### PR DESCRIPTION
## Benchmark

`Special:PageProperty` listing the distinct values of a text property with 200k subjects and 3 distinct values (MariaDB 10.11):

| | query | plan | time |
| --- | --- | --- | --- |
| Before | `SELECT DISTINCT o_blob, o_hash ... ORDER BY o_hash LIMIT 21` | `Using index condition; Using temporary` | ~770 ms |
| After | `SELECT DISTINCT o_hash ... ORDER BY o_hash LIMIT 21` (covering; inline values need no blob fetch) | `Using where; Using index` | ~50 ms |

About 15x on this shape. The gain scales with the partition size and narrows toward parity for high-cardinality properties, which were already fast.

## Problem

Listing the distinct values of a blob/text property (for example the `Special:PageProperty` overflow page linked from property pages and factboxes) runs

```sql
SELECT DISTINCT o_blob, o_hash FROM smw_di_blob WHERE p_id = X ORDER BY o_hash LIMIT N
```

`o_blob` is a non-indexed `MEDIUMBLOB`, so the query cannot be satisfied by the `(p_id, o_hash)` index and reads every blob body in the `p_id` partition. For a property with many subjects but few distinct values the `DISTINCT` + `LIMIT` cannot short-circuit, so it scans the entire partition.

## Change

For a **non-keyword** blob property the value is fully determined by `o_hash` (it is the value when it fits inline, otherwise a truncated prefix plus an md5 that maps back to exactly one `o_blob`). `getPropertyValues( null, $property )` now:

- finds the distinct set with a covering `DISTINCT o_hash`, then
- reconstructs each value, fetching `o_blob` with an indexed point lookup only for the values actually stored out of line (longer than the inline field length).

Keyword (`_keyw`) properties keep the existing `[o_blob, o_hash]` pair `DISTINCT`, because their `o_hash` is a lowercased and transliterated normalisation of a still-distinct `o_blob`, so dedup must stay on the pair.

Result reconstruction, string-condition value matching, sorting and pagination are preserved. The point-lookup fan-out is at most one indexed lookup per distinct long value (bounded by the request limit, and none for the common inline-value case).

## Tests

Adds integration coverage for the blob value listing path (short, long, mixed short and long, keyword distinctness, and limit) and a `Special:PageProperty` render fixture for a text property (the existing special-page fixture only covered a date property).

Refs #6559.