### PR TITLE
Move PeriodicStatsFlusher to the Utils namespace and add a factory

### DIFF
--- a/maintenance/disposeOutdatedEntities.php
+++ b/maintenance/disposeOutdatedEntities.php
@@ -3,13 +3,13 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
-use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\CallbackMessageReporter;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\Maintenance\DataRebuilder\OutdatedDisposer;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Setup;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Load the required class
@@ -124,7 +124,7 @@ class disposeOutdatedEntities extends Maintenance {
 		$outdatedDisposer->setShard( $shard, $of );
 
 		$outdatedDisposer->setStatsFlusher(
-			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
+			PeriodicStatsFlusher::newFromGlobalState()
 		);
 
 		if ( $this->messageReporter === null ) {

--- a/maintenance/dumpRDF.php
+++ b/maintenance/dumpRDF.php
@@ -3,10 +3,10 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
-use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\Exporter\ExporterFactory;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Load the required class
@@ -196,7 +196,7 @@ class dumpRDF extends Maintenance {
 		);
 
 		$exportController->setStatsFlusher(
-			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
+			PeriodicStatsFlusher::newFromGlobalState()
 		);
 
 		if ( $pages !== [] ) {

--- a/maintenance/populateHashField.php
+++ b/maintenance/populateHashField.php
@@ -4,7 +4,6 @@ namespace SMW\Maintenance;
 
 use Iterator;
 use MediaWiki\Maintenance\Maintenance;
-use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SetupFile;
@@ -12,6 +11,7 @@ use SMW\SQLStore\Installer;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Load the required class
@@ -116,8 +116,11 @@ class populateHashField extends Maintenance {
 
 	/**
 	 * Injected only by execute(). populate() also runs via the HashField
-	 * examiner (update.php), which leaves the flusher unset on purpose so
-	 * that path never flushes stats.
+	 * examiner (update.php), which reaches it without execute() and so has
+	 * no injection seam; that path is left unflushed deliberately. It is
+	 * safe without a flusher because populate() only computes a hash and
+	 * updates one row per entity (no parse), so it buffers few samples and
+	 * runs once as a one-time migration.
 	 *
 	 * @since 7.2.0
 	 */
@@ -155,7 +158,7 @@ class populateHashField extends Maintenance {
 		);
 
 		$this->setStatsFlusher(
-			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
+			PeriodicStatsFlusher::newFromGlobalState()
 		);
 
 		$localMessageProvider = $maintenanceFactory->newLocalMessageProvider(

--- a/maintenance/purgeEntityCache.php
+++ b/maintenance/purgeEntityCache.php
@@ -4,7 +4,6 @@ namespace SMW\Maintenance;
 
 use Iterator;
 use MediaWiki\Maintenance\Maintenance;
-use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
@@ -15,6 +14,7 @@ use SMW\Setup;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Load the required class
@@ -213,9 +213,7 @@ class purgeEntityCache extends Maintenance {
 			$cliMsgFormatter->twoCols( "... entities matched ...", "(rows) $count", 3 )
 		);
 
-		$statsFlusher = new PeriodicStatsFlusher(
-			MediaWikiServices::getInstance()->getStatsFactory()
-		);
+		$statsFlusher = PeriodicStatsFlusher::newFromGlobalState();
 
 		foreach ( $rows as $row ) {
 			$statsFlusher->tick();

--- a/maintenance/rebuildConceptCache.php
+++ b/maintenance/rebuildConceptCache.php
@@ -3,10 +3,10 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
-use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Setup;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Load the required class
@@ -154,7 +154,7 @@ class rebuildConceptCache extends Maintenance {
 		$conceptCacheRebuilder->setParameters( $this->mOptions );
 
 		$conceptCacheRebuilder->setStatsFlusher(
-			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
+			PeriodicStatsFlusher::newFromGlobalState()
 		);
 
 		$result = $this->checkForRebuildState(

--- a/maintenance/rebuildData.php
+++ b/maintenance/rebuildData.php
@@ -5,7 +5,6 @@ namespace SMW\Maintenance;
 use DateTimeZone;
 use InvalidArgumentException;
 use MediaWiki\Maintenance\Maintenance;
-use MediaWiki\MediaWikiServices;
 use SMW\MediaWiki\ExtendedDateTime;
 use SMW\Options;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -13,6 +12,7 @@ use SMW\Setup;
 use SMW\Store;
 use SMW\StoreFactory;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Load the required class
@@ -176,7 +176,7 @@ class rebuildData extends Maintenance {
 		);
 
 		$dataRebuilder->setStatsFlusher(
-			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
+			PeriodicStatsFlusher::newFromGlobalState()
 		);
 
 		if ( $this->hasOption( 'f' ) ) {

--- a/maintenance/rebuildElasticIndex.php
+++ b/maintenance/rebuildElasticIndex.php
@@ -3,7 +3,6 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
-use MediaWiki\MediaWikiServices;
 use SMW\Elastic\ElasticStore;
 use SMW\Elastic\Indexer\Rebuilder\Rebuilder;
 use SMW\MediaWiki\JobQueue;
@@ -13,6 +12,7 @@ use SMW\SetupFile;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Load the required class
@@ -415,9 +415,7 @@ class rebuildElasticIndex extends Maintenance {
 			);
 		}
 
-		$statsFlusher = new PeriodicStatsFlusher(
-			MediaWikiServices::getInstance()->getStatsFactory()
-		);
+		$statsFlusher = PeriodicStatsFlusher::newFromGlobalState();
 
 		foreach ( $res as $row ) {
 			$statsFlusher->tick();

--- a/maintenance/rebuildElasticMissingDocuments.php
+++ b/maintenance/rebuildElasticMissingDocuments.php
@@ -4,7 +4,6 @@ namespace SMW\Maintenance;
 
 use Iterator;
 use MediaWiki\Maintenance\Maintenance;
-use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
@@ -18,6 +17,7 @@ use SMW\Setup;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Load the required class
@@ -298,9 +298,7 @@ class rebuildElasticMissingDocuments extends Maintenance {
 		$this->reportMessage( "\nInspecting documents ...\n" );
 		$cliMsgFormatter->setStartTime( (int)microtime( true ) );
 
-		$statsFlusher = new PeriodicStatsFlusher(
-			MediaWikiServices::getInstance()->getStatsFactory()
-		);
+		$statsFlusher = PeriodicStatsFlusher::newFromGlobalState();
 
 		foreach ( $rows as $row ) {
 

--- a/maintenance/rebuildFulltextSearchTable.php
+++ b/maintenance/rebuildFulltextSearchTable.php
@@ -3,7 +3,6 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
-use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\CallbackMessageReporter;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\DataItems\DataItem;
@@ -12,6 +11,7 @@ use SMW\Setup;
 use SMW\SQLStore\QueryEngine\FulltextSearchTableFactory;
 use SMW\SQLStore\SQLStore;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Load the required class
@@ -164,7 +164,7 @@ class rebuildFulltextSearchTable extends Maintenance {
 		$searchTableRebuilder->setMessageReporter( $this->messageReporter );
 
 		$searchTableRebuilder->setStatsFlusher(
-			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
+			PeriodicStatsFlusher::newFromGlobalState()
 		);
 
 		$result = $searchTableRebuilder->rebuild();

--- a/maintenance/rebuildPropertyStatistics.php
+++ b/maintenance/rebuildPropertyStatistics.php
@@ -3,10 +3,10 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
-use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Setup;
 use SMW\SQLStore\SQLStore;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Load the required class
@@ -55,7 +55,7 @@ class rebuildPropertyStatistics extends Maintenance {
 		);
 
 		$statisticsRebuilder->setStatsFlusher(
-			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
+			PeriodicStatsFlusher::newFromGlobalState()
 		);
 
 		$statisticsRebuilder->rebuild();

--- a/maintenance/removeDuplicateEntities.php
+++ b/maintenance/removeDuplicateEntities.php
@@ -3,11 +3,11 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
-use MediaWiki\MediaWikiServices;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Setup;
 use SMW\SQLStore\SQLStore;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Load the required class
@@ -84,7 +84,7 @@ class removeDuplicateEntities extends Maintenance {
 		);
 
 		$duplicateEntitiesDisposer->setStatsFlusher(
-			new PeriodicStatsFlusher( MediaWikiServices::getInstance()->getStatsFactory() )
+			PeriodicStatsFlusher::newFromGlobalState()
 		);
 
 		$this->reportMessage(

--- a/maintenance/updateEntityCollation.php
+++ b/maintenance/updateEntityCollation.php
@@ -13,6 +13,7 @@ use SMW\SetupFile;
 use SMW\SQLStore\SQLStore;
 use SMW\SQLStore\TableFieldUpdater;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Load the required class
@@ -248,9 +249,7 @@ class updateEntityCollation extends Maintenance {
 		$property = new Property( '_SKEY' );
 		$i = 0;
 
-		$statsFlusher = new PeriodicStatsFlusher(
-			MediaWikiServices::getInstance()->getStatsFactory()
-		);
+		$statsFlusher = PeriodicStatsFlusher::newFromGlobalState();
 
 		foreach ( $rows as $row ) {
 

--- a/maintenance/updateEntityCountMap.php
+++ b/maintenance/updateEntityCountMap.php
@@ -3,7 +3,6 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
-use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\DataItems\WikiPage;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -11,6 +10,7 @@ use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Utils\CliMsgFormatter;
 use SMW\Utils\HmacSerializer;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Load the required class
@@ -183,9 +183,7 @@ class updateEntityCountMap extends Maintenance {
 	private function runUpdate() {
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$statsFlusher = new PeriodicStatsFlusher(
-			MediaWikiServices::getInstance()->getStatsFactory()
-		);
+		$statsFlusher = PeriodicStatsFlusher::newFromGlobalState();
 
 		for ( $i = 0; $i <= $this->last; $i++ ) {
 

--- a/maintenance/updateQueryDependencies.php
+++ b/maintenance/updateQueryDependencies.php
@@ -3,7 +3,6 @@
 namespace SMW\Maintenance;
 
 use MediaWiki\Maintenance\Maintenance;
-use MediaWiki\MediaWikiServices;
 use Onoi\MessageReporter\MessageReporter;
 use SMW\DataItems\Property;
 use SMW\MediaWiki\JobFactory;
@@ -11,6 +10,7 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\Setup;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
+use SMW\Utils\PeriodicStatsFlusher;
 
 $basePath = getenv( 'MW_INSTALL_PATH' ) !== false ? getenv( 'MW_INSTALL_PATH' ) : __DIR__ . '/../../..';
 
@@ -171,9 +171,7 @@ class updateQueryDependencies extends Maintenance {
 		$this->reportMessage( "\n   ... found $expected entities ..." );
 		$this->reportMessage( "\n" );
 
-		$statsFlusher = new PeriodicStatsFlusher(
-			MediaWikiServices::getInstance()->getStatsFactory()
-		);
+		$statsFlusher = PeriodicStatsFlusher::newFromGlobalState();
 
 		$titleFactory = $this->getServiceContainer()->getTitleFactory();
 		foreach ( $res as $row ) {

--- a/src/Export/ExportController.php
+++ b/src/Export/ExportController.php
@@ -15,7 +15,6 @@ use SMW\Exporter\Element\ExpResource;
 use SMW\Exporter\Escaper;
 use SMW\Exporter\ExpDataFactory;
 use SMW\Exporter\Serializer\Serializer;
-use SMW\Maintenance\PeriodicStatsFlusher;
 use SMW\MediaWiki\DeepRedirectTargetResolver;
 use SMW\NamespaceExaminer;
 use SMW\Query\Language\ConceptDescription;
@@ -24,6 +23,7 @@ use SMW\Query\Query;
 use SMW\RequestOptions;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\StoreFactory;
+use SMW\Utils\PeriodicStatsFlusher;
 use Wikimedia\Rdbms\IDatabase;
 use Wikimedia\Rdbms\IReadableDatabase;
 

--- a/src/Maintenance/ConceptCacheRebuilder.php
+++ b/src/Maintenance/ConceptCacheRebuilder.php
@@ -11,6 +11,7 @@ use SMW\MediaWiki\TitleLookup;
 use SMW\Settings;
 use SMW\Store;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Is part of the `rebuildConceptCache.php` maintenance script to rebuild

--- a/src/Maintenance/DataRebuilder.php
+++ b/src/Maintenance/DataRebuilder.php
@@ -15,6 +15,7 @@ use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\Rebuilder\Rebuilder;
 use SMW\Store;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 use Throwable;
 
 /**

--- a/src/Maintenance/DataRebuilder/OutdatedDisposer.php
+++ b/src/Maintenance/DataRebuilder/OutdatedDisposer.php
@@ -4,11 +4,11 @@ namespace SMW\Maintenance\DataRebuilder;
 
 use Onoi\MessageReporter\MessageReporterAwareTrait;
 use SMW\IteratorFactory;
-use SMW\Maintenance\PeriodicStatsFlusher;
 use SMW\MediaWiki\Jobs\EntityIdDisposerJob;
 use SMW\RequestOptions;
 use SMW\SQLStore\PropertyTableIdReferenceDisposer;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * @private

--- a/src/Maintenance/DistinctEntityDataRebuilder.php
+++ b/src/Maintenance/DistinctEntityDataRebuilder.php
@@ -15,6 +15,7 @@ use SMW\Query\QueryProcessor;
 use SMW\Query\QueryResult;
 use SMW\Store;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 use Throwable;
 
 /**

--- a/src/Maintenance/DuplicateEntitiesDisposer.php
+++ b/src/Maintenance/DuplicateEntitiesDisposer.php
@@ -10,6 +10,7 @@ use SMW\SQLStore\RedirectStore;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 use Traversable;
 use Wikimedia\ObjectCache\BagOStuff;
 

--- a/src/Maintenance/PropertyStatisticsRebuilder.php
+++ b/src/Maintenance/PropertyStatisticsRebuilder.php
@@ -8,6 +8,7 @@ use SMW\SQLStore\PropertyStatisticsStore;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * Simple class for rebuilding property usage statistics.

--- a/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
+++ b/src/SQLStore/QueryEngine/Fulltext/SearchTableRebuilder.php
@@ -6,9 +6,9 @@ use Onoi\MessageReporter\MessageReporter;
 use Onoi\MessageReporter\MessageReporterFactory;
 use SMW\DataItems\DataItem;
 use SMW\DataItems\Property;
-use SMW\Maintenance\PeriodicStatsFlusher;
 use SMW\MediaWiki\Connection\Database;
 use SMW\Utils\CliMsgFormatter;
+use SMW\Utils\PeriodicStatsFlusher;
 
 /**
  * @license GPL-2.0-or-later

--- a/src/Utils/PeriodicStatsFlusher.php
+++ b/src/Utils/PeriodicStatsFlusher.php
@@ -1,15 +1,17 @@
 <?php
 
-namespace SMW\Maintenance;
+namespace SMW\Utils;
 
+use MediaWiki\MediaWikiServices;
 use Wikimedia\Stats\StatsFactory;
 
 /**
  * Periodically flushes MediaWiki's buffered stats samples during
- * long-running maintenance loops.
+ * long-running loops such as maintenance scripts, RDF exports and rebuild
+ * jobs.
  *
  * Every metric emit buffers a sample in process memory. Web requests flush
- * the buffer when they end; a maintenance process that iterates over a large
+ * the buffer when they end; a long-running process that iterates over a large
  * part of the wiki has no equivalent flush point (MediaWiki 1.43) or does
  * not reliably reach it (1.44+ flushes on output and replication waits,
  * which loops that report sparsely never call), so the buffer grows with
@@ -27,6 +29,17 @@ class PeriodicStatsFlusher {
 	private int $tickCount = 0;
 
 	public function __construct( private readonly StatsFactory $statsFactory ) {
+	}
+
+	/**
+	 * Convenience constructor for the maintenance scripts and other CLI
+	 * entry points, resolving the shared StatsFactory from the global
+	 * service container.
+	 *
+	 * @since 7.2.0
+	 */
+	public static function newFromGlobalState(): self {
+		return new self( MediaWikiServices::getInstance()->getStatsFactory() );
 	}
 
 	/**

--- a/tests/phpunit/Unit/Utils/PeriodicStatsFlusherTest.php
+++ b/tests/phpunit/Unit/Utils/PeriodicStatsFlusherTest.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace SMW\Tests\Unit\Maintenance;
+namespace SMW\Tests\Unit\Utils;
 
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
-use SMW\Maintenance\PeriodicStatsFlusher;
+use SMW\Utils\PeriodicStatsFlusher;
 use Wikimedia\Stats\Emitters\NullEmitter;
 use Wikimedia\Stats\StatsCache;
 use Wikimedia\Stats\StatsFactory;
 
 /**
- * @covers \SMW\Maintenance\PeriodicStatsFlusher
+ * @covers \SMW\Utils\PeriodicStatsFlusher
  * @group semantic-mediawiki
  *
  * @license GPL-2.0-or-later


### PR DESCRIPTION
Follows up #7036 with review-driven cleanup. No behaviour change.

Move `PeriodicStatsFlusher` from `SMW\Maintenance` to `SMW\Utils`. It is a
generic "drain the buffered stats every N iterations" utility with nothing
maintenance-specific about it, yet two of its consumers are runtime classes
rather than maintenance code: `ExportController` (`Special:ExportRDF`) and
`SearchTableRebuilder` (`FulltextSearchTableRebuildJob`). Keeping it under
`SMW\Maintenance` made those paths depend on the maintenance namespace; the
neutral `Utils` home removes that. The unit test moves alongside it.

Add `PeriodicStatsFlusher::newFromGlobalState()` and call it from the
maintenance scripts instead of repeating the same
`new PeriodicStatsFlusher( ...->getStatsFactory() )` and the `MediaWikiServices`
import at every site. The injectable constructor is retained for the test.

Expand the `populateHashField::setStatsFlusher` docblock to explain why the
`update.php` examiner path is safely left unflushed: `populate()` only hashes
and updates one row per entity (no parse) and runs once as a migration.
