### PR TITLE
ci: add experimental MySQL 8 test leg

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,6 +71,7 @@ jobs:
   tests:
     name: Test (MW ${{ matrix.mw }}, PHP ${{ matrix.php }}, ${{ matrix.db }})
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -79,6 +80,7 @@ jobs:
           - { mw: '1.44', php: 8.3, db: "mariadb:11.8" }
           - { mw: '1.45', php: 8.4, db: "mariadb:12.3" }
           - { mw: '1.46-dev-26e9b33', php: 8.5, db: "mariadb:12.3" }
+          - { mw: '1.43', php: 8.2, db: "mysql:8", experimental: true }
     env:
       MW_VERSION: ${{ matrix.mw }}
       PHP_VERSION: ${{ matrix.php }}


### PR DESCRIPTION
## Summary

Closes #6990.

SMW CI tests exclusively against MariaDB. PR #6936 removed the `use-normal-tables` workaround on the basis that Error 1137 no longer reproduces on MariaDB — but MySQL 8 was never in the matrix and was not validated.

This PR adds a single `mysql:8` leg (MW 1.43, PHP 8.2) to the `tests` job, marked `experimental: true` so failures are visible without blocking `ci-success`. Once the underlying Error 1137 issue in `SemanticDataLookup::fetchFromTable()` is fixed, the `experimental` flag can be removed.

## Changes

- Add `continue-on-error: ${{ matrix.experimental == true }}` to the `tests` job
- Add `{ mw: '1.43', php: 8.2, db: "mysql:8", experimental: true }` matrix entry