### PR TITLE
Attribute the enableSemantics deprecation to Semantic MediaWiki

### DIFF
--- a/src/enableSemantics.php
+++ b/src/enableSemantics.php
@@ -14,6 +14,6 @@
 // phpcs:ignore MediaWiki.NamingConventions.PrefixedGlobalFunctions.allowedPrefix
 function enableSemantics( $namespace = null, $complete = false ): void {
 	if ( function_exists( 'wfDeprecated' ) ) {
-		wfDeprecated( __FUNCTION__, '7.0.0' );
+		wfDeprecated( __FUNCTION__, '7.0.0', 'SemanticMediaWiki' );
 	}
 }


### PR DESCRIPTION
## Problem

`enableSemantics()` emits its deprecation notice via `wfDeprecated( __FUNCTION__, '7.0.0' )` with no component argument. When the component is omitted, MediaWiki's `MWDebug::deprecated()` defaults it to `MediaWiki`, so the notice reads:

> Use of enableSemantics was deprecated in MediaWiki 7.0.0.

`enableSemantics` is a Semantic MediaWiki function, deprecated in SMW 7.0.0 in favour of `wfLoadExtension( 'SemanticMediaWiki' )`. Attributing it to MediaWiki is misleading: there is no MediaWiki 7.0.0, and it points the reader at the wrong project.

## Fix

Pass `'SemanticMediaWiki'` as the component so the notice reads:

> Use of enableSemantics was deprecated in SemanticMediaWiki 7.0.0.

The component string matches the one already used for the legacy-constant deprecations in `src/Setup/LegacyConstantNormalizer.php` and the extension's registered `name` in `extension.json`.

## Testing

No automated test is added: the notice text is assembled entirely by core's `MWDebug::deprecated()` from the component argument, and the suite has no existing deprecation-message coverage to extend. A behavioural `expectDeprecationAndContinue()` integration test could pin the attribution if reviewers would prefer one.