### PR TITLE
Stop using deprecated SpecialPage constructor parameters

### DIFF
--- a/src/MediaWiki/Specials/SpecialAdmin.php
+++ b/src/MediaWiki/Specials/SpecialAdmin.php
@@ -44,7 +44,22 @@ class SpecialAdmin extends SpecialPage {
 		private readonly JobFactory $jobFactory,
 		private readonly JobQueue $jobQueue
 	) {
-		parent::__construct( 'SMWAdmin', 'smw-admin' );
+		// MediaWiki 1.46 deprecated passing the restriction through the
+		// SpecialPage constructor in favour of overriding getRestriction().
+		// Versions before 1.46 enforce the restriction via the
+		// constructor-set property, so keep passing it there for them.
+		if ( version_compare( MW_VERSION, '1.46', '<' ) ) {
+			parent::__construct( 'SMWAdmin', 'smw-admin' );
+		} else {
+			parent::__construct( 'SMWAdmin' );
+		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function getRestriction(): string {
+		return 'smw-admin';
 	}
 
 	/**

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -34,7 +34,16 @@ class SpecialBrowse extends SpecialPage {
 		private readonly Settings $settings,
 		private readonly SerializerFactory $serializerFactory
 	) {
-		parent::__construct( 'Browse', '', true, false, 'default', true );
+		// MediaWiki 1.46 deprecated the SpecialPage constructor flags; the
+		// page stays transcludable via the isIncludable() override below.
+		parent::__construct( 'Browse' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isIncludable(): bool {
+		return true;
 	}
 
 	/**

--- a/src/MediaWiki/Specials/SpecialFacetedSearch.php
+++ b/src/MediaWiki/Specials/SpecialFacetedSearch.php
@@ -36,7 +36,16 @@ class SpecialFacetedSearch extends SpecialPage {
 		private readonly Store $store,
 		private readonly SchemaFactory $schemaFactory
 	) {
-		parent::__construct( 'FacetedSearch', '', true, false, 'default', true );
+		// MediaWiki 1.46 deprecated the SpecialPage constructor flags; the
+		// page stays transcludable via the isIncludable() override below.
+		parent::__construct( 'FacetedSearch' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isIncludable(): bool {
+		return true;
 	}
 
 	/**

--- a/src/MediaWiki/Specials/SpecialPageProperty.php
+++ b/src/MediaWiki/Specials/SpecialPageProperty.php
@@ -33,7 +33,16 @@ class SpecialPageProperty extends SpecialPage {
 	public function __construct(
 		private readonly Store $store
 	) {
-		parent::__construct( 'PageProperty', '', false );
+		// MediaWiki 1.46 deprecated the SpecialPage constructor flags; the
+		// page stays unlisted via the isListed() override below.
+		parent::__construct( 'PageProperty' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isListed(): bool {
+		return false;
 	}
 
 	/**

--- a/src/MediaWiki/Specials/SpecialPendingTaskList.php
+++ b/src/MediaWiki/Specials/SpecialPendingTaskList.php
@@ -18,7 +18,16 @@ use SMW\Utils\HtmlTabs;
 class SpecialPendingTaskList extends SpecialPage {
 
 	public function __construct() {
-		parent::__construct( 'PendingTaskList', '', false );
+		// MediaWiki 1.46 deprecated the SpecialPage constructor flags; the
+		// page stays unlisted via the isListed() override below.
+		parent::__construct( 'PendingTaskList' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isListed(): bool {
+		return false;
 	}
 
 	/**

--- a/src/MediaWiki/Specials/SpecialURIResolver.php
+++ b/src/MediaWiki/Specials/SpecialURIResolver.php
@@ -22,7 +22,16 @@ class SpecialURIResolver extends SpecialPage {
 	 * @see SpecialPage::__construct
 	 */
 	public function __construct() {
-		parent::__construct( 'URIResolver', '', false );
+		// MediaWiki 1.46 deprecated the SpecialPage constructor flags; the
+		// page stays unlisted via the isListed() override below.
+		parent::__construct( 'URIResolver' );
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function isListed(): bool {
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
Part of the PHP 8.5 / MediaWiki 1.46 deprecation cleanup (follow-up to #6973).

MediaWiki 1.46 deprecated passing `$restriction`, `$listed`, `$function`, `$file` and `$includable` to the `SpecialPage` constructor. This moves those flags to method overrides:

- `isListed()` returns false for the unlisted pages (`PageProperty`, `PendingTaskList`, `URIResolver`).
- `isIncludable()` returns true for the transcludable pages (`Browse`, `FacetedSearch`).
- `getRestriction()` returns `smw-admin` for `SpecialAdmin`.

`SpecialAdmin` needs version-aware handling. MediaWiki before 1.46 enforces a special page's restriction by reading the constructor-set property directly, not through `getRestriction()`, so simply dropping the constructor argument and overriding `getRestriction()` would silently disable the `smw-admin` permission gate on MediaWiki 1.43. The constructor therefore keeps passing the restriction on versions before 1.46 and relies on the `getRestriction()` override from 1.46 onward, the release where the enforcement path moved to the method. `isListed()` and `isIncludable()` are read through their methods on every supported version, so those five pages need no version guard.

Verified on MediaWiki 1.43 that the `smw-admin` restriction is still enforced (an anonymous request to the admin page receives a permission error while an authorised user sees the page), that the unlisted and transcludable flags are unchanged in `Special:SpecialPages`, and that all six pages render without errors. Unit tests, phpcs and phan pass.
