### PR TITLE
Make jsconfigvars part of HTML output mechanism in SMW\MediaWiki\Outputs

### DIFF
--- a/docs/releasenotes/README.md
+++ b/docs/releasenotes/README.md
@@ -3,7 +3,7 @@
 Major releases and feature releases are indicated in **bold**.
 
 ### Semantic MediaWiki 7.x
-* [SMW 7.1.1 release notes](RELEASE-NOTES-7.1.1.md)
+* **[SMW 7.2.0 release notes](RELEASE-NOTES-7.2.0.md)**
 * **[SMW 7.1.0 release notes](RELEASE-NOTES-7.1.0.md)**
 * **[SMW 7.0.0 release notes](RELEASE-NOTES-7.0.0.md)**
 

--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -9,6 +9,8 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 ## New features and enhancements
 
+* Added `SMW\MediaWiki\Outputs::requireJsConfigVar()` so extensions can register JavaScript configuration variables through the SMW output mechanism, alongside modules, styles and head items, instead of emitting inline scripts ([#7028](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7028))
+
 ## Bug fixes
 
 ## Upgrading

--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -1,13 +1,15 @@
-# Semantic MediaWiki 7.1.1
+# Semantic MediaWiki 7.2.0
 
 Released on TBD.
 
-This is a [patch release](../RELEASE-POLICY.md). Thus, it contains only bug fixes, no new features, and no breaking changes.
+This is a [minor release](../RELEASE-POLICY.md). Thus, it contains no breaking changes, only new features and fixes.
 
 Like SMW 7.1.0, this version is compatible with MediaWiki 1.43 up to 1.46 and PHP 8.1 up to 8.5.
 For more detailed information, see the [compatibility matrix](../COMPATIBILITY.md#compatibility).
 
-## Changes
+## New features and enhancements
+
+## Bug fixes
 
 ## Upgrading
 
@@ -15,7 +17,7 @@ No need to run "update.php" or any other migration scripts.
 
 **Get the new version via Composer:**
 
-* Step 1: if you are upgrading from SMW older than 7.0.0, ensure the SMW version in `composer.local.json` is `^7.1.1`
+* Step 1: if you are upgrading from SMW older than 7.0.0, ensure the SMW version in `composer.local.json` is `^7.2.0`
 * Step 2: run composer in your MediaWiki directory: `composer update --no-dev --optimize-autoloader`
 
 **Get the new version via Git:**

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticMediaWiki",
-	"version": "7.1.1-alpha",
+	"version": "7.2.0-alpha",
 	"author": [
 		"[https://korrekt.org Markus Krötzsch]",
 		"[https://EntropyWins.wtf/mediawiki Jeroen De Dauw]",

--- a/src/MediaWiki/Outputs.php
+++ b/src/MediaWiki/Outputs.php
@@ -10,7 +10,7 @@ use WeakMap;
 /**
  * This class attempts to provide safe yet simple means for managing data that is relevant
  * for the final HTML output of MediaWiki. In particular, this concerns additions to the HTML
- * header in the form of scripts of stylesheets.
+ * header in the form of scripts or stylesheets.
  *
  * The problem is that many components in SMW create hypertext that should eventually be displayed.
  * The normal way of accessing such text are functions of the form getText() which return a
@@ -59,6 +59,11 @@ class Outputs {
 	protected static array $resourceStyles = [];
 
 	/**
+	 * Protected member for temporarily storing JavaScript Configuration Variables
+	 */
+	protected static array $jsConfigVars = [];
+
+	/**
 	 * Top-level content parses (`Parser::parse()` with output type HTML that
 	 * are not interface-message parses) currently in progress, keyed by the
 	 * `Parser` instance running them. Populated by `onParseStart()` (via the
@@ -93,6 +98,18 @@ class Outputs {
 	 */
 	public static function requireStyle( string $stylesName ): void {
 		self::$resourceStyles[$stylesName] = $stylesName;
+	}
+
+	/**
+	 * Require a JS config var so it will be added via
+	 * ParserOutput::setJsConfigVar or OutputPage::addJsConfigVars
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param string $key Key to use under mw.config
+	 */
+	public static function requireJsConfigVar( string $key, mixed $value ): void {
+		self::$jsConfigVars[$key] = $value;
 	}
 
 	/**
@@ -171,6 +188,7 @@ class Outputs {
 		self::$resourceModules = [];
 		self::$headItems = [];
 		self::$scripts = [];
+		self::$jsConfigVars = [];
 	}
 
 	/**
@@ -223,6 +241,8 @@ class Outputs {
 				self::$resourceModules[$module] = $module;
 			}
 		}
+
+		self::$jsConfigVars = array_merge( self::$jsConfigVars, $parserOutput->getJsConfigVars() ?? [] );
 	}
 
 	/**
@@ -236,7 +256,6 @@ class Outputs {
 	 */
 	public static function commitToParser( Parser $parser ): void {
 		$po = $parser->getOutput();
-
 		self::commitToParserOutput( $po );
 	}
 
@@ -264,11 +283,16 @@ class Outputs {
 		$parserOutput->addModuleStyles( array_values( self::$resourceStyles ) );
 		$parserOutput->addModules( array_values( self::$resourceModules ) );
 
+		foreach ( self::$jsConfigVars as $key => $value ) {
+			$parserOutput->setJsConfigVar( $key, $value );
+		}
+
 		if ( !self::isNestedParse() ) {
 			self::$resourceStyles = [];
 			self::$resourceModules = [];
 			self::$headItems = [];
 			self::$scripts = [];
+			self::$jsConfigVars = [];
 		}
 	}
 
@@ -291,10 +315,13 @@ class Outputs {
 		$output->addModuleStyles( array_values( self::$resourceStyles ) );
 		$output->addModules( array_values( self::$resourceModules ) );
 
+		$output->addJsConfigVars( self::$jsConfigVars );
+
 		self::$resourceStyles = [];
 		self::$resourceModules = [];
 		self::$headItems = [];
 		self::$scripts = [];
+		self::$jsConfigVars = [];
 	}
 
 }


### PR DESCRIPTION
On top of #7029

- Bump to 7.2.0-alpha as this is a feature change
- Add changelog entry
- Type `$value` to `mixed` in `requireJsConfigVar()`