### PR TITLE
Bump version to 7.1.0-alpha

### DIFF
--- a/docs/releasenotes/README.md
+++ b/docs/releasenotes/README.md
@@ -3,6 +3,7 @@
 Major releases and feature releases are indicated in **bold**.
 
 ### Semantic MediaWiki 7.x
+* **[SMW 7.1.0 release notes](RELEASE-NOTES-7.1.0.md)**
 * **[SMW 7.0.0 release notes](RELEASE-NOTES-7.0.0.md)**
 
 ### Semantic MediaWiki 6.x

--- a/docs/releasenotes/RELEASE-NOTES-7.1.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.1.0.md
@@ -1,0 +1,30 @@
+# Semantic MediaWiki 7.1.0
+
+Released on TBD.
+
+## Summary
+
+This is a [minor release](../RELEASE-POLICY.md). Thus, it contains no breaking changes, only new features and fixes.
+
+Like SMW 7.0.x, this version is compatible with MediaWiki 1.43 up to 1.46 and PHP 8.1 up to 8.5.
+For more detailed information, see the [compatibility matrix](../COMPATIBILITY.md#compatibility).
+
+## Upgrading
+
+No need to run "update.php" or any other migration scripts.
+
+**Get the new version via Composer:**
+
+* Step 1: if you are upgrading from SMW older than 7.0.0, ensure the SMW version in `composer.local.json` is `^7.1.0`
+* Step 2: run composer in your MediaWiki directory: `composer update --no-dev --optimize-autoloader`
+
+**Get the new version via Git:**
+
+This is only for those who have installed SMW via Git.
+
+* Step 1: do a `git pull` in the SemanticMediaWiki directory
+* Step 2: run `composer update --no-dev --optimize-autoloader` in the MediaWiki directory
+
+## Changes
+
+* Fixed the `smwgSetParserCacheTimestamp` feature overwriting a page's revision date with the current time; it now sets the parser cache time instead ([#6982](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6982))

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticMediaWiki",
-	"version": "7.0.0",
+	"version": "7.1.0-alpha",
 	"author": [
 		"[https://korrekt.org Markus Krötzsch]",
 		"[https://EntropyWins.wtf/mediawiki Jeroen De Dauw]",


### PR DESCRIPTION
Starts the 7.1.0 development cycle, mirroring how the 7.0.0 cycle was opened.

- Adds `docs/releasenotes/RELEASE-NOTES-7.1.0.md` as a scaffold for the next minor release, using the lighter Summary / Upgrading / Changes structure that minor releases (such as 5.1.0) follow, with `Released on TBD.` until release.
- Links the new note from the release-notes index (`docs/releasenotes/README.md`).
- Bumps `extension.json` to `7.1.0-alpha`.

Per the release policy this is a minor release: no breaking changes, and it keeps the 7.0.x compatibility range (MediaWiki 1.43 to 1.46, PHP 8.1 to 8.5).

The Changes section is seeded with the one user-facing fix that has landed since 7.0.0 (#6982: the `smwgSetParserCacheTimestamp` feature was setting the page revision timestamp instead of the parser cache time). Further entries are added here as 7.1.0 work merges.