### PR TITLE
Fix concept combined with a single-page restriction returning non-members

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.1.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.1.0.md
@@ -27,6 +27,7 @@ This is only for those who have installed SMW via Git.
 
 ## Changes
 
+* Fixed queries combining a concept with a single-page restriction (for example `[[Concept:Foo]] [[Bar]]`) returning pages that are not members of the concept ([#6994](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6994))
 * Fixed the `smwgSetParserCacheTimestamp` feature overwriting a page's revision date with the current time; it now sets the parser cache time instead ([#6982](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6982))
 * Fixed read-only requests on SQLite being recorded as having made primary database writes, caused by SMW's query temporary tables not being recognised as temporary by MediaWiki ([#6984](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6984))
 * Fixed queries combining subqueries with `OR` (for example `[[Has color::Brown]] OR [[Has color::Black]]`) failing on SQLite and PostgreSQL with an `INSERT IGNORE` syntax error ([#6987](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/6987))

--- a/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
+++ b/src/SQLStore/QueryEngine/QuerySegmentListProcessor.php
@@ -189,15 +189,35 @@ class QuerySegmentListProcessor {
 
 	private function conjunction( QuerySegment &$query ): void {
 		reset( $query->components );
-		$key = false;
 
-		// Pick one subquery as anchor point ...
+		// Pick one subquery as the anchor that the remaining conjuncts are
+		// joined onto. A component that owns a join table is ideal. Otherwise
+		// prefer a non-value component: a nested conjunction or disjunction
+		// resolves to a real table on its first processing pass, after which
+		// the other conjuncts join onto it correctly. A Q_VALUE has no join
+		// table and its processing ignores appended components, so anchoring
+		// on it silently drops all the other conjuncts, for example a concept
+		// combined with a single-page restriction (#6994). Fall back to the
+		// last component only when every component is a bare value restriction.
+		$key = false;
+		$nonValueKey = false;
+		$lastKey = false;
+
 		foreach ( $query->components as $qkey => $qid ) {
-			$key = $qkey;
+			$lastKey = $qkey;
 
 			if ( $this->querySegmentList[$qkey]->joinTable !== '' ) {
+				$key = $qkey;
 				break;
 			}
+
+			if ( $nonValueKey === false && $this->querySegmentList[$qkey]->type !== QuerySegment::Q_VALUE ) {
+				$nonValueKey = $qkey;
+			}
+		}
+
+		if ( $key === false ) {
+			$key = $nonValueKey !== false ? $nonValueKey : $lastKey;
 		}
 
 		$result = $this->querySegmentList[$key];

--- a/tests/phpunit/Integration/JSONScript/TestCases/q-0205.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/q-0205.json
@@ -1,0 +1,138 @@
+{
+	"description": "Test concept (live-computed) combined with a single-page restriction (#6994, skip virtuoso)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has author",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Member",
+			"contents": "[[Has author::Jane]] [[Category:Book]]"
+		},
+		{
+			"page": "Nonmember",
+			"contents": "[[Has author::Jane]]"
+		},
+		{
+			"page": "Plain page",
+			"contents": "[[Category:Book]]"
+		},
+		{
+			"namespace": "SMW_NS_CONCEPT",
+			"page": "Multi part concept",
+			"contents": "{{#concept: [[Has author::+]] [[Category:Book]] }}"
+		},
+		{
+			"namespace": "SMW_NS_CONCEPT",
+			"page": "Single part concept",
+			"contents": "{{#concept: [[Category:Book]] }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "query",
+			"about": "#0 multi-part concept and a single-page restriction matching a member returns the member",
+			"condition": "[[Concept:Multi part concept]] [[Member]]",
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"results": [
+					"Member#0##"
+				],
+				"count": "1"
+			}
+		},
+		{
+			"type": "query",
+			"about": "#1 multi-part concept and a single-page restriction for a non-member returns nothing (#6994)",
+			"condition": "[[Concept:Multi part concept]] [[Nonmember]]",
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"results": [],
+				"count": "0"
+			}
+		},
+		{
+			"type": "query",
+			"about": "#2 single-part concept and a single-page restriction for a non-member returns nothing",
+			"condition": "[[Concept:Single part concept]] [[Nonmember]]",
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"results": [],
+				"count": "0"
+			}
+		},
+		{
+			"type": "query",
+			"about": "#3 single-page restriction written before the multi-part concept returns nothing",
+			"condition": "[[Nonmember]] [[Concept:Multi part concept]]",
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"results": [],
+				"count": "0"
+			}
+		},
+		{
+			"type": "query",
+			"about": "#4 category hierarchy (depth=0) and a single-page restriction for a non-member returns nothing",
+			"condition": "[[Category:Book|+depth=0]] [[Nonmember]]",
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"results": [],
+				"count": "0"
+			}
+		},
+		{
+			"type": "query",
+			"about": "#5 property hierarchy (depth=0) and a single-page restriction for a non-member returns nothing",
+			"condition": "[[Has author::+|+depth=0]] [[Plain page]]",
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"results": [],
+				"count": "0"
+			}
+		},
+		{
+			"type": "query",
+			"about": "#6 category hierarchy (depth=0) and a single-page restriction for a member returns the member",
+			"condition": "[[Category:Book|+depth=0]] [[Member]]",
+			"parameters": {
+				"limit": "10"
+			},
+			"assert-queryresult": {
+				"results": [
+					"Member#0##"
+				],
+				"count": "1"
+			}
+		}
+	],
+	"settings": {
+		"smwgQueryResultCacheType": false,
+		"smwgQConceptCaching": "none",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_CONCEPT": true
+		}
+	},
+	"meta": {
+		"skip-on": {
+			"virtuoso": "Virtuoso reports 'SPARQL compiler: Blank node ... is not allowed in a constant clause', see https://github.com/openlink/virtuoso-opensource/issues/126"
+		},
+		"version": "2",
+		"is-incomplete": false
+	}
+}


### PR DESCRIPTION
## Problem

A query that combines a concept with a single-page restriction, such as `[[Concept:Foo]] [[Bar]]`, returned the page even when it was not a member of the concept. Writing the concept's condition inline instead, such as `[[Some property::+]] [[Category:Bar]] [[Bar]]`, correctly returned nothing.

The problem only appeared when the concept's definition had more than one condition; single-condition concepts behaved correctly. The same defect applied to a disjunction combined with a single-page restriction.

## Cause

`QuerySegmentListProcessor::conjunction()` picks an anchor segment that the remaining conjuncts are joined onto: the first component that owns a join table, otherwise the last component. A live-computed multi-condition concept compiles to a `Q_CONJUNCTION` with no join table, and a single-page restriction compiles to a `Q_VALUE`, also without a join table. The fallback therefore selected the `Q_VALUE`, and processing a `Q_VALUE` does nothing with the components appended to it, so the concept's condition was discarded. The query degenerated to `WHERE smw_id = id(page)`, returning the page regardless of concept membership.

Single-condition concepts compile to a real table that already won the anchor selection, which is why they were unaffected.

## Fix

When no component owns a join table, prefer a non-value component as the anchor. A nested conjunction or disjunction resolves to a real table on its first processing pass, after which the remaining conjuncts join onto it correctly. The change is order-independent and leaves the existing real-join-table and all-value-component cases untouched.

## Tests

Adds a JSONScript fixture that combines a live-computed multi-condition concept with a single-page restriction and asserts that non-members are excluded while members are returned, including with the conditions written in reverse order. It also covers a category and a property hierarchy combined with a single-page restriction, and forces the live concept path so the fixture fails on the unfixed code.

Closes #6994
