### PR TITLE
Support parallelism and batching for outdated-entity disposal

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.0.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.0.0.md
@@ -100,6 +100,9 @@ Adds MediaWiki 1.45 support (see [Compatibility](#compatibility)).
 * `$wgSearchType` can now be set to `SMW\MediaWiki\Search\ExtendedSearchEngine` to enable the extended search, alongside the deprecated `SMWSearch` alias. ([#6944](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6944))
 * Date values rendered in HTML (result tables, the factbox, `Special:Browse`, `Special:SearchByProperty`) are now wrapped in a semantic `<time datetime>` element, exposing a machine-readable date to assistive technology and other consumers while the displayed text is unchanged. Exports (CSV, JSON, RDF) stay plain. ([#6830](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6830))
 * `rebuildData.php` accepts a new `--use-job` option that queues its update jobs instead of running them inline, so a full rebuild can be processed in parallel with `runJobs.php --type smw.update --procs N`. The per-entity parse cost is unchanged, so set the worker count to what your database can absorb. ([#6952](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6952))
+* Outdated-entity disposal now removes references in batched IN-list deletes, making `disposeOutdatedEntities.php` and the rebuild disposal prologue substantially faster on large wikis. ([#6968](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6968))
+* `disposeOutdatedEntities.php` accepts new `--of`/`--shard` options to run disposal across several parallel processes over disjoint `smw_id` shards (query-link cleanup runs on shard 0). ([#6968](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6968))
+* `rebuildData.php` accepts a new `--skip-dispose` option to skip the disposal prologue, enabling parallel ranged rebuilds after a single (optionally sharded) disposal run. ([#6968](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6968))
 
 ### Bug fixes
 

--- a/maintenance/README.md
+++ b/maintenance/README.md
@@ -73,6 +73,18 @@ Usage:
 php maintenance/run.php SemanticMediaWiki:disposeOutdatedEntities
 ```
 
+To split disposal across N parallel processes (each handling a disjoint `smw_id % N` shard), run one process per shard:
+
+```sh
+php maintenance/run.php SemanticMediaWiki:disposeOutdatedEntities --of 4 --shard 0 &
+php maintenance/run.php SemanticMediaWiki:disposeOutdatedEntities --of 4 --shard 1 &
+php maintenance/run.php SemanticMediaWiki:disposeOutdatedEntities --of 4 --shard 2 &
+php maintenance/run.php SemanticMediaWiki:disposeOutdatedEntities --of 4 --shard 3 &
+wait
+```
+
+Tune N to what the database absorbs (disposal is write-bound). Query-link cleanup runs only on shard 0.
+
 ### dumpRDF.php
 
 Allows to do a complete RDF export of existing triples. Available since SMW 2.0.0
@@ -126,8 +138,10 @@ See also: [Help:Maintenance_script_rebuildData.php](https://www.semantic-mediawi
 
 Usage:
 ```sh
-php maintenance/run.php SemanticMediaWiki:rebuildData [-d|-s|-e|-f|-n|--startidfile|-b|-v|-c|-p|-t|--page|--redirects|--query|-f|--no-cache|--report-runtime|--debug|--skip-properties|--shallow-update|--ignore-exceptions|--exception-log|--with-maintenance-log|--revision-mode|--force-update|--dispose-outdated]
+php maintenance/run.php SemanticMediaWiki:rebuildData [-d|-s|-e|-f|-n|--startidfile|-b|-v|-c|-p|-t|--page|--redirects|--query|-f|--no-cache|--report-runtime|--debug|--skip-properties|--shallow-update|--ignore-exceptions|--exception-log|--with-maintenance-log|--revision-mode|--force-update|--dispose-outdated|--skip-dispose]
 ```
+
+Use `--skip-dispose` to skip the disposal prologue so several ranged rebuilds can run in parallel; run disposeOutdatedEntities.php (optionally sharded) once beforehand.
 
 ### rebuildElasticIndex.php
 

--- a/maintenance/disposeOutdatedEntities.php
+++ b/maintenance/disposeOutdatedEntities.php
@@ -41,6 +41,8 @@ class disposeOutdatedEntities extends Maintenance {
 		parent::__construct();
 		$this->addDescription( "Dispose of outdated entities." );
 		$this->addOption( 'with-maintenance-log', 'Add log entry to `Special:Log` about the maintenance run.', false );
+		$this->addOption( 'of', '<N> Total number of parallel shards to split the disposal across.', false, true );
+		$this->addOption( 'shard', '<k> Zero-based index (0..N-1) of this shard; requires --of.', false, true );
 	}
 
 	/**
@@ -77,10 +79,23 @@ class disposeOutdatedEntities extends Maintenance {
 
 		$title = $this->getServiceContainer()->getTitleFactory()->newFromText( __METHOD__ );
 
+		$of = $this->hasOption( 'of' ) ? (int)$this->getOption( 'of' ) : 1;
+		$shard = $this->hasOption( 'shard' ) ? (int)$this->getOption( 'shard' ) : 0;
+
+		if ( $this->hasOption( 'of' ) !== $this->hasOption( 'shard' ) ) {
+			$this->fatalError( "--of and --shard must be used together.\n" );
+		}
+
+		if ( $of < 1 || $shard < 0 || $shard >= $of ) {
+			$this->fatalError( "Invalid shard configuration: require --of >= 1 and 0 <= --shard < --of.\n" );
+		}
+
 		$outdatedDisposer = new OutdatedDisposer(
 			$applicationFactory->newJobFactory()->newEntityIdDisposerJob( $title ),
 			$applicationFactory->getIteratorFactory()
 		);
+
+		$outdatedDisposer->setShard( $shard, $of );
 
 		if ( $this->messageReporter === null ) {
 			$this->messageReporter = new CallbackMessageReporter( [ $this, 'reportMessage' ] );

--- a/maintenance/disposeOutdatedEntities.php
+++ b/maintenance/disposeOutdatedEntities.php
@@ -64,6 +64,28 @@ class disposeOutdatedEntities extends Maintenance {
 	}
 
 	/**
+	 * Validates the --of/--shard option pair. Returned as a string (rather than
+	 * calling fatalError directly) so the rule is unit-testable without driving
+	 * the maintenance harness, whose fatalError behaviour varies across
+	 * MediaWiki versions.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @return string|null Error message when the configuration is invalid, null when acceptable
+	 */
+	public function getShardConfigError( bool $hasOf, bool $hasShard, int $of, int $shard ): ?string {
+		if ( $hasOf !== $hasShard ) {
+			return '--of and --shard must be used together.';
+		}
+
+		if ( $of < 1 || $shard < 0 || $shard >= $of ) {
+			return 'Invalid shard configuration: require --of >= 1 and 0 <= --shard < --of.';
+		}
+
+		return null;
+	}
+
+	/**
 	 * @see Maintenance::execute
 	 */
 	public function execute() {
@@ -82,12 +104,15 @@ class disposeOutdatedEntities extends Maintenance {
 		$of = $this->hasOption( 'of' ) ? (int)$this->getOption( 'of' ) : 1;
 		$shard = $this->hasOption( 'shard' ) ? (int)$this->getOption( 'shard' ) : 0;
 
-		if ( $this->hasOption( 'of' ) !== $this->hasOption( 'shard' ) ) {
-			$this->fatalError( "--of and --shard must be used together.\n" );
-		}
+		$error = $this->getShardConfigError(
+			$this->hasOption( 'of' ),
+			$this->hasOption( 'shard' ),
+			$of,
+			$shard
+		);
 
-		if ( $of < 1 || $shard < 0 || $shard >= $of ) {
-			$this->fatalError( "Invalid shard configuration: require --of >= 1 and 0 <= --shard < --of.\n" );
+		if ( $error !== null ) {
+			$this->fatalError( $error . "\n" );
 		}
 
 		$outdatedDisposer = new OutdatedDisposer(

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -95,6 +95,7 @@ class rebuildData extends Maintenance {
 		$this->addOption( 'namespace', 'Only refresh pages in the selected namespace. Example: --namespace="NS_MAIN"', false, false );
 		$this->addOption( 'redirects', 'Only refresh redirect pages', false );
 		$this->addOption( 'dispose-outdated', 'Only Remove outdated marked entities (including pending references).', false );
+		$this->addOption( 'skip-dispose', 'Skip the outdated-entity disposal prologue (run disposeOutdatedEntities.php separately, e.g. for parallel ranged rebuilds).', false );
 		$this->addOption( 'remove-remnantentities', 'Check and remove remnant entities (ghosts) from tables without a corresponding hash field entry', false );
 
 		$this->addOption( 'skip-properties', 'Skip the default properties rebuild (only recommended when successive build steps are used)', false );

--- a/src/Maintenance/DataRebuilder.php
+++ b/src/Maintenance/DataRebuilder.php
@@ -284,12 +284,24 @@ class DataRebuilder {
 		);
 
 		// By default we expect the disposal action to take place whenever the
-		// script is run
-		$this->runOutdatedDisposer();
+		// script is run; --skip-dispose opts out so disposal can be run separately
+		// (e.g. sharded) without colliding with parallel ranged rebuilds.
+		$skipDispose = $this->options->safeGet( 'skip-dispose', false );
 
-		// Only expected the disposal action?
 		if ( $this->options->has( 'dispose-outdated' ) ) {
+			if ( $skipDispose ) {
+				$this->reportMessage(
+					"\nNote: --skip-dispose with --dispose-outdated does nothing; no disposal performed.\n"
+				);
+				return true;
+			}
+
+			$this->runOutdatedDisposer();
 			return true;
+		}
+
+		if ( !$skipDispose ) {
+			$this->runOutdatedDisposer();
 		}
 
 		if ( !$this->options->has( 'skip-properties' ) ) {

--- a/src/Maintenance/DataRebuilder/OutdatedDisposer.php
+++ b/src/Maintenance/DataRebuilder/OutdatedDisposer.php
@@ -5,6 +5,8 @@ namespace SMW\Maintenance\DataRebuilder;
 use Onoi\MessageReporter\MessageReporterAwareTrait;
 use SMW\IteratorFactory;
 use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
+use SMW\RequestOptions;
+use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\Utils\CliMsgFormatter;
 
 /**
@@ -20,6 +22,8 @@ class OutdatedDisposer {
 	use MessageReporterAwareTrait;
 
 	private CliMsgFormatter $cliMsgFormatter;
+	private int $shard = 0;
+	private int $of = 1;
 
 	/**
 	 * @since 3.1
@@ -32,9 +36,25 @@ class OutdatedDisposer {
 	}
 
 	/**
+	 * @since 7.0.0
+	 */
+	public function setShard( int $shard, int $of ): void {
+		$this->shard = $shard;
+		$this->of = $of;
+	}
+
+	/**
 	 * @since 3.1
 	 */
 	public function run(): void {
+		$requestOptions = null;
+
+		if ( $this->of > 1 ) {
+			$requestOptions = new RequestOptions();
+			$requestOptions->setOption( PropertyTableIdReferenceDisposer::OPT_SHARD_OF, $this->of );
+			$requestOptions->setOption( PropertyTableIdReferenceDisposer::OPT_SHARD_INDEX, $this->shard );
+		}
+
 		$this->messageReporter->reportMessage(
 			"Removing outdated and invalid entities ...\n"
 		);
@@ -43,7 +63,7 @@ class OutdatedDisposer {
 			$this->cliMsgFormatter->firstCol( '   ... checking outdated entities ...' )
 		);
 
-		$resultIterator = $this->entityIdDisposerJob->newOutdatedEntitiesResultIterator();
+		$resultIterator = $this->entityIdDisposerJob->newOutdatedEntitiesResultIterator( $requestOptions );
 
 		$count = $resultIterator->count();
 		if ( $count > 0 ) {
@@ -58,7 +78,7 @@ class OutdatedDisposer {
 			$this->cliMsgFormatter->firstCol( '   ... checking invalid entities by namespace ...' )
 		);
 
-		$resultIterator = $this->entityIdDisposerJob->newByNamespaceInvalidEntitiesResultIterator();
+		$resultIterator = $this->entityIdDisposerJob->newByNamespaceInvalidEntitiesResultIterator( $requestOptions );
 
 		$count = $resultIterator->count();
 		if ( $count > 0 ) {
@@ -71,41 +91,47 @@ class OutdatedDisposer {
 
 		$this->messageReporter->reportMessage( "   ... done.\n" );
 
-		$this->messageReporter->reportMessage(
-			"\nRemoving query links ...\n"
-		);
+		if ( $this->shard === 0 ) {
+			$this->messageReporter->reportMessage(
+				"\nRemoving query links ...\n"
+			);
 
-		$this->messageReporter->reportMessage(
-			$this->cliMsgFormatter->firstCol( '   ... checking query links (invalid) ...' )
-		);
+			$this->messageReporter->reportMessage(
+				$this->cliMsgFormatter->firstCol( '   ... checking query links (invalid) ...' )
+			);
 
-		$resultIterator = $this->entityIdDisposerJob->newOutdatedQueryLinksResultIterator();
+			$resultIterator = $this->entityIdDisposerJob->newOutdatedQueryLinksResultIterator();
 
-		$count = $resultIterator->count();
-		if ( $count > 0 ) {
-			$this->disposeOutdatedQueryLinks( $resultIterator, $count, 'query links (invalid)' );
+			$count = $resultIterator->count();
+			if ( $count > 0 ) {
+				$this->disposeOutdatedQueryLinks( $resultIterator, $count, 'query links (invalid)' );
+			} else {
+				$this->messageReporter->reportMessage(
+					$this->cliMsgFormatter->secondCol( CliMsgFormatter::OK )
+				);
+			}
+
+			$this->messageReporter->reportMessage(
+				$this->cliMsgFormatter->firstCol( '   ... checking query links (unassigned) ...' )
+			);
+
+			$resultIterator = $this->entityIdDisposerJob->newUnassignedQueryLinksResultIterator();
+
+			$count = $resultIterator->count();
+			if ( $count > 0 ) {
+				$this->disposeOutdatedQueryLinks( $resultIterator, $count, 'query links (unassigned)' );
+			} else {
+				$this->messageReporter->reportMessage(
+					$this->cliMsgFormatter->secondCol( CliMsgFormatter::OK )
+				);
+			}
+
+			$this->messageReporter->reportMessage( "   ... done.\n" );
 		} else {
 			$this->messageReporter->reportMessage(
-				$this->cliMsgFormatter->secondCol( CliMsgFormatter::OK )
+				"\nRemoving query links ... (skipped on shard {$this->shard}; runs on shard 0)\n"
 			);
 		}
-
-		$this->messageReporter->reportMessage(
-			$this->cliMsgFormatter->firstCol( '   ... checking query links (unassigned) ...' )
-		);
-
-		$resultIterator = $this->entityIdDisposerJob->newUnassignedQueryLinksResultIterator();
-
-		$count = $resultIterator->count();
-		if ( $count > 0 ) {
-			$this->disposeOutdatedQueryLinks( $resultIterator, $count, 'query links (unassigned)' );
-		} else {
-			$this->messageReporter->reportMessage(
-				$this->cliMsgFormatter->secondCol( CliMsgFormatter::OK )
-			);
-		}
-
-		$this->messageReporter->reportMessage( "   ... done.\n" );
 	}
 
 	private function disposeOutdatedEntities( $resultIterator, int $count ): void {

--- a/src/Maintenance/DataRebuilder/OutdatedDisposer.php
+++ b/src/Maintenance/DataRebuilder/OutdatedDisposer.php
@@ -115,16 +115,19 @@ class OutdatedDisposer {
 		$counter = 0;
 
 		foreach ( $chunkedIterator as $chunk ) {
+			$rows = [];
+
 			foreach ( $chunk as $row ) {
 				$counter++;
+				$rows[] = $row;
 				$msg = sprintf( "%s (%1.0f%%)", $row->smw_id, round( $counter / $count * 100 ) );
 
 				$this->messageReporter->reportMessage(
 					$this->cliMsgFormatter->twoColsOverride( '       ... cleaning up entity', $msg )
 				);
-
-				$this->entityIdDisposerJob->dispose( $row );
 			}
+
+			$this->entityIdDisposerJob->disposeList( $rows );
 		}
 
 		$this->messageReporter->reportMessage( "\n" );

--- a/src/MediaWiki/Jobs/EntityIdDisposerJob.php
+++ b/src/MediaWiki/Jobs/EntityIdDisposerJob.php
@@ -126,6 +126,28 @@ class EntityIdDisposerJob extends Job {
 	}
 
 	/**
+	 * Batched counterpart to dispose(); resolves the disposer once and removes a
+	 * whole chunk of ids in IN-list deletes.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param array $rows Array of stdClass rows (with smw_id) or ints
+	 */
+	public function disposeList( array $rows ): void {
+		if ( $this->propertyTableIdReferenceDisposer === null ) {
+			$this->propertyTableIdReferenceDisposer = $this->newPropertyTableIdReferenceDisposer();
+		}
+
+		$ids = [];
+
+		foreach ( $rows as $row ) {
+			$ids[] = is_int( $row ) ? $row : (int)$row->smw_id;
+		}
+
+		$this->propertyTableIdReferenceDisposer->cleanUpTableEntriesByIdList( $ids );
+	}
+
+	/**
 	 * @see Job::run
 	 *
 	 * @since 2.5
@@ -181,9 +203,7 @@ class EntityIdDisposerJob extends Job {
 
 			$transactionTicket = $connection->getEmptyTransactionTicket( __METHOD__ );
 
-			foreach ( $chunk as $row ) {
-				$this->dispose( $row );
-			}
+			$this->disposeList( $chunk );
 
 			$connection->commitAndWaitForReplication( __METHOD__, $transactionTicket );
 		}

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -12,6 +12,7 @@ use SMW\MediaWiki\Connection\LegacyOptionsApplier;
 use SMW\RequestOptions;
 use stdClass;
 use Wikimedia\Rdbms\DBError;
+use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
  * @private
@@ -26,6 +27,19 @@ use Wikimedia\Rdbms\DBError;
  * @author mwjames
  */
 class PropertyTableIdReferenceDisposer {
+
+	/**
+	 * RequestOptions key holding the total number of modulo shards (N) for the
+	 * outdated-entity selection. When greater than 1, the selection is
+	 * restricted to a single shard.
+	 */
+	const OPT_SHARD_OF = 'shard.of';
+
+	/**
+	 * RequestOptions key holding this shard's index (k) within the modulo
+	 * sharding scheme (`smw_id % N = k`).
+	 */
+	const OPT_SHARD_INDEX = 'shard.index';
 
 	/**
 	 * @var Database
@@ -142,6 +156,8 @@ class PropertyTableIdReferenceDisposer {
 			->from( SQLStore::ID_TABLE )
 			->where( [ 'smw_iw' => SMW_SQL3_SMWDELETEIW ] );
 
+		$this->applyShard( $qb, $requestOptions );
+
 		LegacyOptionsApplier::applyTo( $qb, $options );
 
 		return new ResultIterator( $qb->caller( __METHOD__ )->fetchResultSet() );
@@ -169,9 +185,29 @@ class PropertyTableIdReferenceDisposer {
 			->from( SQLStore::ID_TABLE )
 			->where( 'smw_namespace NOT IN (' . $this->connection->makeList( array_keys( $this->namespacesWithSemanticLinks ) ) . ')' );
 
+		$this->applyShard( $qb, $requestOptions );
+
 		LegacyOptionsApplier::applyTo( $qb, $options );
 
 		return new ResultIterator( $qb->caller( __METHOD__ )->fetchResultSet() );
+	}
+
+	/**
+	 * Restrict the selection to a single modulo shard (`smw_id % N = k`) when
+	 * shard options are present on the request, letting an operator run N
+	 * disjoint disposal processes. The unsharded path is left untouched.
+	 */
+	private function applyShard( SelectQueryBuilder $qb, ?RequestOptions $requestOptions ): void {
+		if ( $requestOptions === null ) {
+			return;
+		}
+
+		$of = (int)$requestOptions->getOption( self::OPT_SHARD_OF, 1 );
+		$shard = (int)$requestOptions->getOption( self::OPT_SHARD_INDEX, 0 );
+
+		if ( $of > 1 ) {
+			$qb->andWhere( 'smw_id % ' . $of . ' = ' . $shard );
+		}
 	}
 
 	/**

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -196,108 +196,122 @@ class PropertyTableIdReferenceDisposer {
 	 * @param int $id
 	 */
 	public function cleanUpTableEntriesById( $id ) {
-		if ( $this->onTransactionIdle ) {
-			return $this->connection->onTransactionCommitOrIdle( function () use ( $id ): void {
-				$this->cleanUpReferencesById( $id );
-			} );
-		} else {
-			$this->cleanUpReferencesById( $id );
-		}
+		$this->cleanUpTableEntriesByIdList( [ $id ] );
 	}
 
-	private function cleanUpReferencesById( $id ): void {
-		$subject = $this->store->getObjectIds()->getDataItemById( $id );
-		$isRedirect = false;
+	/**
+	 * Batched disposal: one IN-list DELETE per (table, column) for the whole id
+	 * list, inside a single atomic transaction. Per-id cache-invalidation events
+	 * and the per-id completion hook are preserved.
+	 *
+	 * @since 7.0.0
+	 *
+	 * @param int[] $ids
+	 */
+	public function cleanUpTableEntriesByIdList( array $ids ): void {
+		$ids = array_values( array_unique( array_map( 'intval', $ids ) ) );
 
-		if ( $subject instanceof WikiPage ) {
-			$isRedirect = $subject->getInterwiki() === SMW_SQL3_SMWREDIIW;
-
-			// Use the subject without an internal 'smw-delete' iw marker
-			$subject = new WikiPage(
-				$subject->getDBKey(),
-				$subject->getNamespace(),
-				'',
-				$subject->getSubobjectName()
-			);
+		if ( $ids === [] ) {
+			return;
 		}
 
-		$this->triggerCleanUpEvents( $subject );
+		if ( $this->onTransactionIdle ) {
+			$this->connection->onTransactionCommitOrIdle( function () use ( $ids ): void {
+				$this->cleanUpReferencesByIdList( $ids );
+			} );
+			return;
+		}
+
+		$this->cleanUpReferencesByIdList( $ids );
+	}
+
+	private function cleanUpReferencesByIdList( array $ids ): void {
+		$subjects = [];
+		$isRedirect = [];
+		$nonRedirectIds = [];
+
+		foreach ( $ids as $id ) {
+			$subject = $this->store->getObjectIds()->getDataItemById( $id );
+			$redirect = false;
+
+			if ( $subject instanceof WikiPage ) {
+				$redirect = $subject->getInterwiki() === SMW_SQL3_SMWREDIIW;
+
+				// Use the subject without an internal 'smw-delete' iw marker
+				$subject = new WikiPage(
+					$subject->getDBKey(),
+					$subject->getNamespace(),
+					'',
+					$subject->getSubobjectName()
+				);
+			}
+
+			$subjects[$id] = $subject;
+			$isRedirect[$id] = $redirect;
+
+			if ( !$redirect || $this->redirectRemoval ) {
+				$nonRedirectIds[] = $id;
+			}
+
+			$this->triggerCleanUpEvents( $subject );
+		}
 
 		$this->connection->beginAtomicTransaction( __METHOD__ );
 
 		foreach ( $this->store->getPropertyTables() as $proptable ) {
 			if ( $proptable->usesIdSubject() ) {
-				$this->connection->newDeleteQueryBuilder()
-					->deleteFrom( $proptable->getName() )
-					->where( [ 's_id' => $id ] )
-					->caller( __METHOD__ )
-					->execute();
+				$this->deleteByIdList( $proptable->getName(), 's_id', $ids );
 			}
 
 			if ( !$proptable->isFixedPropertyTable() ) {
-				$this->connection->newDeleteQueryBuilder()
-					->deleteFrom( $proptable->getName() )
-					->where( [ 'p_id' => $id ] )
-					->caller( __METHOD__ )
-					->execute();
+				$this->deleteByIdList( $proptable->getName(), 'p_id', $ids );
 			}
 
 			$fields = $proptable->getFields( $this->store );
 
 			// Match tables (including ftp_redi) that contain an object reference
 			if ( isset( $fields['o_id'] ) ) {
-				$this->connection->newDeleteQueryBuilder()
-					->deleteFrom( $proptable->getName() )
-					->where( [ 'o_id' => $id ] )
-					->caller( __METHOD__ )
-					->execute();
+				$this->deleteByIdList( $proptable->getName(), 'o_id', $ids );
 			}
 		}
 
-		$this->cleanUpSecondaryReferencesById( $id, $isRedirect );
+		$this->cleanUpSecondaryReferencesByIdList( $ids, $nonRedirectIds );
 		$this->connection->endAtomicTransaction( __METHOD__ );
 
-		MediaWikiServices::getInstance()
-			->getHookContainer()
-			->run(
+		$hookContainer = MediaWikiServices::getInstance()->getHookContainer();
+
+		foreach ( $ids as $id ) {
+			$hookContainer->run(
 				'SMW::SQLStore::EntityReferenceCleanUpComplete',
-				[ $this->store, $id, $subject, $isRedirect ]
+				[ $this->store, $id, $subjects[$id], $isRedirect[$id] ]
 			);
+		}
 	}
 
-	private function cleanUpSecondaryReferencesById( $id, bool $isRedirect ): void {
-		// When marked as redirect, don't remove the reference
-		if ( !$isRedirect || $this->redirectRemoval ) {
-			$this->connection->newDeleteQueryBuilder()
-				->deleteFrom( SQLStore::ID_TABLE )
-				->where( [ 'smw_id' => $id ] )
-				->caller( __METHOD__ )
-				->execute();
+	private function deleteByIdList( string $table, string $field, array $ids ): void {
+		if ( $ids === [] ) {
+			return;
 		}
 
 		$this->connection->newDeleteQueryBuilder()
-			->deleteFrom( SQLStore::ID_AUXILIARY_TABLE )
-			->where( [ 'smw_id' => $id ] )
+			->deleteFrom( $table )
+			->where( [ $field => $ids ] )
 			->caller( __METHOD__ )
 			->execute();
+	}
 
-		$this->connection->newDeleteQueryBuilder()
-			->deleteFrom( SQLStore::PROPERTY_STATISTICS_TABLE )
-			->where( [ 'p_id' => $id ] )
-			->caller( __METHOD__ )
-			->execute();
+	private function cleanUpSecondaryReferencesById( $id, bool $isRedirect ): void {
+		$nonRedirectIds = ( !$isRedirect || $this->redirectRemoval ) ? [ (int)$id ] : [];
+		$this->cleanUpSecondaryReferencesByIdList( [ (int)$id ], $nonRedirectIds );
+	}
 
-		$this->connection->newDeleteQueryBuilder()
-			->deleteFrom( SQLStore::QUERY_LINKS_TABLE )
-			->where( [ 's_id' => $id ] )
-			->caller( __METHOD__ )
-			->execute();
-
-		$this->connection->newDeleteQueryBuilder()
-			->deleteFrom( SQLStore::QUERY_LINKS_TABLE )
-			->where( [ 'o_id' => $id ] )
-			->caller( __METHOD__ )
-			->execute();
+	private function cleanUpSecondaryReferencesByIdList( array $ids, array $nonRedirectIds ): void {
+		// When marked as redirect, don't remove the reference (nonRedirectIds omits it)
+		$this->deleteByIdList( SQLStore::ID_TABLE, 'smw_id', $nonRedirectIds );
+		$this->deleteByIdList( SQLStore::ID_AUXILIARY_TABLE, 'smw_id', $ids );
+		$this->deleteByIdList( SQLStore::PROPERTY_STATISTICS_TABLE, 'p_id', $ids );
+		$this->deleteByIdList( SQLStore::QUERY_LINKS_TABLE, 's_id', $ids );
+		$this->deleteByIdList( SQLStore::QUERY_LINKS_TABLE, 'o_id', $ids );
 
 		$tableExists = false;
 
@@ -312,11 +326,7 @@ class PropertyTableIdReferenceDisposer {
 		}
 
 		if ( $tableExists ) {
-			$this->connection->newDeleteQueryBuilder()
-				->deleteFrom( SQLStore::FT_SEARCH_TABLE )
-				->where( [ 's_id' => $id ] )
-				->caller( __METHOD__ )
-				->execute();
+			$this->deleteByIdList( SQLStore::FT_SEARCH_TABLE, 's_id', $ids );
 		}
 	}
 

--- a/src/SQLStore/PropertyTableIdReferenceDisposer.php
+++ b/src/SQLStore/PropertyTableIdReferenceDisposer.php
@@ -145,10 +145,13 @@ class PropertyTableIdReferenceDisposer {
 		$options = [];
 
 		if ( $requestOptions !== null ) {
-			$options = [
-				'LIMIT'  => $requestOptions->getLimit(),
-				'OFFSET' => $requestOptions->getOffset(),
-			];
+			if ( $requestOptions->getLimit() > 0 ) {
+				$options['LIMIT'] = $requestOptions->getLimit();
+			}
+
+			if ( $requestOptions->getOffset() > 0 ) {
+				$options['OFFSET'] = $requestOptions->getOffset();
+			}
 		}
 
 		$qb = $this->connection->newSelectQueryBuilder()
@@ -174,10 +177,13 @@ class PropertyTableIdReferenceDisposer {
 		$options = [];
 
 		if ( $requestOptions !== null ) {
-			$options = [
-				'LIMIT'  => $requestOptions->getLimit(),
-				'OFFSET' => $requestOptions->getOffset(),
-			];
+			if ( $requestOptions->getLimit() > 0 ) {
+				$options['LIMIT'] = $requestOptions->getLimit();
+			}
+
+			if ( $requestOptions->getOffset() > 0 ) {
+				$options['OFFSET'] = $requestOptions->getOffset();
+			}
 		}
 
 		$qb = $this->connection->newSelectQueryBuilder()

--- a/tests/phpunit/Unit/Maintenance/DataRebuilder/OutdatedDisposerTest.php
+++ b/tests/phpunit/Unit/Maintenance/DataRebuilder/OutdatedDisposerTest.php
@@ -8,6 +8,8 @@ use SMW\Iterators\ChunkedIterator;
 use SMW\Iterators\ResultIterator;
 use SMW\Maintenance\DataRebuilder\OutdatedDisposer;
 use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
+use SMW\RequestOptions;
+use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\Tests\TestEnvironment;
 use SMW\Tests\Utils\Mock\IteratorMockBuilder;
 use stdClass;
@@ -117,6 +119,69 @@ class OutdatedDisposerTest extends TestCase {
 		$this->assertStringContainsString(
 			'1001 (2%)',
 			$messages
+		);
+	}
+
+	public function testShardSkipsQueryLinksOnNonZeroShard() {
+		$resultIterator = $this->getMockBuilder( ResultIterator::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$resultIterator->expects( $this->exactly( 2 ) )
+			->method( 'count' )
+			->willReturn( 0 );
+
+		$capturedRequestOptions = [];
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newOutdatedEntitiesResultIterator' )
+			->willReturnCallback( static function ( $requestOptions ) use ( &$capturedRequestOptions, $resultIterator ) {
+				$capturedRequestOptions[] = $requestOptions;
+				return $resultIterator;
+			} );
+
+		$this->entityIdDisposerJob->expects( $this->once() )
+			->method( 'newByNamespaceInvalidEntitiesResultIterator' )
+			->willReturnCallback( static function ( $requestOptions ) use ( &$capturedRequestOptions, $resultIterator ) {
+				$capturedRequestOptions[] = $requestOptions;
+				return $resultIterator;
+			} );
+
+		$this->entityIdDisposerJob->expects( $this->never() )
+			->method( 'newOutdatedQueryLinksResultIterator' );
+
+		$this->entityIdDisposerJob->expects( $this->never() )
+			->method( 'newUnassignedQueryLinksResultIterator' );
+
+		$instance = new OutdatedDisposer(
+			$this->entityIdDisposerJob,
+			$this->iteratorFactory
+		);
+
+		$instance->setShard( 1, 4 );
+		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance->run();
+
+		foreach ( $capturedRequestOptions as $requestOptions ) {
+			$this->assertInstanceOf(
+				RequestOptions::class,
+				$requestOptions
+			);
+
+			$this->assertSame(
+				4,
+				$requestOptions->getOption( PropertyTableIdReferenceDisposer::OPT_SHARD_OF )
+			);
+
+			$this->assertSame(
+				1,
+				$requestOptions->getOption( PropertyTableIdReferenceDisposer::OPT_SHARD_INDEX )
+			);
+		}
+
+		$this->assertStringContainsString(
+			'skipped on shard 1',
+			$this->spyMessageReporter->getMessagesAsString()
 		);
 	}
 

--- a/tests/phpunit/Unit/Maintenance/DataRebuilder/OutdatedDisposerTest.php
+++ b/tests/phpunit/Unit/Maintenance/DataRebuilder/OutdatedDisposerTest.php
@@ -87,8 +87,8 @@ class OutdatedDisposerTest extends TestCase {
 			->method( 'newUnassignedQueryLinksResultIterator' )
 			->willReturn( $this->resultIterator );
 
-		$this->entityIdDisposerJob->expects( $this->exactly( 2 ) )
-			->method( 'dispose' );
+		$this->entityIdDisposerJob->expects( $this->atLeastOnce() )
+			->method( 'disposeList' );
 
 		$this->iteratorFactory->expects( $this->exactly( 2 ) )
 			->method( 'newChunkedIterator' )

--- a/tests/phpunit/Unit/Maintenance/DataRebuilderTest.php
+++ b/tests/phpunit/Unit/Maintenance/DataRebuilderTest.php
@@ -683,6 +683,160 @@ class DataRebuilderTest extends TestCase {
 	}
 
 	/**
+	 * @depends testCanConstruct
+	 */
+	public function testRebuildAll_SkipDispose_DoesNotRunDisposer() {
+		$rebuilder = $this->getMockBuilder( Rebuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$rebuilder->expects( $this->once() )
+			->method( 'rebuild' )
+			->willReturnCallback( [ $this, 'refreshDataOnMockCallback' ] );
+
+		$rebuilder->expects( $this->any() )
+			->method( 'getMaxId' )
+			->willReturn( 1000 );
+
+		$rebuilder->expects( $this->any() )
+			->method( 'getDispatchedEntities' )
+			->willReturn( [] );
+
+		$store = $this->getMockBuilder( Store::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'refreshData' ] )
+			->getMockForAbstractClass();
+
+		$store->expects( $this->once() )
+			->method( 'refreshData' )
+			->willReturn( $rebuilder );
+
+		$store->setConnectionManager( $this->connectionManager );
+
+		$titleFactory = $this->getMockBuilder( TitleFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// The disposer is built via jobFactory->newEntityIdDisposerJob(); with
+		// --skip-dispose set it must never be constructed.
+		$jobFactory = $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'newUpdateJob', 'newEntityIdDisposerJob' ] )
+			->getMock();
+
+		$jobFactory->expects( $this->any() )
+			->method( 'newUpdateJob' )
+			->willReturn(
+				$this->getMockBuilder( UpdateJob::class )
+					->disableOriginalConstructor()
+					->getMock()
+			);
+
+		$jobFactory->expects( $this->never() )
+			->method( 'newEntityIdDisposerJob' );
+
+		$instance = new DataRebuilder( $store, $titleFactory, $jobFactory );
+
+		$instance->setOptions( new Options( [
+			'e' => 1,
+			'skip-dispose' => true
+		] ) );
+
+		$this->assertTrue( $instance->rebuild() );
+	}
+
+	/**
+	 * @depends testCanConstruct
+	 */
+	public function testRebuildAll_Default_RunsDisposer() {
+		$rebuilder = $this->getMockBuilder( Rebuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$rebuilder->expects( $this->once() )
+			->method( 'rebuild' )
+			->willReturnCallback( [ $this, 'refreshDataOnMockCallback' ] );
+
+		$rebuilder->expects( $this->any() )
+			->method( 'getMaxId' )
+			->willReturn( 1000 );
+
+		$rebuilder->expects( $this->any() )
+			->method( 'getDispatchedEntities' )
+			->willReturn( [] );
+
+		$store = $this->getMockBuilder( Store::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'refreshData' ] )
+			->getMockForAbstractClass();
+
+		$store->expects( $this->once() )
+			->method( 'refreshData' )
+			->willReturn( $rebuilder );
+
+		$store->setConnectionManager( $this->connectionManager );
+
+		$titleFactory = $this->getMockBuilder( TitleFactory::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// Without --skip-dispose the disposer is built via
+		// jobFactory->newEntityIdDisposerJob() and run.
+		$entityIdDisposerJob = $this->getMockBuilder( EntityIdDisposerJob::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$resultIterator = $this->getMockBuilder( ResultIterator::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$resultIterator->expects( $this->any() )
+			->method( 'count' )
+			->willReturn( 0 );
+
+		$entityIdDisposerJob->expects( $this->any() )
+			->method( 'newOutdatedEntitiesResultIterator' )
+			->willReturn( $resultIterator );
+
+		$entityIdDisposerJob->expects( $this->any() )
+			->method( 'newByNamespaceInvalidEntitiesResultIterator' )
+			->willReturn( $resultIterator );
+
+		$entityIdDisposerJob->expects( $this->any() )
+			->method( 'newOutdatedQueryLinksResultIterator' )
+			->willReturn( $resultIterator );
+
+		$entityIdDisposerJob->expects( $this->any() )
+			->method( 'newUnassignedQueryLinksResultIterator' )
+			->willReturn( $resultIterator );
+
+		$jobFactory = $this->getMockBuilder( JobFactory::class )
+			->disableOriginalConstructor()
+			->setMethods( [ 'newUpdateJob', 'newEntityIdDisposerJob' ] )
+			->getMock();
+
+		$jobFactory->expects( $this->any() )
+			->method( 'newUpdateJob' )
+			->willReturn(
+				$this->getMockBuilder( UpdateJob::class )
+					->disableOriginalConstructor()
+					->getMock()
+			);
+
+		$jobFactory->expects( $this->once() )
+			->method( 'newEntityIdDisposerJob' )
+			->willReturn( $entityIdDisposerJob );
+
+		$instance = new DataRebuilder( $store, $titleFactory, $jobFactory );
+
+		$instance->setOptions( new Options( [
+			'e' => 1
+		] ) );
+
+		$this->assertTrue( $instance->rebuild() );
+	}
+
+	/**
 	 * @see Store::refreshData
 	 */
 	public function refreshDataOnMockCallback( &$index ) {

--- a/tests/phpunit/Unit/Maintenance/DisposeOutdatedEntitiesTest.php
+++ b/tests/phpunit/Unit/Maintenance/DisposeOutdatedEntitiesTest.php
@@ -2,7 +2,6 @@
 
 namespace SMW\Tests\Unit\Maintenance;
 
-use MediaWiki\Maintenance\MaintenanceFatalError;
 use PHPUnit\Framework\TestCase;
 use SMW\Maintenance\disposeOutdatedEntities;
 use SMW\Tests\TestEnvironment;
@@ -55,31 +54,31 @@ class DisposeOutdatedEntitiesTest extends TestCase {
 		);
 	}
 
-	public function testExecuteAbortsOnShardWithoutOf() {
+	/**
+	 * @dataProvider shardConfigProvider
+	 */
+	public function testGetShardConfigError( bool $hasOf, bool $hasShard, int $of, int $shard, ?string $expected ) {
 		$instance = new disposeOutdatedEntities();
 
-		$instance->setMessageReporter(
-			$this->spyMessageReporter
+		$this->assertSame(
+			$expected,
+			$instance->getShardConfigError( $hasOf, $hasShard, $of, $shard )
 		);
-
-		$instance->setOption( 'shard', '1' );
-
-		$this->expectException( MaintenanceFatalError::class );
-		$instance->execute();
 	}
 
-	public function testExecuteAbortsOnShardOutsideRange() {
-		$instance = new disposeOutdatedEntities();
+	public function shardConfigProvider() {
+		$together = '--of and --shard must be used together.';
+		$range = 'Invalid shard configuration: require --of >= 1 and 0 <= --shard < --of.';
 
-		$instance->setMessageReporter(
-			$this->spyMessageReporter
-		);
-
-		$instance->setOption( 'of', '2' );
-		$instance->setOption( 'shard', '5' );
-
-		$this->expectException( MaintenanceFatalError::class );
-		$instance->execute();
+		yield 'unsharded default (neither option)' => [ false, false, 1, 0, null ];
+		yield 'valid shard 0 of 4' => [ true, true, 4, 0, null ];
+		yield 'valid shard 3 of 4' => [ true, true, 4, 3, null ];
+		yield 'shard without of' => [ false, true, 1, 1, $together ];
+		yield 'of without shard' => [ true, false, 4, 0, $together ];
+		yield 'of below 1' => [ true, true, 0, 0, $range ];
+		yield 'shard equals of' => [ true, true, 4, 4, $range ];
+		yield 'shard above range' => [ true, true, 2, 5, $range ];
+		yield 'negative shard' => [ true, true, 4, -1, $range ];
 	}
 
 }

--- a/tests/phpunit/Unit/Maintenance/DisposeOutdatedEntitiesTest.php
+++ b/tests/phpunit/Unit/Maintenance/DisposeOutdatedEntitiesTest.php
@@ -2,6 +2,7 @@
 
 namespace SMW\Tests\Unit\Maintenance;
 
+use MediaWiki\Maintenance\MaintenanceFatalError;
 use PHPUnit\Framework\TestCase;
 use SMW\Maintenance\disposeOutdatedEntities;
 use SMW\Tests\TestEnvironment;
@@ -52,6 +53,33 @@ class DisposeOutdatedEntitiesTest extends TestCase {
 			'Outdated entitie(s)',
 			$this->spyMessageReporter->getMessagesAsString()
 		);
+	}
+
+	public function testExecuteAbortsOnShardWithoutOf() {
+		$instance = new disposeOutdatedEntities();
+
+		$instance->setMessageReporter(
+			$this->spyMessageReporter
+		);
+
+		$instance->setOption( 'shard', '1' );
+
+		$this->expectException( MaintenanceFatalError::class );
+		$instance->execute();
+	}
+
+	public function testExecuteAbortsOnShardOutsideRange() {
+		$instance = new disposeOutdatedEntities();
+
+		$instance->setMessageReporter(
+			$this->spyMessageReporter
+		);
+
+		$instance->setOption( 'of', '2' );
+		$instance->setOption( 'shard', '5' );
+
+		$this->expectException( MaintenanceFatalError::class );
+		$instance->execute();
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Connection/MockSelectQueryBuilderTrait.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/MockSelectQueryBuilderTrait.php
@@ -35,13 +35,17 @@ trait MockSelectQueryBuilderTrait {
 	 *   order. Each invocation appends one entry. Lets tests verify whether (and
 	 *   with which index) an index hint was applied. Subqueries share the same
 	 *   array.
+	 * @param array &$capturedLimits Captures limit() arguments in call order.
+	 *   Each invocation appends one entry. Lets tests verify that no negative
+	 *   (or otherwise invalid) LIMIT is applied. Subqueries share the same array.
 	 */
 	private function createMockSelectQueryBuilder(
 		array $rows = [],
 		array &$whereConditions = [],
 		array &$capturedSelects = [],
 		array &$capturedTables = [],
-		array &$capturedUseIndex = []
+		array &$capturedUseIndex = [],
+		array &$capturedLimits = []
 	): SelectQueryBuilder {
 		$queryBuilder = $this->getMockBuilder( SelectQueryBuilder::class )
 			->disableOriginalConstructor()
@@ -50,7 +54,7 @@ trait MockSelectQueryBuilderTrait {
 		$chainMethods = [ 'fields', 'field',
 			'join', 'leftJoin', 'straightJoin', 'joinConds',
 			'groupBy', 'having', 'orderBy', 'caller', 'distinct',
-			'limit', 'offset', 'options', 'option', 'conds',
+			'offset', 'options', 'option', 'conds',
 			'ignoreIndex', 'recency', 'clearFields',
 			'lockInShareMode', 'forUpdate' ];
 
@@ -59,6 +63,13 @@ trait MockSelectQueryBuilderTrait {
 				->method( $method )
 				->willReturnSelf();
 		}
+
+		$queryBuilder->expects( $this->any() )
+			->method( 'limit' )
+			->willReturnCallback( static function ( $limit ) use ( $queryBuilder, &$capturedLimits ) {
+				$capturedLimits[] = $limit;
+				return $queryBuilder;
+			} );
 
 		$captureWhere = static function ( $conds ) use ( $queryBuilder, &$whereConditions ) {
 			$whereConditions[] = $conds;
@@ -101,7 +112,7 @@ trait MockSelectQueryBuilderTrait {
 			->method( 'newSubquery' )
 			->willReturnCallback(
 				fn () => $this->createMockSelectQueryBuilder(
-					$rows, $whereConditions, $capturedSelects, $capturedTables, $capturedUseIndex
+					$rows, $whereConditions, $capturedSelects, $capturedTables, $capturedUseIndex, $capturedLimits
 				)
 			);
 

--- a/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/EntityIdDisposerJobTest.php
@@ -11,6 +11,7 @@ use SMW\Iterators\ResultIterator;
 use SMW\MediaWiki\Connection\Database;
 use SMW\MediaWiki\JobFactory;
 use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
+use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\SQLStore\SQLStore;
 use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 
@@ -178,6 +179,54 @@ class EntityIdDisposerJobTest extends TestCase {
 		$this->assertTrue(
 			$instance->run()
 		);
+	}
+
+	public function testDisposeList() {
+		$disposer = $this->getMockBuilder( PropertyTableIdReferenceDisposer::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$disposer->expects( $this->once() )
+			->method( 'cleanUpTableEntriesByIdList' )
+			->with( [ 1, 2 ] );
+
+		$store = $this->getMockBuilder( SQLStore::class )
+			->onlyMethods( [ 'service' ] )
+			->getMockForAbstractClass();
+
+		$connectionManager = $this->getMockBuilder( ConnectionManager::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connectionManager->expects( $this->any() )
+			->method( 'getConnection' )
+			->willReturn( $this->connection );
+
+		$store->setConnectionManager( $connectionManager );
+
+		$store->expects( $this->any() )
+			->method( 'service' )
+			->with( 'PropertyTableIdReferenceDisposer' )
+			->willReturn( $disposer );
+
+		$title = $this->getMockBuilder( Title::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$row1 = new \stdClass;
+		$row1->smw_id = 1;
+		$row2 = new \stdClass;
+		$row2->smw_id = 2;
+
+		$instance = new EntityIdDisposerJob(
+			$title,
+			[],
+			$store,
+			$this->newIteratorFactory(),
+			$this->newJobFactory()
+		);
+
+		$instance->disposeList( [ $row1, $row2 ] );
 	}
 
 	public function parametersProvider() {

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -310,6 +310,123 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 		);
 	}
 
+	public function testOutdatedEntitiesResultIterator_ShardedRequestAppliesNoNegativeLimit() {
+		$whereConditions = [];
+		$capturedSelects = [];
+		$capturedTables = [];
+		$capturedUseIndex = [];
+		$capturedLimits = [];
+		$queryBuilder = $this->createMockSelectQueryBuilder( [], $whereConditions, $capturedSelects, $capturedTables, $capturedUseIndex, $capturedLimits );
+
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $queryBuilder );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->willReturn( $connection );
+
+		$instance = new PropertyTableIdReferenceDisposer(
+			$this->store,
+			$this->eventDispatcher
+		);
+
+		// Sharded selection without an explicit limit: RequestOptions::$limit
+		// defaults to -1 ("no limit"). The iterator must NOT translate that
+		// into `LIMIT -1`, which MariaDB rejects (error 1064).
+		$requestOptions = new RequestOptions();
+		$requestOptions->setOption( PropertyTableIdReferenceDisposer::OPT_SHARD_OF, 2 );
+		$requestOptions->setOption( PropertyTableIdReferenceDisposer::OPT_SHARD_INDEX, 0 );
+
+		$instance->newOutdatedEntitiesResultIterator( $requestOptions );
+
+		$this->assertSame(
+			[],
+			$capturedLimits,
+			'No LIMIT clause should be applied for a sharded/no-limit request.'
+		);
+	}
+
+	public function testByNamespaceInvalidEntitiesResultIterator_ShardedRequestAppliesNoNegativeLimit() {
+		$whereConditions = [];
+		$capturedSelects = [];
+		$capturedTables = [];
+		$capturedUseIndex = [];
+		$capturedLimits = [];
+		$queryBuilder = $this->createMockSelectQueryBuilder( [], $whereConditions, $capturedSelects, $capturedTables, $capturedUseIndex, $capturedLimits );
+
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $queryBuilder );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->willReturn( $connection );
+
+		$instance = new PropertyTableIdReferenceDisposer(
+			$this->store,
+			$this->eventDispatcher
+		);
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->setOption( PropertyTableIdReferenceDisposer::OPT_SHARD_OF, 2 );
+		$requestOptions->setOption( PropertyTableIdReferenceDisposer::OPT_SHARD_INDEX, 0 );
+
+		$instance->newByNamespaceInvalidEntitiesResultIterator( $requestOptions );
+
+		$this->assertSame(
+			[],
+			$capturedLimits,
+			'No LIMIT clause should be applied for a sharded/no-limit request.'
+		);
+	}
+
+	public function testOutdatedEntitiesResultIterator_PositiveLimitIsApplied() {
+		$whereConditions = [];
+		$capturedSelects = [];
+		$capturedTables = [];
+		$capturedUseIndex = [];
+		$capturedLimits = [];
+		$queryBuilder = $this->createMockSelectQueryBuilder( [], $whereConditions, $capturedSelects, $capturedTables, $capturedUseIndex, $capturedLimits );
+
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $queryBuilder );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->willReturn( $connection );
+
+		$instance = new PropertyTableIdReferenceDisposer(
+			$this->store,
+			$this->eventDispatcher
+		);
+
+		// The EntityIdDisposerJob path sets an explicit positive limit which
+		// must still be applied verbatim.
+		$requestOptions = new RequestOptions();
+		$requestOptions->setLimit( 5000 );
+
+		$instance->newOutdatedEntitiesResultIterator( $requestOptions );
+
+		$this->assertSame(
+			[ 5000 ],
+			$capturedLimits
+		);
+	}
+
 	public function testCleanUpTableEntriesByRow() {
 		$row = new stdClass;
 		$row->smw_id = 42;

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -404,4 +404,114 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 		);
 	}
 
+	public function testCleanUpTableEntriesByIdList_NonRedirect() {
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( [ 'getDataItemById' ] )
+			->getMock();
+
+		$idTable->expects( $this->any() )
+			->method( 'getDataItemById' )
+			->willReturn( new WikiPage( 'Foo', NS_MAIN, '' ) );
+
+		$store = $this->getMockBuilder( SQLStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->willReturn( $idTable );
+
+		$capturedTables = [];
+		$capturedWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $capturedTables, $capturedWheres );
+
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$store->expects( $this->any() )
+			->method( 'getConnection' )
+			->willReturn( $connection );
+
+		$store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->willReturn( [] );
+
+		$instance = new PropertyTableIdReferenceDisposer(
+			$store,
+			$this->eventDispatcher
+		);
+
+		$instance->cleanUpTableEntriesByIdList( [ 42, 43 ] );
+
+		$this->assertSame(
+			[
+				SQLStore::ID_TABLE,
+				SQLStore::ID_AUXILIARY_TABLE,
+				SQLStore::PROPERTY_STATISTICS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+				SQLStore::QUERY_LINKS_TABLE,
+			],
+			$capturedTables
+		);
+
+		$this->assertSame( [ 'smw_id' => [ 42, 43 ] ], $capturedWheres[0] );
+	}
+
+	public function testCleanUpTableEntriesByIdList_ExcludesRedirectFromIdTable() {
+		$idTable = $this->getMockBuilder( '\stdClass' )
+			->setMethods( [ 'getDataItemById' ] )
+			->getMock();
+
+		$idTable->expects( $this->any() )
+			->method( 'getDataItemById' )
+			->willReturnCallback( static function ( $id ) {
+				return $id === 42
+					? new WikiPage( 'Foo', NS_MAIN, SMW_SQL3_SMWREDIIW )
+					: new WikiPage( 'Bar', NS_MAIN, '' );
+			} );
+
+		$store = $this->getMockBuilder( SQLStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->willReturn( $idTable );
+
+		$capturedTables = [];
+		$capturedWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $capturedTables, $capturedWheres );
+
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$store->expects( $this->any() )
+			->method( 'getConnection' )
+			->willReturn( $connection );
+
+		$store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->willReturn( [] );
+
+		$instance = new PropertyTableIdReferenceDisposer(
+			$store,
+			$this->eventDispatcher
+		);
+
+		$instance->cleanUpTableEntriesByIdList( [ 42, 43 ] );
+
+		// ID_TABLE delete only for the non-redirect id (43).
+		$this->assertSame( [ 'smw_id' => [ 43 ] ], $capturedWheres[0] );
+	}
+
 }

--- a/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
+++ b/tests/phpunit/Unit/SQLStore/PropertyTableIdReferenceDisposerTest.php
@@ -8,6 +8,7 @@ use SMW\DataItems\WikiPage;
 use SMW\EventDispatcher\EventDispatcher;
 use SMW\Iterators\ResultIterator;
 use SMW\MediaWiki\Connection\Database;
+use SMW\RequestOptions;
 use SMW\SQLStore\PropertyTableDefinition;
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\SQLStore\PropertyTableIdReferenceFinder;
@@ -215,6 +216,97 @@ class PropertyTableIdReferenceDisposerTest extends TestCase {
 		$this->assertInstanceOf(
 			ResultIterator::class,
 			$instance->newByNamespaceInvalidEntitiesResultIterator()
+		);
+	}
+
+	public function testOutdatedEntitiesResultIterator_AppliesShardModulo() {
+		$whereConditions = [];
+		$queryBuilder = $this->createMockSelectQueryBuilder( [], $whereConditions );
+
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $queryBuilder );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->willReturn( $connection );
+
+		$instance = new PropertyTableIdReferenceDisposer(
+			$this->store,
+			$this->eventDispatcher
+		);
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->setOption( PropertyTableIdReferenceDisposer::OPT_SHARD_OF, 4 );
+		$requestOptions->setOption( PropertyTableIdReferenceDisposer::OPT_SHARD_INDEX, 1 );
+
+		$instance->newOutdatedEntitiesResultIterator( $requestOptions );
+
+		$this->assertContains( 'smw_id % 4 = 1', $whereConditions );
+	}
+
+	public function testByNamespaceInvalidEntitiesResultIterator_AppliesShardModulo() {
+		$whereConditions = [];
+		$queryBuilder = $this->createMockSelectQueryBuilder( [], $whereConditions );
+
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $queryBuilder );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->willReturn( $connection );
+
+		$instance = new PropertyTableIdReferenceDisposer(
+			$this->store,
+			$this->eventDispatcher
+		);
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->setOption( PropertyTableIdReferenceDisposer::OPT_SHARD_OF, 3 );
+		$requestOptions->setOption( PropertyTableIdReferenceDisposer::OPT_SHARD_INDEX, 2 );
+
+		$instance->newByNamespaceInvalidEntitiesResultIterator( $requestOptions );
+
+		$this->assertContains( 'smw_id % 3 = 2', $whereConditions );
+	}
+
+	public function testOutdatedEntitiesResultIterator_NoShardLeavesWhereUnchanged() {
+		$whereConditions = [];
+		$queryBuilder = $this->createMockSelectQueryBuilder( [], $whereConditions );
+
+		$connection = $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$connection->expects( $this->atLeastOnce() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $queryBuilder );
+
+		$this->store->expects( $this->any() )
+			->method( 'getConnection' )
+			->willReturn( $connection );
+
+		$instance = new PropertyTableIdReferenceDisposer(
+			$this->store,
+			$this->eventDispatcher
+		);
+
+		// Without shard options (OPT_SHARD_OF defaults to 1), no modulo
+		// condition is added; only the base where() remains.
+		$instance->newOutdatedEntitiesResultIterator( new RequestOptions() );
+
+		$this->assertSame(
+			[ [ 'smw_iw' => SMW_SQL3_SMWDELETEIW ] ],
+			$whereConditions
 		);
 	}
 


### PR DESCRIPTION
## Problem

Disposing a large backlog of outdated entities is slow and cannot be sped up. `disposeOutdatedEntities.php` runs single threaded, and the equivalent job is effectively single threaded too: every cycle selects the same `:smw-delete` marked set with no partition key, so running copies in parallel just collide on the same rows and fail with database lock-wait timeouts. `rebuildData` compounds this by running the same disposal prologue unconditionally on every invocation, which blocks parallel ranged rebuilds.

## Changes

Two orthogonal speedups plus a decoupling, all opt-in and behaviour-preserving by default.

1. **Batched disposal.** The reference disposer now removes a chunk of ids with one `WHERE col IN (...)` delete per table and column instead of dozens of single-row deletes per entity, inside one atomic transaction per chunk. The per-entity cache-invalidation events and the `SMW::SQLStore::EntityReferenceCleanUpComplete` hook still fire per id, and redirect ids are still kept out of the id-table delete. A single `disposeOutdatedEntities.php` run is materially faster with an identical end state.

2. **Parallel sharding.** `disposeOutdatedEntities.php` gains `--of N` and `--shard k` (zero based). Each worker selects a disjoint slice via `smw_id % N = k`, so N processes can run at once over non-overlapping rows. A modulo partition is used rather than contiguous id ranges because it is snapshot independent: an id belongs to exactly one shard regardless of when each worker starts or how far the others have progressed, so coverage stays complete and disjoint with no coordination. The query-link cleanup passes are not id-shardable and run on shard 0 only.

3. **rebuildData decoupling.** `rebuildData` gains `--skip-dispose`, which skips the disposal prologue so several ranged rebuilds can run in parallel (run `disposeOutdatedEntities.php`, optionally sharded, once beforehand). Default behaviour is unchanged, mirroring the existing `--skip-properties`.

## Usage

Parallel disposal:

```
php maintenance/run.php SemanticMediaWiki:disposeOutdatedEntities --of 4 --shard 0 &
php maintenance/run.php SemanticMediaWiki:disposeOutdatedEntities --of 4 --shard 1 &
php maintenance/run.php SemanticMediaWiki:disposeOutdatedEntities --of 4 --shard 2 &
php maintenance/run.php SemanticMediaWiki:disposeOutdatedEntities --of 4 --shard 3 &
wait
```

Parallel ranged rebuilds (run disposal once, then rebuild in ranges):

```
php maintenance/run.php SemanticMediaWiki:disposeOutdatedEntities
php maintenance/run.php SemanticMediaWiki:rebuildData -s 1      -e 250000 --skip-dispose &
php maintenance/run.php SemanticMediaWiki:rebuildData -s 250001 -e 500000 --skip-dispose &
wait
```

Tune N to what the database absorbs; disposal is write bound, so beyond some point added workers trade against lock and IO contention.

## Benchmark

Disposing 3,000 outdated entities on a local MariaDB, previous per-entity disposal vs the batched path (identical synthetic dataset, same container):

| | per-entity (before) | batched (after) |
| --- | --- | --- |
| DELETE statements | ~162,000 | ~3,800 |
| transactions | 3,000 | 15 |
| wall-clock | ~60 s | ~6.6 s |

Batching collapses one transaction per entity into one per ~200-entity chunk, roughly a 9x wall-clock improvement at this size, and the gain grows with the size of the backlog. Absolute timings are not representative of production hardware (local dev database, synthetic data); the ratios are the portable result.

## Testing

Unit tests cover the batched delete path (IN-list deletes, redirect exclusion, per-id events and hook), the modulo shard predicate on both entity-selection iterators, the `--of`/`--shard` validation, the query-links-on-shard-0 gating, and the `--skip-dispose` gating. Verified end to end against MariaDB: sharded runs (sequential and parallel, with N=2 and N=3) dispose the full marked set with no lock-wait timeouts, the unsharded run is behaviour-equivalent to before, and `--skip-dispose` leaves the marked set in place until an explicit disposal pass.

Closes #6968