### PR TITLE
Fix infinite datatable loading when DPL is on the same page

### DIFF
--- a/src/MediaWiki/Hooks/ParserAfterTidy.php
+++ b/src/MediaWiki/Hooks/ParserAfterTidy.php
@@ -9,6 +9,7 @@ use MediaWiki\Parser\ParserOutputLinkTypes;
 use MediaWiki\Permissions\RestrictionStore;
 use Psr\Log\LoggerInterface;
 use SMW\DataModel\SemanticData;
+use SMW\MediaWiki\Outputs;
 use SMW\NamespaceExaminer;
 use SMW\ParserData;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -132,6 +133,7 @@ class ParserAfterTidy implements ParserAfterTidyHook {
 	 */
 	public function onParserAfterTidy( $parser, &$text ) {
 		if ( !Site::isReady() ) {
+			Outputs::onParseEnd();
 			$this->doAbort();
 			return true;
 		}
@@ -162,6 +164,8 @@ class ParserAfterTidy implements ParserAfterTidyHook {
 			if ( self::$inFlightParses !== null ) {
 				unset( self::$inFlightParses[$parser] );
 			}
+
+			Outputs::onParseEnd();
 		}
 
 		return true;

--- a/src/MediaWiki/Hooks/ParserClearState.php
+++ b/src/MediaWiki/Hooks/ParserClearState.php
@@ -3,12 +3,16 @@
 namespace SMW\MediaWiki\Hooks;
 
 use MediaWiki\Hook\ParserClearStateHook;
+use SMW\MediaWiki\Outputs;
 
 /**
  * Hook: ParserClearState fires at the start of every `Parser::parse()`
  * call. Used to track in-flight parses per title so that `ParserAfterTidy`
  * can distinguish the outermost fire from inner (nested) fires triggered
  * by extensions that clone the parser, see #5923.
+ *
+ * Also increments the global parse-depth counter in `Outputs` so that
+ * nested parses do not drain the resource-module buffer prematurely.
  *
  * @see https://www.mediawiki.org/wiki/Manual:Hooks/ParserClearState
  *
@@ -21,6 +25,11 @@ class ParserClearState implements ParserClearStateHook {
 	 * @since 7.0.0
 	 */
 	public function onParserClearState( $parser ) {
+		// Depth counter must be incremented unconditionally because
+		// ParserAfterTidy (where it is decremented) fires for every
+		// Parser::parse() call. The in-flight-parse tracker has its
+		// own guards and can safely be called for all parsers too.
+		Outputs::onParseStart();
 		ParserAfterTidy::onParserClearState( $parser );
 
 		return true;

--- a/src/MediaWiki/Outputs.php
+++ b/src/MediaWiki/Outputs.php
@@ -142,8 +142,14 @@ class Outputs {
 
 	/**
 	 * Similar to Outputs::commitToParser() but acting on a ParserOutput object.
+	 *
+	 * By default the internal buffers are preserved so that the same items can
+	 * be committed again to another ParserOutput later. This is necessary when
+	 * a nested Parser::parse() call (e.g. from DynamicPageList) triggers this
+	 * method via hooks; clearing the buffers at that point would lose modules
+	 * that still need to reach the top-level ParserOutput.
 	 */
-	public static function commitToParserOutput( ParserOutput $parserOutput ): void {
+	public static function commitToParserOutput( ParserOutput $parserOutput, bool $clear = false ): void {
 		foreach ( self::$scripts as $key => $script ) {
 			$parserOutput->addHeadItem( $script . "\n", $key );
 		}
@@ -155,9 +161,11 @@ class Outputs {
 		$parserOutput->addModuleStyles( array_values( self::$resourceStyles ) );
 		$parserOutput->addModules( array_values( self::$resourceModules ) );
 
-		self::$resourceStyles = [];
-		self::$resourceModules = [];
-		self::$headItems = [];
+		if ( $clear ) {
+			self::$resourceStyles = [];
+			self::$resourceModules = [];
+			self::$headItems = [];
+		}
 	}
 
 	/**

--- a/src/MediaWiki/Outputs.php
+++ b/src/MediaWiki/Outputs.php
@@ -58,6 +58,20 @@ class Outputs {
 	protected static array $resourceStyles = [];
 
 	/**
+	 * Number of `Parser::parse()` calls currently on the call stack.
+	 * Incremented by `onParseStart()` (via `ParserClearState` hook) and
+	 * decremented by `onParseEnd()` (via `ParserAfterTidy` hook).
+	 *
+	 * When depth > 0, `commitToParserOutput()` preserves the static
+	 * buffers so that modules registered in an outer parse survive a
+	 * nested parse that also commits (e.g. DynamicPageList). When the
+	 * outermost parse ends, `onParseEnd()` clears the buffers so that
+	 * modules do not leak into subsequent, unrelated page parses in
+	 * batch processes (job queue, maintenance scripts).
+	 */
+	private static int $parseDepth = 0;
+
+	/**
 	 * Adds a resource module to the parser output.
 	 *
 	 * @since 1.5.3
@@ -71,6 +85,44 @@ class Outputs {
 	 */
 	public static function requireStyle( string $stylesName ): void {
 		self::$resourceStyles[$stylesName] = $stylesName;
+	}
+
+	/**
+	 * Called from the `ParserClearState` hook at the start of every
+	 * `Parser::parse()` invocation (including nested ones).
+	 */
+	public static function onParseStart(): void {
+		self::$parseDepth++;
+	}
+
+	/**
+	 * Called from the `ParserAfterTidy` hook at the end of every
+	 * `Parser::parse()` invocation. When the outermost parse finishes,
+	 * clears the static buffers so that modules do not leak into the
+	 * next page parsed in the same process.
+	 */
+	public static function onParseEnd(): void {
+		if ( self::$parseDepth > 0 ) {
+			self::$parseDepth--;
+		}
+
+		if ( self::$parseDepth === 0 ) {
+			self::$resourceStyles = [];
+			self::$resourceModules = [];
+			self::$headItems = [];
+			self::$scripts = [];
+		}
+	}
+
+	/**
+	 * Reset the parse-depth counter and buffers. Intended for tests.
+	 */
+	public static function resetParseDepth(): void {
+		self::$parseDepth = 0;
+		self::$resourceStyles = [];
+		self::$resourceModules = [];
+		self::$headItems = [];
+		self::$scripts = [];
 	}
 
 	/**
@@ -143,13 +195,14 @@ class Outputs {
 	/**
 	 * Similar to Outputs::commitToParser() but acting on a ParserOutput object.
 	 *
-	 * By default the internal buffers are preserved so that the same items can
-	 * be committed again to another ParserOutput later. This is necessary when
-	 * a nested Parser::parse() call (e.g. from DynamicPageList) triggers this
-	 * method via hooks; clearing the buffers at that point would lose modules
-	 * that still need to reach the top-level ParserOutput.
+	 * The internal buffers are cleared only when no `Parser::parse()` call is
+	 * on the stack (i.e. outside of parsing) or when the caller is the
+	 * outermost parse. During a nested parse (e.g. triggered by
+	 * DynamicPageList) the buffers are preserved so that modules registered
+	 * by the outer parse survive. The outermost-parse cleanup is handled by
+	 * `onParseEnd()`, called from `ParserAfterTidy`.
 	 */
-	public static function commitToParserOutput( ParserOutput $parserOutput, bool $clear = false ): void {
+	public static function commitToParserOutput( ParserOutput $parserOutput ): void {
 		foreach ( self::$scripts as $key => $script ) {
 			$parserOutput->addHeadItem( $script . "\n", $key );
 		}
@@ -161,7 +214,12 @@ class Outputs {
 		$parserOutput->addModuleStyles( array_values( self::$resourceStyles ) );
 		$parserOutput->addModules( array_values( self::$resourceModules ) );
 
-		if ( $clear ) {
+		// Clear only when we are not inside a nested parse. During nested
+		// parses the buffers must survive so the outermost ParserOutput
+		// receives all modules. When parseDepth is 0 we are outside of
+		// any Parser::parse() call (e.g. special pages calling
+		// commitToParser directly) and must clear to avoid stale data.
+		if ( self::$parseDepth <= 1 ) {
 			self::$resourceStyles = [];
 			self::$resourceModules = [];
 			self::$headItems = [];

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ParserAfterTidyTest.php
@@ -16,6 +16,7 @@ use ReflectionProperty;
 use RuntimeException;
 use SMW\MediaWiki\Hooks\ArticlePurge;
 use SMW\MediaWiki\Hooks\ParserAfterTidy;
+use SMW\MediaWiki\Outputs;
 use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\RevisionGuard;
 use SMW\NamespaceExaminer;
@@ -105,6 +106,7 @@ class ParserAfterTidyTest extends TestCase {
 
 	protected function tearDown(): void {
 		ParserAfterTidy::resetInFlightParses();
+		Outputs::resetParseDepth();
 		$this->testEnvironment->tearDown();
 		parent::tearDown();
 	}

--- a/tests/phpunit/Unit/MediaWiki/OutputsTest.php
+++ b/tests/phpunit/Unit/MediaWiki/OutputsTest.php
@@ -1,0 +1,195 @@
+<?php
+
+namespace SMW\Tests\Unit\MediaWiki;
+
+use MediaWiki\Parser\ParserOutput;
+use PHPUnit\Framework\TestCase;
+use SMW\MediaWiki\Outputs;
+
+/**
+ * @covers \SMW\MediaWiki\Outputs
+ * @group semantic-mediawiki
+ */
+class OutputsTest extends TestCase {
+
+	protected function tearDown(): void {
+		Outputs::resetParseDepth();
+		parent::tearDown();
+	}
+
+	private function newMockParserOutput(): ParserOutput {
+		$modules = [];
+		$styles = [];
+
+		$po = $this->createMock( ParserOutput::class );
+
+		$po->method( 'addModules' )
+			->willReturnCallback( static function ( array $m ) use ( &$modules ) {
+				$modules = array_values( array_unique( array_merge( $modules, $m ) ) );
+			} );
+
+		$po->method( 'addModuleStyles' )
+			->willReturnCallback( static function ( array $s ) use ( &$styles ) {
+				$styles = array_values( array_unique( array_merge( $styles, $s ) ) );
+			} );
+
+		$po->method( 'getModules' )
+			->willReturnCallback( static function () use ( &$modules ) {
+				return $modules;
+			} );
+
+		$po->method( 'getModuleStyles' )
+			->willReturnCallback( static function () use ( &$styles ) {
+				return $styles;
+			} );
+
+		$po->method( 'addHeadItem' );
+
+		return $po;
+	}
+
+	/**
+	 * Modules registered in an outer parse must survive a nested parse
+	 * that also calls commitToParserOutput().
+	 *
+	 * Timeline:
+	 *   1. Outer parse starts          → onParseStart (depth 1)
+	 *   2. {{#ask:}} registers module  → requireResource('smw.tableprinter.datatable')
+	 *   3. {{#dpl:}} triggers nested   → onParseStart (depth 2)
+	 *   4. Nested commitToParserOutput → modules go to nested PO, buffer preserved
+	 *   5. Nested parse ends           → onParseEnd (depth 1)
+	 *   6. Outer commitToParserOutput  → modules go to outer PO, buffer cleared
+	 *   7. Outer parse ends            → onParseEnd (depth 0), final cleanup
+	 */
+	public function testModulesSurviveNestedParse(): void {
+		$outerPO = $this->newMockParserOutput();
+		$nestedPO = $this->newMockParserOutput();
+
+		// Step 1: outer parse starts
+		Outputs::onParseStart();
+
+		// Step 2: SMW query registers a module
+		Outputs::requireResource( 'smw.tableprinter.datatable' );
+		Outputs::requireStyle( 'smw.tableprinter.datatable.styles' );
+
+		// Step 3: DPL triggers a nested parse
+		Outputs::onParseStart();
+
+		// Step 4: nested InternalParseBeforeLinks commits to nested PO
+		Outputs::commitToParserOutput( $nestedPO );
+
+		// Step 5: nested parse ends
+		Outputs::onParseEnd();
+
+		// Step 6: outer InternalParseBeforeLinks commits to outer PO
+		Outputs::commitToParserOutput( $outerPO );
+
+		// Step 7: outer parse ends
+		Outputs::onParseEnd();
+
+		// The outer ParserOutput must have the datatable module
+		$this->assertContains(
+			'smw.tableprinter.datatable',
+			$outerPO->getModules(),
+			'Datatable module must reach the outer ParserOutput'
+		);
+
+		$this->assertContains(
+			'smw.tableprinter.datatable.styles',
+			$outerPO->getModuleStyles(),
+			'Datatable styles must reach the outer ParserOutput'
+		);
+	}
+
+	/**
+	 * Modules from one page must not leak into a subsequent page parsed
+	 * in the same process (batch/job scenario).
+	 */
+	public function testModulesDoNotLeakAcrossPages(): void {
+		$pageAPO = $this->newMockParserOutput();
+		$pageBPO = $this->newMockParserOutput();
+
+		// Parse page A (has datatable)
+		Outputs::onParseStart();
+		Outputs::requireResource( 'smw.tableprinter.datatable' );
+		Outputs::commitToParserOutput( $pageAPO );
+		Outputs::onParseEnd();
+
+		// Parse page B (plain text, no SMW modules registered)
+		Outputs::onParseStart();
+		Outputs::commitToParserOutput( $pageBPO );
+		Outputs::onParseEnd();
+
+		$this->assertContains(
+			'smw.tableprinter.datatable',
+			$pageAPO->getModules(),
+			'Page A must have the datatable module'
+		);
+
+		$this->assertNotContains(
+			'smw.tableprinter.datatable',
+			$pageBPO->getModules(),
+			'Page B must NOT inherit page A\'s datatable module'
+		);
+	}
+
+	/**
+	 * Both scenarios combined: page A has a datatable + nested DPL parse,
+	 * page B is plain. Modules must survive the nested parse on page A
+	 * but must not leak to page B.
+	 */
+	public function testNestedParseThenSecondPage(): void {
+		$pageAPO = $this->newMockParserOutput();
+		$nestedPO = $this->newMockParserOutput();
+		$pageBPO = $this->newMockParserOutput();
+
+		// --- Page A with nested parse ---
+		Outputs::onParseStart();
+		Outputs::requireResource( 'smw.tableprinter.datatable' );
+
+		// Nested parse (DPL)
+		Outputs::onParseStart();
+		Outputs::commitToParserOutput( $nestedPO );
+		Outputs::onParseEnd();
+
+		// Outer commit for page A
+		Outputs::commitToParserOutput( $pageAPO );
+		Outputs::onParseEnd();
+
+		// --- Page B (plain) ---
+		Outputs::onParseStart();
+		Outputs::commitToParserOutput( $pageBPO );
+		Outputs::onParseEnd();
+
+		$this->assertContains(
+			'smw.tableprinter.datatable',
+			$pageAPO->getModules(),
+			'Page A must have the datatable module after nested parse'
+		);
+
+		$this->assertNotContains(
+			'smw.tableprinter.datatable',
+			$pageBPO->getModules(),
+			'Page B must NOT inherit page A\'s modules'
+		);
+	}
+
+	/**
+	 * commitToParserOutput outside of any parse (depth 0) must still
+	 * clear the buffers. This is the path used by special pages that
+	 * call commitToParser() without going through Parser::parse().
+	 */
+	public function testCommitOutsideParseClears(): void {
+		$po1 = $this->newMockParserOutput();
+		$po2 = $this->newMockParserOutput();
+
+		Outputs::requireResource( 'ext.smw.ask' );
+		Outputs::commitToParserOutput( $po1 );
+
+		// Second commit should see empty buffers
+		Outputs::commitToParserOutput( $po2 );
+
+		$this->assertContains( 'ext.smw.ask', $po1->getModules() );
+		$this->assertNotContains( 'ext.smw.ask', $po2->getModules() );
+	}
+}


### PR DESCRIPTION
When a page contains both an SMW datatable query and a DPL query, DPL's triggerEndResets() creates a nested Parser::parse() call which triggers SMW's InternalParseBeforeLinks hook. This calls Outputs::commitToParserOutput() on the nested parser's output, draining the static module buffers. The smw.tableprinter.datatable module is flushed to a discarded ParserOutput and never reaches the main page, causing the datatable spinner to load infinitely.

Change commitToParserOutput() to preserve the static buffers by default so modules survive nested parse calls and are re-committed to the top-level ParserOutput. ParserOutput::addModules() deduplicates, so re-adding the same modules is safe. commitToOutputPage() still clears the buffers as before.

Fixes: #7009