### PR TITLE
Fix prefetch cache key handling

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -13,6 +13,8 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 ## Bug fixes
 
+* Fixed a query showing incorrect printout values when the same property is requested through different printout contexts, such as a direct and an inverse printout or the same property with different sort options ([#7026](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7026))
+
 ## Upgrading
 
 No need to run "update.php" or any other migration scripts.

--- a/src/Query/Result/ItemFetcher.php
+++ b/src/Query/Result/ItemFetcher.php
@@ -139,7 +139,7 @@ class ItemFetcher {
 
 		// If its a chain we need to reload since the DataItem's use are traversed
 		// from each chain element
-		if ( !$this->prefetchCache->isCached( $property ) || $requestOptions->isChain ) {
+		if ( !$this->prefetchCache->isCached( $property, $requestOptions ) || $requestOptions->isChain ) {
 			$list = $this->dataItems;
 
 			if ( $requestOptions->isChain ) {

--- a/src/RequestOptions.php
+++ b/src/RequestOptions.php
@@ -401,4 +401,70 @@ class RequestOptions {
 		] );
 	}
 
+	/**
+	 * Option-bag keys that only steer query execution or prime a lower-level
+	 * cache; they never change which values, or in what order, are selected and
+	 * are therefore excluded from getValueHash(). Every option NOT listed here
+	 * is treated as value-affecting and included, so a newly added
+	 * value-affecting option participates in the value identity by default.
+	 */
+	private const NON_VALUE_OPTIONS = [
+		self::PREFETCH_FINGERPRINT,
+		'ORDER BY',
+		'GROUP BY',
+		'DISTINCT',
+		'NO_GROUPBY',
+		'NO_DISTINCT',
+		'hash.index',
+	];
+
+	/**
+	 * Value identity of this request: two RequestOptions with the same value
+	 * hash select the same set of values in the same order.
+	 *
+	 * Unlike getHash(), which is a whole-object identity relied on by
+	 * lower-level lookup caches that must key on execution hints (for example
+	 * PREFETCH_FINGERPRINT), this deliberately excludes those hints so it is
+	 * safe as a value cache key, such as the one built by PrefetchCache. The
+	 * typed value fields are listed explicitly; the option bag is included in
+	 * full minus NON_VALUE_OPTIONS, so a new value-affecting option is covered
+	 * by default.
+	 *
+	 * lookahead and exclude_limit are omitted on purpose: both are normalized
+	 * to a fixed value by the prefetch machinery, so they are constants in the
+	 * path that consumes this hash and are not part of the caller's value
+	 * identity. RequestOptionsTest guards that every declared property stays
+	 * classified.
+	 *
+	 * @since 7.2.0
+	 */
+	public function getValueHash(): string {
+		$stringConditions = '';
+
+		foreach ( $this->stringConditions as $stringCondition ) {
+			$stringConditions .= $stringCondition->getHash();
+		}
+
+		$options = array_diff_key( $this->options, array_flip( self::NON_VALUE_OPTIONS ) );
+
+		// The insertion order of options must not change the identity.
+		ksort( $options );
+
+		return md5( json_encode( [
+			$this->limit,
+			$this->offset,
+			$this->sort,
+			$this->ascending,
+			$this->boundary,
+			$this->include_boundary,
+			$this->conditionConstraint,
+			$this->natural,
+			$this->cursorAfter,
+			$this->cursorBefore,
+			$stringConditions,
+			$this->extraConditions,
+			$options,
+		] ) );
+	}
+
 }

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -38,11 +38,12 @@ class PrefetchCache {
 	 * @since 3.1
 	 *
 	 * @param Property $property
+	 * @param RequestOptions $requestOptions
 	 *
 	 * @return bool
 	 */
-	public function isCached( Property $property ): bool {
-		return isset( $this->cache[$property->getKey()] );
+	public function isCached( Property $property, RequestOptions $requestOptions ): bool {
+		return isset( $this->cache[self::makeCacheKey( $property, $requestOptions )] );
 	}
 
 	/**
@@ -62,13 +63,12 @@ class PrefetchCache {
 	 * @return string
 	 */
 	public static function makeCacheKey( Property $property, RequestOptions $requestOptions ): string {
-		$key = $property->getKey();
+		$key = $property->getKey() . '#' . (string)(int)$property->isInverse();
 
-		// Use the .dot notation to distingish it from other prrintouts that
-		// use the same property
+		// Use the chain state to distinguish it from other printouts that use
+		// the same property.
 		if ( $requestOptions->isChain ) {
-			$key .= '#' . (string)$requestOptions->isChain;
-			$key .= '#' . (string)$property->isInverse();
+			$key .= '#' . (string)(int)$requestOptions->isChain;
 		}
 
 		// T:P0467, requires an extra identification to ensure the test passes
@@ -78,6 +78,13 @@ class PrefetchCache {
 		}
 
 		return $key;
+	}
+
+	private static function makeRequestOptionsHash( RequestOptions $requestOptions ): string {
+		$requestOptions = clone $requestOptions;
+		$requestOptions->deleteOption( RequestOptions::PREFETCH_FINGERPRINT );
+
+		return (string)$requestOptions->getHash();
 	}
 
 	/**
@@ -98,12 +105,13 @@ class PrefetchCache {
 			$fingerprint .= $subject->getHash();
 		}
 
+		$requestOptionsHash = self::makeRequestOptionsHash( $requestOptions );
 		$requestOptions->setOption( RequestOptions::PREFETCH_FINGERPRINT, md5( $fingerprint ) );
 		$key = $this->makeCacheKey( $property, $requestOptions );
 
 		// Use an aggressive cache strategy to avoid repetitive queries especially
 		// when called as part of a printrequest chain
-		$lookupKey = md5( $key . '#' . $fingerprint );
+		$lookupKey = md5( $key . '#' . $fingerprint . '#' . $requestOptionsHash );
 
 		if ( isset( $this->lookupCache[$lookupKey] ) ) {
 			return;

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -78,7 +78,9 @@ class PrefetchCache {
 		// Missing markers represent the default request context. Markers are
 		// appended in a fixed order and each marker is self-identifying, so
 		// chain, inverse, and printout-local request options cannot contaminate
-		// values cached for the same property key.
+		// values cached for the same property key. This is a normalized value
+		// identity, not a reversible serialization of RequestOptions; null and
+		// false default states are represented by the absence of a marker.
 		if ( $requestOptions->isChain ) {
 			$key .= '#' . 'isChain';
 		}
@@ -139,8 +141,8 @@ class PrefetchCache {
 		return md5( json_encode( $subjectHashes ) );
 	}
 
-	private static function makeExecutedPrefetchLookupKey( string $valueCacheKey, array $subjects ): string {
-		return md5( $valueCacheKey . '#' . self::makeSubjectSetKey( $subjects ) );
+	private static function makeExecutedPrefetchLookupKey( string $valueCacheKey, string $subjectSetKey ): string {
+		return md5( $valueCacheKey . '#' . $subjectSetKey );
 	}
 
 	/**
@@ -157,15 +159,19 @@ class PrefetchCache {
 		$this->store->getObjectIds()->warmUpCache( $subjects );
 
 		$key = $this->makeCacheKey( $property, $requestOptions );
-		$executedLookupKey = self::makeExecutedPrefetchLookupKey( $key, $subjects );
+		$subjectSetKey = self::makeSubjectSetKey( $subjects );
+		$executedLookupKey = self::makeExecutedPrefetchLookupKey( $key, $subjectSetKey );
 
 		if ( isset( $this->executedPrefetchLookups[$executedLookupKey] ) ) {
 			return;
 		}
 
-		// Lower-level lookups add temporary SQL/cache hints to RequestOptions.
-		// Keep those mutations out of the value cache key used by this class.
+		// Lower-level lookup caches use PREFETCH_FINGERPRINT as the subject-set
+		// part of their bulk request identity. Keep that request identity on a
+		// clone so it cannot leak into this value cache key or the caller's
+		// RequestOptions instance.
 		$lookupRequestOptions = clone $requestOptions;
+		$lookupRequestOptions->setOption( RequestOptions::PREFETCH_FINGERPRINT, $subjectSetKey );
 
 		$result = $this->prefetchItemLookup->getPropertyValues(
 			$subjects,

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -82,6 +82,10 @@ class PrefetchCache {
 
 	private static function makeRequestOptionsHash( RequestOptions $requestOptions ): string {
 		$requestOptions = clone $requestOptions;
+
+		// The prefetch fingerprint is added below for lower-level caches to
+		// identify the subject set. It must not make this lookup cache key
+		// change when the same RequestOptions instance is prefetched again.
 		$requestOptions->deleteOption( RequestOptions::PREFETCH_FINGERPRINT );
 
 		return (string)$requestOptions->getHash();
@@ -110,7 +114,10 @@ class PrefetchCache {
 		$key = $this->makeCacheKey( $property, $requestOptions );
 
 		// Use an aggressive cache strategy to avoid repetitive queries especially
-		// when called as part of a printrequest chain
+		// when called as part of a printrequest chain. Request options belong to
+		// the lookup identity because printout-local options such as +order or
+		// +limit can produce a different value list for the same property and
+		// subject set.
 		$lookupKey = md5( $key . '#' . $fingerprint . '#' . $requestOptionsHash );
 
 		if ( isset( $this->lookupCache[$lookupKey] ) ) {

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -78,14 +78,13 @@ class PrefetchCache {
 		// caches.
 		//
 		// Format:
-		// <property-key>[#isChain][#isInverse][#isFirstChain][#valueOptions:<discriminator>]
+		// <property-key>[#isChain][#isInverse][#isFirstChain]#valueOptions:<discriminator>
 		//
-		// Missing markers represent the default request context. Markers are
-		// appended in a fixed order and each marker is self-identifying, so
-		// chain, inverse, and printout-local request options cannot contaminate
-		// values cached for the same property key. This is a normalized value
-		// identity, not a reversible serialization of RequestOptions; null and
-		// false default states are represented by the absence of a marker.
+		// Context markers are appended in a fixed order and each marker is
+		// self-identifying, so chain, inverse, and value-affecting request
+		// options cannot contaminate values cached for the same property key.
+		// This is a normalized value identity, not a reversible serialization
+		// of RequestOptions.
 		if ( $requestOptions->isChain ) {
 			$key .= '#' . 'isChain';
 		}
@@ -100,24 +99,13 @@ class PrefetchCache {
 			$key .= '#' . 'isFirstChain';
 		}
 
-		$valueOptionsDiscriminator = self::makeValueRequestOptionsDiscriminator( $requestOptions );
-
-		if ( $valueOptionsDiscriminator !== '' ) {
-			$key .= '#valueOptions:' . $valueOptionsDiscriminator;
-		}
+		$key .= '#valueOptions:' . self::makeValueRequestOptionsDiscriminator( $requestOptions );
 
 		return $key;
 	}
 
 	private static function makeValueRequestOptionsDiscriminator( RequestOptions $requestOptions ): string {
-		$discriminatorSource = self::makeValueRequestOptionsDiscriminatorSource( $requestOptions );
-		$defaultDiscriminatorSource = self::makeValueRequestOptionsDiscriminatorSource( new RequestOptions() );
-
-		if ( $discriminatorSource === $defaultDiscriminatorSource ) {
-			return '';
-		}
-
-		return md5( $discriminatorSource );
+		return md5( self::makeValueRequestOptionsDiscriminatorSource( $requestOptions ) );
 	}
 
 	private static function makeValueRequestOptionsDiscriminatorSource( RequestOptions $requestOptions ): string {

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -105,10 +105,6 @@ class PrefetchCache {
 	}
 
 	private static function makeValueRequestOptionsDiscriminator( RequestOptions $requestOptions ): string {
-		return md5( self::makeValueRequestOptionsDiscriminatorSource( $requestOptions ) );
-	}
-
-	private static function makeValueRequestOptionsDiscriminatorSource( RequestOptions $requestOptions ): string {
 		$stringConditions = [];
 
 		foreach ( $requestOptions->getStringConditions() as $stringCondition ) {
@@ -119,7 +115,7 @@ class PrefetchCache {
 		// returned to the caller. Do not use RequestOptions::getHash() here:
 		// lower-level lookup caches also need execution options in their request
 		// identity, but this value cache must not depend on those internal hints.
-		return (string)json_encode( [
+		return md5( (string)json_encode( [
 			$requestOptions->limit,
 			$requestOptions->offset,
 			$requestOptions->lookahead,
@@ -133,7 +129,7 @@ class PrefetchCache {
 			$requestOptions->natural,
 			$requestOptions->getCursorAfter(),
 			$requestOptions->getCursorBefore(),
-		] );
+		] ) );
 	}
 
 	private static function makeSubjectSetFingerprint( array $subjects ): string {

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -171,7 +171,10 @@ class PrefetchCache {
 			$lookupRequestOptions
 		);
 
-		$this->valuesByCacheKey[$valueCacheKey] = $result + ( $this->valuesByCacheKey[$valueCacheKey] ?? [] );
+		// Merge in newly fetched subjects without replacing values that are
+		// already cached for this value identity.
+		$this->valuesByCacheKey[$valueCacheKey] =
+			( $this->valuesByCacheKey[$valueCacheKey] ?? [] ) + $result;
 		$this->executedPrefetchLookups[$valueCacheKey][$subjectSetFingerprint] = true;
 	}
 

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -141,10 +141,6 @@ class PrefetchCache {
 		return md5( json_encode( $subjectHashes ) );
 	}
 
-	private static function makeExecutedPrefetchLookupKey( string $valueCacheKey, string $subjectSetKey ): string {
-		return md5( $valueCacheKey . '#' . $subjectSetKey );
-	}
-
 	/**
 	 * Prefetch related data so getPropertyValues() can return individual
 	 * subject values without issuing one lookup per subject.
@@ -160,7 +156,9 @@ class PrefetchCache {
 
 		$key = $this->makeCacheKey( $property, $requestOptions );
 		$subjectSetKey = self::makeSubjectSetKey( $subjects );
-		$executedLookupKey = self::makeExecutedPrefetchLookupKey( $key, $subjectSetKey );
+
+		// Track executed bulk lookups by requested value identity and subject set.
+		$executedLookupKey = md5( $key . '#' . $subjectSetKey );
 
 		if ( isset( $this->executedPrefetchLookups[$executedLookupKey] ) ) {
 			return;

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -99,38 +99,11 @@ class PrefetchCache {
 			$key .= '#' . 'isFirstChain';
 		}
 
-		$key .= '#valueOptions:' . self::makeValueRequestOptionsDiscriminator( $requestOptions );
+		// RequestOptions::getValueHash() is the single source of truth for which
+		// request options change the selected values; see its guard test.
+		$key .= '#valueOptions:' . $requestOptions->getValueHash();
 
 		return $key;
-	}
-
-	private static function makeValueRequestOptionsDiscriminator( RequestOptions $requestOptions ): string {
-		$stringConditions = [];
-
-		foreach ( $requestOptions->getStringConditions() as $stringCondition ) {
-			$stringConditions[] = $stringCondition->getHash();
-		}
-
-		// Use the request fields that can change the values, order, or slice
-		// returned to the caller. Do not use RequestOptions::getHash() here:
-		// lower-level lookup caches also need execution options in their request
-		// identity, but this value cache must not depend on those internal hints.
-		// This is a PHP-internal identity, not a JSON data model.
-		return md5( serialize( [
-			$requestOptions->limit,
-			$requestOptions->offset,
-			$requestOptions->lookahead,
-			$requestOptions->sort,
-			$requestOptions->ascending,
-			$requestOptions->boundary,
-			$requestOptions->include_boundary,
-			$stringConditions,
-			$requestOptions->getExtraConditions(),
-			$requestOptions->conditionConstraint,
-			$requestOptions->natural,
-			$requestOptions->getCursorAfter(),
-			$requestOptions->getCursorBefore(),
-		] ) );
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -63,12 +63,21 @@ class PrefetchCache {
 	 * @return string
 	 */
 	public static function makeCacheKey( Property $property, RequestOptions $requestOptions ): string {
-		$key = $property->getKey() . '#' . (string)(int)$property->isInverse();
+		$key = $property->getKey();
 
-		// Use the chain state to distinguish it from other printouts that use
-		// the same property.
+		// Cache key format:
+		// <property-key>[#isChain][#isInverse][#isFirstChain]
+		//
+		// Missing markers represent the default request context. Markers are
+		// appended in a fixed order and each marker is self-identifying, so
+		// chain and inverse lookups for the same property key cannot contaminate
+		// each other by changing the meaning of another key segment.
 		if ( $requestOptions->isChain ) {
-			$key .= '#' . (string)(int)$requestOptions->isChain;
+			$key .= '#' . 'isChain';
+		}
+
+		if ( $property->isInverse() ) {
+			$key .= '#' . 'isInverse';
 		}
 
 		// T:P0467, requires an extra identification to ensure the test passes

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -115,7 +115,8 @@ class PrefetchCache {
 		// returned to the caller. Do not use RequestOptions::getHash() here:
 		// lower-level lookup caches also need execution options in their request
 		// identity, but this value cache must not depend on those internal hints.
-		return md5( (string)json_encode( [
+		// This is a PHP-internal identity, not a JSON data model.
+		return md5( serialize( [
 			$requestOptions->limit,
 			$requestOptions->offset,
 			$requestOptions->lookahead,

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -132,16 +132,6 @@ class PrefetchCache {
 		] ) );
 	}
 
-	private static function makeSubjectSetFingerprint( array $subjects ): string {
-		$fingerprint = '';
-
-		foreach ( $subjects as $subject ) {
-			$fingerprint .= $subject->getHash();
-		}
-
-		return md5( $fingerprint );
-	}
-
 	/**
 	 * Prefetch related data so getPropertyValues() can return individual
 	 * subject values without issuing one lookup per subject.
@@ -155,8 +145,14 @@ class PrefetchCache {
 	public function prefetch( array $subjects, Property $property, RequestOptions $requestOptions ): void {
 		$this->store->getObjectIds()->warmUpCache( $subjects );
 
+		$fingerprint = '';
+
+		foreach ( $subjects as $subject ) {
+			$fingerprint .= $subject->getHash();
+		}
+
 		$valueCacheKey = $this->makeCacheKey( $property, $requestOptions );
-		$subjectSetFingerprint = self::makeSubjectSetFingerprint( $subjects );
+		$subjectSetFingerprint = md5( $fingerprint );
 
 		if ( isset( $this->executedPrefetchLookups[$valueCacheKey][$subjectSetFingerprint] ) ) {
 			return;

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -16,14 +16,21 @@ use SMW\SQLStore\SQLStore;
 class PrefetchCache {
 
 	/**
+	 * Fetched values grouped by value cache key, then subject ID.
+	 *
 	 * @var array
 	 */
-	private $cache = [];
+	private array $valuesByCacheKey = [];
 
 	/**
+	 * Set of bulk prefetch lookups that have already been executed.
+	 *
+	 * This does not store values. It only prevents running the same bulk lookup
+	 * twice while values remain stored in $valuesByCacheKey.
+	 *
 	 * @var array
 	 */
-	private array $lookupCache = [];
+	private array $executedPrefetchLookups = [];
 
 	/**
 	 * @since 3.1
@@ -43,15 +50,15 @@ class PrefetchCache {
 	 * @return bool
 	 */
 	public function isCached( Property $property, RequestOptions $requestOptions ): bool {
-		return isset( $this->cache[self::makeCacheKey( $property, $requestOptions )] );
+		return isset( $this->valuesByCacheKey[self::makeCacheKey( $property, $requestOptions )] );
 	}
 
 	/**
 	 * @since 3.1
 	 */
 	public function clear(): void {
-		$this->cache = [];
-		$this->lookupCache = [];
+		$this->valuesByCacheKey = [];
+		$this->executedPrefetchLookups = [];
 	}
 
 	/**
@@ -65,13 +72,13 @@ class PrefetchCache {
 	public static function makeCacheKey( Property $property, RequestOptions $requestOptions ): string {
 		$key = $property->getKey();
 
-		// Cache key format:
-		// <property-key>[#isChain][#isInverse][#isFirstChain]
+		// Value cache key format:
+		// <property-key>[#isChain][#isInverse][#isFirstChain][#requestOptions:<hash>]
 		//
 		// Missing markers represent the default request context. Markers are
 		// appended in a fixed order and each marker is self-identifying, so
-		// chain and inverse lookups for the same property key cannot contaminate
-		// each other by changing the meaning of another key segment.
+		// chain, inverse, and printout-local request options cannot contaminate
+		// values cached for the same property key.
 		if ( $requestOptions->isChain ) {
 			$key .= '#' . 'isChain';
 		}
@@ -86,23 +93,59 @@ class PrefetchCache {
 			$key .= '#' . 'isFirstChain';
 		}
 
+		$requestOptionsKey = self::makeRequestOptionsCacheKeyPart( $requestOptions );
+
+		if ( $requestOptionsKey !== '' ) {
+			$key .= '#requestOptions:' . $requestOptionsKey;
+		}
+
 		return $key;
 	}
 
-	private static function makeRequestOptionsHash( RequestOptions $requestOptions ): string {
+	private static function makeRequestOptionsCacheKeyPart( RequestOptions $requestOptions ): string {
+		$hash = self::makeNormalizedRequestOptionsHash( $requestOptions );
+
+		if ( $hash === self::makeNormalizedRequestOptionsHash( new RequestOptions() ) ) {
+			return '';
+		}
+
+		return md5( $hash );
+	}
+
+	private static function makeNormalizedRequestOptionsHash( RequestOptions $requestOptions ): string {
 		$requestOptions = clone $requestOptions;
 
-		// The prefetch fingerprint is added below for lower-level caches to
-		// identify the subject set. It must not make this lookup cache key
-		// change when the same RequestOptions instance is prefetched again.
+		// Prefetch mode and lower-level SQL lookups mutate these internal flags
+		// while executing a lookup. They must not change the identity of the
+		// caller's requested values.
+		$requestOptions->exclude_limit = false;
 		$requestOptions->deleteOption( RequestOptions::PREFETCH_FINGERPRINT );
+		$requestOptions->deleteOption( 'NO_GROUPBY' );
+		$requestOptions->deleteOption( 'NO_DISTINCT' );
+		$requestOptions->deleteOption( 'ORDER BY' );
+		$requestOptions->deleteOption( 'GROUP BY' );
+		$requestOptions->deleteOption( 'DISTINCT' );
 
-		return (string)$requestOptions->getHash();
+		return (string)$requestOptions->getHash() . '#' . (string)$requestOptions->natural;
+	}
+
+	private static function makeSubjectSetKey( array $subjects ): string {
+		$subjectHashes = [];
+
+		foreach ( $subjects as $subject ) {
+			$subjectHashes[] = $subject->getHash();
+		}
+
+		return md5( json_encode( $subjectHashes ) );
+	}
+
+	private static function makeExecutedPrefetchLookupKey( string $valueCacheKey, array $subjects ): string {
+		return md5( $valueCacheKey . '#' . self::makeSubjectSetKey( $subjects ) );
 	}
 
 	/**
-	 * Prefetch related data into the cache in order for the `LookupCache::get`
-	 * to return the individual data.
+	 * Prefetch related data so getPropertyValues() can return individual
+	 * subject values without issuing one lookup per subject.
 	 *
 	 * @since 3.1
 	 *
@@ -111,36 +154,27 @@ class PrefetchCache {
 	 * @param RequestOptions $requestOptions
 	 */
 	public function prefetch( array $subjects, Property $property, RequestOptions $requestOptions ): void {
-		$fingerprint = '';
 		$this->store->getObjectIds()->warmUpCache( $subjects );
 
-		foreach ( $subjects as $subject ) {
-			$fingerprint .= $subject->getHash();
-		}
-
-		$requestOptionsHash = self::makeRequestOptionsHash( $requestOptions );
-		$requestOptions->setOption( RequestOptions::PREFETCH_FINGERPRINT, md5( $fingerprint ) );
 		$key = $this->makeCacheKey( $property, $requestOptions );
+		$executedLookupKey = self::makeExecutedPrefetchLookupKey( $key, $subjects );
 
-		// Use an aggressive cache strategy to avoid repetitive queries especially
-		// when called as part of a printrequest chain. Request options belong to
-		// the lookup identity because printout-local options such as +order or
-		// +limit can produce a different value list for the same property and
-		// subject set.
-		$lookupKey = md5( $key . '#' . $fingerprint . '#' . $requestOptionsHash );
-
-		if ( isset( $this->lookupCache[$lookupKey] ) ) {
+		if ( isset( $this->executedPrefetchLookups[$executedLookupKey] ) ) {
 			return;
 		}
+
+		// Lower-level lookups add temporary SQL/cache hints to RequestOptions.
+		// Keep those mutations out of the value cache key used by this class.
+		$lookupRequestOptions = clone $requestOptions;
 
 		$result = $this->prefetchItemLookup->getPropertyValues(
 			$subjects,
 			$property,
-			$requestOptions
+			$lookupRequestOptions
 		);
 
-		$this->cache[$key] = $result + ( $this->cache[$key] ?? [] );
-		$this->lookupCache[$lookupKey] = true;
+		$this->valuesByCacheKey[$key] = $result + ( $this->valuesByCacheKey[$key] ?? [] );
+		$this->executedPrefetchLookups[$executedLookupKey] = true;
 	}
 
 	/**
@@ -167,11 +201,11 @@ class PrefetchCache {
 				true
 			);
 
-		if ( !isset( $this->cache[$key][$sid] ) ) {
+		if ( !isset( $this->valuesByCacheKey[$key][$sid] ) ) {
 			return [];
 		}
 
-		return array_values( $this->cache[$key][$sid] );
+		return array_values( $this->valuesByCacheKey[$key][$sid] );
 	}
 
 }

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -133,13 +133,13 @@ class PrefetchCache {
 	}
 
 	private static function makeSubjectSetFingerprint( array $subjects ): string {
-		$subjectHashes = [];
+		$fingerprint = '';
 
 		foreach ( $subjects as $subject ) {
-			$subjectHashes[] = $subject->getHash();
+			$fingerprint .= $subject->getHash();
 		}
 
-		return md5( json_encode( $subjectHashes ) );
+		return md5( $fingerprint );
 	}
 
 	/**

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -23,7 +23,8 @@ class PrefetchCache {
 	private array $valuesByCacheKey = [];
 
 	/**
-	 * Set of bulk prefetch lookups that have already been executed.
+	 * Set of bulk prefetch lookups that have already been executed, grouped
+	 * by value cache key and subject set fingerprint.
 	 *
 	 * This does not store values. It only prevents running the same bulk lookup
 	 * twice while values remain stored in $valuesByCacheKey.
@@ -72,8 +73,12 @@ class PrefetchCache {
 	public static function makeCacheKey( Property $property, RequestOptions $requestOptions ): string {
 		$key = $property->getKey();
 
-		// Value cache key format:
-		// <property-key>[#isChain][#isInverse][#isFirstChain][#requestOptions:<hash>]
+		// This value cache key is the contract between prefetch(), isCached(),
+		// and getPropertyValues(). It is not shared with lower-level lookup
+		// caches.
+		//
+		// Format:
+		// <property-key>[#isChain][#isInverse][#isFirstChain][#printoutOptions:<discriminator>]
 		//
 		// Missing markers represent the default request context. Markers are
 		// appended in a fixed order and each marker is self-identifying, so
@@ -95,43 +100,44 @@ class PrefetchCache {
 			$key .= '#' . 'isFirstChain';
 		}
 
-		$requestOptionsKey = self::makeRequestOptionsCacheKeyPart( $requestOptions );
+		$printoutOptionsDiscriminator = self::makePrintoutOptionsDiscriminator( $requestOptions );
 
-		if ( $requestOptionsKey !== '' ) {
-			$key .= '#requestOptions:' . $requestOptionsKey;
+		if ( $printoutOptionsDiscriminator !== '' ) {
+			$key .= '#printoutOptions:' . $printoutOptionsDiscriminator;
 		}
 
 		return $key;
 	}
 
-	private static function makeRequestOptionsCacheKeyPart( RequestOptions $requestOptions ): string {
-		$hash = self::makeNormalizedRequestOptionsHash( $requestOptions );
+	private static function makePrintoutOptionsDiscriminator( RequestOptions $requestOptions ): string {
+		$printoutOptions = clone $requestOptions;
 
-		if ( $hash === self::makeNormalizedRequestOptionsHash( new RequestOptions() ) ) {
+		// RequestOptions::getHash() mixes caller-visible value options with
+		// temporary execution hints added by prefetch and lower-level SQL
+		// lookups. The value cache must include the former, for example
+		// printout-local sort order, and ignore the latter.
+		$printoutOptions->exclude_limit = false;
+		$printoutOptions->deleteOption( RequestOptions::PREFETCH_FINGERPRINT );
+		$printoutOptions->deleteOption( 'NO_GROUPBY' );
+		$printoutOptions->deleteOption( 'NO_DISTINCT' );
+		$printoutOptions->deleteOption( 'ORDER BY' );
+		$printoutOptions->deleteOption( 'GROUP BY' );
+		$printoutOptions->deleteOption( 'DISTINCT' );
+
+		// getHash() does not include "natural", but natural sorting changes
+		// the requested value order, so it is part of this discriminator.
+		$discriminatorSource = (string)$printoutOptions->getHash() . '#' . (string)$printoutOptions->natural;
+		$defaultOptions = new RequestOptions();
+		$defaultDiscriminatorSource = (string)$defaultOptions->getHash() . '#' . (string)$defaultOptions->natural;
+
+		if ( $discriminatorSource === $defaultDiscriminatorSource ) {
 			return '';
 		}
 
-		return md5( $hash );
+		return md5( $discriminatorSource );
 	}
 
-	private static function makeNormalizedRequestOptionsHash( RequestOptions $requestOptions ): string {
-		$requestOptions = clone $requestOptions;
-
-		// Prefetch mode and lower-level SQL lookups mutate these internal flags
-		// while executing a lookup. They must not change the identity of the
-		// caller's requested values.
-		$requestOptions->exclude_limit = false;
-		$requestOptions->deleteOption( RequestOptions::PREFETCH_FINGERPRINT );
-		$requestOptions->deleteOption( 'NO_GROUPBY' );
-		$requestOptions->deleteOption( 'NO_DISTINCT' );
-		$requestOptions->deleteOption( 'ORDER BY' );
-		$requestOptions->deleteOption( 'GROUP BY' );
-		$requestOptions->deleteOption( 'DISTINCT' );
-
-		return (string)$requestOptions->getHash() . '#' . (string)$requestOptions->natural;
-	}
-
-	private static function makeSubjectSetKey( array $subjects ): string {
+	private static function makeSubjectSetFingerprint( array $subjects ): string {
 		$subjectHashes = [];
 
 		foreach ( $subjects as $subject ) {
@@ -154,13 +160,10 @@ class PrefetchCache {
 	public function prefetch( array $subjects, Property $property, RequestOptions $requestOptions ): void {
 		$this->store->getObjectIds()->warmUpCache( $subjects );
 
-		$key = $this->makeCacheKey( $property, $requestOptions );
-		$subjectSetKey = self::makeSubjectSetKey( $subjects );
+		$valueCacheKey = $this->makeCacheKey( $property, $requestOptions );
+		$subjectSetFingerprint = self::makeSubjectSetFingerprint( $subjects );
 
-		// Track executed bulk lookups by requested value identity and subject set.
-		$executedLookupKey = md5( $key . '#' . $subjectSetKey );
-
-		if ( isset( $this->executedPrefetchLookups[$executedLookupKey] ) ) {
+		if ( isset( $this->executedPrefetchLookups[$valueCacheKey][$subjectSetFingerprint] ) ) {
 			return;
 		}
 
@@ -169,7 +172,7 @@ class PrefetchCache {
 		// clone so it cannot leak into this value cache key or the caller's
 		// RequestOptions instance.
 		$lookupRequestOptions = clone $requestOptions;
-		$lookupRequestOptions->setOption( RequestOptions::PREFETCH_FINGERPRINT, $subjectSetKey );
+		$lookupRequestOptions->setOption( RequestOptions::PREFETCH_FINGERPRINT, $subjectSetFingerprint );
 
 		$result = $this->prefetchItemLookup->getPropertyValues(
 			$subjects,
@@ -177,8 +180,8 @@ class PrefetchCache {
 			$lookupRequestOptions
 		);
 
-		$this->valuesByCacheKey[$key] = $result + ( $this->valuesByCacheKey[$key] ?? [] );
-		$this->executedPrefetchLookups[$executedLookupKey] = true;
+		$this->valuesByCacheKey[$valueCacheKey] = $result + ( $this->valuesByCacheKey[$valueCacheKey] ?? [] );
+		$this->executedPrefetchLookups[$valueCacheKey][$subjectSetFingerprint] = true;
 	}
 
 	/**
@@ -191,7 +194,7 @@ class PrefetchCache {
 	 * @return array
 	 */
 	public function getPropertyValues( WikiPage $subject, Property $property, RequestOptions $requestOptions ): array {
-		$key = $this->makeCacheKey( $property, $requestOptions );
+		$valueCacheKey = $this->makeCacheKey( $property, $requestOptions );
 
 		// 0 is the default ID of the subject, if it already has an ID,
 		// there is no need to do a DB query for the ID.
@@ -205,11 +208,11 @@ class PrefetchCache {
 				true
 			);
 
-		if ( !isset( $this->valuesByCacheKey[$key][$sid] ) ) {
+		if ( !isset( $this->valuesByCacheKey[$valueCacheKey][$sid] ) ) {
 			return [];
 		}
 
-		return array_values( $this->valuesByCacheKey[$key][$sid] );
+		return array_values( $this->valuesByCacheKey[$valueCacheKey][$sid] );
 	}
 
 }

--- a/src/SQLStore/EntityStore/PrefetchCache.php
+++ b/src/SQLStore/EntityStore/PrefetchCache.php
@@ -78,7 +78,7 @@ class PrefetchCache {
 		// caches.
 		//
 		// Format:
-		// <property-key>[#isChain][#isInverse][#isFirstChain][#printoutOptions:<discriminator>]
+		// <property-key>[#isChain][#isInverse][#isFirstChain][#valueOptions:<discriminator>]
 		//
 		// Missing markers represent the default request context. Markers are
 		// appended in a fixed order and each marker is self-identifying, so
@@ -100,41 +100,52 @@ class PrefetchCache {
 			$key .= '#' . 'isFirstChain';
 		}
 
-		$printoutOptionsDiscriminator = self::makePrintoutOptionsDiscriminator( $requestOptions );
+		$valueOptionsDiscriminator = self::makeValueRequestOptionsDiscriminator( $requestOptions );
 
-		if ( $printoutOptionsDiscriminator !== '' ) {
-			$key .= '#printoutOptions:' . $printoutOptionsDiscriminator;
+		if ( $valueOptionsDiscriminator !== '' ) {
+			$key .= '#valueOptions:' . $valueOptionsDiscriminator;
 		}
 
 		return $key;
 	}
 
-	private static function makePrintoutOptionsDiscriminator( RequestOptions $requestOptions ): string {
-		$printoutOptions = clone $requestOptions;
-
-		// RequestOptions::getHash() mixes caller-visible value options with
-		// temporary execution hints added by prefetch and lower-level SQL
-		// lookups. The value cache must include the former, for example
-		// printout-local sort order, and ignore the latter.
-		$printoutOptions->exclude_limit = false;
-		$printoutOptions->deleteOption( RequestOptions::PREFETCH_FINGERPRINT );
-		$printoutOptions->deleteOption( 'NO_GROUPBY' );
-		$printoutOptions->deleteOption( 'NO_DISTINCT' );
-		$printoutOptions->deleteOption( 'ORDER BY' );
-		$printoutOptions->deleteOption( 'GROUP BY' );
-		$printoutOptions->deleteOption( 'DISTINCT' );
-
-		// getHash() does not include "natural", but natural sorting changes
-		// the requested value order, so it is part of this discriminator.
-		$discriminatorSource = (string)$printoutOptions->getHash() . '#' . (string)$printoutOptions->natural;
-		$defaultOptions = new RequestOptions();
-		$defaultDiscriminatorSource = (string)$defaultOptions->getHash() . '#' . (string)$defaultOptions->natural;
+	private static function makeValueRequestOptionsDiscriminator( RequestOptions $requestOptions ): string {
+		$discriminatorSource = self::makeValueRequestOptionsDiscriminatorSource( $requestOptions );
+		$defaultDiscriminatorSource = self::makeValueRequestOptionsDiscriminatorSource( new RequestOptions() );
 
 		if ( $discriminatorSource === $defaultDiscriminatorSource ) {
 			return '';
 		}
 
 		return md5( $discriminatorSource );
+	}
+
+	private static function makeValueRequestOptionsDiscriminatorSource( RequestOptions $requestOptions ): string {
+		$stringConditions = [];
+
+		foreach ( $requestOptions->getStringConditions() as $stringCondition ) {
+			$stringConditions[] = $stringCondition->getHash();
+		}
+
+		// Use the request fields that can change the values, order, or slice
+		// returned to the caller. Do not use RequestOptions::getHash() here:
+		// lower-level lookup caches also need execution options in their request
+		// identity, but this value cache must not depend on those internal hints.
+		return (string)json_encode( [
+			$requestOptions->limit,
+			$requestOptions->offset,
+			$requestOptions->lookahead,
+			$requestOptions->sort,
+			$requestOptions->ascending,
+			$requestOptions->boundary,
+			$requestOptions->include_boundary,
+			$stringConditions,
+			$requestOptions->getExtraConditions(),
+			$requestOptions->conditionConstraint,
+			$requestOptions->natural,
+			$requestOptions->getCursorAfter(),
+			$requestOptions->getCursorBefore(),
+		] );
 	}
 
 	private static function makeSubjectSetFingerprint( array $subjects ): string {

--- a/tests/phpunit/Unit/Query/Result/ItemFetcherTest.php
+++ b/tests/phpunit/Unit/Query/Result/ItemFetcherTest.php
@@ -141,6 +141,13 @@ class ItemFetcherTest extends TestCase {
 			->getMock();
 
 		$prefetchCache->expects( $this->once() )
+			->method( 'isCached' )
+			->with(
+				$property,
+				$this->requestOptions )
+			->willReturn( false );
+
+		$prefetchCache->expects( $this->once() )
 			->method( 'getPropertyValues' )
 			->with(
 				$dataItem,

--- a/tests/phpunit/Unit/Query/Result/ItemFetcherTest.php
+++ b/tests/phpunit/Unit/Query/Result/ItemFetcherTest.php
@@ -151,7 +151,8 @@ class ItemFetcherTest extends TestCase {
 			->method( 'getPropertyValues' )
 			->with(
 				$dataItem,
-				$property )
+				$property,
+				$this->requestOptions )
 			->willReturn( $expected );
 
 		$this->store->expects( $this->atLeastOnce() )

--- a/tests/phpunit/Unit/RequestOptionsTest.php
+++ b/tests/phpunit/Unit/RequestOptionsTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Unit;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionClass;
 use SMW\RequestOptions;
 use SMW\StringCondition;
 
@@ -162,6 +163,109 @@ class RequestOptionsTest extends TestCase {
 		$b->setCursorAfter( 1 );
 
 		$this->assertNotSame( $a->getHash(), $b->getHash() );
+	}
+
+	/**
+	 * Guards against silent value-cache collisions: any newly added property
+	 * must be consciously classified as value-affecting (folded into
+	 * getValueHash) or explicitly excluded with a reason.
+	 */
+	public function testEveryDeclaredPropertyIsClassifiedForValueHash() {
+		// Folded into getValueHash() as value identity.
+		$valueAffecting = [
+			'limit', 'offset', 'sort', 'ascending', 'boundary', 'include_boundary',
+			'conditionConstraint', 'natural', 'cursorAfter', 'cursorBefore',
+			'stringConditions', 'extraConditions',
+		];
+
+		// Deliberately excluded, each for a documented reason.
+		$excluded = [
+			'options', // included via the NON_VALUE_OPTIONS denylist, not by name
+			'exclude_limit', // forced true across the prefetch path (a constant there)
+			'lookahead', // normalized to a fixed value by the prefetch machinery
+			'isChain', // encoded by PrefetchCache::makeCacheKey() markers
+			'isFirstChain', // encoded by PrefetchCache::makeCacheKey() markers
+			'caller', // SQL-comment telemetry only
+			'firstCursor', // output metadata written back by the lookup
+			'lastCursor', // output metadata written back by the lookup
+			'cursorHasMore', // output metadata written back by the lookup
+		];
+
+		$classified = array_merge( $valueAffecting, $excluded );
+
+		foreach ( ( new ReflectionClass( RequestOptions::class ) )->getProperties() as $property ) {
+			if ( $property->isStatic() ) {
+				continue;
+			}
+
+			$this->assertContains(
+				$property->getName(),
+				$classified,
+				"New RequestOptions property '{$property->getName()}' must be classified in " .
+				'getValueHash(): add it to the value tuple or to the documented excluded list.'
+			);
+		}
+	}
+
+	public function testGetValueHashIgnoresExecutionHintsAndNormalizedFields() {
+		$base = new RequestOptions();
+
+		$withHints = new RequestOptions();
+		$withHints->exclude_limit = true;
+		$withHints->lookahead = 5;
+		$withHints->setOption( RequestOptions::PREFETCH_FINGERPRINT, 'subject-set' );
+		$withHints->setOption( 'NO_GROUPBY', true );
+		$withHints->setOption( 'NO_DISTINCT', true );
+		$withHints->setOption( 'ORDER BY', 'smw_sort' );
+		$withHints->setOption( 'GROUP BY', 'smw_id' );
+		$withHints->setOption( 'DISTINCT', true );
+
+		$this->assertSame(
+			$base->getValueHash(),
+			$withHints->getValueHash()
+		);
+	}
+
+	public function testGetValueHashDistinguishesValueAffectingOption() {
+		$base = new RequestOptions();
+
+		$withOption = new RequestOptions();
+		$withOption->setOption( RequestOptions::CONDITION_CONSTRAINT_RESULT, true );
+
+		$this->assertNotSame(
+			$base->getValueHash(),
+			$withOption->getValueHash()
+		);
+	}
+
+	public function testGetValueHashDistinguishesSortDirection() {
+		$ascending = new RequestOptions();
+		$ascending->sort = true;
+		$ascending->ascending = true;
+
+		$descending = new RequestOptions();
+		$descending->sort = true;
+		$descending->ascending = false;
+
+		$this->assertNotSame(
+			$ascending->getValueHash(),
+			$descending->getValueHash()
+		);
+	}
+
+	public function testGetValueHashIsOptionOrderIndependent() {
+		$a = new RequestOptions();
+		$a->setOption( 'alpha', 1 );
+		$a->setOption( 'beta', 2 );
+
+		$b = new RequestOptions();
+		$b->setOption( 'beta', 2 );
+		$b->setOption( 'alpha', 1 );
+
+		$this->assertSame(
+			$a->getValueHash(),
+			$b->getValueHash()
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
@@ -58,6 +58,36 @@ class PrefetchCacheTest extends TestCase {
 		);
 	}
 
+	public function testCacheKeyUsesSelfIdentifyingContextMarkers() {
+		$requestOptions = new RequestOptions();
+		$requestOptions->isChain = false;
+		$requestOptions->isFirstChain = false;
+
+		$this->assertSame(
+			'Foo',
+			PrefetchCache::makeCacheKey( new Property( 'Foo' ), $requestOptions )
+		);
+
+		$this->assertSame(
+			'Foo#isInverse',
+			PrefetchCache::makeCacheKey( new Property( 'Foo', true ), $requestOptions )
+		);
+
+		$requestOptions->isChain = true;
+
+		$this->assertSame(
+			'Foo#isChain',
+			PrefetchCache::makeCacheKey( new Property( 'Foo' ), $requestOptions )
+		);
+
+		$requestOptions->isFirstChain = true;
+
+		$this->assertSame(
+			'Foo#isChain#isInverse#isFirstChain',
+			PrefetchCache::makeCacheKey( new Property( 'Foo', true ), $requestOptions )
+		);
+	}
+
 	public function testIsCachedUsesRequestOptionsCacheKey() {
 		// Wikitext equivalent:
 		// {{#ask: [[Category:Example]] |?Foo |?Bar.Foo }}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
@@ -46,6 +46,8 @@ class PrefetchCacheTest extends TestCase {
 	}
 
 	public function testCacheKeySeparatesDirectAndInverseProperty() {
+		// Wikitext equivalent:
+		// {{#ask: [[Category:Example]] |?Foo |?-Foo }}
 		$requestOptions = new RequestOptions();
 		$requestOptions->isChain = false;
 		$requestOptions->isFirstChain = false;
@@ -57,6 +59,8 @@ class PrefetchCacheTest extends TestCase {
 	}
 
 	public function testIsCachedUsesRequestOptionsCacheKey() {
+		// Wikitext equivalent:
+		// {{#ask: [[Category:Example]] |?Foo |?Bar.Foo }}
 		$property = new Property( 'Foo' );
 		$subject = WikiPage::newFromText( __METHOD__ );
 
@@ -173,6 +177,8 @@ class PrefetchCacheTest extends TestCase {
 	}
 
 	public function testLookupCacheSeparatesRequestOptions() {
+		// Wikitext equivalent:
+		// {{#ask: [[Category:Example]] |?Po|+order=asc |?Po|+order=desc }}
 		$property = new Property( 'Po' );
 		$subject = WikiPage::newFromText( 'Subject' );
 
@@ -220,6 +226,8 @@ class PrefetchCacheTest extends TestCase {
 	}
 
 	public function testLookupCacheIgnoresPrefetchFingerprintOption() {
+		// Wikitext equivalent when evaluated twice:
+		// {{#ask: [[Category:Example]] |?Pf }}
 		$property = new Property( 'Pf' );
 		$subject = WikiPage::newFromText( 'Subject' );
 

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
@@ -109,6 +109,26 @@ class PrefetchCacheTest extends TestCase {
 		);
 	}
 
+	public function testCacheKeyIgnoresInternalLookupOptions() {
+		$requestOptions = new RequestOptions();
+		$requestOptions->isChain = false;
+		$requestOptions->isFirstChain = false;
+
+		$lookupOptions = clone $requestOptions;
+		$lookupOptions->exclude_limit = true;
+		$lookupOptions->setOption( RequestOptions::PREFETCH_FINGERPRINT, 'subject-set' );
+		$lookupOptions->setOption( 'NO_GROUPBY', true );
+		$lookupOptions->setOption( 'NO_DISTINCT', true );
+		$lookupOptions->setOption( 'ORDER BY', 'smw_sort' );
+		$lookupOptions->setOption( 'GROUP BY', 'smw_id' );
+		$lookupOptions->setOption( 'DISTINCT', true );
+
+		$this->assertSame(
+			PrefetchCache::makeCacheKey( new Property( 'Foo' ), $requestOptions ),
+			PrefetchCache::makeCacheKey( new Property( 'Foo' ), $lookupOptions )
+		);
+	}
+
 	public function testIsCachedUsesRequestOptionsCacheKey() {
 		// Wikitext equivalent:
 		// {{#ask: [[Category:Example]] |?Foo |?Bar.Foo }}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
@@ -290,11 +290,14 @@ class PrefetchCacheTest extends TestCase {
 		);
 	}
 
-	public function testPrefetchDoesNotMutateRequestOptionsWithPrefetchFingerprint() {
+	public function testPrefetchPassesFingerprintToLookupRequestOptionsWithoutMutatingOriginal() {
 		// Wikitext equivalent when evaluated twice:
 		// {{#ask: [[Category:Example]] |?Pf }}
 		$property = new Property( 'Pf' );
 		$subject = WikiPage::newFromText( 'Subject' );
+		$requestOptions = new RequestOptions();
+		$requestOptions->isChain = false;
+		$requestOptions->isFirstChain = false;
 
 		$idTable = $this->getMockBuilder( EntityIdManager::class )
 			->disableOriginalConstructor()
@@ -305,11 +308,16 @@ class PrefetchCacheTest extends TestCase {
 
 		$this->prefetchItemLookup->expects( $this->once() )
 			->method( 'getPropertyValues' )
-			->willReturn( [] );
+			->willReturnCallback(
+				function ( array $subjects, Property $property, RequestOptions $lookupRequestOptions ) use ( $requestOptions ): array {
+					$this->assertNotSame( $requestOptions, $lookupRequestOptions );
+					$this->assertNotNull(
+						$lookupRequestOptions->getOption( RequestOptions::PREFETCH_FINGERPRINT )
+					);
 
-		$requestOptions = new RequestOptions();
-		$requestOptions->isChain = false;
-		$requestOptions->isFirstChain = false;
+					return [];
+				}
+			);
 
 		$instance = new PrefetchCache(
 			$this->store,

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
@@ -245,9 +245,12 @@ class PrefetchCacheTest extends TestCase {
 
 		$this->prefetchItemLookup->expects( $this->exactly( 2 ) )
 			->method( 'getPropertyValues' )
-			->willReturnOnConsecutiveCalls(
-				[ 103 => [ WikiPage::newFromText( 'Ascending' ) ] ],
-				[ 103 => [ WikiPage::newFromText( 'Descending' ) ] ]
+			->willReturnCallback(
+				static function ( array $subjects, Property $property, RequestOptions $requestOptions ): array {
+					$value = $requestOptions->ascending ? 'Ascending' : 'Descending';
+
+					return [ 103 => [ WikiPage::newFromText( $value ) ] ];
+				}
 			);
 
 		$ascendingOptions = new RequestOptions();

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
@@ -88,6 +88,27 @@ class PrefetchCacheTest extends TestCase {
 		);
 	}
 
+	public function testCacheKeySeparatesRequestOptions() {
+		// Wikitext equivalent:
+		// {{#ask: [[Category:Example]] |?Foo|+order=asc |?Foo|+order=desc }}
+		$ascendingOptions = new RequestOptions();
+		$ascendingOptions->isChain = false;
+		$ascendingOptions->isFirstChain = false;
+		$ascendingOptions->sort = true;
+		$ascendingOptions->ascending = true;
+
+		$descendingOptions = new RequestOptions();
+		$descendingOptions->isChain = false;
+		$descendingOptions->isFirstChain = false;
+		$descendingOptions->sort = true;
+		$descendingOptions->ascending = false;
+
+		$this->assertNotSame(
+			PrefetchCache::makeCacheKey( new Property( 'Foo' ), $ascendingOptions ),
+			PrefetchCache::makeCacheKey( new Property( 'Foo' ), $descendingOptions )
+		);
+	}
+
 	public function testIsCachedUsesRequestOptionsCacheKey() {
 		// Wikitext equivalent:
 		// {{#ask: [[Category:Example]] |?Foo |?Bar.Foo }}
@@ -166,7 +187,7 @@ class PrefetchCacheTest extends TestCase {
 		);
 	}
 
-	public function testCacheMergeWithDifferentFingerprints() {
+	public function testCacheMergeWithDifferentSubjectSets() {
 		$property = new Property( 'Pm' );
 		$subject1 = WikiPage::newFromText( 'Subject1' );
 		$subject2 = WikiPage::newFromText( 'Subject2' );
@@ -206,7 +227,7 @@ class PrefetchCacheTest extends TestCase {
 		);
 	}
 
-	public function testLookupCacheSeparatesRequestOptions() {
+	public function testCacheAndExecutedLookupSetSeparateRequestOptions() {
 		// Wikitext equivalent:
 		// {{#ask: [[Category:Example]] |?Po|+order=asc |?Po|+order=desc }}
 		$property = new Property( 'Po' );
@@ -247,7 +268,18 @@ class PrefetchCacheTest extends TestCase {
 		);
 
 		$instance->prefetch( [ $subject ], $property, $ascendingOptions );
+
+		$this->assertEquals(
+			[ WikiPage::newFromText( 'Ascending' ) ],
+			$instance->getPropertyValues( $subject, $property, $ascendingOptions )
+		);
+
 		$instance->prefetch( [ $subject ], $property, $descendingOptions );
+
+		$this->assertEquals(
+			[ WikiPage::newFromText( 'Ascending' ) ],
+			$instance->getPropertyValues( $subject, $property, $ascendingOptions )
+		);
 
 		$this->assertEquals(
 			[ WikiPage::newFromText( 'Descending' ) ],
@@ -255,7 +287,7 @@ class PrefetchCacheTest extends TestCase {
 		);
 	}
 
-	public function testLookupCacheIgnoresPrefetchFingerprintOption() {
+	public function testPrefetchDoesNotMutateRequestOptionsWithPrefetchFingerprint() {
 		// Wikitext equivalent when evaluated twice:
 		// {{#ask: [[Category:Example]] |?Pf }}
 		$property = new Property( 'Pf' );
@@ -283,6 +315,10 @@ class PrefetchCacheTest extends TestCase {
 
 		$instance->prefetch( [ $subject ], $property, $requestOptions );
 		$instance->prefetch( [ $subject ], $property, $requestOptions );
+
+		$this->assertNull(
+			$requestOptions->getOption( RequestOptions::PREFETCH_FINGERPRINT )
+		);
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
@@ -35,15 +35,62 @@ class PrefetchCacheTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->requestOptions = $this->getMockBuilder( RequestOptions::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->requestOptions = new RequestOptions();
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			PrefetchCache::class,
 			new PrefetchCache( $this->store, $this->prefetchItemLookup )
+		);
+	}
+
+	public function testCacheKeySeparatesDirectAndInverseProperty() {
+		$requestOptions = new RequestOptions();
+		$requestOptions->isChain = false;
+		$requestOptions->isFirstChain = false;
+
+		$this->assertNotSame(
+			PrefetchCache::makeCacheKey( new Property( 'Foo' ), $requestOptions ),
+			PrefetchCache::makeCacheKey( new Property( 'Foo', true ), $requestOptions )
+		);
+	}
+
+	public function testIsCachedUsesRequestOptionsCacheKey() {
+		$property = new Property( 'Foo' );
+		$subject = WikiPage::newFromText( __METHOD__ );
+
+		$idTable = $this->getMockBuilder( EntityIdManager::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->method( 'getObjectIds' )
+			->willReturn( $idTable );
+
+		$this->prefetchItemLookup->method( 'getPropertyValues' )
+			->willReturn( [] );
+
+		$chainOptions = new RequestOptions();
+		$chainOptions->isChain = true;
+		$chainOptions->isFirstChain = true;
+
+		$directOptions = new RequestOptions();
+		$directOptions->isChain = false;
+		$directOptions->isFirstChain = false;
+
+		$instance = new PrefetchCache(
+			$this->store,
+			$this->prefetchItemLookup
+		);
+
+		$instance->prefetch( [ $subject ], $property, $chainOptions );
+
+		$this->assertTrue(
+			$instance->isCached( $property, $chainOptions )
+		);
+
+		$this->assertFalse(
+			$instance->isCached( $property, $directOptions )
 		);
 	}
 
@@ -123,6 +170,81 @@ class PrefetchCacheTest extends TestCase {
 			[ WikiPage::newFromText( 'Result2' ) ],
 			$instance->getPropertyValues( $subject2, $property, $this->requestOptions )
 		);
+	}
+
+	public function testLookupCacheSeparatesRequestOptions() {
+		$property = new Property( 'Po' );
+		$subject = WikiPage::newFromText( 'Subject' );
+
+		$idTable = $this->getMockBuilder( EntityIdManager::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$idTable->method( 'getSMWPageID' )
+			->willReturn( 103 );
+
+		$this->store->method( 'getObjectIds' )
+			->willReturn( $idTable );
+
+		$this->prefetchItemLookup->expects( $this->exactly( 2 ) )
+			->method( 'getPropertyValues' )
+			->willReturnOnConsecutiveCalls(
+				[ 103 => [ WikiPage::newFromText( 'Ascending' ) ] ],
+				[ 103 => [ WikiPage::newFromText( 'Descending' ) ] ]
+			);
+
+		$ascendingOptions = new RequestOptions();
+		$ascendingOptions->isChain = false;
+		$ascendingOptions->isFirstChain = false;
+		$ascendingOptions->sort = true;
+		$ascendingOptions->ascending = true;
+
+		$descendingOptions = new RequestOptions();
+		$descendingOptions->isChain = false;
+		$descendingOptions->isFirstChain = false;
+		$descendingOptions->sort = true;
+		$descendingOptions->ascending = false;
+
+		$instance = new PrefetchCache(
+			$this->store,
+			$this->prefetchItemLookup
+		);
+
+		$instance->prefetch( [ $subject ], $property, $ascendingOptions );
+		$instance->prefetch( [ $subject ], $property, $descendingOptions );
+
+		$this->assertEquals(
+			[ WikiPage::newFromText( 'Descending' ) ],
+			$instance->getPropertyValues( $subject, $property, $descendingOptions )
+		);
+	}
+
+	public function testLookupCacheIgnoresPrefetchFingerprintOption() {
+		$property = new Property( 'Pf' );
+		$subject = WikiPage::newFromText( 'Subject' );
+
+		$idTable = $this->getMockBuilder( EntityIdManager::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->method( 'getObjectIds' )
+			->willReturn( $idTable );
+
+		$this->prefetchItemLookup->expects( $this->once() )
+			->method( 'getPropertyValues' )
+			->willReturn( [] );
+
+		$requestOptions = new RequestOptions();
+		$requestOptions->isChain = false;
+		$requestOptions->isFirstChain = false;
+
+		$instance = new PrefetchCache(
+			$this->store,
+			$this->prefetchItemLookup
+		);
+
+		$instance->prefetch( [ $subject ], $property, $requestOptions );
+		$instance->prefetch( [ $subject ], $property, $requestOptions );
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
@@ -63,27 +63,27 @@ class PrefetchCacheTest extends TestCase {
 		$requestOptions->isChain = false;
 		$requestOptions->isFirstChain = false;
 
-		$this->assertSame(
-			'Foo',
+		$this->assertMatchesRegularExpression(
+			'/^Foo#valueOptions:[a-f0-9]{32}$/',
 			PrefetchCache::makeCacheKey( new Property( 'Foo' ), $requestOptions )
 		);
 
-		$this->assertSame(
-			'Foo#isInverse',
+		$this->assertMatchesRegularExpression(
+			'/^Foo#isInverse#valueOptions:[a-f0-9]{32}$/',
 			PrefetchCache::makeCacheKey( new Property( 'Foo', true ), $requestOptions )
 		);
 
 		$requestOptions->isChain = true;
 
-		$this->assertSame(
-			'Foo#isChain',
+		$this->assertMatchesRegularExpression(
+			'/^Foo#isChain#valueOptions:[a-f0-9]{32}$/',
 			PrefetchCache::makeCacheKey( new Property( 'Foo' ), $requestOptions )
 		);
 
 		$requestOptions->isFirstChain = true;
 
-		$this->assertSame(
-			'Foo#isChain#isInverse#isFirstChain',
+		$this->assertMatchesRegularExpression(
+			'/^Foo#isChain#isInverse#isFirstChain#valueOptions:[a-f0-9]{32}$/',
 			PrefetchCache::makeCacheKey( new Property( 'Foo', true ), $requestOptions )
 		);
 	}

--- a/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php
@@ -10,6 +10,7 @@ use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\EntityStore\PrefetchCache;
 use SMW\SQLStore\EntityStore\PrefetchItemLookup;
 use SMW\SQLStore\SQLStore;
+use SMW\StringCondition;
 
 /**
  * @covers \SMW\SQLStore\EntityStore\PrefetchCache
@@ -109,6 +110,20 @@ class PrefetchCacheTest extends TestCase {
 		);
 	}
 
+	public function testCacheKeySeparatesStringConditions() {
+		$requestOptions = new RequestOptions();
+		$requestOptions->isChain = false;
+		$requestOptions->isFirstChain = false;
+
+		$stringConditionOptions = clone $requestOptions;
+		$stringConditionOptions->addStringCondition( 'Value', StringCondition::COND_PRE );
+
+		$this->assertNotSame(
+			PrefetchCache::makeCacheKey( new Property( 'Foo' ), $requestOptions ),
+			PrefetchCache::makeCacheKey( new Property( 'Foo' ), $stringConditionOptions )
+		);
+	}
+
 	public function testCacheKeyIgnoresInternalLookupOptions() {
 		$requestOptions = new RequestOptions();
 		$requestOptions->isChain = false;
@@ -205,6 +220,41 @@ class PrefetchCacheTest extends TestCase {
 			$expected,
 			$instance->getPropertyValues( $subject, $property, $this->requestOptions )
 		);
+	}
+
+	public function testClearResetsCachedValuesAndExecutedLookups() {
+		$property = new Property( 'Pc' );
+		$subject = WikiPage::newFromText( 'Subject' );
+
+		$idTable = $this->getMockBuilder( EntityIdManager::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->method( 'getObjectIds' )
+			->willReturn( $idTable );
+
+		$this->prefetchItemLookup->expects( $this->exactly( 2 ) )
+			->method( 'getPropertyValues' )
+			->willReturn( [] );
+
+		$instance = new PrefetchCache(
+			$this->store,
+			$this->prefetchItemLookup
+		);
+
+		$instance->prefetch( [ $subject ], $property, $this->requestOptions );
+
+		$this->assertTrue(
+			$instance->isCached( $property, $this->requestOptions )
+		);
+
+		$instance->clear();
+
+		$this->assertFalse(
+			$instance->isCached( $property, $this->requestOptions )
+		);
+
+		$instance->prefetch( [ $subject ], $property, $this->requestOptions );
 	}
 
 	public function testCacheMergeWithDifferentSubjectSets() {


### PR DESCRIPTION
## Summary

Some prefetch cache combinations are not handled independently today. A query can ask for the same property through different printout contexts, but the prefetch cache can treat those requests as equivalent and then reuse or skip a lookup that belongs to another context.

Examples of supported wikitext combinations that need independent prefetch cache entries:

- direct and inverse property printouts: `{{#ask: [[Category:Example]] |?Foo |?-Foo }}`
- direct and chained property printouts: `{{#ask: [[Category:Example]] |?Foo |?Bar.Foo }}`
- the same printout with different printout-local options: `{{#ask: [[Category:Example]] |?Po|+order=asc |?Po|+order=desc }}`

This patch makes the prefetch cache identity match those supported combinations:

- make `PrefetchCache::isCached()` use the same request-aware value cache key as prefetch storage and retrieval
- separate direct, inverse, and chained property lookups with self-identifying cache key markers
- include value-affecting request option differences, such as sort order, in the value cache key
- build the value option discriminator from explicit request fields instead of `RequestOptions::getHash()`, so temporary prefetch and lower-level SQL execution hints do not change the requested value identity
- keep the bulk prefetch de-duplication set separate from the value cache, indexed by value cache identity and subject set
- keep `RequestOptions::PREFETCH_FINGERPRINT` as the subject-set part of the lower-level lookup request identity, but set it only on a cloned `RequestOptions` instance
- add unit coverage for the supported direct/inverse, chain/direct, request option, and non-mutating prefetch cases

## Testing

- `git diff --check`

Earlier revisions were checked with:

- `php -l src/SQLStore/EntityStore/PrefetchCache.php`
- `php -l src/Query/Result/ItemFetcher.php`
- `php -l tests/phpunit/Unit/SQLStore/EntityStore/PrefetchCacheTest.php`
- `php -l tests/phpunit/Unit/Query/Result/ItemFetcherTest.php`

PHP lint was not rerun after the latest refactor because `php` is not available in the current shell. PHPUnit was not run locally because this checkout does not have `vendor/` or `vendor/bin/phpunit`.
