### PR TITLE
Fix #ask offset pagination being capped by the subquery rewrite (#6983)

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.1.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.1.0.md
@@ -29,3 +29,4 @@ This is only for those who have installed SMW via Git.
 
 * Fixed the `smwgSetParserCacheTimestamp` feature overwriting a page's revision date with the current time; it now sets the parser cache time instead ([#6982](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6982))
 * Fixed read-only requests on SQLite being recorded as having made primary database writes, caused by SMW's query temporary tables not being recognised as temporary by MediaWiki ([#6984](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6984))
+* Fixed `#ask` queries with an `offset` being capped to a small number of results; deeper result pages now return correctly ([#6983](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6983))

--- a/src/SQLStore/QueryEngine/SubqueryQueryBuilder.php
+++ b/src/SQLStore/QueryEngine/SubqueryQueryBuilder.php
@@ -80,7 +80,7 @@ class SubqueryQueryBuilder {
 			$root,
 			$sortfieldPairs,
 			$orderBy,
-			$this->innerLimit( $outerLimit ),
+			$this->innerLimit( $outerLimit, $offset ),
 			$cursorPredicate,
 			$cursorSortColumns
 		);
@@ -157,8 +157,14 @@ class SubqueryQueryBuilder {
 		return $sql;
 	}
 
-	private function innerLimit( int $outerLimit ): int {
-		return max( $outerLimit + 5, (int)ceil( $outerLimit * 1.2 ) + 10 );
+	private function innerLimit( int $outerLimit, int $offset ): int {
+		// The outer query pages the derived table with LIMIT/OFFSET, so the
+		// inner LIMIT must cover the offset as well as the page. Without the
+		// offset term the outer OFFSET skips past the entire inner result and
+		// any page beyond `innerLimit - 1` comes back empty (#6983). The
+		// headroom term (outer filter-loss / dedup buffer) is preserved and
+		// applied on top of the offset.
+		return $offset + max( $outerLimit + 5, (int)ceil( $outerLimit * 1.2 ) + 10 );
 	}
 
 	/**

--- a/tests/phpunit/Integration/Query/SubqueryQueryEquivalenceDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/SubqueryQueryEquivalenceDBIntegrationTest.php
@@ -244,6 +244,61 @@ class SubqueryQueryEquivalenceDBIntegrationTest extends SMWIntegrationTestCase {
 		$this->assertQueryEquivalent( $factory, 'disjunction across two properties' );
 	}
 
+	public function testOffsetPaginationBeyondInnerLimitMatchesLegacyPath(): void {
+		// Regression for #6983 ("Offset capped at 45"). The derived-table
+		// rewrite sized the inner subquery LIMIT from the page size alone,
+		// ignoring the offset. Any page whose offset reached that inner cap
+		// returned an empty slice while the legacy path still paged
+		// correctly. Seed more rows than the (old) inner cap and page past
+		// it: legacy and rewrite must agree, and the page must be non-empty.
+		$paginationProperty = new Property( 'EquivalencePaginationNumber' );
+		$paginationProperty->setPropertyValueType( '_num' );
+
+		// 25 distinct, totally-ordered values. The old inner LIMIT for a
+		// page size of 2 was max((2+5)+5, ceil((2+5)*1.2)+10) = 19, so an
+		// offset of 20 paged past every inner row under the bug.
+		for ( $value = 1; $value <= 25; $value++ ) {
+			$semanticData = $this->semanticDataFactory
+				->setTitle( __CLASS__ . '-pagination-' . sprintf( '%02d', $value ) )
+				->newEmptySemanticData();
+			$semanticData->addPropertyObjectValue(
+				$paginationProperty,
+				new Number( $value )
+			);
+			$this->getStore()->updateData( $semanticData );
+			$this->subjectsToBeCleared[] = $semanticData->getSubject();
+		}
+
+		$factory = static function () use ( $paginationProperty ): Query {
+			$description = new SomeProperty(
+				$paginationProperty,
+				new ThingDescription()
+			);
+			$query = new Query( $description );
+			$query->querymode = Query::MODE_INSTANCES;
+			$query->sort = true;
+			$query->sortkeys = [ $paginationProperty->getKey() => 'ASC' ];
+			$query->setUnboundLimit( 2 );
+			$query->setUnboundOffset( 20 );
+			return $query;
+		};
+
+		$this->assertQueryEquivalent( $factory, 'offset pagination beyond inner limit' );
+
+		// Guard against the degenerate case where both paths return an
+		// empty slice (which would falsely satisfy equivalence). With 25
+		// totally-ordered rows, offset 20 + limit 2 yields the 21st and
+		// 22nd values on the rewrite path.
+		$rewriteHashes = $this->subjectHashes(
+			$this->runUnderLegacyFlag( false, $factory )
+		);
+		$this->assertCount(
+			2,
+			$rewriteHashes,
+			'Offset page beyond the old inner cap returned a short/empty slice'
+		);
+	}
+
 	public function testCursorWalkOverDefaultSortMatchesLegacyPath(): void {
 		$this->assertCursorWalkEquivalent(
 			function ( ?array $cursorPayload ): Query {

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/SubqueryQueryBuilderTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/SubqueryQueryBuilderTest.php
@@ -57,6 +57,53 @@ class SubqueryQueryBuilderTest extends TestCase {
 		$this->assertMatchesRegularExpression( '/ORDER BY inner_q\.\w+ ASC/', $sql );
 	}
 
+	public function testInnerLimitCoversOffsetSoDeepPagesAreNotCapped() {
+		// Regression for #6983 ("Offset capped at 45"). The derived table
+		// must contain every row the outer query pages over, so the inner
+		// LIMIT has to cover the OFFSET, not just the page size. When the
+		// offset was ignored the inner LIMIT was max(L+5, ceil(L*1.2)+10)
+		// and any OFFSET at or beyond that value paged past the entire
+		// inner result, capping results at `innerLimit - 1` rows.
+		$root = new QuerySegment();
+		$root->joinTable = 'smw_object_ids';
+		$root->alias = 't0';
+		$root->joinfield = 't0.smw_id';
+		$root->from = ' INNER JOIN `smw_fpt_inst` AS t1 ON t0.smw_id=t1.s_id';
+		$root->where = 't1.o_id=8536';
+		$root->sortfields = [ '_SKEY' => 't0.smw_sort' ];
+
+		$sqlOptions = [
+			'LIMIT' => 30,
+			'OFFSET' => 46,
+			'ORDER BY' => 't0.smw_sort ASC',
+		];
+
+		$builder = new SubqueryQueryBuilder( $this->connection );
+		$sql = $builder->buildInstanceQuerySQL( $root, $sqlOptions, '' );
+
+		// Inner LIMIT = offset + max(30+5, ceil(30*1.2)+10) = 46 + 46 = 92.
+		$this->assertMatchesRegularExpression(
+			'/INNER JOIN \(.*LIMIT 92\) AS inner_q/s',
+			$sql
+		);
+
+		// The invariant the bug violated: the inner LIMIT must exceed the
+		// outer OFFSET, otherwise the outer slice is guaranteed empty.
+		$this->assertSame(
+			1,
+			preg_match( '/INNER JOIN \(.*LIMIT (\d+)\) AS inner_q/s', $sql, $matches ),
+			'Could not locate the inner LIMIT in the generated SQL.'
+		);
+		$this->assertGreaterThan(
+			46,
+			(int)$matches[1],
+			'Inner LIMIT must exceed the outer OFFSET so the page is not capped.'
+		);
+
+		// Outer pagination is unchanged.
+		$this->assertMatchesRegularExpression( '/LIMIT 30 OFFSET 46\s*$/', $sql );
+	}
+
 	public function testInstanceQueryWithoutSort() {
 		$root = new QuerySegment();
 		$root->joinTable = 'smw_fpt_askdu';


### PR DESCRIPTION
## Problem

`#ask` queries with an `offset` return far fewer results than they should. With the category query from #6983, `offset=45` showed 1 row and `offset=46` showed 0, even though the category has over 100 members. The cap sits at offset 45 regardless of how much data matches.

## Cause

SMW 7.0.0 rewrites instance queries as a derived-table subquery (`SubqueryQueryBuilder`): DISTINCT, ORDER BY and an inner LIMIT are hoisted into an inner subquery, which is then joined to the ID table by an outer query that carries the user's `LIMIT`/`OFFSET`.

The inner LIMIT was derived from the page size alone:

```
max( $outerLimit + 5, (int)ceil( $outerLimit * 1.2 ) + 10 )
```

It never accounted for the offset. The outer query then applies `OFFSET` against that truncated inner result set, so once the offset reaches the inner cap the outer slice is empty. For a default-sized page the inner cap is 46, so the last offset that returns anything is 45.

## Fix

`innerLimit()` now adds the offset on top of the existing headroom, so the derived table always contains every row the outer query pages over:

```
return $offset + max( $outerLimit + 5, (int)ceil( $outerLimit * 1.2 ) + 10 );
```

The headroom term (which absorbs outer filter losses and post-DISTINCT dedup) stays page-proportional rather than offset-proportional. `offset = 0` is byte-for-byte unchanged, cursor-based pagination is unaffected (it unsets `OFFSET` before reaching the builder), and the count path has no inner LIMIT.

## Testing

- A unit test pins the inner LIMIT to `offset + headroom` and asserts it exceeds the offset, so the outer slice can never be empty.
- A real-database test runs the same offset query under both the legacy and the rewrite query paths and asserts they return identical rows for a page past the old inner cap. It fails against the unfixed code (the rewrite returns nothing while the legacy path returns the page) and passes with the fix.
- Verified end to end on a seeded wiki: `#ask [[Category:...]]` with offsets past the old cap now return the correct rows.

Fixes #6983
