### PR TITLE
Store the --auto-recovery checkpoint in the database

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -14,6 +14,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 ## Bug fixes
 
 * Fixed a query showing incorrect printout values when the same property is requested through different printout contexts, such as a direct and an inverse printout or the same property with different sort options ([#7026](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7026))
+* Fixed maintenance scripts run with `--auto-recovery` (such as `rebuildData` and `rebuildElasticIndex`) aborting with a `FileNotWritableException` on deployments where the extension directory is not writable; the recovery checkpoint is now stored in the database instead of a `.smw.json` file, so it no longer depends on a writable `$smwgConfigFileDir` ([#7030](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7030))
 
 ## Upgrading
 

--- a/src/DatabaseMetaRepo.php
+++ b/src/DatabaseMetaRepo.php
@@ -4,10 +4,13 @@ declare( strict_types = 1 );
 
 namespace SMW;
 
+use InvalidArgumentException;
 use SMW\SQLStore\SQLStore;
 use Throwable;
 use Wikimedia\Rdbms\DBQueryError;
+use Wikimedia\Rdbms\IExpression;
 use Wikimedia\Rdbms\ILoadBalancer;
+use Wikimedia\Rdbms\LikeValue;
 
 /**
  * `SmwJsonRepo` implementation backed by the `smw_meta` table.
@@ -19,12 +22,28 @@ use Wikimedia\Rdbms\ILoadBalancer;
  * (e.g. before `update.php`/`setupStore.php` has run), `loadSmwJson` returns
  * `null` rather than throwing.
  *
+ * Rows whose key starts with {@see self::RESERVED_PREFIX} are treated as
+ * out-of-band: they are neither returned by `loadSmwJson` (they are not
+ * install state) nor removed by `saveSmwJson`'s full-slice sync-delete. They
+ * are read and written one row at a time through {@see self::readValue} /
+ * {@see self::writeValue}. The maintenance-script auto-recovery checkpoint
+ * (#7030) stores one such row per script identifier, so frequent per-entity
+ * writes neither trigger a whole-slice rewrite, clobber install-state keys
+ * through a stale snapshot, nor overwrite a concurrent script's checkpoint.
+ *
  * @license GPL-2.0-or-later
  * @since 7.0.0
  *
  * @private
  */
 class DatabaseMetaRepo implements SmwJsonRepo {
+
+	/**
+	 * Key prefix for rows that live in `smw_meta` but are not part of the
+	 * install-state slice managed by `SetupFile`. Kept in sync with
+	 * {@see \SMW\Maintenance\AutoRecovery::TOPIC_IDENTIFIER}.
+	 */
+	private const RESERVED_PREFIX = 'maintenance_script.auto_recovery';
 
 	/**
 	 * @since 7.0.0
@@ -63,6 +82,11 @@ class DatabaseMetaRepo implements SmwJsonRepo {
 
 		$entries = [];
 		foreach ( $rows as $row ) {
+			// Reserved rows are out-of-band and must not surface as install
+			// state; they are read via `readValue` instead.
+			if ( str_starts_with( (string)$row->meta_key, self::RESERVED_PREFIX ) ) {
+				continue;
+			}
 			$entries[ $row->meta_key ] = $this->decode( $row->meta_value );
 		}
 
@@ -111,9 +135,23 @@ class DatabaseMetaRepo implements SmwJsonRepo {
 				->deleteFrom( SQLStore::META_TABLE )
 				->caller( __METHOD__ );
 
-			if ( $inputKeys === [] ) {
-				$deleteBuilder->where( '1=1' );
-			} else {
+			// Never delete reserved rows: they are managed one row at a time
+			// via readValue/writeValue, not as part of the install-state slice,
+			// so a full or partial slice save must leave them untouched.
+			// `LikeValue` escapes the prefix (including its `_`), so this
+			// matches only the reserved namespace.
+			$deleteBuilder->where(
+				$db->expr(
+					'meta_key',
+					IExpression::NOT_LIKE,
+					new LikeValue( self::RESERVED_PREFIX, $db->anyString() )
+				)
+			);
+
+			// Among the remaining (install-state) rows, delete those the slice
+			// no longer carries. When the slice is empty this clause is omitted
+			// and every non-reserved row is removed.
+			if ( $inputKeys !== [] ) {
 				$deleteBuilder->where( $db->expr( 'meta_key', '!=', $inputKeys ) );
 			}
 
@@ -144,6 +182,86 @@ class DatabaseMetaRepo implements SmwJsonRepo {
 		} catch ( Throwable $e ) {
 			$db->cancelAtomic( __METHOD__ );
 			throw $e;
+		}
+	}
+
+	/**
+	 * Reads a single out-of-band {@see self::RESERVED_PREFIX} row, bypassing
+	 * the install-state slice. Returns `null` when the row (or the table) is
+	 * absent, mirroring `loadSmwJson`'s missing-table semantics.
+	 *
+	 * Reads from the primary (unlike `loadSmwJson`) so a resuming maintenance
+	 * run sees the checkpoint its previous run wrote: the row is written to the
+	 * primary and read exactly once per run, so replication lag must not hide
+	 * it and there is no replica-offload benefit to gain.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @return mixed
+	 */
+	public function readValue( string $key ) {
+		$this->assertReserved( $key );
+
+		$db = $this->loadBalancer->getConnection( DB_PRIMARY );
+
+		try {
+			$value = $db->newSelectQueryBuilder()
+				->select( 'meta_value' )
+				->from( SQLStore::META_TABLE )
+				->where( [ 'meta_key' => $key ] )
+				->caller( __METHOD__ )
+				->fetchField();
+		} catch ( DBQueryError $e ) {
+			if ( !$db->tableExists( SQLStore::META_TABLE, __METHOD__ ) ) {
+				return null;
+			}
+			throw $e;
+		}
+
+		if ( $value === false ) {
+			return null;
+		}
+
+		return $this->decode( $value );
+	}
+
+	/**
+	 * Upserts a single out-of-band {@see self::RESERVED_PREFIX} row. Unlike
+	 * `saveSmwJson` this touches only the one row (no full-slice sync-delete),
+	 * so it cannot remove install-state keys or a concurrent script's row.
+	 * Silently no-ops when the table does not exist yet, mirroring
+	 * `saveSmwJson`.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @param string $key
+	 * @param mixed $value
+	 */
+	public function writeValue( string $key, $value ): void {
+		$this->assertReserved( $key );
+
+		$db = $this->loadBalancer->getConnection( DB_PRIMARY );
+
+		if ( !$db->tableExists( SQLStore::META_TABLE, __METHOD__ ) ) {
+			return;
+		}
+
+		$db->newReplaceQueryBuilder()
+			->replaceInto( SQLStore::META_TABLE )
+			->uniqueIndexFields( [ 'meta_key' ] )
+			->row( [
+				'meta_key' => $key,
+				'meta_value' => $this->encode( $value ),
+			] )
+			->caller( __METHOD__ )
+			->execute();
+	}
+
+	private function assertReserved( string $key ): void {
+		if ( !str_starts_with( $key, self::RESERVED_PREFIX ) ) {
+			throw new InvalidArgumentException(
+				"'$key' is not a reserved meta key; use loadSmwJson/saveSmwJson for install-state keys."
+			);
 		}
 	}
 

--- a/src/Maintenance/AutoRecovery.php
+++ b/src/Maintenance/AutoRecovery.php
@@ -2,11 +2,24 @@
 
 namespace SMW\Maintenance;
 
-use SMW\SetupFile;
-use SMW\Site;
-use SMW\Utils\File;
+use MediaWiki\MediaWikiServices;
+use SMW\DatabaseMetaRepo;
 
 /**
+ * Persists a resumable checkpoint for long-running maintenance scripts (e.g.
+ * `rebuildData`, `rebuildElasticIndex`) run with `--auto-recovery`, so an
+ * aborted run can restart from the last processed entity id.
+ *
+ * Since 7.0.0 the install-state metadata that used to live in the `.smw.json`
+ * file is stored in the `smw_meta` database table. The auto-recovery checkpoint
+ * now lives there too, in its own row per script identifier
+ * (`{@see self::TOPIC_IDENTIFIER}.<identifier>`) that {@see \SMW\DatabaseMetaRepo}
+ * keeps out of the install-state slice. This means `--auto-recovery` no longer
+ * depends on a writable `$smwgConfigFileDir` / `.smw.json` file (#7030); reads
+ * never write, the per-entity checkpoint is a single-row upsert that cannot
+ * touch install-state keys, and because each script owns its own row, running
+ * two rebuild scripts concurrently cannot clobber each other's checkpoint.
+ *
  * @license GPL-2.0-or-later
  * @since 3.1
  *
@@ -14,74 +27,46 @@ use SMW\Utils\File;
  */
 class AutoRecovery {
 
+	/**
+	 * Reserved `smw_meta` key prefix; the checkpoint is stored one row per
+	 * script identifier at `TOPIC_IDENTIFIER . '.' . $identifier`. See
+	 * {@see \SMW\DatabaseMetaRepo}'s reserved-key handling.
+	 */
 	const TOPIC_IDENTIFIER = 'maintenance_script.auto_recovery';
-
-	private string $site;
 
 	private bool $enabled = false;
 
-	/**
-	 * @var int
-	 */
-	private $safeMargin = 0;
+	private int $safeMargin = 0;
 
 	/**
-	 * @var array
+	 * This identifier's checkpoint payload shaped as `[ key => value ]`. Loaded
+	 * once from `smw_meta` on first access and mirrored back on every `set`.
 	 */
-	private $contents;
+	private array $contents = [];
 
-	private string $dir;
+	private bool $loaded = false;
 
 	/**
 	 * @since 3.1
 	 */
 	public function __construct(
-		private $identifier,
-		private ?File $file = null,
+		private readonly string $identifier,
+		private ?DatabaseMetaRepo $repo = null
 	) {
-		$this->site = Site::id();
-
-		if ( $this->file === null ) {
-			$this->file = new File();
-		}
-
-		$this->dir = $GLOBALS['smwgConfigFileDir'];
 	}
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param bool $enabled
 	 */
-	public function enable( $enabled ): void {
-		$this->enabled = (bool)$enabled;
+	public function enable( bool $enabled ): void {
+		$this->enabled = $enabled;
 	}
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param string $dir
 	 */
-	public function setDir( string $dir ): void {
-		$this->dir = $dir;
-	}
-
-	/**
-	 * @since 3.1
-	 *
-	 * @param int $safeMargin
-	 */
-	public function safeMargin( $safeMargin ): void {
+	public function safeMargin( int $safeMargin ): void {
 		$this->safeMargin = $safeMargin;
-	}
-
-	/**
-	 * @since 3.1
-	 *
-	 * @return string
-	 */
-	public function getFile(): string {
-		return $this->dir . "/" . SetupFile::FILE_NAME;
 	}
 
 	/**
@@ -90,21 +75,16 @@ class AutoRecovery {
 	 * @param string $key
 	 * @param mixed $value
 	 */
-	public function set( $key, $value ): bool {
+	public function set( string $key, $value ): bool {
 		if ( !$this->enabled ) {
 			return false;
 		}
 
-		if ( $this->contents === null ) {
-			$this->initContents( $key );
-		}
+		$this->initContents( $key );
 
-		$this->contents[$this->site][self::TOPIC_IDENTIFIER][$this->identifier][$key] = $value;
+		$this->contents[$key] = $value;
 
-		$this->file->write(
-			$this->getFile(),
-			json_encode( $this->contents, JSON_PRETTY_PRINT )
-		);
+		$this->getRepo()->writeValue( $this->metaKey(), $this->contents );
 
 		return true;
 	}
@@ -112,20 +92,16 @@ class AutoRecovery {
 	/**
 	 * @since 3.1
 	 *
-	 * @param string $key
-	 *
 	 * @return mixed
 	 */
-	public function get( $key ) {
+	public function get( string $key ) {
 		if ( !$this->enabled ) {
 			return false;
 		}
 
-		if ( $this->contents === null ) {
-			$this->initContents( $key );
-		}
+		$this->initContents( $key );
 
-		$value = $this->contents[$this->site][self::TOPIC_IDENTIFIER][$this->identifier][$key];
+		$value = $this->contents[$key];
 
 		if ( is_int( $value ) ) {
 			return max( 0, $value - $this->safeMargin );
@@ -136,44 +112,41 @@ class AutoRecovery {
 
 	/**
 	 * @since 3.1
-	 *
-	 * @param string $key
-	 *
-	 * @return bool
 	 */
-	public function has( $key ): bool {
+	public function has( string $key ): bool {
 		if ( !$this->enabled ) {
 			return false;
 		}
 
-		if ( $this->contents === null ) {
-			$this->initContents( $key );
-		}
+		$this->initContents( $key );
 
-		if ( !isset( $this->contents[$this->site][self::TOPIC_IDENTIFIER][$this->identifier][$key] ) ) {
-			return false;
-		}
-
-		// @phan-suppress-next-line PhanTypeArraySuspiciousNullable
-		return $this->contents[$this->site][self::TOPIC_IDENTIFIER][$this->identifier][$key] !== false;
+		return $this->contents[$key] !== false;
 	}
 
-	private function initContents( $key ): void {
-		$file = $this->getFile();
-
-		$this->contents = [
-			$this->site => [ self::TOPIC_IDENTIFIER => [ $this->identifier => [ $key => false ] ] ]
-		];
-
-		if ( !$this->file->exists( $file ) ) {
-			$this->file->write( $file, json_encode( $this->contents, JSON_PRETTY_PRINT ) );
-		} else {
-			$this->contents = json_decode( $this->file->read( $file ), true );
+	private function initContents( string $key ): void {
+		if ( !$this->loaded ) {
+			$stored = $this->getRepo()->readValue( $this->metaKey() );
+			$this->contents = is_array( $stored ) ? $stored : [];
+			$this->loaded = true;
 		}
 
-		if ( !isset( $this->contents[$this->site][self::TOPIC_IDENTIFIER][$this->identifier][$key] ) ) {
-			$this->contents[$this->site][self::TOPIC_IDENTIFIER][$this->identifier][$key] = false;
+		if ( !isset( $this->contents[$key] ) ) {
+			$this->contents[$key] = false;
 		}
+	}
+
+	private function metaKey(): string {
+		return self::TOPIC_IDENTIFIER . '.' . $this->identifier;
+	}
+
+	private function getRepo(): DatabaseMetaRepo {
+		if ( $this->repo === null ) {
+			$this->repo = new DatabaseMetaRepo(
+				MediaWikiServices::getInstance()->getDBLoadBalancer()
+			);
+		}
+
+		return $this->repo;
 	}
 
 }

--- a/tests/phpunit/Integration/Maintenance/AutoRecoveryDatabaseIntegrationTest.php
+++ b/tests/phpunit/Integration/Maintenance/AutoRecoveryDatabaseIntegrationTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare( strict_types = 1 );
+
+namespace SMW\Tests\Integration\Maintenance;
+
+use SMW\Maintenance\AutoRecovery;
+use SMW\SetupFile;
+use SMW\SQLStore\SQLStore;
+use SMW\Tests\SMWIntegrationTestCase;
+use Wikimedia\Rdbms\IExpression;
+use Wikimedia\Rdbms\LikeValue;
+
+/**
+ * Exercises {@see \SMW\Maintenance\AutoRecovery} end-to-end against the real
+ * `smw_meta` table, verifying the #7030 fix: the `--auto-recovery` checkpoint
+ * persists in the database (no `.smw.json` / writable `$smwgConfigFileDir`
+ * dependency), the read path never writes, the checkpoint survives an
+ * install-state (`SetupFile`) write, never leaks into the install-state slice,
+ * and is isolated per script so concurrent runs cannot clobber each other.
+ *
+ * @covers \SMW\Maintenance\AutoRecovery
+ * @covers \SMW\DatabaseMetaRepo
+ * @group semantic-mediawiki
+ * @group Database
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.2.0
+ */
+class AutoRecoveryDatabaseIntegrationTest extends SMWIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->deleteCheckpointRows();
+	}
+
+	protected function tearDown(): void {
+		$this->deleteCheckpointRows();
+		parent::tearDown();
+	}
+
+	public function testCheckpointRoundTripsThroughDatabase(): void {
+		$writer = new AutoRecovery( 'rebuildData.php' );
+		$writer->enable( true );
+		$writer->set( 'ar_id', 1234 );
+
+		// A fresh instance must read the checkpoint back from `smw_meta`,
+		// with no dependency on a writable extension directory.
+		$reader = new AutoRecovery( 'rebuildData.php' );
+		$reader->enable( true );
+
+		$this->assertTrue( $reader->has( 'ar_id' ) );
+		$this->assertSame( 1234, $reader->get( 'ar_id' ) );
+	}
+
+	public function testDistinctIdentifiersDoNotCollide(): void {
+		$data = new AutoRecovery( 'rebuildData.php' );
+		$data->enable( true );
+		$data->set( 'ar_id', 11 );
+
+		$elastic = new AutoRecovery( 'rebuildElasticIndex.php' );
+		$elastic->enable( true );
+		$elastic->set( 'ar_id', 22 );
+
+		$dataReader = new AutoRecovery( 'rebuildData.php' );
+		$dataReader->enable( true );
+
+		$this->assertSame( 11, $dataReader->get( 'ar_id' ) );
+	}
+
+	public function testConcurrentWritersPreserveEachOthersCheckpoint(): void {
+		// Simulate two maintenance scripts that both loaded their (absent)
+		// checkpoint before either wrote. With a single shared row the later
+		// write, built from a stale snapshot, would clobber the first script's
+		// checkpoint. Per-identifier rows keep them isolated.
+		$data = new AutoRecovery( 'rebuildData.php' );
+		$data->enable( true );
+		$elastic = new AutoRecovery( 'rebuildElasticIndex.php' );
+		$elastic->enable( true );
+
+		// Both load their (empty) state first.
+		$this->assertFalse( $data->has( 'ar_id' ) );
+		$this->assertFalse( $elastic->has( 'ar_id' ) );
+
+		// Then both persist.
+		$data->set( 'ar_id', 100 );
+		$elastic->set( 'ar_id', 5 );
+
+		// Both checkpoints must survive.
+		$dataReader = new AutoRecovery( 'rebuildData.php' );
+		$dataReader->enable( true );
+		$elasticReader = new AutoRecovery( 'rebuildElasticIndex.php' );
+		$elasticReader->enable( true );
+
+		$this->assertSame( 100, $dataReader->get( 'ar_id' ) );
+		$this->assertSame( 5, $elasticReader->get( 'ar_id' ) );
+	}
+
+	public function testReadPathDoesNotCreateRow(): void {
+		$reader = new AutoRecovery( 'rebuildData.php' );
+		$reader->enable( true );
+
+		// The pre-run abort check calls has(); the #7030 crash was a write
+		// triggered from this read path. It must not create a row.
+		$this->assertFalse( $reader->has( 'ar_id' ) );
+
+		$this->assertFalse(
+			$this->getDb()->newSelectQueryBuilder()
+				->select( 'meta_value' )
+				->from( SQLStore::META_TABLE )
+				->where( [ 'meta_key' => AutoRecovery::TOPIC_IDENTIFIER . '.rebuildData.php' ] )
+				->caller( __METHOD__ )
+				->fetchField(),
+			'has() must not create the auto-recovery row'
+		);
+	}
+
+	public function testCheckpointDecoupledFromInstallStateSlice(): void {
+		$writer = new AutoRecovery( 'rebuildData.php' );
+		$writer->enable( true );
+		$writer->set( 'ar_id', 1234 );
+
+		// A full-slice SetupFile write must neither delete the checkpoint row
+		// (its sync-delete exempts reserved rows) nor surface it as install
+		// state.
+		$vars = [ 'smwgConfigFileDir' => sys_get_temp_dir() ];
+		$setupFile = new SetupFile();
+		$setupFile->loadSchema( $vars );
+		$setupFile->set( [ SetupFile::LATEST_VERSION => '7.2.0' ], $vars );
+
+		$reader = new AutoRecovery( 'rebuildData.php' );
+		$reader->enable( true );
+		$this->assertSame(
+			1234,
+			$reader->get( 'ar_id' ),
+			'checkpoint must survive an install-state write'
+		);
+
+		$readerVars = [ 'smwgConfigFileDir' => sys_get_temp_dir() ];
+		$freshSetupFile = new SetupFile();
+		$freshSetupFile->loadSchema( $readerVars );
+		$this->assertNull(
+			$freshSetupFile->get( AutoRecovery::TOPIC_IDENTIFIER . '.rebuildData.php', $readerVars ),
+			'auto-recovery row must not appear in the install-state slice'
+		);
+	}
+
+	private function deleteCheckpointRows(): void {
+		$db = $this->getDb();
+		$db->newDeleteQueryBuilder()
+			->deleteFrom( SQLStore::META_TABLE )
+			->where(
+				$db->expr(
+					'meta_key',
+					IExpression::LIKE,
+					new LikeValue( AutoRecovery::TOPIC_IDENTIFIER, $db->anyString() )
+				)
+			)
+			->caller( __METHOD__ )
+			->execute();
+	}
+
+}

--- a/tests/phpunit/Unit/DatabaseMetaRepoTest.php
+++ b/tests/phpunit/Unit/DatabaseMetaRepoTest.php
@@ -4,8 +4,10 @@ declare( strict_types = 1 );
 
 namespace SMW\Tests\Unit;
 
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use SMW\DatabaseMetaRepo;
+use SMW\Maintenance\AutoRecovery;
 use SMW\Site;
 use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use Wikimedia\Rdbms\DBQueryError;
@@ -15,6 +17,7 @@ use Wikimedia\Rdbms\IDatabase;
 use Wikimedia\Rdbms\IExpression;
 use Wikimedia\Rdbms\ILoadBalancer;
 use Wikimedia\Rdbms\IMaintainableDatabase;
+use Wikimedia\Rdbms\LikeMatch;
 use Wikimedia\Rdbms\SelectQueryBuilder;
 
 /**
@@ -27,6 +30,12 @@ use Wikimedia\Rdbms\SelectQueryBuilder;
 class DatabaseMetaRepoTest extends TestCase {
 
 	use MockWriteQueryBuilderTrait;
+
+	/**
+	 * A per-identifier reserved row key (the auto-recovery checkpoint stores
+	 * one row per maintenance script).
+	 */
+	private const RESERVED_ROW = AutoRecovery::TOPIC_IDENTIFIER . '.rebuildData.php';
 
 	public function testLoadSmwJsonReturnsNullWhenTableMissing(): void {
 		// IMaintainableDatabase is needed for the tableExists() fallback;
@@ -89,15 +98,11 @@ class DatabaseMetaRepoTest extends TestCase {
 			$capturedDeleteWheres
 		);
 
-		$db = $this->createMock( IMaintainableDatabase::class );
-		$db->method( 'tableExists' )->willReturn( true );
-		$db->method( 'expr' )->willReturnCallback(
-			static fn ( string $field, string $op, $value ): Expression => new Expression( $field, $op, $value )
-		);
+		$db = $this->makeExprDatabase();
 		$db->expects( $this->exactly( 2 ) )
 			->method( 'newReplaceQueryBuilder' )
 			->willReturn( $replaceBuilder );
-		// One sync-delete (keys NOT IN input); no per-key null deletes.
+		// One sync-delete builder; no per-key null deletes.
 		$db->expects( $this->once() )
 			->method( 'newDeleteQueryBuilder' )
 			->willReturn( $deleteBuilder );
@@ -121,10 +126,12 @@ class DatabaseMetaRepoTest extends TestCase {
 		);
 		$this->assertSame( [ [ 'meta_key' ], [ 'meta_key' ] ], $capturedReplaceUniqueIndexFields );
 
-		// Sync delete targets `smw_meta` with a NOT-IN-the-input-keys expression.
+		// The sync-delete targets `smw_meta` with two AND'd conditions: a
+		// NOT-LIKE that exempts reserved rows and a NOT-IN-the-input-keys clause.
 		$this->assertSame( [ 'smw_meta' ], $capturedDeleteTables );
-		$this->assertCount( 1, $capturedDeleteWheres );
+		$this->assertCount( 2, $capturedDeleteWheres );
 		$this->assertInstanceOf( IExpression::class, $capturedDeleteWheres[0] );
+		$this->assertInstanceOf( IExpression::class, $capturedDeleteWheres[1] );
 	}
 
 	public function testSaveSmwJsonDeletesNullValues(): void {
@@ -135,13 +142,8 @@ class DatabaseMetaRepoTest extends TestCase {
 			$capturedWheres
 		);
 
-		$db = $this->createMock( IMaintainableDatabase::class );
-		$db->method( 'tableExists' )->willReturn( true );
-		$db->method( 'expr' )->willReturnCallback(
-			static fn ( string $field, string $op, $value ): Expression => new Expression( $field, $op, $value )
-		);
-		// Two delete calls: one sync-delete (keys NOT IN input), one per-key
-		// delete for the null value.
+		$db = $this->makeExprDatabase();
+		// Two delete builders: one sync-delete, one per-key delete for the null.
 		$db->expects( $this->exactly( 2 ) )
 			->method( 'newDeleteQueryBuilder' )
 			->willReturn( $deleteBuilder );
@@ -157,11 +159,12 @@ class DatabaseMetaRepoTest extends TestCase {
 		] );
 
 		$this->assertSame( [ 'smw_meta', 'smw_meta' ], $capturedTables );
-		$this->assertCount( 2, $capturedWheres );
-		// First where = sync-delete NOT-IN expression.
+		// Sync-delete contributes two expressions (NOT LIKE + NOT IN); the
+		// per-key null delete contributes the meta_key match.
+		$this->assertCount( 3, $capturedWheres );
 		$this->assertInstanceOf( IExpression::class, $capturedWheres[0] );
-		// Second where = per-key delete by meta_key.
-		$this->assertSame( [ 'meta_key' => 'maintenance_mode' ], $capturedWheres[1] );
+		$this->assertInstanceOf( IExpression::class, $capturedWheres[1] );
+		$this->assertSame( [ 'meta_key' => 'maintenance_mode' ], $capturedWheres[2] );
 	}
 
 	public function testSaveSmwJsonNoopsWhenTableMissing(): void {
@@ -198,12 +201,216 @@ class DatabaseMetaRepoTest extends TestCase {
 		$repo->loadSmwJson( '/tmp' );
 	}
 
+	public function testLoadSmwJsonExcludesReservedRows(): void {
+		$db = $this->createMock( IDatabase::class );
+		$sqb = $this->createSelectBuilderMock( $db );
+		$sqb->method( 'fetchResultSet' )->willReturn(
+			new FakeResultWrapper( [
+				(object)[ 'meta_key' => 'upgrade_key', 'meta_value' => '"abc123"' ],
+				(object)[ 'meta_key' => self::RESERVED_ROW, 'meta_value' => '{"ar_id":42}' ],
+			] )
+		);
+		$db->method( 'newSelectQueryBuilder' )->willReturn( $sqb );
+
+		$repo = new DatabaseMetaRepo( $this->makeLoadBalancer( $db ) );
+
+		// The reserved auto-recovery row is out-of-band; it must not surface
+		// as part of the install-state slice.
+		$this->assertSame(
+			[ Site::id() => [ 'upgrade_key' => 'abc123' ] ],
+			$repo->loadSmwJson( '/tmp' )
+		);
+	}
+
+	public function testLoadSmwJsonReturnsNullWhenOnlyReservedRowsPresent(): void {
+		$db = $this->createMock( IDatabase::class );
+		$sqb = $this->createSelectBuilderMock( $db );
+		$sqb->method( 'fetchResultSet' )->willReturn(
+			new FakeResultWrapper( [
+				(object)[ 'meta_key' => self::RESERVED_ROW, 'meta_value' => '{"ar_id":1}' ],
+			] )
+		);
+		$db->method( 'newSelectQueryBuilder' )->willReturn( $sqb );
+
+		$repo = new DatabaseMetaRepo( $this->makeLoadBalancer( $db ) );
+
+		// Only reserved rows means no install state, indistinguishable from
+		// an empty table.
+		$this->assertNull( $repo->loadSmwJson( '/tmp' ) );
+	}
+
+	public function testSaveSmwJsonExemptsReservedPrefixFromSyncDelete(): void {
+		$capturedOps = [];
+
+		$db = $this->makeExprDatabase( $capturedOps );
+		$db->method( 'newReplaceQueryBuilder' )->willReturn( $this->createMockReplaceQueryBuilder() );
+		$db->method( 'newDeleteQueryBuilder' )->willReturn( $this->createMockDeleteQueryBuilder() );
+
+		$repo = new DatabaseMetaRepo( $this->makeLoadBalancer( $db ) );
+
+		$repo->saveSmwJson( '/tmp', [
+			Site::id() => [ 'upgrade_key' => 'abc123' ],
+		] );
+
+		// The sync-delete must protect reserved rows with a NOT LIKE on
+		// meta_key, alongside the NOT-IN clause for the install-state keys.
+		$notLike = array_filter(
+			$capturedOps,
+			static fn ( array $e ): bool => $e['field'] === 'meta_key' && $e['op'] === IExpression::NOT_LIKE
+		);
+		$this->assertCount( 1, $notLike, 'sync-delete must exempt reserved rows via NOT LIKE' );
+
+		$notIn = array_filter(
+			$capturedOps,
+			static fn ( array $e ): bool => $e['field'] === 'meta_key' && $e['op'] === '!='
+		);
+		$this->assertCount( 1, $notIn, 'sync-delete must still remove obsolete install-state keys' );
+	}
+
+	public function testSaveSmwJsonEmptySliceStillExemptsReservedPrefix(): void {
+		$capturedOps = [];
+
+		$db = $this->makeExprDatabase( $capturedOps );
+		$db->expects( $this->never() )->method( 'newReplaceQueryBuilder' );
+		$db->method( 'newDeleteQueryBuilder' )->willReturn( $this->createMockDeleteQueryBuilder() );
+
+		$repo = new DatabaseMetaRepo( $this->makeLoadBalancer( $db ) );
+
+		// A reset (empty slice) must clear install-state rows but still leave
+		// reserved rows untouched: only the NOT LIKE clause, no NOT IN.
+		$repo->saveSmwJson( '/tmp', [ Site::id() => [] ] );
+
+		$ops = array_column( $capturedOps, 'op' );
+		$this->assertContains( IExpression::NOT_LIKE, $ops );
+		$this->assertNotContains( '!=', $ops );
+	}
+
+	public function testReadValueReturnsDecodedValue(): void {
+		$db = $this->createMock( IDatabase::class );
+		$sqb = $this->createSelectBuilderMock( $db );
+		$sqb->method( 'fetchField' )->willReturn( '{"ar_id":42}' );
+		$db->method( 'newSelectQueryBuilder' )->willReturn( $sqb );
+
+		$repo = new DatabaseMetaRepo( $this->makeLoadBalancer( $db ) );
+
+		$this->assertSame(
+			[ 'ar_id' => 42 ],
+			$repo->readValue( self::RESERVED_ROW )
+		);
+	}
+
+	public function testReadValueReturnsNullWhenRowMissing(): void {
+		$db = $this->createMock( IDatabase::class );
+		$sqb = $this->createSelectBuilderMock( $db );
+		$sqb->method( 'fetchField' )->willReturn( false );
+		$db->method( 'newSelectQueryBuilder' )->willReturn( $sqb );
+
+		$repo = new DatabaseMetaRepo( $this->makeLoadBalancer( $db ) );
+
+		$this->assertNull( $repo->readValue( self::RESERVED_ROW ) );
+	}
+
+	public function testReadValueReturnsNullWhenTableMissing(): void {
+		$db = $this->createMock( IMaintainableDatabase::class );
+		$sqb = $this->createSelectBuilderMock( $db );
+		$sqb->method( 'fetchField' )->willThrowException(
+			new DBQueryError( $db, "Table 'wiki.smw_meta' doesn't exist", 1146, '', '' )
+		);
+		$db->method( 'newSelectQueryBuilder' )->willReturn( $sqb );
+		$db->method( 'tableExists' )->willReturn( false );
+
+		$repo = new DatabaseMetaRepo( $this->makeLoadBalancer( $db ) );
+
+		$this->assertNull( $repo->readValue( self::RESERVED_ROW ) );
+	}
+
+	public function testReadValueRejectsNonReservedKey(): void {
+		$repo = new DatabaseMetaRepo(
+			$this->makeLoadBalancer( $this->createMock( IDatabase::class ) )
+		);
+
+		$this->expectException( InvalidArgumentException::class );
+		$repo->readValue( 'upgrade_key' );
+	}
+
+	public function testWriteValueUpsertsSingleRowWithoutSyncDelete(): void {
+		$capturedTables = [];
+		$capturedRows = [];
+		$capturedUnique = [];
+		$replaceBuilder = $this->createMockReplaceQueryBuilder(
+			$capturedTables,
+			$capturedRows,
+			$capturedUnique
+		);
+
+		$db = $this->createMock( IMaintainableDatabase::class );
+		$db->method( 'tableExists' )->willReturn( true );
+		$db->expects( $this->once() )
+			->method( 'newReplaceQueryBuilder' )
+			->willReturn( $replaceBuilder );
+		// A single-row write must never issue a full-slice sync-delete.
+		$db->expects( $this->never() )->method( 'newDeleteQueryBuilder' );
+
+		$repo = new DatabaseMetaRepo( $this->makeLoadBalancer( $db ) );
+
+		$repo->writeValue( self::RESERVED_ROW, [ 'ar_id' => 42 ] );
+
+		$this->assertSame( [ 'smw_meta' ], $capturedTables );
+		$this->assertSame(
+			[ [
+				'meta_key' => self::RESERVED_ROW,
+				'meta_value' => '{"ar_id":42}',
+			] ],
+			$capturedRows
+		);
+		$this->assertSame( [ [ 'meta_key' ] ], $capturedUnique );
+	}
+
+	public function testWriteValueNoopsWhenTableMissing(): void {
+		$db = $this->createMock( IMaintainableDatabase::class );
+		$db->method( 'tableExists' )->willReturn( false );
+		$db->expects( $this->never() )->method( 'newReplaceQueryBuilder' );
+
+		$repo = new DatabaseMetaRepo( $this->makeLoadBalancer( $db ) );
+
+		$repo->writeValue( self::RESERVED_ROW, [ 'ar_id' => 1 ] );
+	}
+
+	public function testWriteValueRejectsNonReservedKey(): void {
+		$repo = new DatabaseMetaRepo(
+			$this->makeLoadBalancer( $this->createMock( IMaintainableDatabase::class ) )
+		);
+
+		$this->expectException( InvalidArgumentException::class );
+		$repo->writeValue( 'upgrade_key', 'x' );
+	}
+
+	/**
+	 * A table mock with `tableExists()` true and a real-`Expression`-producing
+	 * `expr()`/`anyString()` so `saveSmwJson`'s NOT-LIKE/NOT-IN clauses build.
+	 * When `$capturedOps` is supplied, each `expr()` call records its
+	 * `[ field, op ]` for assertions.
+	 */
+	private function makeExprDatabase( array &$capturedOps = [] ): IMaintainableDatabase {
+		$db = $this->createMock( IMaintainableDatabase::class );
+		$db->method( 'tableExists' )->willReturn( true );
+		$db->method( 'anyString' )->willReturn( $this->createMock( LikeMatch::class ) );
+		$db->method( 'expr' )->willReturnCallback(
+			static function ( string $field, string $op, $value ) use ( &$capturedOps ): Expression {
+				$capturedOps[] = [ 'field' => $field, 'op' => $op ];
+				return new Expression( $field, $op, $value );
+			}
+		);
+		return $db;
+	}
+
 	private function createSelectBuilderMock( IDatabase $db ): SelectQueryBuilder {
 		$sqb = $this->getMockBuilder( SelectQueryBuilder::class )
 			->disableOriginalConstructor()
 			->getMock();
 		$sqb->method( 'select' )->willReturnSelf();
 		$sqb->method( 'from' )->willReturnSelf();
+		$sqb->method( 'where' )->willReturnSelf();
 		$sqb->method( 'caller' )->willReturnSelf();
 		return $sqb;
 	}

--- a/tests/phpunit/Unit/Maintenance/AutoRecoveryTest.php
+++ b/tests/phpunit/Unit/Maintenance/AutoRecoveryTest.php
@@ -3,10 +3,8 @@
 namespace SMW\Tests\Unit\Maintenance;
 
 use PHPUnit\Framework\TestCase;
+use SMW\DatabaseMetaRepo;
 use SMW\Maintenance\AutoRecovery;
-use SMW\Site;
-use SMW\Tests\TestEnvironment;
-use SMW\Utils\File;
 
 /**
  * @covers \SMW\Maintenance\AutoRecovery
@@ -19,47 +17,38 @@ use SMW\Utils\File;
  */
 class AutoRecoveryTest extends TestCase {
 
-	private $testEnvironment;
-	private $file;
-	private $site;
+	/**
+	 * Per-identifier `smw_meta` row key for the 'foo' identifier used below.
+	 */
+	private const META_KEY = AutoRecovery::TOPIC_IDENTIFIER . '.foo';
+
+	private $repo;
 
 	protected function setUp(): void {
-		$this->testEnvironment = new TestEnvironment();
-		$this->site = Site::id();
+		parent::setUp();
 
-		$this->file = $this->getMockBuilder( File::class )
-			->disableOriginalConstructor()
-			->getMock();
-	}
-
-	protected function tearDown(): void {
-		$this->testEnvironment->tearDown();
-		parent::tearDown();
+		$this->repo = $this->createMock( DatabaseMetaRepo::class );
 	}
 
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			AutoRecovery::class,
-			new AutoRecovery( 'Foo' )
+			new AutoRecovery( 'Foo', $this->repo )
 		);
 	}
 
-	public function testCheckForID() {
-		$contents = [
-			$this->site => [ 'maintenance_script.auto_recovery' => [ 'foo' => [ 'ar_id' => false ] ] ]
-		];
+	public function testHasReadsWithoutWriting() {
+		// #7030 regression guard: the read path (has) must never persist.
+		// Previously `has()` created a `.smw.json` file and threw on a
+		// non-writable `$smwgConfigFileDir`.
+		$this->repo->method( 'readValue' )
+			->with( self::META_KEY )
+			->willReturn( null );
 
-		$this->file->expects( $this->atLeastOnce() )
-			->method( 'write' )
-			->with(
-				$this->anything(),
-				json_encode( $contents, JSON_PRETTY_PRINT ) );
+		$this->repo->expects( $this->never() )
+			->method( 'writeValue' );
 
-		$this->file->expects( $this->atLeastOnce() )
-			->method( 'exists' )
-			->willReturn( false );
-
-		$instance = new AutoRecovery( 'foo', $this->file );
+		$instance = new AutoRecovery( 'foo', $this->repo );
 		$instance->enable( true );
 
 		$this->assertFalse(
@@ -68,29 +57,15 @@ class AutoRecoveryTest extends TestCase {
 	}
 
 	public function testGetSet() {
-		$init = [
-			$this->site => [ 'maintenance_script.auto_recovery' => [ 'foo' => [ 'ar_id' => false ] ] ]
-		];
+		$this->repo->method( 'readValue' )
+			->with( self::META_KEY )
+			->willReturn( [ 'ar_id' => false ] );
 
-		$this->file->expects( $this->atLeastOnce() )
-			->method( 'read' )
-			->willReturn( json_encode( $init ) );
+		$this->repo->expects( $this->once() )
+			->method( 'writeValue' )
+			->with( self::META_KEY, [ 'ar_id' => 1001 ] );
 
-		$contents = [
-			$this->site => [ 'maintenance_script.auto_recovery' => [ 'foo' => [ 'ar_id' => 1001 ] ] ]
-		];
-
-		$this->file->expects( $this->atLeastOnce() )
-			->method( 'write' )
-			->with(
-				$this->anything(),
-				json_encode( $contents, JSON_PRETTY_PRINT ) );
-
-		$this->file->expects( $this->atLeastOnce() )
-			->method( 'exists' )
-			->willReturn( true );
-
-		$instance = new AutoRecovery( 'foo', $this->file );
+		$instance = new AutoRecovery( 'foo', $this->repo );
 		$instance->enable( true );
 		$instance->safeMargin( 101 );
 
@@ -108,29 +83,15 @@ class AutoRecoveryTest extends TestCase {
 	}
 
 	public function testSetClosed() {
-		$init = [
-			$this->site => [ 'maintenance_script.auto_recovery' => [ 'foo' => [ 'ar_id' => 42 ] ] ]
-		];
+		$this->repo->method( 'readValue' )
+			->with( self::META_KEY )
+			->willReturn( [ 'ar_id' => 42 ] );
 
-		$this->file->expects( $this->atLeastOnce() )
-			->method( 'read' )
-			->willReturn( json_encode( $init ) );
+		$this->repo->expects( $this->once() )
+			->method( 'writeValue' )
+			->with( self::META_KEY, [ 'ar_id' => false ] );
 
-		$contents = [
-			$this->site => [ 'maintenance_script.auto_recovery' => [ 'foo' => [ 'ar_id' => false ] ] ]
-		];
-
-		$this->file->expects( $this->atLeastOnce() )
-			->method( 'write' )
-			->with(
-				$this->anything(),
-				json_encode( $contents, JSON_PRETTY_PRINT ) );
-
-		$this->file->expects( $this->atLeastOnce() )
-			->method( 'exists' )
-			->willReturn( true );
-
-		$instance = new AutoRecovery( 'foo', $this->file );
+		$instance = new AutoRecovery( 'foo', $this->repo );
 		$instance->enable( true );
 
 		$this->assertEquals(
@@ -141,24 +102,16 @@ class AutoRecoveryTest extends TestCase {
 		$instance->set( 'ar_id', false );
 
 		$this->assertFalse(
-						$instance->get( 'ar_id' )
+			$instance->get( 'ar_id' )
 		);
 	}
 
 	public function testGetSafeMargin() {
-		$init = [
-			$this->site => [ 'maintenance_script.auto_recovery' => [ 'foo' => [ 'ar_id' => 42 ] ] ]
-		];
+		$this->repo->method( 'readValue' )
+			->with( self::META_KEY )
+			->willReturn( [ 'ar_id' => 42 ] );
 
-		$this->file->expects( $this->atLeastOnce() )
-			->method( 'read' )
-			->willReturn( json_encode( $init, JSON_PRETTY_PRINT ) );
-
-		$this->file->expects( $this->atLeastOnce() )
-			->method( 'exists' )
-			->willReturn( true );
-
-		$instance = new AutoRecovery( 'foo', $this->file );
+		$instance = new AutoRecovery( 'foo', $this->repo );
 		$instance->enable( true );
 		$instance->safeMargin( 9999 );
 
@@ -166,6 +119,18 @@ class AutoRecoveryTest extends TestCase {
 			0,
 			$instance->get( 'ar_id' )
 		);
+	}
+
+	public function testDisabledShortCircuitsWithoutTouchingStore() {
+		$this->repo->expects( $this->never() )->method( 'readValue' );
+		$this->repo->expects( $this->never() )->method( 'writeValue' );
+
+		$instance = new AutoRecovery( 'foo', $this->repo );
+		// Not enabled.
+
+		$this->assertFalse( $instance->has( 'ar_id' ) );
+		$this->assertFalse( $instance->get( 'ar_id' ) );
+		$this->assertFalse( $instance->set( 'ar_id', 1001 ) );
 	}
 
 }


### PR DESCRIPTION
## Problem

In 7.0.0 (#6892) the install-state metadata that used to live in the `.smw.json` file moved into the `smw_meta` database table, and `$smwgConfigFileDir` was deprecated. That migration did not cover the `--auto-recovery` code path: `AutoRecovery` still wrote a `.smw.json` file to `$smwgConfigFileDir`.

On a deployment where that directory is not writable by the maintenance user (containerized or read-only image, root-owned extension files), any rebuild script run with `--auto-recovery` aborted with `FileNotWritableException` before doing any work. The failure happened during the pre-run abort check, because `AutoRecovery::has()` (a read) created the file as a side effect.

## Fix

`AutoRecovery` now stores its checkpoint in the `smw_meta` table instead of a file, so it no longer depends on a writable `$smwgConfigFileDir`, and the read path (`has`/`get`) never writes.

Because `smw_meta` is otherwise owned by `SetupFile`, which persists install state with a full-slice sync (every write deletes any key not present in its in-memory snapshot), the checkpoint is kept deliberately separate from that slice:

- `DatabaseMetaRepo` treats the auto-recovery key as a reserved, out-of-band key: it is excluded from the install-state slice returned by `loadSmwJson`, and exempted from `saveSmwJson`'s sync-delete, so an ordinary install-state write never removes it.
- The checkpoint is read and written one row at a time through dedicated single-row `readValue`/`writeValue` methods. The per-entity checkpoint write is therefore a single-row upsert that cannot rewrite the whole slice and cannot clobber install-state keys (`upgrade_key`, `maintenance_mode`, ...) through a stale snapshot. The read comes from the primary so a resuming run always sees the checkpoint its previous run wrote.

No schema change and no `update.php` run are required; the `smw_meta` table already exists since 7.0.0.

## Testing

- Unit coverage for the reserved-key exclusion and exemption, the single-row read/write path, and the rewritten `AutoRecovery` (including a guard that the read path never writes).
- A database integration test covering the checkpoint round-tripping through `smw_meta`, distinct maintenance scripts not colliding, the read path not creating a row, and the checkpoint surviving an install-state write without leaking into the install-state slice.
- Verified live: `rebuildData --auto-recovery` on a non-writable extension directory now completes without error, stores its checkpoint in `smw_meta`, creates no `.smw.json`, and leaves the install-state rows intact.
