### PR TITLE
Use a real title in PageBuilderTest to avoid a null array offset

### DIFF
--- a/tests/phpunit/Unit/MediaWiki/Specials/SearchByProperty/PageBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SearchByProperty/PageBuilderTest.php
@@ -58,9 +58,7 @@ class PageBuilderTest extends TestCase {
 	}
 
 	public function testGetHtmlForExactValueSearch() {
-		$title = $this->getMockBuilder( Title::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$title = Title::makeTitle( NS_SPECIAL, 'SearchByProperty' );
 
 		$language = MediaWikiServices::getInstance()->getContentLanguage();
 
@@ -95,9 +93,7 @@ class PageBuilderTest extends TestCase {
 	}
 
 	public function testGetHtmlForNearbyResultsSearch() {
-		$title = $this->getMockBuilder( Title::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$title = Title::makeTitle( NS_SPECIAL, 'SearchByProperty' );
 
 		$language = MediaWikiServices::getInstance()->getContentLanguage();
 


### PR DESCRIPTION
## Problem

On the MW 1.46 / PHP 8.5 CI leg, the unit-test step emits a deprecation:

```
Deprecated: Using null as an array offset is deprecated, use an empty string instead
in .../includes/Parser/PPTemplateFrame_Hash.php on line 53
```

It fires twice, both from `PageBuilderTest`: `testGetHtmlForExactValueSearch` and `testGetHtmlForNearbyResultsSearch`.

## Root cause

Both tests build the form renderer with a bare `Title` mock, whose unstubbed `getPrefixedDBkey()` returns `null`. Rendering the results form draws a pager (`PagerNavigationBuilder`), which parses the `viewprevnext` message. That message contains `{{int:pipe-separator}}`, so MediaWiki expands a template in the context of the given title. `PPTemplateFrame_Hash` computes `$pdbk = $title ? $title->getPrefixedDBkey() : false;` and then guards it only with `if ( $pdbk !== false )`, so a `null` prefixed DB key slips past the guard and is used as an array offset, tripping the deprecation.

In production the title is a real `Special:SearchByProperty` page, whose `getPrefixedDBkey()` always returns a string, so this only ever surfaces from the test mock.

## Fix

Pass a real `Special:SearchByProperty` title (`Title::makeTitle( NS_SPECIAL, 'SearchByProperty' )`), matching what the special page uses in production, so `getPrefixedDBkey()` returns a proper string and no null reaches the preprocessor.

## Testing

- `PageBuilderTest` passes (the two pager cases exercise the real title path).
- Verified by instrumenting `PPTemplateFrame_Hash` to record when the prefixed DB key is null: with the mock title the two tests each produce one null (matching the two CI deprecations); with the real title none do.
- PHPCS and `php -l` are clean on the changed file.
