### PR TITLE
Use SpecialPage's native methods to access RequestContext

### DIFF
--- a/src/MediaWiki/Specials/SpecialConcepts.php
+++ b/src/MediaWiki/Specials/SpecialConcepts.php
@@ -2,7 +2,6 @@
 
 namespace SMW\MediaWiki\Specials;
 
-use MediaWiki\Context\RequestContext;
 use MediaWiki\Html\Html;
 use MediaWiki\Navigation\PagerNavigationBuilder;
 use MediaWiki\SpecialPage\SpecialPage;
@@ -212,7 +211,7 @@ class SpecialConcepts extends SpecialPage {
 
 		if ( $cursorOptions !== null ) {
 			$isFirstPage = !$cursorOptions->hasCursor();
-			$navBuilder = new PagerNavigationBuilder( RequestContext::getMain() );
+			$navBuilder = new PagerNavigationBuilder( $this->getContext() );
 			$navBuilder
 				->setPage( $this->getPageTitle() )
 				->setLinkQuery( [ 'limit' => $limit ] )

--- a/src/MediaWiki/Specials/SpecialTypes.php
+++ b/src/MediaWiki/Specials/SpecialTypes.php
@@ -3,7 +3,6 @@
 namespace SMW\MediaWiki\Specials;
 
 use Iterator;
-use MediaWiki\Context\RequestContext;
 use MediaWiki\Html\Html;
 use MediaWiki\Linker\Linker;
 use MediaWiki\Navigation\PagerNavigationBuilder;
@@ -388,7 +387,7 @@ class SpecialTypes extends SpecialPage {
 	): string {
 		$isFirstPage = !$cursorOptions->hasCursor();
 
-		$navBuilder = new PagerNavigationBuilder( RequestContext::getMain() );
+		$navBuilder = new PagerNavigationBuilder( $this->getContext() );
 		$navBuilder
 			->setPage( $this->getTitleFor( 'Types', $typeLabel ) )
 			->setLinkQuery( [ 'limit' => $limit ] )


### PR DESCRIPTION
Not harmful but special pages shouldn't need to use `RequestContext->getMain()` when a native function is available.