### PR TITLE
FileIndexer: Fix "Argument 1 passed to SMW\MediaWiki\RevisionGuard::getFile() must be an instance of Title, null given"

### DIFF
--- a/src/Elastic/Indexer/FileIndexer.php
+++ b/src/Elastic/Indexer/FileIndexer.php
@@ -115,6 +115,10 @@ class FileIndexer {
 	public function index( WikiPage $dataItem, ?File $file = null ): void {
 		$title = $dataItem->getTitle();
 
+		if ( $title === null ) {
+			return;
+		}
+
 		// Allow any third-party extension to modify the file used as base for
 		// the index process
 		$file = $this->revisionGuard->getFile( $title, $file );


### PR DESCRIPTION
Fixes #4832