### PR TITLE
Replace deprecated ParserOutput::getImages with getLinkList in test

### DIFF
--- a/tests/phpunit/Integration/Parser/InTextAnnotationParserFileUsageTest.php
+++ b/tests/phpunit/Integration/Parser/InTextAnnotationParserFileUsageTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Integration\Parser;
 
 use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Parser\ParserOutputLinkTypes;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -55,7 +56,9 @@ class InTextAnnotationParserFileUsageTest extends TestCase {
 
 		$this->applicationFactory->newInTextAnnotationParser( $parserData )->parse( $text );
 
-		return [ $text, array_keys( $parserOutput->getImages() ) ];
+		$media = $parserOutput->getLinkList( ParserOutputLinkTypes::MEDIA );
+
+		return [ $text, array_map( static fn ( array $item ): string => $item['link']->getDBkey(), $media ) ];
 	}
 
 	public function testNonImageFileValueIsTrackedWithoutChangingItsRendering() {


### PR DESCRIPTION
## Problem

The MW 1.46 CI leg fails with a `Deprecated` notice:

```
Deprecated: Use of MediaWiki\Parser\ParserOutput::getImages was deprecated in MediaWiki 1.43.
[Called from SMW\Tests\Integration\Parser\InTextAnnotationParserFileUsageTest::parse ... at line 58]
```

`InTextAnnotationParserFileUsageTest` read back the tracked file dependencies via `ParserOutput::getImages()`, which MediaWiki deprecated in 1.43 in favour of `getLinkList( ParserOutputLinkTypes::MEDIA )`.

## Fix

The test now reads the media links through `getLinkList( ParserOutputLinkTypes::MEDIA )`, the same non-deprecated API the production `ParserAfterTidy` hook already uses. That call returns a list of entries whose `link` is a File-namespace `TitleValue`, so mapping `getDBkey()` yields the identical set of file dbkeys the assertions rely on. The returned values and their order are unchanged, so every assertion behaves exactly as before.

`getLinkList()` and `ParserOutputLinkTypes::MEDIA` exist in MediaWiki 1.43 (SMW's minimum), so the change is compatible across the supported version range.

Production code is untouched: `InTextAnnotationParser` registers the dependency via `ParserOutput::addImage()`, which is not deprecated.

## Testing

- `InTextAnnotationParserFileUsageTest` passes against the real annotation-parser path.
- PHPCS and `php -l` are clean on the changed file.
