### PR TITLE
Removing experimental from MySQL CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,10 +77,10 @@ jobs:
       matrix:
         include:
           - { mw: '1.43', php: 8.2, db: "mariadb:10.11" }
+          - { mw: '1.43', php: 8.2, db: "mysql:8" }
           - { mw: '1.44', php: 8.3, db: "mariadb:11.8" }
           - { mw: '1.45', php: 8.4, db: "mariadb:12.3" }
           - { mw: '1.46-dev-26e9b33', php: 8.5, db: "mariadb:12.3" }
-          - { mw: '1.43', php: 8.2, db: "mysql:8", experimental: true }
     env:
       MW_VERSION: ${{ matrix.mw }}
       PHP_VERSION: ${{ matrix.php }}


### PR DESCRIPTION
It is passing now, no longer needed.