### PR TITLE
Update user-defined fixed table message in en.json

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -895,7 +895,7 @@
 	"smw-property-preferred-label-language-combination-exists": "\"$1\" cannot be used as preferred label because the language \"$2\" is already assigned to the \"$3\" label.",
 	"smw-parse": "$1",
 	"smw-clipboard-copy-link": "Copy link to clipboard",
-	"smw-property-userdefined-fixedtable": "\"$1\" is configured as a [https://www.semantic-mediawiki.org/wiki/Help:Fixed_properties fixed property]. Whenever its [https://www.semantic-mediawiki.org/wiki/Type_declaration type declaration] is changed, be sure to either run <code>setupStore.php</code> or run the \"Database setup\" task on [[Special:SemanticMediaWiki]]."
+	"smw-property-userdefined-fixedtable": "\"$1\" is configured as a [https://www.semantic-mediawiki.org/wiki/Help:Fixed_properties fixed property]. Whenever its [https://www.semantic-mediawiki.org/wiki/Type_declaration type declaration] is changed, be sure to either run <code>setupStore.php</code> or run the \"Database setup\" task on [[Special:SemanticMediaWiki]].",
 	"smw-data-lookup": "Fetching data...",
 	"smw-data-lookup-with-wait": "The request is being processed and may take a moment.",
 	"smw-no-data-available": "No data available.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -895,7 +895,7 @@
 	"smw-property-preferred-label-language-combination-exists": "\"$1\" cannot be used as preferred label because the language \"$2\" is already assigned to the \"$3\" label.",
 	"smw-parse": "$1",
 	"smw-clipboard-copy-link": "Copy link to clipboard",
-	"smw-property-userdefined-fixedtable": "\"$1\" was configured as [https://www.semantic-mediawiki.org/wiki/Fixed_properties fixed property] and any modification to its [https://www.semantic-mediawiki.org/wiki/Type_declaration type declaration] requires to either run <code>setupStore.php</code> or to complete the special [[Special:SemanticMediaWiki|\"Database installation and upgrade\"]] task.",
+	"smw-property-userdefined-fixedtable": "\"$1\" is configured as a [https://www.semantic-mediawiki.org/wiki/Help:Fixed_properties fixed property]. Whenever its [https://www.semantic-mediawiki.org/wiki/Type_declaration type declaration] is changed, be sure to either run <code>setupStore.php</code> or run the \"Database setup\" task on [[Special:SemanticMediaWiki]]."
 	"smw-data-lookup": "Fetching data...",
 	"smw-data-lookup-with-wait": "The request is being processed and may take a moment.",
 	"smw-no-data-available": "No data available.",


### PR DESCRIPTION
- Rephrase to make it more idiomatic and reader-friendly. The earlier message ("was configured ... and ... requires to") could potentially fool readers into thinking `setup.php` or its alternative must be run again.
- A belated update from "Database installation and upgrade" to "Database setup". Should we clarify, too, it's under "Maintenance".