### PR TITLE
Bump version to 7.1.1-alpha

### DIFF
--- a/docs/releasenotes/README.md
+++ b/docs/releasenotes/README.md
@@ -3,6 +3,7 @@
 Major releases and feature releases are indicated in **bold**.
 
 ### Semantic MediaWiki 7.x
+* [SMW 7.1.1 release notes](RELEASE-NOTES-7.1.1.md)
 * **[SMW 7.1.0 release notes](RELEASE-NOTES-7.1.0.md)**
 * **[SMW 7.0.0 release notes](RELEASE-NOTES-7.0.0.md)**
 

--- a/docs/releasenotes/RELEASE-NOTES-7.1.1.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.1.1.md
@@ -1,0 +1,26 @@
+# Semantic MediaWiki 7.1.1
+
+Released on TBD.
+
+This is a [patch release](../RELEASE-POLICY.md). Thus, it contains only bug fixes, no new features, and no breaking changes.
+
+Like SMW 7.1.0, this version is compatible with MediaWiki 1.43 up to 1.46 and PHP 8.1 up to 8.5.
+For more detailed information, see the [compatibility matrix](../COMPATIBILITY.md#compatibility).
+
+## Changes
+
+## Upgrading
+
+No need to run "update.php" or any other migration scripts.
+
+**Get the new version via Composer:**
+
+* Step 1: if you are upgrading from SMW older than 7.0.0, ensure the SMW version in `composer.local.json` is `^7.1.1`
+* Step 2: run composer in your MediaWiki directory: `composer update --no-dev --optimize-autoloader`
+
+**Get the new version via Git:**
+
+This is only for those who have installed SMW via Git.
+
+* Step 1: do a `git pull` in the SemanticMediaWiki directory
+* Step 2: run `composer update --no-dev --optimize-autoloader` in the MediaWiki directory

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticMediaWiki",
-	"version": "7.1.0",
+	"version": "7.1.1-alpha",
 	"author": [
 		"[https://korrekt.org Markus Krötzsch]",
 		"[https://EntropyWins.wtf/mediawiki Jeroen De Dauw]",


### PR DESCRIPTION
Starts the 7.1.1 development cycle after the 7.1.0 release.

* Set the extension version from `7.1.0` to `7.1.1-alpha`.
* Add the `RELEASE-NOTES-7.1.1.md` scaffold (patch release: fixes only, same MediaWiki 1.43 to 1.46 and PHP 8.1 to 8.5 support as 7.1.0).
* Link the new notes from the release-notes index.

The next release defaults to the patch `7.1.1`; it will be promoted to a minor (`7.2.0`) only if a feature change lands.