### PR TITLE
Use normal tables for MySQL integration tests to avoid Error 1137

### DIFF
--- a/tests/phpunit/SMWIntegrationTestCase.php
+++ b/tests/phpunit/SMWIntegrationTestCase.php
@@ -36,6 +36,42 @@ abstract class SMWIntegrationTestCase extends MediaWikiIntegrationTestCase {
 
 		// Load default settings specific to SMW
 		TestEnvironment::loadDefaultSettings( [ 'smwgQEqualitySupport' ] );
+
+		// MySQL (unlike MariaDB) cannot reference a TEMPORARY table more than
+		// once in a single query, so SMW lookups that self-join smw_object_ids
+		// fail with "Error 1137: Can't reopen table" when MediaWiki clones the
+		// test tables as temporary tables. Force normal tables on MySQL only;
+		// MariaDB lifted this restriction long ago and keeps temporary tables,
+		// which avoid the teardown TRUNCATE lock-wait timeout (see #6936). The
+		// flag must be set before maybeSetupDB() reads it.
+		// https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/80/commits/565061cd0b9ccabe521f0382938d013a599e4673
+		if ( self::isMySqlServer() ) {
+			static::setCliArg( 'use-normal-tables', true );
+		}
+	}
+
+	/**
+	 * MediaWiki reports both MySQL and MariaDB as the 'mysql' database type, so
+	 * only the server version string distinguishes them: MariaDB embeds its own
+	 * name there. The "Can't reopen table" limitation is specific to genuine
+	 * MySQL servers.
+	 */
+	private static function isMySqlServer(): bool {
+		$db = MediaWikiServices::getInstance()
+			->getConnectionProvider()
+			->getReplicaDatabase();
+
+		if ( $db->getType() !== 'mysql' ) {
+			return false;
+		}
+
+		// Match MediaWiki core's own discriminator, which treats both the
+		// "MariaDB" name and the "-maria-" build suffix as MariaDB markers
+		// (see Wikimedia\Rdbms\DatabaseMySQL::getMySqlServerVariant()).
+		$version = $db->getServerVersion();
+
+		return !str_contains( $version, 'MariaDB' )
+			&& !str_contains( $version, '-maria-' );
 	}
 
 	/**


### PR DESCRIPTION
## Problem

The experimental `mysql:8` CI leg (added in #6990) fails with hundreds of `Error 1137: Can't reopen table`. MySQL, unlike MariaDB, cannot reference a `TEMPORARY` table more than once in a single query, and SMW lookups self-join `smw_object_ids`. Since #6936 switched the integration tests to clone their tables as temporary tables (to fix the recurring teardown lock-wait timeout, `1205`), every self-joining lookup now errors on MySQL. MariaDB lifted this restriction years ago, so its CI legs are unaffected.

## Fix

Force normal (persistent) tables for the integration tests on genuine MySQL only, selectively restoring the pre-#6936 behaviour. MediaWiki reports both MySQL and MariaDB as the `mysql` database type, so the server is distinguished by its version string, matching core's own discriminator (`MariaDB` / `-maria-`). MariaDB legs keep temporary tables, so the lock-wait timeout #6936 addressed does not return for them.

The flag is set in `setUpBeforeClass()` because it must be in place before MediaWiki's `maybeSetupDB()` reads it.

## Validation

On a MySQL 8.0.46 stack, a JSONScript case that errored with `1137` on master passes with this change, and a multi-class SQLStore integration run completes cleanly. MariaDB behaviour is unchanged.

This is one of two changes needed for the experimental `mysql:8` leg to pass; the companion fixes an unrelated result-ordering issue in `PropertySubjectsLookup`.
