### PR TITLE
Use CREATE TEMPORARY TABLE for SQLite query temp tables

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.1.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.1.0.md
@@ -28,3 +28,4 @@ This is only for those who have installed SMW via Git.
 ## Changes
 
 * Fixed the `smwgSetParserCacheTimestamp` feature overwriting a page's revision date with the current time; it now sets the parser cache time instead ([#6982](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6982))
+* Fixed read-only requests on SQLite being recorded as having made primary database writes, caused by SMW's query temporary tables not being recognised as temporary by MediaWiki ([#6984](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6984))

--- a/src/SQLStore/TableBuilder/TemporaryTableBuilder.php
+++ b/src/SQLStore/TableBuilder/TemporaryTableBuilder.php
@@ -118,13 +118,17 @@ class TemporaryTableBuilder {
 				. "END\$\$";
 		}
 
-		// SQLite: TEMP keyword (TEMPORARY also accepted) and no engine clause.
-		// `INTEGER PRIMARY KEY` is a SQLite-specific rowid alias — the column
+		// SQLite: use TEMPORARY rather than the TEMP synonym SQLite also
+		// accepts, and no engine clause. MediaWiki's rdbms Query verb parser
+		// only recognises `CREATE TEMPORARY` as temporary-table creation; with
+		// `CREATE TEMP` the table is never registered as temporary, so later
+		// INSERT/DELETE into it are accounted as permanent primary writes.
+		// `INTEGER PRIMARY KEY` is a SQLite-specific rowid alias: the column
 		// accepts explicit values supplied via INSERT (HierarchyTempTableBuilder
 		// supplies them) and rejects duplicates, so dedup later via
 		// INSERT OR IGNORE works without an extra constraint clause.
 		if ( $this->connection->isType( 'sqlite' ) ) {
-			return 'CREATE TEMP TABLE IF NOT EXISTS ' . $tableName . ' ( id INTEGER PRIMARY KEY )';
+			return 'CREATE TEMPORARY TABLE IF NOT EXISTS ' . $tableName . ' ( id INTEGER PRIMARY KEY )';
 		}
 
 		// MySQL: temporary memory table; dedup via INSERT IGNORE later.

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/TemporaryTableBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/TemporaryTableBuilderTest.php
@@ -136,10 +136,13 @@ class TemporaryTableBuilderTest extends TestCase {
 		$this->connection->method( 'isType' )
 			->willReturnCallback( static fn ( $type ) => $type === 'sqlite' );
 
+		// Must be CREATE TEMPORARY (not the TEMP synonym): MediaWiki's rdbms
+		// Query verb parser only registers `CREATE TEMPORARY` tables as
+		// temporary, otherwise later inserts count as permanent primary writes.
 		$this->connection->expects( $this->once() )
 			->method( 'query' )
 			->with(
-				$this->stringContains( 'CREATE TEMP TABLE IF NOT EXISTS Foo' ),
+				$this->stringContains( 'CREATE TEMPORARY TABLE IF NOT EXISTS Foo' ),
 				$this->anything(),
 				$this->anything()
 			);


### PR DESCRIPTION
## Summary

On SQLite, `TemporaryTableBuilder` created SMW's query temp tables (`smw_new`, `smw_res`) with `CREATE TEMP TABLE`. MediaWiki's rdbms `Query` verb parser only lists `CREATE TEMPORARY` in `MULTIWORD_VERBS`, so the two forms parse differently:

| SQL | parsed verb | registered temporary? |
|---|---|---|
| `CREATE TEMP TABLE …` | `CREATE` | no |
| `CREATE TEMPORARY TABLE …` | `CREATE TEMPORARY` | yes |

Because the table is never registered as temporary, `Database::hasPermanentTable()` returns true for a later `INSERT INTO smw_new`, so those writes are accounted as permanent primary writes. On a SQLite install a category query (which builds the subcategory-hierarchy temp tables) then flips `LBFactory::hasOrMadeRecentPrimaryChanges()` from false to true purely from temp-table inserts, with downstream ChronologyProtector and read-only-role effects on otherwise read-only requests.

MySQL/MariaDB and PostgreSQL are unaffected: their branches already use `CREATE TEMPORARY TABLE`.

## Fix

Use `CREATE TEMPORARY TABLE IF NOT EXISTS …` in the SQLite branch. SQLite accepts `TEMPORARY` as a synonym for `TEMP`, so the DDL semantics are unchanged; the table is now registered as temporary and later inserts are no longer counted as primary writes. `DROP TABLE` teardown is unaffected.

## Testing

`TemporaryTableBuilderTest::testCreateOnSQLite` now asserts the emitted DDL uses `CREATE TEMPORARY TABLE`. Reverting only the production line makes that test fail, confirming it guards the regression.

Fixes #6980