### PR TITLE
Support negated property existence in SPARQL queries

### DIFF
--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -196,14 +196,33 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			return "$subjectName $propertyName $objectName .\n";
 		}
 
-		$subPropExpElement = $this->exporter->getSpecialPropertyResource( '_SUBP', SMW_NS_PROPERTY );
-		$namespaces[$subPropExpElement->getNamespaceId()] = $subPropExpElement->getNamespace();
+		[ $propertyByVariable, $subpropertyPathCondition, $subpropertyPathNamespaces ] = $this->createSubpropertyPathPattern(
+			$propertyName,
+			$depth
+		);
+		$namespaces = array_merge( $namespaces, $subpropertyPathNamespaces );
 
+		return $subpropertyPathCondition .
+			"$subjectName $propertyByVariable $objectName .\n";
+	}
+
+	private function createSubpropertyPathPattern( string $propertyName, $depth ): array {
+		$subPropExpElement = $this->exporter->getSpecialPropertyResource( '_SUBP', SMW_NS_PROPERTY );
+
+		// A discret depth other than 0 or 1 is difficult to achieve
+		// @see https://stackoverflow.com/questions/18126949/limit-the-sparql-query-result-to-first-level-in-hierarchy
+		// Path operator is defined as:
+		// - elt* ZeroOrMorePath
+		// - elt? ZeroOrOnePath
 		$pathOp = $depth > 1 || $depth === null ? '*' : '?';
+
 		$propertyByVariable = '?' . $this->conditionBuilder->getNextVariable( 'sp' );
 
-		return "$propertyByVariable " . $subPropExpElement->getQName() . "$pathOp $propertyName .\n" .
-			"$subjectName $propertyByVariable $objectName .\n";
+		return [
+			$propertyByVariable,
+			"$propertyByVariable " . $subPropExpElement->getQName() . "$pathOp $propertyName .\n",
+			[ $subPropExpElement->getNamespaceId() => $subPropExpElement->getNamespace() ]
+		];
 	}
 
 	private function canUsePropertyHierarchyInAbsencePattern( Property $property, $depth ): bool {
@@ -353,17 +372,12 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 			return;
 		}
 
-		$subPropExpElement = $this->exporter->getSpecialPropertyResource( '_SUBP', SMW_NS_PROPERTY );
-
-		// A discret depth other than 0 or 1 is difficult to achieve
-		// @see https://stackoverflow.com/questions/18126949/limit-the-sparql-query-result-to-first-level-in-hierarchy
-		// Path operator is defined as:
-		// - elt* ZeroOrMorePath
-		// - elt? ZeroOrOnePath
-		$pathOp = $depth > 1 || $depth === null ? '*' : '?';
-
-		$propertyByVariable = '?' . $this->conditionBuilder->getNextVariable( 'sp' );
-		$condition->weakConditions[$propertyName] = "\n" . "$propertyByVariable " . $subPropExpElement->getQName() . "$pathOp $propertyName .\n" . "";
+		[ $propertyByVariable, $subpropertyPathCondition, $subpropertyPathNamespaces ] = $this->createSubpropertyPathPattern(
+			$propertyName,
+			$depth
+		);
+		$condition->namespaces = array_merge( $condition->namespaces, $subpropertyPathNamespaces );
+		$condition->weakConditions[$propertyName] = "\n" . $subpropertyPathCondition;
 		$propertyName = $propertyByVariable;
 	}
 

