### PR TITLE
Fix PHP 8.5 and MediaWiki deprecation warnings

### DIFF
--- a/src/DataTypeRegistry.php
+++ b/src/DataTypeRegistry.php
@@ -423,7 +423,7 @@ class DataTypeRegistry {
 	 * @param string $typeId
 	 */
 	public function hasDataTypeClassById( $typeId ): bool {
-		if ( !isset( $this->typeClasses[$typeId] ) ) {
+		if ( !isset( $this->typeClasses[$typeId ?? ''] ) ) {
 			return false;
 		}
 

--- a/src/DependencyValidator.php
+++ b/src/DependencyValidator.php
@@ -48,7 +48,7 @@ class DependencyValidator {
 	 * @param Title $title
 	 */
 	public function markTitle( Title $title ): void {
-		self::$titles[$title->getPrefixedText()] = true;
+		self::$titles[$title->getPrefixedText() ?? ''] = true;
 	}
 
 	/**
@@ -59,7 +59,7 @@ class DependencyValidator {
 	 * @return bool
 	 */
 	public static function hasLikelyOutdatedDependencies( Title $title ): bool {
-		return self::$titles[$title->getPrefixedText()] ?? false;
+		return self::$titles[$title->getPrefixedText() ?? ''] ?? false;
 	}
 
 	/**

--- a/src/Exporter/ElementFactory.php
+++ b/src/Exporter/ElementFactory.php
@@ -60,7 +60,7 @@ class ElementFactory {
 	}
 
 	private function newElement( DataItem $dataItem ) {
-		$type = $dataItem->getDIType();
+		$type = $dataItem->getDIType() ?? '';
 
 		if ( isset( $this->dataItemMappers[$type] ) && is_callable( $this->dataItemMappers[$type] ) ) {
 			return $this->dataItemMappers[$type]( $dataItem );

--- a/src/GlobalFunctions.php
+++ b/src/GlobalFunctions.php
@@ -153,7 +153,7 @@ function smwfCacheKey( $namespace, $key ): string {
 		$key = json_encode( $key );
 	}
 
-	return $cachePrefix . $namespace . ':' . md5( $key );
+	return $cachePrefix . $namespace . ':' . md5( $key ?? '' );
 }
 
 /**

--- a/src/Listener/ChangeListener/ChangeListeners/PropertyChangeListener.php
+++ b/src/Listener/ChangeListener/ChangeListeners/PropertyChangeListener.php
@@ -63,7 +63,12 @@ class PropertyChangeListener implements ChangeListener {
 			$property
 		);
 
-		$this->propertyIdKeyMap[$pid] = $key;
+		// A property without a stored id (getSMWPropertyID() returns null) has
+		// no entry to match against later, so skip it rather than coerce the
+		// null into an array offset (deprecated as of PHP 8.5).
+		if ( $pid !== null ) {
+			$this->propertyIdKeyMap[$pid] = $key;
+		}
 
 		if ( !isset( $this->changeListeners[$key] ) ) {
 			$this->changeListeners[$key] = [];

--- a/src/MediaWiki/Connection/ConnectionProvider.php
+++ b/src/MediaWiki/Connection/ConnectionProvider.php
@@ -54,7 +54,7 @@ class ConnectionProvider implements IConnectionProvider {
 			'write' => DB_PRIMARY
 		];
 
-		if ( isset( $this->localConnectionConf[$this->provider] ) ) {
+		if ( isset( $this->localConnectionConf[$this->provider ?? ''] ) ) {
 			$conf = $this->localConnectionConf[$this->provider];
 		}
 

--- a/src/MediaWiki/Page/ListBuilder.php
+++ b/src/MediaWiki/Page/ListBuilder.php
@@ -148,6 +148,7 @@ class ListBuilder {
 			if ( $startChar === '' ) {
 				$startChar = '...';
 			}
+			$startChar ??= '';
 
 			if ( !isset( $contents[$startChar] ) ) {
 				$contents[$startChar] = [];

--- a/src/MediaWiki/PageInfoProvider.php
+++ b/src/MediaWiki/PageInfoProvider.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki;
 
+use MediaWiki\Content\TextContent;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\Title\Title;
@@ -98,7 +99,7 @@ class PageInfoProvider implements PageInfo {
 			return '';
 		}
 
-		return $content->getNativeData();
+		return $content instanceof TextContent ? $content->getText() : '';
 	}
 
 	/**

--- a/src/MediaWiki/Search/SearchResultSet.php
+++ b/src/MediaWiki/Search/SearchResultSet.php
@@ -92,7 +92,7 @@ class SearchResultSet extends \SearchResultSet {
 		foreach ( $this->pages as $page ) {
 			$title = $page->getTitle();
 			if ( $title !== null ) {
-				$key = $title->getPrefixedDBKey();
+				$key = $title->getPrefixedDBKey() ?? '';
 
 				if ( $title->getNamespace() !== SMW_NS_PROPERTY && !$title->exists() ) {
 					continue;

--- a/src/Query/QueryProcessor.php
+++ b/src/Query/QueryProcessor.php
@@ -469,7 +469,7 @@ class QueryProcessor implements QueryContext {
 	public static function getFormatParameters( $format ): array {
 		ResultFormat::resolveFormatAliases( $format );
 
-		if ( !array_key_exists( $format, $GLOBALS['smwgResultFormats'] ) ) {
+		if ( !array_key_exists( $format ?? '', $GLOBALS['smwgResultFormats'] ) ) {
 			return [];
 		}
 

--- a/src/QueryPages/QueryPage.php
+++ b/src/QueryPages/QueryPage.php
@@ -194,7 +194,8 @@ abstract class QueryPage extends MWQueryPage {
 			'action' => $GLOBALS['wgScript'],
 			'class' => 'plainlinks'
 		], Html::hidden( 'title', $this->getContext()->getTitle()->getPrefixedText() ) .
-			Xml::fieldset( $this->msg( 'smw-special-property-searchform-options' )->text(),
+			Html::rawElement( 'fieldset', [],
+				Html::element( 'legend', [], $this->msg( 'smw-special-property-searchform-options' )->text() ) .
 				Xml::tags( 'p', [], $resultCount ) .
 				Xml::tags( 'p', [], $selection ) .
 				$cacheDate .

--- a/src/SQLStore/EntityStore/CachingSemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/CachingSemanticDataLookup.php
@@ -302,7 +302,7 @@ class CachingSemanticDataLookup {
 		$this->initLookupCache( $id, $subject );
 
 		// @see also setLookupCache
-		$name = $propertyTableDef->getName();
+		$name = $propertyTableDef->getName() ?? '';
 
 		if ( isset( self::$state[$id][$name] ) ) {
 			$this->unlockCache();

--- a/src/SQLStore/EntityStore/SemanticDataLookup.php
+++ b/src/SQLStore/EntityStore/SemanticDataLookup.php
@@ -816,8 +816,8 @@ class SemanticDataLookup {
 		// Replicates the legacy `Query::hasField()` check by testing whether the
 		// field already appears either as a select expression (value) or as an
 		// alias (key) in the in-progress select list.
-		if ( !in_array( $valueField, $selectFields, true ) && !array_key_exists( $valueField, $selectFields ) ) {
-			$map[$valueField] = "v" . ( $valueCount + 1 );
+		if ( !in_array( $valueField, $selectFields, true ) && !array_key_exists( $valueField ?? '', $selectFields ) ) {
+			$map[$valueField ?? ''] = "v" . ( $valueCount + 1 );
 			$selectFields[ 'v' . ( $valueCount + 1 ) ] = $valueField;
 		}
 	}

--- a/src/SQLStore/Lookup/TableStatisticsLookup.php
+++ b/src/SQLStore/Lookup/TableStatisticsLookup.php
@@ -150,7 +150,7 @@ class TableStatisticsLookup {
 					'unassigned_count' => $unassigned_query_links_count,
 				],
 			],
-			$blobTable => [
+			( $blobTable ?? '' ) => [
 				'total_row_count' => $rows_blob_table_total_count,
 				'unique_terms_occurrence_in_percent' => $unique_hash_field_terms_in_percent,
 				'rows' => [

--- a/src/SQLStore/PropertyTableRowDiffer.php
+++ b/src/SQLStore/PropertyTableRowDiffer.php
@@ -138,7 +138,7 @@ class PropertyTableRowDiffer {
 				continue;
 			}
 
-			$tableName = $propertyTable->getName();
+			$tableName = $propertyTable->getName() ?? '';
 			$fixedProperty = [];
 
 			// Fixed property tables have no p_id declared, the auxiliary

--- a/src/SQLStore/PropertyTableRowMapper.php
+++ b/src/SQLStore/PropertyTableRowMapper.php
@@ -204,7 +204,7 @@ class PropertyTableRowMapper {
 					continue;
 				}
 
-				$tableName = $propertyTable->getName();
+				$tableName = $propertyTable->getName() ?? '';
 
 				if ( !array_key_exists( $tableName, $rows ) ) {
 					$rows[$tableName] = [];

--- a/src/SQLStore/QueryEngine/ConceptQuerySegmentBuilder.php
+++ b/src/SQLStore/QueryEngine/ConceptQuerySegmentBuilder.php
@@ -73,7 +73,7 @@ class ConceptQuerySegmentBuilder {
 
 		$this->querySegmentListProcessor->process( $qid );
 
-		return $querySegmentList[$qid] ?? null;
+		return $querySegmentList[$qid ?? ''] ?? null;
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/DescriptionInterpreters/ComparatorMapper.php
+++ b/src/SQLStore/QueryEngine/DescriptionInterpreters/ComparatorMapper.php
@@ -39,7 +39,7 @@ class ComparatorMapper {
 
 		$comparator = $description->getComparator();
 
-		if ( !isset( $comparatorMap[$comparator] ) ) {
+		if ( !isset( $comparatorMap[$comparator ?? ''] ) ) {
 			throw new RuntimeException( "Unsupported comparator $comparator in value description." );
 		}
 

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
@@ -200,7 +200,7 @@ class SearchTableRebuilder {
 
 			// Only care for Blob/Uri tables
 			if ( !$this->getSearchTable()->isValidByType( $proptable->getDiType() ) ) {
-				$this->skippedTables[$proptable->getName()] = '[INVALID]';
+				$this->skippedTables[$proptable->getName() ?? ''] = '[INVALID]';
 				continue;
 			}
 

--- a/src/SQLStore/TableBuilder/Examiner/CountMapField.php
+++ b/src/SQLStore/TableBuilder/Examiner/CountMapField.php
@@ -49,7 +49,7 @@ class CountMapField {
 		);
 
 		$connection = $this->store->getConnection( DB_PRIMARY );
-		$tableName = $connection->tableName( SQLStore::ID_AUXILIARY_TABLE );
+		$tableName = $connection->tableName( SQLStore::ID_AUXILIARY_TABLE ) ?? '';
 
 		if (
 			isset( $log[$tableName]['smw_countmap'] ) &&

--- a/src/SQLStore/TableBuilder/TableSchemaManager.php
+++ b/src/SQLStore/TableBuilder/TableSchemaManager.php
@@ -54,7 +54,7 @@ class TableSchemaManager {
 		$hash = [];
 
 		foreach ( $this->getTables() as $table ) {
-			$hash[$table->getName()] = $table->getHash();
+			$hash[$table->getName() ?? ''] = $table->getHash();
 		}
 
 		// Avoid by-chance sorting with an eventual differing hash
@@ -438,7 +438,7 @@ class TableSchemaManager {
 			return;
 		}
 
-		$this->tables[$table->getName()] = $table;
+		$this->tables[$table->getName() ?? ''] = $table;
 	}
 
 }

--- a/src/Schema/SchemaTypes.php
+++ b/src/Schema/SchemaTypes.php
@@ -153,7 +153,7 @@ class SchemaTypes implements JsonSerializable {
 	 * @return bool
 	 */
 	public function isRegisteredType( ?string $type ): bool {
-		return isset( $this->schemaTypes[$type] );
+		return isset( $this->schemaTypes[$type ?? ''] );
 	}
 
 	/**

--- a/tests/phpunit/Integration/MediaWiki/Specials/SpecialConceptsKeysetIntegrationTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Specials/SpecialConceptsKeysetIntegrationTest.php
@@ -303,7 +303,6 @@ class SpecialConceptsKeysetIntegrationTest extends SMWIntegrationTestCase {
 		$reflection = new \ReflectionClass( $instance );
 
 		$doFetch = $reflection->getMethod( 'doCursorFetch' );
-		$doFetch->setAccessible( true );
 		$result = $doFetch->invoke( $instance, $options );
 
 		$titles = [];

--- a/tests/phpunit/Unit/MediaWiki/Connection/MockSelectQueryBuilderTrait.php
+++ b/tests/phpunit/Unit/MediaWiki/Connection/MockSelectQueryBuilderTrait.php
@@ -105,7 +105,7 @@ trait MockSelectQueryBuilderTrait {
 		$firstField = false;
 		if ( is_object( $firstRow ) ) {
 			$vars = get_object_vars( $firstRow );
-			$firstField = $vars[array_key_first( $vars )] ?? false;
+			$firstField = $vars[array_key_first( $vars ) ?? ''] ?? false;
 		} elseif ( is_array( $firstRow ) ) {
 			$firstField = reset( $firstRow );
 		}

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -118,7 +118,6 @@ class ParserAfterTidyTest extends TestCase {
 	 */
 	private function setParserLocked( Parser $parser ): void {
 		$prop = new ReflectionProperty( Parser::class, 'mInParse' );
-		$prop->setAccessible( true );
 		$prop->setValue( $parser, true );
 	}
 

--- a/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/ChangePropagationDispatchJobTest.php
@@ -293,7 +293,6 @@ class ChangePropagationDispatchJobTest extends TestCase {
 
 		$reflector = new ReflectionClass( ChangePropagationDispatchJob::class );
 		$method = $reflector->getMethod( 'chooseUpdateStrategy' );
-		$method->setAccessible( true );
 
 		$this->assertSame( $expected, $method->invoke( $job ) );
 	}

--- a/tests/phpunit/Unit/MediaWiki/Jobs/UpdateDispatcherJobTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Jobs/UpdateDispatcherJobTest.php
@@ -416,7 +416,6 @@ class UpdateDispatcherJobTest extends TestCase {
 
 		$reflector = new ReflectionClass( UpdateDispatcherJob::class );
 		$jobsProp = $reflector->getProperty( 'jobs' );
-		$jobsProp->setAccessible( true );
 
 		// Unrestricted dispatch
 		$unrestricted = new UpdateDispatcherJob(

--- a/tests/phpunit/Unit/MediaWiki/PageInfoProviderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/PageInfoProviderTest.php
@@ -2,7 +2,7 @@
 
 namespace SMW\Tests\Unit\MediaWiki;
 
-use MediaWiki\Content\Content;
+use MediaWiki\Content\TextContent;
 use MediaWiki\Revision\RevisionLookup;
 use MediaWiki\Revision\RevisionRecord;
 use MediaWiki\User\User;
@@ -289,12 +289,12 @@ class PageInfoProviderTest extends TestCase {
 	}
 
 	public function testWikiPage_NativeData() {
-		$content = $this->getMockBuilder( Content::class )
+		$content = $this->getMockBuilder( TextContent::class )
 			->disableOriginalConstructor()
 			->getMock();
 
 		$content->expects( $this->any() )
-			->method( 'getNativeData' )
+			->method( 'getText' )
 			->willReturn( 'Foo' );
 
 		$wikiPage = $this->getMockBuilder( '\WikiPage' )

--- a/tests/phpunit/Unit/SetupFileTest.php
+++ b/tests/phpunit/Unit/SetupFileTest.php
@@ -496,7 +496,6 @@ class SetupFileTest extends TestCase {
 
 	private function withRepo( SetupFile $file, SmwJsonRepo $repo ): void {
 		$ref = new ReflectionProperty( $file, 'repo' );
-		$ref->setAccessible( true );
 		$ref->setValue( $file, $repo );
 	}
 


### PR DESCRIPTION
Removes the Semantic MediaWiki deprecation notices emitted under PHP 8.5 / MediaWiki 1.46 while preserving behaviour on all supported versions (MediaWiki 1.43+, PHP 8.1+). The changes are grouped into four commits by deprecation type.

- **Null as an array offset or key (PHP 8.5).** PHP 8.5 deprecates `null` as an array offset, as the key argument to `array_key_exists()`, and as a string argument to `md5()`. Several lookups relied on the implicit null-to-empty-string coercion, mostly for mocked or edge-case values (property-table names, comparators, table ids, format names). Each value is now coalesced to `''` explicitly, or the write is skipped when the value is absent, so the prior behaviour is unchanged.
- **`Reflection::setAccessible()` (PHP 8.5).** These calls have been no-ops since PHP 8.1 (the project minimum) and are deprecated in 8.5; they are removed from the affected tests.
- **`TextContent::getNativeData()` (MediaWiki 1.33).** Replaced with `getText()`, guarded by an `instanceof TextContent` check that falls back to an empty string for any non-text content. `getText()` is available on all supported MediaWiki versions.
- **`Xml::fieldset()` (MediaWiki 1.42).** Replaced with the equivalent `Html` fieldset and legend markup, leaving the surrounding non-deprecated `Xml::tags()` calls in place.

The `SpecialPage` constructor-parameter deprecation (MediaWiki 1.46) is intentionally left for a separate change, since it needs version-aware handling to keep the pre-1.46 permission restriction intact.

Verified under PHP 8.5 / MediaWiki 1.46 that these notices no longer appear, with the unit and integration suites passing. Behaviour is unchanged on MediaWiki 1.43 (PHP 8.2), where the PHP 8.5 deprecations are not emitted.
