### PR TITLE
Fix Special:Ask internal error for format=debug

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -16,6 +16,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed a query showing incorrect printout values when the same property is requested through different printout contexts, such as a direct and an inverse printout or the same property with different sort options ([#7026](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7026))
 * Fixed maintenance scripts run with `--auto-recovery` (such as `rebuildData` and `rebuildElasticIndex`) aborting with a `FileNotWritableException` on deployments where the extension directory is not writable; the recovery checkpoint is now stored in the database instead of a `.smw.json` file, so it no longer depends on a writable `$smwgConfigFileDir` ([#7030](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7030))
 * Fixed viewing an old revision failing with a "This ParserOutput contains no text!" error on wikis running an extension that adds parser output metadata to the page, such as PageNotice ([#7033](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7033))
+* Fixed `Special:Ask` returning an internal error when a query is run with `format=debug` ([#7035](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7035))
 
 ## Upgrading
 

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -491,7 +491,9 @@ class SpecialAsk extends SpecialPage {
 			}
 		}
 
-		$scoreSet = $res->getScoreSet();
+		// A debug query (format=debug) returns the debug output as a string rather
+		// than a QueryResult, so only query results expose a score set.
+		$scoreSet = $res instanceof QueryResult ? $res->getScoreSet() : null;
 		if ( $this->getRequest()->getVal( 'score_set', false ) && $scoreSet !== null ) {
 			$table = $scoreSet->asTable( 'sortable wikitable smwtable-striped broadtable' );
 

--- a/tests/phpunit/Integration/JSONScript/TestCases/special-ask-debug-0001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/special-ask-debug-0001.json
@@ -1,0 +1,51 @@
+{
+	"description": "Test `Special:Ask` `format=debug` output (regression: a debug query returns a string result, not a QueryResult, so the score set must not be accessed on it)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has debug property",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"page": "Example/AskDebug/1",
+			"contents": "[[Has debug property::123]] [[Category:AskDebug]]"
+		}
+	],
+	"tests": [
+		{
+			"type": "special",
+			"about": "#0 (format=debug renders the debug output without a fatal error)",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"limit": "10",
+						"offset": "0",
+						"format": "debug"
+					},
+					"q": "[[Category:AskDebug]]",
+					"po": "?Has debug property"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"Debug output",
+					"ASK Query"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLanguageCode": "en",
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true
+		}
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}


### PR DESCRIPTION
`Special:Ask` returns an internal error (`Call to a member function getScoreSet() on string`) whenever a query is run with `format=debug`. A debug query returns its output as a string rather than a `QueryResult`, but `fetchResults()` called `getScoreSet()` on the result unconditionally.

Only read the score set when the result is a `QueryResult`; a debug string result has none. Every other result access in that method is already guarded the same way.

Adds a JSONScript test that runs `format=debug` and asserts the debug output renders — it errors with the fatal before the change and passes after.