--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -53,6 +53,12 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 	 * {@inheritDoc}
 	 */
 	public function interpretDescription( Description $description ): Condition {
+		if ( !$description instanceof SomeProperty ) {
+			throw new UnexpectedValueException(
+				'Expected SomeProperty description'
+			);
+		}
+
 		$joinVariable = $this->conditionBuilder->getJoinVariable();
 		$orderByProperty = $this->conditionBuilder->getOrderByProperty();
 

--- a/src/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
+++ b/src/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php
@@ -10,6 +10,7 @@ use SMW\Exporter\Element\ExpNsResource;
 use SMW\Exporter\Serializer\TurtleSerializer;
 use SMW\Query\Language\Description;
 use SMW\Query\Language\SomeProperty;
+use SMW\Query\Language\ThingDescription;
 use SMW\SPARQLStore\QueryEngine\Condition\Condition;
 use SMW\SPARQLStore\QueryEngine\Condition\FalseCondition;
 use SMW\SPARQLStore\QueryEngine\Condition\FilterCondition;
@@ -56,10 +57,20 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 		$orderByProperty = $this->conditionBuilder->getOrderByProperty();
 
 		$property = $description->getProperty();
+		$innerDescription = $description->getDescription();
+
+		if ( $this->isNegatedPropertyExistenceDescription( $innerDescription ) ) {
+			return $this->createConditionForNegatedPropertyExistence(
+				$description,
+				$property,
+				$joinVariable,
+				$orderByProperty
+			);
+		}
 
 		[ $innerOrderByProperty, $innerCondition, $innerJoinVariable ] = $this->doResolveInnerConditionRecursively(
 			$property,
-			$description->getDescription()
+			$innerDescription
 		);
 
 		if ( $innerCondition instanceof FalseCondition ) {
@@ -117,6 +128,100 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 		);
 
 		return $result;
+	}
+
+	private function isNegatedPropertyExistenceDescription( Description $description ): bool {
+		return $description instanceof ThingDescription && $description->isNegation === true;
+	}
+
+	private function createConditionForNegatedPropertyExistence(
+		SomeProperty $description,
+		Property $property,
+		string $joinVariable,
+		$orderByProperty
+	): WhereCondition {
+		$namespaces = [];
+		$objectName = '?' . $this->conditionBuilder->getNextVariable();
+
+		[ $subjectName, $objectName, $nonInverseProperty ] = $this->doExchangeForWhenInversePropertyIsUsed(
+			$property,
+			$objectName,
+			$joinVariable
+		);
+
+		$propertyName = $this->findMostSuitablePropertyRepresentation(
+			$property,
+			$nonInverseProperty,
+			$namespaces
+		);
+
+		$condition = 'FILTER NOT EXISTS {' . "\n" .
+			$this->createPropertyAbsencePattern(
+				$nonInverseProperty,
+				$subjectName,
+				$propertyName,
+				$objectName,
+				$description->getHierarchyDepth(),
+				$namespaces
+			) .
+			'}' . "\n";
+
+		$result = new WhereCondition( $condition, false, $namespaces );
+
+		$this->conditionBuilder->addOrderByDataForProperty(
+			$result,
+			$joinVariable,
+			$orderByProperty,
+			DataItem::TYPE_WIKIPAGE
+		);
+
+		return $result;
+	}
+
+	private function createPropertyAbsencePattern(
+		Property $property,
+		string $subjectName,
+		string $propertyName,
+		string $objectName,
+		$depth,
+		array &$namespaces
+	): string {
+		if ( !$this->canUsePropertyHierarchyInAbsencePattern( $property, $depth ) ) {
+			return "$subjectName $propertyName $objectName .\n";
+		}
+
+		$subPropExpElement = $this->exporter->getSpecialPropertyResource( '_SUBP', SMW_NS_PROPERTY );
+		$namespaces[$subPropExpElement->getNamespaceId()] = $subPropExpElement->getNamespace();
+
+		$pathOp = $depth > 1 || $depth === null ? '*' : '?';
+		$propertyByVariable = '?' . $this->conditionBuilder->getNextVariable( 'sp' );
+
+		return "$propertyByVariable " . $subPropExpElement->getQName() . "$pathOp $propertyName .\n" .
+			"$subjectName $propertyByVariable $objectName .\n";
+	}
+
+	private function canUsePropertyHierarchyInAbsencePattern( Property $property, $depth ): bool {
+		if ( !$this->canUsePropertyHierarchy( $property, $depth ) ) {
+			return false;
+		}
+
+		if ( $this->conditionBuilder->getHierarchyLookup() == null || !$this->conditionBuilder->getHierarchyLookup()->hasSubproperty( $property ) ) {
+			return false;
+		}
+
+		return true;
+	}
+
+	private function canUsePropertyHierarchy( Property $property, $depth ): bool {
+		if ( !$this->conditionBuilder->isSetFlag( SMW_SPARQL_QF_SUBP ) ) {
+			return false;
+		}
+
+		if ( !$property->isUserDefined() ) {
+			return false;
+		}
+
+		return $depth === null || $depth >= 1;
 	}
 
 	private function doResolveInnerConditionRecursively( Property $property, Description $description ): array {
@@ -234,7 +339,7 @@ class SomePropertyInterpreter implements DescriptionInterpreter {
 	 * @see http://www.w3.org/TR/sparql11-query/#propertypath-arbitrary-length
 	 */
 	private function tryToAddPropertyPathForSaturatedHierarchy( &$condition, Property $property, &$propertyName, $depth ): void {
-		if ( !$this->conditionBuilder->isSetFlag( SMW_SPARQL_QF_SUBP ) || !$property->isUserDefined() || ( $depth !== null && $depth < 1 ) ) {
+		if ( !$this->canUsePropertyHierarchy( $property, $depth ) ) {
 			return;
 		}
 

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreterTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreterTest.php
@@ -144,6 +144,54 @@ class SomePropertyInterpreterTest extends TestCase {
 		);
 	}
 
+	public function testNegatedThingDescriptionKeepsHierarchyPatternInsideNotExists() {
+		$engineOptions = new EngineOptions();
+		$engineOptions->set( 'smwgSparqlQFeatures', SMW_SPARQL_QF_SUBP );
+
+		$property = new Property( 'Foo' );
+
+		$hierarchyLookup = $this->getMockBuilder( HierarchyLookup::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$hierarchyLookup->expects( $this->once() )
+			->method( 'hasSubproperty' )
+			->with( $property )
+			->willReturn( true );
+
+		$resultVariable = 'result';
+
+		$conditionBuilder = new ConditionBuilder( $this->descriptionInterpreterFactory, $engineOptions );
+		$conditionBuilder->setHierarchyLookup( $hierarchyLookup );
+		$conditionBuilder->setResultVariable( $resultVariable );
+		$conditionBuilder->setJoinVariable( $resultVariable );
+
+		$instance = new SomePropertyInterpreter( $conditionBuilder );
+
+		$thingDescription = new ThingDescription();
+		$thingDescription->isNegation = true;
+
+		$description = new SomeProperty(
+			$property,
+			$thingDescription
+		);
+
+		$condition = $instance->interpretDescription( $description );
+
+		$expected = UtilityFactory::getInstance()->newStringBuilder()
+			->addString( '?result swivt:page ?url .' )->addNewLine()
+			->addString( 'FILTER NOT EXISTS {' )->addNewLine()
+			->addString( '?sp2 rdfs:subPropertyOf* property:Foo .' )->addNewLine()
+			->addString( '?result ?sp2 ?v1 .' )->addNewLine()
+			->addString( '}' )->addNewLine()
+			->getString();
+
+		$this->assertEquals(
+			$expected,
+			$conditionBuilder->convertConditionToString( $condition )
+		);
+	}
+
 	public function descriptionProvider() {
 		$stringBuilder = UtilityFactory::getInstance()->newStringBuilder();
 
@@ -537,6 +585,61 @@ class SomePropertyInterpreterTest extends TestCase {
 		$expected = $stringBuilder
 			->addString( '?result swivt:wikiPageSortKey ?resultsk .' )->addNewLine()
 			->addString( '?result property:Modification_date-23aux "2440587.5423611"^^xsd:double .' )->addNewLine()
+			->getString();
+
+		$provider[] = [
+			$description,
+			$orderByProperty,
+			$sortkeys,
+			$conditionType,
+			$expected
+		];
+
+		# 15
+		$conditionType = WhereCondition::class;
+
+		$thingDescription = new ThingDescription();
+		$thingDescription->isNegation = true;
+
+		$description = new SomeProperty(
+			new Property( 'Foo' ),
+			$thingDescription
+		);
+
+		$orderByProperty = null;
+		$sortkeys = [];
+
+		$expected = $stringBuilder
+			->addString( '?result swivt:page ?url .' )->addNewLine()
+			->addString( 'FILTER NOT EXISTS {' )->addNewLine()
+			->addString( '?result property:Foo ?v1 .' )->addNewLine()
+			->addString( '}' )->addNewLine()
+			->getString();
+
+		$provider[] = [
+			$description,
+			$orderByProperty,
+			$sortkeys,
+			$conditionType,
+			$expected
+		];
+
+		# 16 Inverse
+		$conditionType = WhereCondition::class;
+
+		$thingDescription = new ThingDescription();
+		$thingDescription->isNegation = true;
+
+		$description = new SomeProperty(
+			new Property( 'Foo', true ),
+			$thingDescription
+		);
+
+		$expected = $stringBuilder
+			->addString( '?result swivt:page ?url .' )->addNewLine()
+			->addString( 'FILTER NOT EXISTS {' )->addNewLine()
+			->addString( '?v1 property:Foo ?result .' )->addNewLine()
+			->addString( '}' )->addNewLine()
 			->getString();
 
 		$provider[] = [

--- a/tests/phpunit/Unit/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreterTest.php
+++ b/tests/phpunit/Unit/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreterTest.php
@@ -68,6 +68,18 @@ class SomePropertyInterpreterTest extends TestCase {
 		);
 	}
 
+	public function testThrowsExceptionForNonSomePropertyDescription() {
+		$conditionBuilder = $this->getMockBuilder( ConditionBuilder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$instance = new SomePropertyInterpreter( $conditionBuilder );
+
+		$this->expectException( \UnexpectedValueException::class );
+
+		$instance->interpretDescription( new ThingDescription() );
+	}
+
 	/**
 	 * @dataProvider descriptionProvider
 	 */
@@ -96,6 +108,96 @@ class SomePropertyInterpreterTest extends TestCase {
 
 		$this->assertEquals(
 			$expectedConditionString,
+			$conditionBuilder->convertConditionToString( $condition )
+		);
+	}
+
+	public function testNegatedThingDescriptionDoesNotUseHierarchyPatternWithoutSubproperty() {
+		$engineOptions = new EngineOptions();
+		$engineOptions->set( 'smwgSparqlQFeatures', SMW_SPARQL_QF_SUBP );
+
+		$property = new Property( 'Foo' );
+
+		$hierarchyLookup = $this->getMockBuilder( HierarchyLookup::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$hierarchyLookup->expects( $this->once() )
+			->method( 'hasSubproperty' )
+			->with( $property )
+			->willReturn( false );
+
+		$resultVariable = 'result';
+
+		$conditionBuilder = new ConditionBuilder( $this->descriptionInterpreterFactory, $engineOptions );
+		$conditionBuilder->setHierarchyLookup( $hierarchyLookup );
+		$conditionBuilder->setResultVariable( $resultVariable );
+		$conditionBuilder->setJoinVariable( $resultVariable );
+
+		$instance = new SomePropertyInterpreter( $conditionBuilder );
+
+		$thingDescription = new ThingDescription();
+		$thingDescription->isNegation = true;
+
+		$description = new SomeProperty(
+			$property,
+			$thingDescription
+		);
+
+		$condition = $instance->interpretDescription( $description );
+
+		$expected = UtilityFactory::getInstance()->newStringBuilder()
+			->addString( '?result swivt:page ?url .' )->addNewLine()
+			->addString( 'FILTER NOT EXISTS {' )->addNewLine()
+			->addString( '?result property:Foo ?v1 .' )->addNewLine()
+			->addString( '}' )->addNewLine()
+			->getString();
+
+		$this->assertEquals(
+			$expected,
+			$conditionBuilder->convertConditionToString( $condition )
+		);
+	}
+
+	public function testNegatedThingDescriptionDoesNotUseHierarchyPatternForPredefinedProperty() {
+		$engineOptions = new EngineOptions();
+		$engineOptions->set( 'smwgSparqlQFeatures', SMW_SPARQL_QF_SUBP );
+
+		$hierarchyLookup = $this->getMockBuilder( HierarchyLookup::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$hierarchyLookup->expects( $this->never() )
+			->method( 'hasSubproperty' );
+
+		$resultVariable = 'result';
+
+		$conditionBuilder = new ConditionBuilder( $this->descriptionInterpreterFactory, $engineOptions );
+		$conditionBuilder->setHierarchyLookup( $hierarchyLookup );
+		$conditionBuilder->setResultVariable( $resultVariable );
+		$conditionBuilder->setJoinVariable( $resultVariable );
+
+		$instance = new SomePropertyInterpreter( $conditionBuilder );
+
+		$thingDescription = new ThingDescription();
+		$thingDescription->isNegation = true;
+
+		$description = new SomeProperty(
+			new Property( Property::TYPE_SORTKEY ),
+			$thingDescription
+		);
+
+		$condition = $instance->interpretDescription( $description );
+
+		$expected = UtilityFactory::getInstance()->newStringBuilder()
+			->addString( '?result swivt:page ?url .' )->addNewLine()
+			->addString( 'FILTER NOT EXISTS {' )->addNewLine()
+			->addString( '?result swivt:wikiPageSortKey ?v1 .' )->addNewLine()
+			->addString( '}' )->addNewLine()
+			->getString();
+
+		$this->assertEquals(
+			$expected,
 			$conditionBuilder->convertConditionToString( $condition )
 		);
 	}


### PR DESCRIPTION
## Summary
- Translate `[[Property::!+]]` in the SPARQLStore query engine to a `FILTER NOT EXISTS` property pattern.
- Preserve inverse property handling and keep subproperty hierarchy expansion inside the `NOT EXISTS` block.
- Add unit coverage using dummy `Foo` properties for direct, inverse, and hierarchy cases.

## Rationale
The query parser already represents `!+` as a negated `ThingDescription`. The SPARQLStore previously treated that inner description the same as `+`, causing `[[Property::!+]]` to still require a matching property triple. This was not a limitation of SPARQL itself; it was a missing translation in `SomePropertyInterpreter`.

## Tests
- `php -l src/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreter.php`
- `php -l tests/phpunit/Unit/SPARQLStore/QueryEngine/DescriptionInterpreters/SomePropertyInterpreterTest.php`
- `git diff --check`

Full targeted PHPUnit was attempted through the Docker test environment, but the local build stalled on Packagist access during Composer dependency resolution.