### PR TITLE
Skip the OutputPageParserOutput hook for text-less parser output

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -15,6 +15,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 * Fixed a query showing incorrect printout values when the same property is requested through different printout contexts, such as a direct and an inverse printout or the same property with different sort options ([#7026](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7026))
 * Fixed maintenance scripts run with `--auto-recovery` (such as `rebuildData` and `rebuildElasticIndex`) aborting with a `FileNotWritableException` on deployments where the extension directory is not writable; the recovery checkpoint is now stored in the database instead of a `.smw.json` file, so it no longer depends on a writable `$smwgConfigFileDir` ([#7030](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7030))
+* Fixed viewing an old revision failing with a "This ParserOutput contains no text!" error on wikis running an extension that adds parser output metadata to the page, such as PageNotice ([#7033](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7033))
 
 ## Upgrading
 

--- a/src/MediaWiki/Hooks/OutputPageParserOutput.php
+++ b/src/MediaWiki/Hooks/OutputPageParserOutput.php
@@ -67,6 +67,20 @@ class OutputPageParserOutput implements OutputPageParserOutputHook {
 			return;
 		}
 
+		// #7033
+		//
+		// `OutputPage::addParserOutputMetadata` runs this hook and is free to pass a
+		// metadata-only `ParserOutput`, an object that holds no rendered text and
+		// therefore nothing to derive a Factbox from. Reading its text raises a
+		// `LogicException`.
+		//
+		// The page's own `ParserOutput` is unaffected, `addParserOutput` reads its
+		// text before running this hook, so it always carries text by the time the
+		// handler is reached.
+		if ( !$parserOutput->hasText() ) {
+			return;
+		}
+
 		$context = $outputPage->getContext();
 		$request = $context->getRequest();
 		$user = $outputPage->getUser();

--- a/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/OutputPageParserOutputTest.php
@@ -230,6 +230,87 @@ class OutputPageParserOutputTest extends TestCase {
 		$this->newInstance()->onOutputPageParserOutput( $outputPage, $parserOutput );
 	}
 
+	/**
+	 * `OutputPage::addParserOutputMetadata` runs this hook and makes no promise
+	 * that the `ParserOutput` carries any rendered text. An extension that hands
+	 * over a metadata-only `ParserOutput` (`hasText` returns false) must not make
+	 * SMW trip over `getContentHolderText`.
+	 *
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7033
+	 */
+	public function testProcessReturnsEarlyForParserOutputWithoutText() {
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+		$language = $languageFactory->getLanguage( 'en' );
+
+		$title = MockTitle::buildMock( __METHOD__ . 'title-no-text' );
+		$title->expects( $this->atLeastOnce() )
+			->method( 'getNamespace' )
+			->willReturn( NS_MAIN );
+
+		// The `oldid` branch is the one that reaches for the text.
+		$context = new RequestContext();
+		$context->setRequest( new FauxRequest( [ 'oldid' => 9001 ], true ) );
+		$outputPage = $this->makeOutputPageWithContext( $title, $language, $context );
+
+		$this->namespaceExaminer->expects( $this->once() )
+			->method( 'isSemanticEnabled' )
+			->willReturn( true );
+
+		// No `never()` expectation on the Factbox factory here, it would fail
+		// ahead of `getContentHolderText` and hide the `LogicException` this
+		// test pins. The skipped Factbox is asserted in the test below.
+		$this->inTextAnnotationParserFactory->expects( $this->never() )
+			->method( 'newFor' );
+
+		// A metadata-only `ParserOutput`, it holds no text to work with.
+		$parserOutput = new ParserOutput();
+		$this->assertFalse( $parserOutput->hasText() );
+
+		$this->newInstance()->onOutputPageParserOutput( $outputPage, $parserOutput );
+
+		$this->assertFalse( $this->factboxText->hasText() );
+	}
+
+	/**
+	 * The `oldid` branch is only where it becomes fatal. A metadata-only
+	 * `ParserOutput` is not the rendered content of the page in the first place,
+	 * so the handler is skipped as a whole and neither a Factbox, an indicator
+	 * nor a post-processing element is derived from it.
+	 *
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7033
+	 */
+	public function testProcessBuildsNothingForParserOutputWithoutText() {
+		$languageFactory = MediaWikiServices::getInstance()->getLanguageFactory();
+		$language = $languageFactory->getLanguage( 'en' );
+
+		$title = MockTitle::buildMock( __METHOD__ . 'title-no-text-no-oldid' );
+		$title->expects( $this->atLeastOnce() )
+			->method( 'getNamespace' )
+			->willReturn( NS_MAIN );
+
+		$outputPage = $this->makeOutputPageWithContext( $title, $language, new RequestContext() );
+
+		$this->namespaceExaminer->expects( $this->once() )
+			->method( 'isSemanticEnabled' )
+			->willReturn( true );
+
+		$this->indicatorRegistryFactory->expects( $this->never() )
+			->method( 'newFor' );
+
+		$this->factboxFactory->expects( $this->never() )
+			->method( 'newCachedFactbox' );
+
+		$this->postProcHandlerFactory->expects( $this->never() )
+			->method( 'newFor' );
+
+		$parserOutput = new ParserOutput();
+		$this->assertFalse( $parserOutput->hasText() );
+
+		$this->newInstance()->onOutputPageParserOutput( $outputPage, $parserOutput );
+
+		$this->assertFalse( $this->factboxText->hasText() );
+	}
+
 	private function makeTitleForFactboxBuild( string $name, $language ) {
 		$title = MockTitle::buildMock( $name );
 		$title->expects( $this->atLeastOnce() )->method( 'exists' )->willReturn( true );


### PR DESCRIPTION
Fixes #7033.

## Problem

Viewing an old revision fatalled with `LogicException: This ParserOutput contains no text!`, raised from SMW's `OutputPageParserOutput` hook handler.

`OutputPage::addParserOutputMetadata` is the only place MediaWiki runs the `OutputPageParserOutput` hook from, and it makes no promise that the `ParserOutput` carries rendered text. `ParserOutput::hasText` exists to express exactly that metadata-only case ("If this returns false, the ParserOutput contains meta-data only").

Extensions call it with output from their own parse. PageNotice, named in the report, does `startExternalParse()` plus `recursiveTagParseFully()` and then hands over `Parser::getOutput()`. That object is a fresh `ParserOutput` whose raw text is never set, so it holds metadata only. When it reached the `oldid` branch of `getParserOutput`, `ParserOutput::getContentHolderText` threw and the revision view returned a 500.

This is not a regression. The branch that re-parses in-text annotations for a historical revision dates back to the introduction of the historical Factbox, and the call it previously made, `ParserOutput::getText`, funnels into the same `getRawText` and threw identically. It needed a wiki running an extension of this kind, plus an `oldid` request, to surface.

## Fix

The handler now returns early when the parser output holds no text.

Such an object is not the rendered content of the page, so there is nothing to build a Factbox from, nothing to run the in-text annotation parser over and nothing to post-process. It also keeps it away from the Factbox cache, which is keyed on the page and its revision while taking its data from whatever parser output the hook is handed, and which clears the shared Factbox text as its first step. Guarding only the throwing call would have left that mismatch in place on every ordinary page view and merely turned a loud error into a quiet one.

The page's own `ParserOutput` is unaffected. `OutputPage::addParserOutput` reads its text before delegating to `addParserOutputMetadata`, so anything reaching the handler through it always carries text. Viewing an old revision still renders the Factbox of that revision.

`ParserOutput::hasText` is available on every supported MediaWiki version.

## Scope

`hasText` identifies parser output that holds no text, which is the signal MediaWiki exposes for "this is not the rendered content of the page". A parser output that belongs to another parse but does carry text would still be treated as the page's own. That is a separate concern and is not addressed here.

## Testing

Covered by unit tests for both the `oldid` path, which reproduces the reported error on unpatched code, and the ordinary page view, which pins that nothing is derived from a text-less parser output.

Verified on a wiki configured with an extension that passes metadata-only parser output from `ArticleViewHeader`: the old revision view no longer errors, and the Factbox of a historical revision still shows that revision's data rather than the current one's.
