### PR TITLE
Flush buffered stats periodically in long-running maintenance scripts

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -17,6 +17,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed maintenance scripts run with `--auto-recovery` (such as `rebuildData` and `rebuildElasticIndex`) aborting with a `FileNotWritableException` on deployments where the extension directory is not writable; the recovery checkpoint is now stored in the database instead of a `.smw.json` file, so it no longer depends on a writable `$smwgConfigFileDir` ([#7030](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7030))
 * Fixed viewing an old revision failing with a "This ParserOutput contains no text!" error on wikis running an extension that adds parser output metadata to the page, such as PageNotice ([#7033](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7033))
 * Fixed `Special:Ask` returning an internal error when a query is run with `format=debug` ([#7035](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7035))
+* Fixed long-running maintenance scripts (such as `rebuildData`, `rebuildFulltextSearchTable` and `dumpRDF`) exhausting memory on large wikis; MediaWiki's buffered stats samples, which accumulate in process memory for every processed entity and have no flush point on the command line, are now flushed periodically during the rebuild loops ([#7036](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7036))
 
 ## Upgrading
 

--- a/maintenance/disposeOutdatedEntities.php
+++ b/maintenance/disposeOutdatedEntities.php
@@ -3,6 +3,7 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\CallbackMessageReporter;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\Maintenance\DataRebuilder\OutdatedDisposer;
@@ -121,6 +122,10 @@ class disposeOutdatedEntities extends Maintenance {
 		);
 
 		$outdatedDisposer->setShard( $shard, $of );
+
+		$outdatedDisposer->setStatsFlusher(
+			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
+		);
 
 		if ( $this->messageReporter === null ) {
 			$this->messageReporter = new CallbackMessageReporter( [ $this, 'reportMessage' ] );

--- a/maintenance/dumpRDF.php
+++ b/maintenance/dumpRDF.php
@@ -3,6 +3,7 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\Exporter\ExporterFactory;
 use SMW\Utils\CliMsgFormatter;
@@ -192,6 +193,10 @@ class dumpRDF extends Maintenance {
 
 		$exportController = $exporterFactory->newExportController(
 			$exporterFactory->newRDFXMLSerializer()
+		);
+
+		$exportController->setStatsFlusher(
+			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
 		);
 
 		if ( $pages !== [] ) {

--- a/maintenance/populateHashField.php
+++ b/maintenance/populateHashField.php
@@ -4,6 +4,7 @@ namespace SMW\Maintenance;
 
 use Iterator;
 use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SetupFile;
@@ -60,6 +61,8 @@ class populateHashField extends Maintenance {
 	 */
 	private $last = 0;
 
+	private ?PeriodicStatsFlusher $statsFlusher = null;
+
 	/**
 	 * @since 3.1
 	 */
@@ -112,6 +115,17 @@ class populateHashField extends Maintenance {
 	}
 
 	/**
+	 * Injected only by execute(). populate() also runs via the HashField
+	 * examiner (update.php), which leaves the flusher unset on purpose so
+	 * that path never flushes stats.
+	 *
+	 * @since 7.2.0
+	 */
+	public function setStatsFlusher( PeriodicStatsFlusher $statsFlusher ): void {
+		$this->statsFlusher = $statsFlusher;
+	}
+
+	/**
 	 * @since 3.1
 	 *
 	 * @param string $message
@@ -138,6 +152,10 @@ class populateHashField extends Maintenance {
 
 		$this->store = $applicationFactory->getStore(
 			SQLStore::class
+		);
+
+		$this->setStatsFlusher(
+			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
 		);
 
 		$localMessageProvider = $maintenanceFactory->newLocalMessageProvider(
@@ -250,6 +268,10 @@ class populateHashField extends Maintenance {
 		);
 
 		foreach ( $rows as $row ) {
+
+			if ( $this->statsFlusher !== null ) {
+				$this->statsFlusher->tick();
+			}
 
 			$hash = $idTable->computeSha1(
 				[

--- a/maintenance/purgeEntityCache.php
+++ b/maintenance/purgeEntityCache.php
@@ -4,6 +4,7 @@ namespace SMW\Maintenance;
 
 use Iterator;
 use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
@@ -212,7 +213,12 @@ class purgeEntityCache extends Maintenance {
 			$cliMsgFormatter->twoCols( "... entities matched ...", "(rows) $count", 3 )
 		);
 
+		$statsFlusher = new PeriodicStatsFlusher(
+			MediaWikiServices::getInstance()->getStatsFactory()
+		);
+
 		foreach ( $rows as $row ) {
+			$statsFlusher->tick();
 			$i++;
 
 			$msg = $cliMsgFormatter->progressCompact( $i, $count, $row->smw_id, $this->lastId );

--- a/maintenance/rebuildConceptCache.php
+++ b/maintenance/rebuildConceptCache.php
@@ -3,6 +3,7 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Setup;
 use SMW\Utils\CliMsgFormatter;
@@ -151,6 +152,10 @@ class rebuildConceptCache extends Maintenance {
 		);
 
 		$conceptCacheRebuilder->setParameters( $this->mOptions );
+
+		$conceptCacheRebuilder->setStatsFlusher(
+			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
+		);
 
 		$result = $this->checkForRebuildState(
 			$conceptCacheRebuilder->rebuild()

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -5,6 +5,7 @@ namespace SMW\Maintenance;
 use DateTimeZone;
 use InvalidArgumentException;
 use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
 use SMW\MediaWiki\ExtendedDateTime;
 use SMW\Options;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -172,6 +173,10 @@ class rebuildData extends Maintenance {
 		$dataRebuilder = $maintenanceFactory->newDataRebuilder(
 			$store,
 			[ $this, 'reportMessage' ]
+		);
+
+		$dataRebuilder->setStatsFlusher(
+			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
 		);
 
 		if ( $this->hasOption( 'f' ) ) {

--- a/maintenance/rebuildElasticIndex.php
+++ b/maintenance/rebuildElasticIndex.php
@@ -3,6 +3,7 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
 use SMW\Elastic\ElasticStore;
 use SMW\Elastic\Indexer\Rebuilder\Rebuilder;
 use SMW\MediaWiki\JobQueue;
@@ -414,7 +415,12 @@ class rebuildElasticIndex extends Maintenance {
 			);
 		}
 
+		$statsFlusher = new PeriodicStatsFlusher(
+			MediaWikiServices::getInstance()->getStatsFactory()
+		);
+
 		foreach ( $res as $row ) {
+			$statsFlusher->tick();
 			$this->rebuildFromRow( ++$i, $count, $row, $last );
 		}
 

--- a/maintenance/rebuildElasticMissingDocuments.php
+++ b/maintenance/rebuildElasticMissingDocuments.php
@@ -4,6 +4,7 @@ namespace SMW\Maintenance;
 
 use Iterator;
 use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
@@ -297,7 +298,13 @@ class rebuildElasticMissingDocuments extends Maintenance {
 		$this->reportMessage( "\nInspecting documents ...\n" );
 		$cliMsgFormatter->setStartTime( (int)microtime( true ) );
 
+		$statsFlusher = new PeriodicStatsFlusher(
+			MediaWikiServices::getInstance()->getStatsFactory()
+		);
+
 		foreach ( $rows as $row ) {
+
+			$statsFlusher->tick();
 
 			if ( $row->smw_title === '_INST' ) {
 				continue;

--- a/maintenance/rebuildFulltextSearchTable.php
+++ b/maintenance/rebuildFulltextSearchTable.php
@@ -3,6 +3,7 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\CallbackMessageReporter;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\DataItems\DataItem;
@@ -161,6 +162,11 @@ class rebuildFulltextSearchTable extends Maintenance {
 		$maintenanceHelper->initRuntimeValues();
 
 		$searchTableRebuilder->setMessageReporter( $this->messageReporter );
+
+		$searchTableRebuilder->setStatsFlusher(
+			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
+		);
+
 		$result = $searchTableRebuilder->rebuild();
 
 		if ( $this->hasOption( 'report-runtime' ) ) {

--- a/maintenance/rebuildPropertyStatistics.php
+++ b/maintenance/rebuildPropertyStatistics.php
@@ -3,6 +3,7 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Setup;
 use SMW\SQLStore\SQLStore;
@@ -51,6 +52,10 @@ class rebuildPropertyStatistics extends Maintenance {
 		$statisticsRebuilder = $maintenanceFactory->newPropertyStatisticsRebuilder(
 			$applicationFactory->getStore( SQLStore::class ),
 			[ $this, 'reportMessage' ]
+		);
+
+		$statisticsRebuilder->setStatsFlusher(
+			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
 		);
 
 		$statisticsRebuilder->rebuild();

--- a/maintenance/removeDuplicateEntities.php
+++ b/maintenance/removeDuplicateEntities.php
@@ -3,6 +3,7 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Setup;
 use SMW\SQLStore\SQLStore;
@@ -80,6 +81,10 @@ class removeDuplicateEntities extends Maintenance {
 		$duplicateEntitiesDisposer = $maintenanceFactory->newDuplicateEntitiesDisposer(
 			$applicationFactory->getStore( SQLStore::class ),
 			[ $this, 'reportMessage' ]
+		);
+
+		$duplicateEntitiesDisposer->setStatsFlusher(
+			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
 		);
 
 		$this->reportMessage(

--- a/maintenance/updateEntityCollation.php
+++ b/maintenance/updateEntityCollation.php
@@ -248,7 +248,13 @@ class updateEntityCollation extends Maintenance {
 		$property = new Property( '_SKEY' );
 		$i = 0;
 
+		$statsFlusher = new PeriodicStatsFlusher(
+			MediaWikiServices::getInstance()->getStatsFactory()
+		);
+
 		foreach ( $rows as $row ) {
+
+			$statsFlusher->tick();
 
 			if ( $row->smw_title === '' ) {
 				continue;

--- a/maintenance/updateEntityCountMap.php
+++ b/maintenance/updateEntityCountMap.php
@@ -3,6 +3,7 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\DataItems\WikiPage;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -182,7 +183,13 @@ class updateEntityCountMap extends Maintenance {
 	private function runUpdate() {
 		$connection = $this->store->getConnection( 'mw.db' );
 
+		$statsFlusher = new PeriodicStatsFlusher(
+			MediaWikiServices::getInstance()->getStatsFactory()
+		);
+
 		for ( $i = 0; $i <= $this->last; $i++ ) {
+
+			$statsFlusher->tick();
 
 			$row = $connection->newSelectQueryBuilder()
 				->select( [

--- a/maintenance/updateQueryDependencies.php
+++ b/maintenance/updateQueryDependencies.php
@@ -3,6 +3,7 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
+use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\DataItems\Property;
 use SMW\MediaWiki\JobFactory;
@@ -170,8 +171,13 @@ class updateQueryDependencies extends Maintenance {
 		$this->reportMessage( "\n   ... found $expected entities ..." );
 		$this->reportMessage( "\n" );
 
+		$statsFlusher = new PeriodicStatsFlusher(
+			MediaWikiServices::getInstance()->getStatsFactory()
+		);
+
 		$titleFactory = $this->getServiceContainer()->getTitleFactory();
 		foreach ( $res as $row ) {
+			$statsFlusher->tick();
 			$i++;
 
 			$this->reportMessage(

--- a/src/Export/ExportController.php
+++ b/src/Export/ExportController.php
@@ -15,6 +15,7 @@ use SMW\Exporter\Element\ExpResource;
 use SMW\Exporter\Escaper;
 use SMW\Exporter\ExpDataFactory;
 use SMW\Exporter\Serializer\Serializer;
+use SMW\Maintenance\PeriodicStatsFlusher;
 use SMW\MediaWiki\DeepRedirectTargetResolver;
 use SMW\NamespaceExaminer;
 use SMW\Query\Language\ConceptDescription;
@@ -70,6 +71,8 @@ class ExportController {
 
 	private ?NamespaceExaminer $namespaceExaminer = null;
 
+	private ?PeriodicStatsFlusher $statsFlusher = null;
+
 	/**
 	 * @since 1.5.5
 	 */
@@ -86,6 +89,13 @@ class ExportController {
 	 */
 	public function enableBacklinks( bool $enable ): void {
 		$this->add_backlinks = $enable;
+	}
+
+	/**
+	 * @since 7.2.0
+	 */
+	public function setStatsFlusher( PeriodicStatsFlusher $statsFlusher ): void {
+		$this->statsFlusher = $statsFlusher;
 	}
 
 	/**
@@ -444,6 +454,10 @@ class ExportController {
 		);
 
 		while ( $this->queue->count() > 0 ) {
+			if ( $this->statsFlusher !== null ) {
+				$this->statsFlusher->tick();
+			}
+
 			$diPage = $this->queue->reset();
 			$this->serializePage( $diPage, $diPage->recdepth );
 			$this->flush();
@@ -527,6 +541,10 @@ class ExportController {
 		$delaycount = $delayeach;
 
 		for ( $id = 1; $id <= $end; $id += 1 ) {
+			if ( $this->statsFlusher !== null ) {
+				$this->statsFlusher->tick();
+			}
+
 			$title = $titleFactory->newFromID( $id );
 			if ( $title === null || !$this->isSemanticEnabled( $title->getNamespace() ) ) {
 				continue;

--- a/src/Maintenance/ConceptCacheRebuilder.php
+++ b/src/Maintenance/ConceptCacheRebuilder.php
@@ -37,6 +37,7 @@ class ConceptCacheRebuilder {
 	private int $endId   = 0;
 	private int $lines   = 0;
 	private bool $verbose = false;
+	private ?PeriodicStatsFlusher $statsFlusher = null;
 
 	/**
 	 * @since 1.9.2
@@ -55,6 +56,13 @@ class ConceptCacheRebuilder {
 	 */
 	public function setMessageReporter( MessageReporter $reporter ): void {
 		$this->reporter = $reporter;
+	}
+
+	/**
+	 * @since 7.2.0
+	 */
+	public function setStatsFlusher( PeriodicStatsFlusher $statsFlusher ): void {
+		$this->statsFlusher = $statsFlusher;
 	}
 
 	/**
@@ -153,6 +161,9 @@ class ConceptCacheRebuilder {
 		$concepts = $this->getConcepts();
 
 		foreach ( $concepts as $concept ) {
+			if ( $this->statsFlusher !== null ) {
+				$this->statsFlusher->tick();
+			}
 			$this->workOnConcept( $concept );
 		}
 

--- a/src/Maintenance/DataRebuilder.php
+++ b/src/Maintenance/DataRebuilder.php
@@ -42,6 +42,8 @@ class DataRebuilder {
 
 	private ?AutoRecovery $autoRecovery = null;
 
+	private ?PeriodicStatsFlusher $statsFlusher = null;
+
 	private DistinctEntityDataRebuilder $distinctEntityDataRebuilder;
 
 	private ExceptionFileLogger $exceptionFileLogger;
@@ -98,6 +100,14 @@ class DataRebuilder {
 	 */
 	public function setAutoRecovery( AutoRecovery $autoRecovery ): void {
 		$this->autoRecovery = $autoRecovery;
+	}
+
+	/**
+	 * @since 7.2.0
+	 */
+	public function setStatsFlusher( PeriodicStatsFlusher $statsFlusher ): void {
+		$this->statsFlusher = $statsFlusher;
+		$this->distinctEntityDataRebuilder->setStatsFlusher( $statsFlusher );
 	}
 
 	/**
@@ -511,6 +521,10 @@ class DataRebuilder {
 			MediaWikiServices::getInstance()->getLinkCache()->clear(); // avoid memory leaks
 		}
 
+		if ( $this->statsFlusher !== null ) {
+			$this->statsFlusher->tick();
+		}
+
 		$this->rebuildCount++;
 	}
 
@@ -625,6 +639,11 @@ class DataRebuilder {
 		);
 
 		$outdatedDisposer->setMessageReporter( $this->reporter );
+
+		if ( $this->statsFlusher !== null ) {
+			$outdatedDisposer->setStatsFlusher( $this->statsFlusher );
+		}
+
 		$outdatedDisposer->run();
 	}
 

--- a/src/Maintenance/DataRebuilder/OutdatedDisposer.php
+++ b/src/Maintenance/DataRebuilder/OutdatedDisposer.php
@@ -4,6 +4,7 @@ namespace SMW\Maintenance\DataRebuilder;
 
 use Onoi\MessageReporter\MessageReporterAwareTrait;
 use SMW\IteratorFactory;
+use SMW\Maintenance\PeriodicStatsFlusher;
 use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
 use SMW\RequestOptions;
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
@@ -24,6 +25,7 @@ class OutdatedDisposer {
 	private CliMsgFormatter $cliMsgFormatter;
 	private int $shard = 0;
 	private int $of = 1;
+	private ?PeriodicStatsFlusher $statsFlusher = null;
 
 	/**
 	 * @since 3.1
@@ -41,6 +43,13 @@ class OutdatedDisposer {
 	public function setShard( int $shard, int $of ): void {
 		$this->shard = $shard;
 		$this->of = $of;
+	}
+
+	/**
+	 * @since 7.2.0
+	 */
+	public function setStatsFlusher( PeriodicStatsFlusher $statsFlusher ): void {
+		$this->statsFlusher = $statsFlusher;
 	}
 
 	/**
@@ -144,6 +153,9 @@ class OutdatedDisposer {
 			$rows = [];
 
 			foreach ( $chunk as $row ) {
+				if ( $this->statsFlusher !== null ) {
+					$this->statsFlusher->tick();
+				}
 				$counter++;
 				$rows[] = $row;
 				$msg = sprintf( "%s (%1.0f%%)", $row->smw_id, round( $counter / $count * 100 ) );
@@ -168,6 +180,9 @@ class OutdatedDisposer {
 		$counter = 0;
 
 		foreach ( $resultIterator as $row ) {
+			if ( $this->statsFlusher !== null ) {
+				$this->statsFlusher->tick();
+			}
 			$counter++;
 			$msg = sprintf( "%s (%1.0f%%)", $row->id, round( $counter / $count * 100 ) );
 

--- a/src/Maintenance/DistinctEntityDataRebuilder.php
+++ b/src/Maintenance/DistinctEntityDataRebuilder.php
@@ -34,6 +34,8 @@ class DistinctEntityDataRebuilder {
 
 	private ?ExceptionFileLogger $exceptionFileLogger = null;
 
+	private ?PeriodicStatsFlusher $statsFlusher = null;
+
 	private array $filters = [];
 
 	private int $rebuildCount = 0;
@@ -74,6 +76,13 @@ class DistinctEntityDataRebuilder {
 	 */
 	public function setExceptionFileLogger( ExceptionFileLogger $exceptionFileLogger ): void {
 		$this->exceptionFileLogger = $exceptionFileLogger;
+	}
+
+	/**
+	 * @since 7.2.0
+	 */
+	public function setStatsFlusher( PeriodicStatsFlusher $statsFlusher ): void {
+		$this->statsFlusher = $statsFlusher;
 	}
 
 	/**
@@ -127,6 +136,10 @@ class DistinctEntityDataRebuilder {
 		);
 
 		foreach ( $pages as $key => $page ) {
+
+			if ( $this->statsFlusher !== null ) {
+				$this->statsFlusher->tick();
+			}
 
 			$this->rebuildCount++;
 			$progress = $cliMsgFormatter->progressCompact( $this->rebuildCount, $total );

--- a/src/Maintenance/DuplicateEntitiesDisposer.php
+++ b/src/Maintenance/DuplicateEntitiesDisposer.php
@@ -23,6 +23,8 @@ class DuplicateEntitiesDisposer {
 
 	use MessageReporterAwareTrait;
 
+	private ?PeriodicStatsFlusher $statsFlusher = null;
+
 	/**
 	 * @since 3.0
 	 */
@@ -30,6 +32,13 @@ class DuplicateEntitiesDisposer {
 		private Store $store,
 		private ?BagOStuff $cache = null,
 	) {
+	}
+
+	/**
+	 * @since 7.2.0
+	 */
+	public function setStatsFlusher( PeriodicStatsFlusher $statsFlusher ): void {
+		$this->statsFlusher = $statsFlusher;
 	}
 
 	/**
@@ -145,6 +154,10 @@ class DuplicateEntitiesDisposer {
 
 		foreach ( $duplicates as $duplicate ) {
 
+			if ( $this->statsFlusher !== null ) {
+				$this->statsFlusher->tick();
+			}
+
 			if ( $i > 0 && ( $i ) % CliMsgFormatter::MAX_LEN === 0 ) {
 				$this->messageReporter->reportMessage( "\n       " );
 			} elseif ( $i == 0 ) {
@@ -191,6 +204,10 @@ class DuplicateEntitiesDisposer {
 			->caller( __METHOD__ );
 
 		foreach ( $duplicates as $duplicate ) {
+
+			if ( $this->statsFlusher !== null ) {
+				$this->statsFlusher->tick();
+			}
 
 			if ( $i > 0 && ( $i ) % CliMsgFormatter::MAX_LEN === 0 ) {
 				$this->messageReporter->reportMessage( "\n       " );
@@ -239,6 +256,10 @@ class DuplicateEntitiesDisposer {
 		$i = 0;
 
 		foreach ( $duplicates as $duplicate ) {
+
+			if ( $this->statsFlusher !== null ) {
+				$this->statsFlusher->tick();
+			}
 
 			if ( $i > 0 && ( $i ) % CliMsgFormatter::MAX_LEN === 0 ) {
 				$this->messageReporter->reportMessage( "\n       " );

--- a/src/Maintenance/PeriodicStatsFlusher.php
+++ b/src/Maintenance/PeriodicStatsFlusher.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SMW\Maintenance;
+
+use Wikimedia\Stats\StatsFactory;
+
+/**
+ * Periodically flushes MediaWiki's buffered stats samples during
+ * long-running maintenance loops.
+ *
+ * Every metric emit buffers a sample in process memory. Web requests flush
+ * the buffer when they end; a maintenance process that iterates over a large
+ * part of the wiki has no equivalent flush point (MediaWiki 1.43) or does
+ * not reliably reach it (1.44+ flushes on output and replication waits,
+ * which loops that report sparsely never call), so the buffer grows with
+ * every processed entity until the process hits its memory limit. Draining
+ * the buffer every few hundred entities keeps memory flat; with no stats
+ * target configured the flush is a near-free no-op emit.
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.2.0
+ */
+class PeriodicStatsFlusher {
+
+	private const FLUSH_INTERVAL = 100;
+
+	private int $tickCount = 0;
+
+	public function __construct( private readonly StatsFactory $statsFactory ) {
+	}
+
+	/**
+	 * Marks one loop iteration; flushes the stats buffer each time the
+	 * flush interval completes.
+	 *
+	 * @since 7.2.0
+	 */
+	public function tick(): void {
+		$this->tickCount++;
+
+		if ( $this->tickCount % self::FLUSH_INTERVAL === 0 ) {
+			$this->statsFactory->flush();
+		}
+	}
+
+}

--- a/src/Maintenance/PropertyStatisticsRebuilder.php
+++ b/src/Maintenance/PropertyStatisticsRebuilder.php
@@ -22,6 +22,8 @@ class PropertyStatisticsRebuilder {
 
 	private MessageReporter $messageReporter;
 
+	private ?PeriodicStatsFlusher $statsFlusher = null;
+
 	/**
 	 * @since 1.9
 	 */
@@ -37,6 +39,13 @@ class PropertyStatisticsRebuilder {
 	 */
 	public function setMessageReporter( MessageReporter $messageReporter ): void {
 		$this->messageReporter = $messageReporter;
+	}
+
+	/**
+	 * @since 7.2.0
+	 */
+	public function setStatsFlusher( PeriodicStatsFlusher $statsFlusher ): void {
+		$this->statsFlusher = $statsFlusher;
 	}
 
 	/**
@@ -105,6 +114,10 @@ class PropertyStatisticsRebuilder {
 		$i = 0;
 
 		foreach ( $res as $row ) {
+
+			if ( $this->statsFlusher !== null ) {
+				$this->statsFlusher->tick();
+			}
 
 			$i++;
 

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
@@ -6,6 +6,7 @@ use Onoi\MessageReporter\MessageReporter;
 use Onoi\MessageReporter\MessageReporterFactory;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Property;
+use SMW\Maintenance\PeriodicStatsFlusher;
 use SMW\MediaWiki\Connection\Database;
 use SMW\Utils\CliMsgFormatter;
 
@@ -27,6 +28,8 @@ class SearchTableRebuilder {
 	private bool $optimization = false;
 
 	private array $skippedTables = [];
+
+	private ?PeriodicStatsFlusher $statsFlusher = null;
 
 	/**
 	 * @since 2.5
@@ -54,6 +57,13 @@ class SearchTableRebuilder {
 	 */
 	public function setMessageReporter( MessageReporter $messageReporter ): void {
 		$this->messageReporter = $messageReporter;
+	}
+
+	/**
+	 * @since 7.2.0
+	 */
+	public function setStatsFlusher( PeriodicStatsFlusher $statsFlusher ): void {
+		$this->statsFlusher = $statsFlusher;
 	}
 
 	/**
@@ -307,6 +317,10 @@ class SearchTableRebuilder {
 		}
 
 		foreach ( $rows as $row ) {
+
+			if ( $this->statsFlusher !== null ) {
+				$this->statsFlusher->tick();
+			}
 
 			$sid = $row->s_id;
 			$pid = !isset( $row->p_id ) ? $pid : $row->p_id;

--- a/tests/phpunit/Unit/Maintenance/PeriodicStatsFlusherTest.php
+++ b/tests/phpunit/Unit/Maintenance/PeriodicStatsFlusherTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace SMW\Tests\Unit\Maintenance;
+
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use SMW\Maintenance\PeriodicStatsFlusher;
+use Wikimedia\Stats\Emitters\NullEmitter;
+use Wikimedia\Stats\StatsCache;
+use Wikimedia\Stats\StatsFactory;
+
+/**
+ * @covers \SMW\Maintenance\PeriodicStatsFlusher
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.2.0
+ */
+class PeriodicStatsFlusherTest extends TestCase {
+
+	public function testDoesNotFlushBeforeIntervalCompletes(): void {
+		$statsFactory = $this->newStatsFactorySpy();
+		$flusher = new PeriodicStatsFlusher( $statsFactory );
+
+		$this->tickTimes( $flusher, 99 );
+
+		$this->assertSame( 0, $statsFactory->flushCount );
+	}
+
+	public function testFlushesOnEachCompletedInterval(): void {
+		$statsFactory = $this->newStatsFactorySpy();
+		$flusher = new PeriodicStatsFlusher( $statsFactory );
+
+		$this->tickTimes( $flusher, 250 );
+
+		$this->assertSame( 2, $statsFactory->flushCount );
+	}
+
+	private function tickTimes( PeriodicStatsFlusher $flusher, int $times ): void {
+		for ( $i = 0; $i < $times; $i++ ) {
+			$flusher->tick();
+		}
+	}
+
+	private function newStatsFactorySpy() {
+		return new class( new StatsCache(), new NullEmitter(), new NullLogger() ) extends StatsFactory {
+			public int $flushCount = 0;
+
+			public function flush(): void {
+				$this->flushCount++;
+			}
+		};
+	}
+
+}


### PR DESCRIPTION
[MediaWiki's stats library](https://www.mediawiki.org/wiki/Manual:Stats) buffers a sample in process memory on every metric emit. Web requests flush the buffer when they end, but maintenance processes never do on MediaWiki 1.43. MediaWiki 1.44 added periodic CLI flush points in Maintenance::output() and the replication waits ([T380609](https://phabricator.wikimedia.org/T380609)), but that fix was not backported to the 1.43 LTS, and those flush points fire only as a side effect of progress printing and core-managed transaction waits, which several SMW rebuild loops do sparsely or not at all. Long entity sweeps therefore grow the buffer without bound: rebuildData retains roughly 115 samples (about 15 KB) per processed entity, which exhausts a 1 GB memory limit after about 65k entities and makes full rebuilds impossible on large wikis regardless of the limit.

Older versions are unaffected in practice: on MediaWiki 1.39 the buffered stats library existed only as the experimental Metrics predecessor, with no emitters on the parser and object cache hot paths, and the legacy statsd buffer is cleared unconditionally at the periodic maintenance flush points from [T181385](https://phabricator.wikimedia.org/T181385). The exposure arrived as core migrated its metrics onto the modern stats library ([T350592](https://phabricator.wikimedia.org/T350592)): the parser cache counters in MediaWiki 1.42, and the object cache and parser output access layers in 1.43, which is what pushed per-entity accumulation to the scale measured here.

A failing run dies with the generic OOM fatal at whichever allocation happens to cross the limit; observed frames include the stats recording path itself, Monolog timestamp creation while logging during the shutdown, and SMW's own cache serializer:

> PHP Fatal error:  Allowed memory size of 1073741824 bytes exhausted (tried to allocate 4096 bytes) in /var/www/html/w/includes/libs/Stats/Metrics/BaseMetric.php on line 193
>
> PHP Fatal error:  Allowed memory size of 1073741824 bytes exhausted (tried to allocate 32768 bytes) in /var/www/html/w/vendor/monolog/monolog/src/Monolog/DateTimeImmutable.php on line 1
>
> PHP Fatal error:  Allowed memory size of 536870912 bytes exhausted (tried to allocate 131072 bytes) in /var/www/html/w/extensions/SemanticMediaWiki/src/Utils/HmacSerializer.php on line 138

Add PeriodicStatsFlusher, which drains the buffer every 100 loop iterations, and wire it into every maintenance loop whose iteration count scales with wiki size. Maintenance scripts construct it and inject it into their worker classes via setter, so web requests are unaffected; with no stats target configured the flush is a near-free no-op.

The periodic flush also composes safely with the core flush points on MediaWiki 1.44 and later: a flush drains and clears the shared buffer, so each sample is still emitted exactly once, by whichever flush point fires first, and a flush that finds an empty buffer does next to nothing (1.45 short-circuits it explicitly). The per-loop flush still earns its place on those versions, covering the loops whose reporting pattern never passes through Maintenance::output().

Measured on a 30k-entity wiki (MediaWiki 1.43): rebuildData memory use drops from 511 MB (about 15 KB per entity, unbounded) to 66 MB (flat). At a 512M limit on the same wiki, the unpatched script dies a third of the way through the sweep while the patched script completes it.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; investigation and workflow directed by @malberts, ~10 steering rounds after PR creation; independently AI-reviewed after publication (max-effort pass, zero blockers), human review pending; TDD unit test run against real MediaWiki 1.43 classes, end-to-end verified on a seeded 30k-entity MediaWiki 1.43.9 wiki (unpatched run OOMs, patched run completes using 66 MB), CI green on the reviewed head and re-running on the final one.</sub>

<details><summary>Production notes</summary>

Design and review by `Fable 5 (max)`; implementation and measurement runs by `Opus 4.8` subagents. Two independent adversarial AI review passes (correctness/completeness and project-conventions lenses) preceded this PR; their findings are reflected in the diff. Verification included a direct A/B at a 512M memory limit on identical warm-cache state: the unpatched code dies with the OOM fatal at entity ~9,995 of 30,537, the patched code completes all entities reporting 66 MB used. A further independent review pass after publication (six read-only passes including mutation testing and a live re-verification) found zero blockers; its one advisory, dropping the configurable flush interval in favour of a private constant, is applied.

</details>
