### PR TITLE
Add the #property_link parser function

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -11,6 +11,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 * Added the `+display` option to the `#set` parser function, so a value can be stored and shown in one call without inline annotation syntax. The option follows a property assignment like `+sep` does and shows the values stored for that property, rendered the way the corresponding inline annotation would: `+display` or `+display=link` produce the linked, formatted value, `+display=text` the formatted value without a link ([#5624](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5624))
 * Added `SMW\MediaWiki\Outputs::requireJsConfigVar()` so extensions can register JavaScript configuration variables through the SMW output mechanism, alongside modules, styles and head items, instead of emitting inline scripts ([#7028](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7028))
+* Added the `{{#property_link:}}` parser function for linking to a property page from running text: `{{#property_link:Foo}}` and `{{#property_link:Foo|custom label}}` render the same output as the `[[Foo::@@@]]` and `[[Foo::@@@|custom label]]` annotation syntax, providing a dedicated syntax that does not rely on intercepting `[[…]]` links ([#5624](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5624), [#1855](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1855))
 
 ## Bug fixes
 

--- a/i18n/extra/SemanticMediaWiki.magic.php
+++ b/i18n/extra/SemanticMediaWiki.magic.php
@@ -22,6 +22,7 @@ $magicWords['en'] = [
 	'set' => [ 0, 'set' ],
 	'set_recurring_event' => [ 0, 'set_recurring_event' ],
 	'declare' => [ 0, 'declare' ],
+	'property_link' => [ 0, 'property_link' ],
 	'SMW_NOFACTBOX' => [ 0, '__NOFACTBOX__' ],
 	'SMW_SHOWFACTBOX' => [ 0, '__SHOWFACTBOX__' ],
 ];

--- a/src/Parser/InTextAnnotationParser.php
+++ b/src/Parser/InTextAnnotationParser.php
@@ -8,9 +8,6 @@ use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\DataValueFactory;
 use SMW\DataValues\DataValue;
-use SMW\DataValues\PropertyValue;
-use SMW\Formatters\Highlighter;
-use SMW\Localizer\Localizer;
 use SMW\MediaWiki\MagicWordsFinder;
 use SMW\MediaWiki\Outputs;
 use SMW\MediaWiki\RedirectTargetFinder;
@@ -344,7 +341,8 @@ class InTextAnnotationParser {
 
 		// #1855
 		if ( substr( $value, 0, 3 ) === '@@@' ) {
-			return $this->makePropertyLink( $subject, $properties, $value, $valueCaption );
+			$propertyLinkRenderer = new PropertyLinkRenderer( $this->parserData );
+			return $propertyLinkRenderer->render( $properties, $value, $valueCaption );
 		}
 
 		return $this->addPropertyValue( $subject, $properties, $value, $valueCaption );
@@ -469,58 +467,6 @@ class InTextAnnotationParser {
 
 	private function isSemanticEnabledForNamespace( Title $title ) {
 		return $this->applicationFactory->getNamespaceExaminer()->isSemanticEnabled( $title->getNamespace() );
-	}
-
-	private function makePropertyLink( WikiPage $subject, $properties, $value, $caption ) {
-		$property = end( $properties );
-		$linker = smwfGetLinker();
-		$class = 'smw-property';
-
-		// #4037
-		// [[Foo::@@@|#] where `|#` indicates a noLink request
-		if ( $caption === '#' ) {
-			$linker = false;
-			$caption = false;
-			$class = 'smw-property nolink';
-		}
-
-		$dataValue = DataValueFactory::getInstance()->newPropertyValueByLabel(
-			$property,
-			$caption,
-			$subject
-		);
-
-		$dataValue->setLinkAttributes( [ 'class' => $class ] );
-
-		$lang = Localizer::getAnnotatedLanguageCodeFrom( $value );
-		if ( $lang !== false ) {
-			$dataValue->setOption( $dataValue::OPT_USER_LANGUAGE, $lang );
-			$dataValue->setCaption(
-				$caption === false ? $dataValue->getWikiValue() : $caption
-			);
-		}
-
-		if ( $dataValue instanceof PropertyValue ) {
-			$dataValue->setOption( $dataValue::OPT_HIGHLIGHT_LINKER, true );
-		}
-
-		$result = $dataValue->getShortWikitext( $linker );
-
-		// The `@@@` property-link path returns its output directly rather than
-		// going through addPropertyValue(), so the user-language signal must be
-		// recorded here. A property link renders a tooltip (title and, for
-		// predefined properties, a localized description) in the viewer's
-		// interface language, unless an explicit language was annotated
-		// (`@@@<lang>`), in which case the output is content-stable. An invalid
-		// property renders a localized error. Record this so the `userlang`
-		// parser-cache key is added (see InTextAnnotationParser::parse()).
-		if ( !$dataValue->isValid() ||
-			( $lang === false && Highlighter::hasHighlighterClass( $result ) )
-		) {
-			$this->parserData->markVariesByUserLanguage();
-		}
-
-		return $result;
 	}
 
 }

--- a/src/Parser/PropertyLinkRenderer.php
+++ b/src/Parser/PropertyLinkRenderer.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace SMW\Parser;
+
+use SMW\DataValueFactory;
+use SMW\DataValues\PropertyValue;
+use SMW\Formatters\Highlighter;
+use SMW\Localizer\Localizer;
+use SMW\ParserData;
+
+/**
+ * Renders a link to a property page, as produced by the `[[Foo::@@@]]`
+ * in-text annotation syntax (#1855) and the {{#property_link}} parser
+ * function (#5624).
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.2.0
+ */
+class PropertyLinkRenderer {
+
+	public function __construct( private ParserData $parserData ) {
+	}
+
+	/**
+	 * @param string[] $properties
+	 * @param string $value the annotated value, `@@@` or `@@@<lang>`
+	 * @param string|false $caption
+	 */
+	public function render( array $properties, string $value, string|false $caption ): string {
+		$property = end( $properties );
+		$linker = smwfGetLinker();
+		$class = 'smw-property';
+
+		// #4037
+		// [[Foo::@@@|#] where `|#` indicates a noLink request
+		if ( $caption === '#' ) {
+			$linker = false;
+			$caption = false;
+			$class = 'smw-property nolink';
+		}
+
+		$dataValue = DataValueFactory::getInstance()->newPropertyValueByLabel(
+			$property,
+			$caption,
+			$this->parserData->getSubject()
+		);
+
+		$dataValue->setLinkAttributes( [ 'class' => $class ] );
+
+		$lang = Localizer::getAnnotatedLanguageCodeFrom( $value );
+		if ( $lang !== false ) {
+			$dataValue->setOption( $dataValue::OPT_USER_LANGUAGE, $lang );
+			$dataValue->setCaption(
+				$caption === false ? $dataValue->getWikiValue() : $caption
+			);
+		}
+
+		if ( $dataValue instanceof PropertyValue ) {
+			$dataValue->setOption( $dataValue::OPT_HIGHLIGHT_LINKER, true );
+		}
+
+		$result = $dataValue->getShortWikitext( $linker );
+
+		// The property-link output is returned directly rather than going
+		// through InTextAnnotationParser::addPropertyValue(), so the
+		// user-language signal must be recorded here. A property link renders
+		// a tooltip (title and, for predefined properties, a localized
+		// description) in the viewer's interface language, unless an explicit
+		// language was annotated (`@@@<lang>`), in which case the output is
+		// content-stable. An invalid property renders no output.
+		// Recording this lets the caller add the `userlang` parser-cache key
+		// (see InTextAnnotationParser::parse() and PropertyLinkParserFunction).
+		if ( !$dataValue->isValid() ||
+			( $lang === false && Highlighter::hasHighlighterClass( $result ) )
+		) {
+			$this->parserData->markVariesByUserLanguage();
+		}
+
+		return $result;
+	}
+
+}

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -8,6 +8,7 @@ use MediaWiki\Parser\PPFrame;
 use ParamProcessor\Processor;
 use SMW\DataModel\Subobject;
 use SMW\Formatters\MessageFormatter;
+use SMW\Parser\PropertyLinkRenderer;
 use SMW\Parser\RecursiveTextProcessor;
 use SMW\ParserFunctions\AskParserFunction;
 use SMW\ParserFunctions\ConceptParserFunction;
@@ -15,6 +16,7 @@ use SMW\ParserFunctions\DeclareParserFunction;
 use SMW\ParserFunctions\DocumentationParserFunction;
 use SMW\ParserFunctions\ExpensiveFuncExecutionWatcher;
 use SMW\ParserFunctions\InfoParserFunction;
+use SMW\ParserFunctions\PropertyLinkParserFunction;
 use SMW\ParserFunctions\RecurringEventsParserFunction as RecurringEventsParserFunc;
 use SMW\ParserFunctions\SetParserFunction;
 use SMW\ParserFunctions\ShowParserFunction;
@@ -74,6 +76,9 @@ class ParserFunctionFactory {
 		$parser->setFunctionHook( $name, $definition, $flag );
 
 		[ $name, $definition, $flag ] = $this->getDeclareParserFunctionDefinition();
+		$parser->setFunctionHook( $name, $definition, $flag );
+
+		[ $name, $definition, $flag ] = $this->getPropertyLinkParserFunctionDefinition();
 		$parser->setFunctionHook( $name, $definition, $flag );
 	}
 
@@ -323,6 +328,21 @@ class ParserFunctionFactory {
 	}
 
 	/**
+	 * @since 7.2.0
+	 */
+	public function newPropertyLinkParserFunction( Parser $parser ): PropertyLinkParserFunction {
+		$parserData = ApplicationFactory::getInstance()->newParserData(
+			$parser->getTitle(),
+			$parser->getOutput()
+		);
+
+		return new PropertyLinkParserFunction(
+			$parserData,
+			new PropertyLinkRenderer( $parserData )
+		);
+	}
+
+	/**
 	 * @since 2.3
 	 */
 	public function getAskParserFunctionDefinition(): array {
@@ -497,6 +517,21 @@ class ParserFunctionFactory {
 		};
 
 		return [ 'info', $infoDefinition, Parser::SFH_OBJECT_ARGS ];
+	}
+
+	/**
+	 * @since 7.2.0
+	 */
+	public function getPropertyLinkParserFunctionDefinition(): array {
+		$propertyLinkParserFunctionDefinition = function ( Parser $parser ): string {
+			$propertyLinkParserFunction = $this->newPropertyLinkParserFunction(
+				$parser
+			);
+
+			return $propertyLinkParserFunction->parse( func_get_args() );
+		};
+
+		return [ 'property_link', $propertyLinkParserFunctionDefinition, 0 ];
 	}
 
 }

--- a/src/ParserFunctions/PropertyLinkParserFunction.php
+++ b/src/ParserFunctions/PropertyLinkParserFunction.php
@@ -4,6 +4,7 @@ namespace SMW\ParserFunctions;
 
 use MediaWiki\Parser\Parser;
 use SMW\MediaWiki\Outputs;
+use SMW\Parser\LinksEncoder;
 use SMW\Parser\PropertyLinkRenderer;
 use SMW\ParserData;
 use SMW\Services\ServicesFactory as ApplicationFactory;
@@ -38,6 +39,10 @@ class PropertyLinkParserFunction {
 		$property = array_shift( $rawParams ) ?? '';
 		$caption = array_shift( $rawParams ) ?? false;
 
+		if ( $caption !== false ) {
+			$caption = $this->neutralizeAnnotations( $caption );
+		}
+
 		$result = $this->propertyLinkRenderer->render( [ $property ], '@@@', $caption );
 
 		// Mirrors InTextAnnotationParser::parse() where the `userlang`
@@ -52,6 +57,25 @@ class PropertyLinkParserFunction {
 		}
 
 		return $result;
+	}
+
+	/**
+	 * A caption is display text and must not annotate. `[[Foo::@@@|caption]]`
+	 * hands its caption to InTextAnnotationParser, which never rescans it, but
+	 * this function returns wikitext before InTextAnnotationParser runs, so an
+	 * unhandled caption would reach that scan: `[[Bar::Baz]]` would store an
+	 * annotation of its own and `[[SMW::off]]` would discard the annotations of
+	 * everything that follows it on the page.
+	 *
+	 * removeAnnotation() reduces an annotation to the text it displays, leaving
+	 * ordinary links alone; obfuscateAnnotation() then encodes the brackets of
+	 * whatever remains, since removeAnnotation() unwraps only the outermost
+	 * annotation and would otherwise expose a nested one.
+	 */
+	private function neutralizeAnnotations( string $caption ): string {
+		return (string)LinksEncoder::obfuscateAnnotation(
+			LinksEncoder::removeAnnotation( $caption )
+		);
 	}
 
 	/**

--- a/src/ParserFunctions/PropertyLinkParserFunction.php
+++ b/src/ParserFunctions/PropertyLinkParserFunction.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace SMW\ParserFunctions;
+
+use MediaWiki\Parser\Parser;
+use SMW\MediaWiki\Outputs;
+use SMW\Parser\PropertyLinkRenderer;
+use SMW\ParserData;
+use SMW\Services\ServicesFactory as ApplicationFactory;
+
+/**
+ * Provides the {{#property_link}} parser function to link to a property page
+ * from running text (#5624), as the parser-function equivalent of the
+ * `[[Foo::@@@]]` in-text annotation syntax (#1855).
+ *
+ * {{#property_link:Foo}} renders the same output as [[Foo::@@@]], and
+ * {{#property_link:Foo|custom label}} the same as [[Foo::@@@|custom label]].
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.2.0
+ */
+class PropertyLinkParserFunction {
+
+	public function __construct(
+		private ParserData $parserData,
+		private PropertyLinkRenderer $propertyLinkRenderer
+	) {
+	}
+
+	public function parse( array $rawParams ): string {
+		$parser = null;
+
+		// Remove parser object from parameters array
+		if ( isset( $rawParams[0] ) && $rawParams[0] instanceof Parser ) {
+			$parser = array_shift( $rawParams );
+		}
+
+		$property = array_shift( $rawParams ) ?? '';
+		$caption = array_shift( $rawParams ) ?? false;
+
+		$result = $this->propertyLinkRenderer->render( [ $property ], '@@@', $caption );
+
+		// Mirrors InTextAnnotationParser::parse() where the `userlang`
+		// parser-cache key is only applied for namespaces with semantic
+		// links enabled
+		if ( $this->parserData->variesByUserLanguage() && $this->isSemanticEnabledNamespace() ) {
+			$this->parserData->addExtraParserKey( 'userlang' );
+		}
+
+		if ( $parser !== null ) {
+			$this->commitRequestedResources( $parser );
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Resources requested during rendering (tooltip styles and scripts) must
+	 * be committed here because the result bypasses the commit performed by
+	 * InTextAnnotationParser::parse()
+	 */
+	private function commitRequestedResources( Parser $parser ): void {
+		if ( $parser->getTitle()->isSpecialPage() ) {
+			global $wgOut;
+			Outputs::commitToOutputPage( $wgOut );
+		} else {
+			Outputs::commitToParser( $parser );
+		}
+	}
+
+	private function isSemanticEnabledNamespace(): bool {
+		return ApplicationFactory::getInstance()->getNamespaceExaminer()->isSemanticEnabled(
+			$this->parserData->getTitle()->getNamespace()
+		);
+	}
+
+}

--- a/tests/phpunit/Integration/JSONScript/README.md
+++ b/tests/phpunit/Integration/JSONScript/README.md
@@ -23,8 +23,8 @@ It will also generate the descriptions for each test based on the contents of th
 
 ## List of tests
 
-- Files: 338 (includes 1460 tests)
-- Last update: 2025-04-02
+- Files: 345 (includes 1508 tests)
+- Last update: 2026-07-16
 
 ### A
 * [api-ask-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/api-ask-0001.json) Test API `action=ask` with `api_version` 2 + 3
@@ -97,6 +97,9 @@ It will also generate the descriptions for each test based on the contents of th
 * [p-0211.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0211.json) Test `#set`/`#subobject` to import annotation via `@json` syntax (`wgContLang=en`, `wgLang=en`)
 * [p-0212.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0212.json) Test `@@@` in-text annotation syntax (#1855, #1875 `wgContLang=en`, `wgLang=en`)
 * [p-0213.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0213.json) Test different "wrong" uses of `#show` (#4349)
+* [p-0214.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0214.json) Test `#set` parser with `+display` option to store and show values in one call (#5624, en, `wgContLang=en`, `wgLang=en`)
+* [p-0215.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0215.json) Test `#set` parser with `+display` option on a keyword formatter schema and on strip-marker values (#5624, `smwgCompactLinkSupport`, `SMW_PARSER_UNSTRIP`)
+* [p-0216.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0216.json) Test `{{#property_link:}}` parser function output parity with the `[[Foo::@@@]]` annotation syntax (#5624, #1855, `wgContLang=en`, `wgLang=en`)
 * [p-0301.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0301.json) Test #subobject category annotation (#1172)
 * [p-0302.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0302.json) Test #subobject parser to use invalid assignments and create `_ERRC` (#1299, en)
 * [p-0303.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0303.json) Test `#subobject` and `#set` parser on values with spaces (`wgContLang=en`, `wgLang=en`)
@@ -165,6 +168,7 @@ It will also generate the descriptions for each test based on the contents of th
 * [p-0463.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0463.json) Test removal of entity references
 * [p-0464.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0464.json) Test output of the `ISO` formatter with `#show` for `_dat` datatype (#4373)
 * [p-0465.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0465.json) Test output of the `ISO-P` formatter with `#show` (#5309)
+* [p-0466.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0466.json) Test `@@@` and `{{#property_link:}}` property links under a non-English content language (#1855, #5624, `wgContLang=de`, `wgLang=en`)
 * [p-0467.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0467.json) Test use case for lookup prefetch cache strategy in connection with printrequest chain filtering
 * [p-0501.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0501.json) Test `#concept` on predefined property (`wgContLang=en`, `wgLang=es`)
 * [p-0502.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0502.json) Test in-text annotation allows value list (#2295, `wgContLang=en`, `wgLang=en`)
@@ -174,7 +178,7 @@ It will also generate the descriptions for each test based on the contents of th
 * [p-0702.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0702.json) Test #ask with `format=table` on inverse property/printrequest (#1270, #1360)
 * [p-0703.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0703.json) Test `#ask` on `format=table` using different printrequest label output (#1270, `wgContLang=en`, `wgLang=en`)
 * [p-0704.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0704.json) Test `#ask` sanitization of printrequest labels to avoid XSS injection (`wgContLang=en`, `wgLang=en`)
-* [p-0705.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0705.json) Test `#ask`/ NS_FILE option, `noimage` (`wgEnableUploads`, `wgFileExtensions`, `wgDefaultUserOptions`)
+* [p-0705.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0705.json) Test `#ask`/ NS_FILE option, `noimage` (`wgEnableUploads`, `wgFileExtensions`, `wgDefaultUserOptions`, `wgThumbLimits`)
 * [p-0706.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0706.json) Test `#ask` on `format=template` with message parse (`wgContLang=en`, `wgLang=en`)
 * [p-0707.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0707.json) Test `#ask` with enabled execution limit (`wgContLang=en`, `wgLang=en`, `smwgQExpensiveThreshold`, `smwgQExpensiveExecutionLimit`)
 * [p-0708.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-0708.json) Test `#ask` NS_FILE and DISPLAYTITLE (`wgContLang=en`, `wgLang=en`, `wgEnableUploads`, `wgFileExtensions`, 'wgDefaultUserOptions', `wgRestrictDisplayTitle`)
@@ -218,6 +222,7 @@ It will also generate the descriptions for each test based on the contents of th
 * [p-1010.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-1010.json) Query test on pages with numberic titles (T239877)
 * [p-1011.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-1011.json) Test property page, '...' more than (`smwgMaxPropertyValues`)
 * [p-1012.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-1012.json) Test category page (#4759)
+* [p-1013.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-1013.json) Change-propagation pipeline smoke test: category _SUBC propagation (shallow path) and an unchanged typed property (pipeline survives forced/shallow split)
 * [p-1100.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-1100.json) Test `smw/schema` on `PROPERTY_CONSTRAINT_SCHEMA` with `allowed_namespaces` and `Constraint schema`
 * [p-1101.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-1101.json) Test `smw/schema` on `PROPERTY_CONSTRAINT_SCHEMA` with `non_negative_integer` and `Constraint schema`
 * [p-1102.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/p-1102.json) Test `smw/schema` on `PROPERTY_CONSTRAINT_SCHEMA` with `must_exists` and `Constraint schema`
@@ -239,6 +244,7 @@ It will also generate the descriptions for each test based on the contents of th
 * [q-0202.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0202.json) Test `_CONC` for guarding against circular/self-reference which otherwise would fail with 'Maximum function nesting level ... reached, aborting' (#945, skip virtuoso)
 * [q-0203.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0203.json) Test `_CONC` to use `CONCEPT_CACHE_ALL` (#1050, skip all SPARQL repository)
 * [q-0204.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0204.json) Test `_CONC` on predefined inverse query and subobject inverse query (#1096, skip virtuoso)
+* [q-0205.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0205.json) Test concept (live-computed) combined with a single-page restriction (#6994, skip virtuoso)
 * [q-0301.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0301.json) Test `_IMPO` queries for imported foaf vocabulary (#891, en)
 * [q-0401.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0401.json) Test `_SUBP` on a simple 'family' subproperty hierarchy example query (#1003, skip virtuoso)
 * [q-0402.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/q-0402.json) Test `_SUBP` to map DC imported vocabulary with MARC 21 bibliographic terms (#1003, http://www.loc.gov/marc/bibliographic/bd20x24x.html)
@@ -355,7 +361,7 @@ It will also generate the descriptions for each test based on the contents of th
 * [special-ask-0017.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-ask-0017.json) Test `format=csv` output via `Special:Ask` for display units (`wgContLang=en`, `wgLang=en`)
 * [special-ask-0018.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-ask-0018.json) Test `format=json` output via `Special:Ask` to check limit, default limit, `smwgQMaxInlineLimit` type (#2474, #4172)
 * [special-ask-0019.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-ask-0019.json) Test output via `Special:Ask` to verify limit, offset
-* [special-ask-0020.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-ask-0020.json) Test `Special:Ask` output `#ask` (#4348)
+* [special-ask-debug-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-ask-debug-0001.json) Test `Special:Ask` `format=debug` output (regression: a debug query returns a string result, not a QueryResult, so the score set must not be accessed on it)
 * [special-browse-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-browse-0001.json) Test `Special:Browse` output for `_dat` (`wgContLang=en`, `wgLang=ja`)
 * [special-browse-0002.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-browse-0002.json) Test `Special:Browse` output for `_dat`, '_REDI' (`wgContLang=en`, `wgLang=en`, `smwgDVFeatures=SMW_DV_TIMEV_CM | SMW_DV_WPV_DTITLE`, `wgRestrictDisplayTitle=false`)
 * [special-browse-0003.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-browse-0003.json) Test `Special:Browse` output for `_dat`, `_boo`, `_sobj`, `_uri` (`wgContLang=en`, `wgLang=es`, skip-on 1.25.6)
@@ -366,6 +372,7 @@ It will also generate the descriptions for each test based on the contents of th
 * [special-browse-0008.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-browse-0008.json) Test `Special:Browse` limited value list
 * [special-concepts-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-concepts-0001.json) Test `Special:Concepts`
 * [special-page-property-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-page-property-0001.json) Test output from `Special:PageProperty` (with `_dat`)
+* [special-page-property-0002.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-page-property-0002.json) Test output from `Special:PageProperty` listing the distinct values of a text property (`_txt`, covering fast path)
 * [special-properties-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-properties-0001.json) Test output of `Special:Properties` (`wgContLang=en`, skip-on sqlite)
 * [special-search-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-search-0001.json) Test output in `Special:Search` for SMWSearch (`wgLanguageCode=en`, `wgContLang=en`, `wgSearchType=SMWSearch`)
 * [special-search-by-property-0001.json](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/tests/phpunit/Integration/JSONScript/TestCases/special-search-by-property-0001.json) Test output from `Special:SearchByProperty` for `_num`, `_txt`, `_tel` (#1728, #2009, `wgContLang=en`, `wgLang=en`, skip-on sqlite, postgres)

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0216.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0216.json
@@ -1,5 +1,5 @@
 {
-	"description": "Test `@@@` in-text annotation syntax (#1855, #1875 `wgContLang=en`, `wgLang=en`)",
+	"description": "Test `{{#property_link:}}` parser function output parity with the `[[Foo::@@@]]` annotation syntax (#5624, #1855, `wgContLang=en`, `wgLang=en`)",
 	"setup": [
 		{
 			"namespace": "SMW_NS_PROPERTY",
@@ -12,51 +12,43 @@
 			"contents": "[[Has type::Text]] [[Has preferred property label::occupation@en]] [[Has preferred property label::직업@ko]] [[Has preferred property label::職業@ja]] [[Has property description::人物の職業。「専門分野」@ja]] [[Has property description::대상 인물의 직업@ko]]"
 		},
 		{
-			"page": "Example/P0212/1",
-			"contents": "[[Has date::@@@]]"
+			"page": "Example/P0216/1",
+			"contents": "{{#property_link:Has date}}"
 		},
 		{
-			"page": "Example/P0212/2",
-			"contents": "[[Has date::@@@|With extra caption]]"
+			"page": "Example/P0216/2",
+			"contents": "{{#property_link:Has date|With extra caption}}"
 		},
 		{
-			"page": "Example/P0212/3",
-			"contents": "[[P106::@@@ja]]"
+			"page": "Example/P0216/3",
+			"contents": "{{#property_link:P106}}"
 		},
 		{
-			"page": "Example/P0212/4",
-			"contents": "[[P106::@@@ko|WithCaption]]"
+			"page": "Example/P0216/4",
+			"contents": "{{#property_link:P106|WithCaption}}"
 		},
 		{
-			"page": "Example/P0212/5",
-			"contents": "[[P106::@@@ko|#]]"
+			"page": "Example/P0216/5",
+			"contents": "{{#property_link:Has date|#}}"
 		},
 		{
-			"page": "Example/P0212/6",
-			"contents": "[[P106::@@@]]"
+			"page": "Example/P0216/6",
+			"contents": "{{#property_link:Has nonexistent property}}"
 		},
 		{
-			"page": "Example/P0212/7",
-			"contents": "[[P106::@@@|WithCaption]]"
+			"page": "Example/P0216/7",
+			"contents": "{{#property_link:Fo%o}}"
 		},
 		{
-			"page": "Example/P0212/8",
-			"contents": "[[Has date::@@@|#]]"
-		},
-		{
-			"page": "Example/P0212/9",
-			"contents": "[[Has nonexistent property::@@@]]"
-		},
-		{
-			"page": "Example/P0212/10",
-			"contents": "[[Fo%o::@@@]]"
+			"page": "Example/P0216/8",
+			"contents": "{{#property_link:}}"
 		}
 	],
 	"tests": [
 		{
 			"type": "parser",
-			"about": "#0",
-			"subject": "Example/P0212/1",
+			"about": "#0 same output as `[[Has date::@@@]]` (p-0212 #0)",
+			"subject": "Example/P0216/1",
 			"assert-output": {
 				"to-contain": [
 					"<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"Some text with a link to foo and stripped `li` in title element\">",
@@ -67,8 +59,8 @@
 		},
 		{
 			"type": "parser",
-			"about": "#1",
-			"subject": "Example/P0212/2",
+			"about": "#1 same output as `[[Has date::@@@|With extra caption]]` (p-0212 #1)",
+			"subject": "Example/P0216/2",
 			"assert-output": {
 				"to-contain": [
 					"<span class=\"smw-highlighter\" data-type=\"1\" data-state=\"inline\" data-title=\"Property\" title=\"Some text with a link to foo and stripped `li` in title element\">",
@@ -79,38 +71,8 @@
 		},
 		{
 			"type": "parser",
-			"about": "#2",
-			"subject": "Example/P0212/3",
-			"assert-output": {
-				"to-contain": [
-					"<span class=\"smw-property\">.*title=\"Property:P106\">職業</a></span></span><span class=\"smwttcontent\">人物の職業。「専門分野」</span></span>&#160;<span title=\"P106\"><sup>ᵖ</sup>"
-				]
-			}
-		},
-		{
-			"type": "parser",
-			"about": "#3",
-			"subject": "Example/P0212/4",
-			"assert-output": {
-				"to-contain": [
-					"<span class=\"smw-property\">.*title=\"Property:P106\">WithCaption</a></span></span><span class=\"smwttcontent\">대상 인물의 직업</span></span>"
-				]
-			}
-		},
-		{
-			"type": "parser",
-			"about": "#4 (no link)",
-			"subject": "Example/P0212/5",
-			"assert-output": {
-				"to-contain": [
-					"<span class=\"smw-highlighter\" .* title=\"대상 인물의 직업\"><span class=\"smwtext\"><span class=\"smw-property nolink\">직업</span></span><span class=\"smwttcontent\">대상 인물의 직업</span></span>&#160;<span title=\"P106\"><sup>ᵖ</sup></span>"
-				]
-			}
-		},
-		{
-			"type": "parser",
-			"about": "#5 plain `@@@` on a property with preferred labels resolves the label by user language",
-			"subject": "Example/P0212/6",
+			"about": "#2 same output as `[[P106::@@@]]` (p-0212 #5)",
+			"subject": "Example/P0216/3",
 			"assert-output": {
 				"to-contain": [
 					"title=\"Property:P106\">occupation</a>",
@@ -120,8 +82,8 @@
 		},
 		{
 			"type": "parser",
-			"about": "#6 caption overrides the preferred label",
-			"subject": "Example/P0212/7",
+			"about": "#3 same output as `[[P106::@@@|WithCaption]]` (p-0212 #6)",
+			"subject": "Example/P0216/4",
 			"assert-output": {
 				"to-contain": [
 					"title=\"Property:P106\">WithCaption</a>"
@@ -130,8 +92,8 @@
 		},
 		{
 			"type": "parser",
-			"about": "#7 (no link) with tooltip from the property description",
-			"subject": "Example/P0212/8",
+			"about": "#4 same output as `[[Has date::@@@|#]]` (p-0212 #7)",
+			"subject": "Example/P0216/5",
 			"assert-output": {
 				"to-contain": [
 					"<span class=\"smw-property nolink\">Has date</span>",
@@ -141,8 +103,8 @@
 		},
 		{
 			"type": "parser",
-			"about": "#8 nonexistent property renders a red link",
-			"subject": "Example/P0212/9",
+			"about": "#5 same output as `[[Has nonexistent property::@@@]]` (p-0212 #8)",
+			"subject": "Example/P0216/6",
 			"assert-output": {
 				"to-contain": [
 					"class=\"new\"",
@@ -152,8 +114,18 @@
 		},
 		{
 			"type": "parser",
-			"about": "#9 invalid property name renders nothing",
-			"subject": "Example/P0212/10",
+			"about": "#6 same output as `[[Fo%o::@@@]]` (p-0212 #9)",
+			"subject": "Example/P0216/7",
+			"assert-output": {
+				"to-contain": [
+					"<div class=\"mw-content-ltr mw-parser-output\" lang=\"en\" dir=\"ltr\"></div>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#7 empty property name renders nothing",
+			"subject": "Example/P0216/8",
 			"assert-output": {
 				"to-contain": [
 					"<div class=\"mw-content-ltr mw-parser-output\" lang=\"en\" dir=\"ltr\"></div>"

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0466.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0466.json
@@ -1,0 +1,109 @@
+{
+	"description": "Test `@@@` and `{{#property_link:}}` property links under a non-English content language (#1855, #5624, `wgContLang=de`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Testeigenschaft",
+			"contents": "Property page."
+		},
+		{
+			"page": "Example/P0466/1",
+			"contents": "[[Testeigenschaft::@@@]]"
+		},
+		{
+			"page": "Example/P0466/2",
+			"contents": "[[Testeigenschaft::@@@|Eigenes Etikett]]"
+		},
+		{
+			"page": "Example/P0466/3",
+			"contents": "[[Fehlende Eigenschaft::@@@]]"
+		},
+		{
+			"page": "Example/P0466/4",
+			"contents": "{{#property_link:Testeigenschaft}}"
+		},
+		{
+			"page": "Example/P0466/5",
+			"contents": "{{#property_link:Testeigenschaft|Eigenes Etikett}}"
+		},
+		{
+			"page": "Example/P0466/6",
+			"contents": "{{#property_link:Fehlende Eigenschaft}}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 property link under a non-English content language",
+			"subject": "Example/P0466/1",
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"smw-property\">",
+					"title=\"Property:Testeigenschaft\">Testeigenschaft</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 custom caption",
+			"subject": "Example/P0466/2",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Property:Testeigenschaft\">Eigenes Etikett</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 nonexistent property renders a red link",
+			"subject": "Example/P0466/3",
+			"assert-output": {
+				"to-contain": [
+					"class=\"new\"",
+					"title=\"Property:Fehlende Eigenschaft (Seite nicht vorhanden)\">Fehlende Eigenschaft</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 same output as `[[Testeigenschaft::@@@]]` (#0)",
+			"subject": "Example/P0466/4",
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"smw-property\">",
+					"title=\"Property:Testeigenschaft\">Testeigenschaft</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 same output as `[[Testeigenschaft::@@@|Eigenes Etikett]]` (#1)",
+			"subject": "Example/P0466/5",
+			"assert-output": {
+				"to-contain": [
+					"title=\"Property:Testeigenschaft\">Eigenes Etikett</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#5 same output as `[[Fehlende Eigenschaft::@@@]]` (#2)",
+			"subject": "Example/P0466/6",
+			"assert-output": {
+				"to-contain": [
+					"class=\"new\"",
+					"title=\"Property:Fehlende Eigenschaft (Seite nicht vorhanden)\">Fehlende Eigenschaft</a>"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "de",
+		"wgLang": "en"
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/Parser/InTextAnnotationParserTemplateTransclusionTest.php
+++ b/tests/phpunit/Integration/Parser/InTextAnnotationParserTemplateTransclusionTest.php
@@ -131,7 +131,7 @@ class InTextAnnotationParserTemplateTransclusionTest extends TestCase {
 		// The `@@@` syntax renders a property link. `Modification date` is a
 		// predefined property whose link carries a tooltip with a localized
 		// title and description, so the rendered output (returned directly by
-		// makePropertyLink) varies by the viewer's interface language.
+		// the PropertyLinkRenderer) varies by the viewer's interface language.
 		$text = 'Foo [[Modification date::@@@]] baz';
 		$instance->parse( $text );
 

--- a/tests/phpunit/Integration/Parser/PropertyLinkParserFunctionParityTest.php
+++ b/tests/phpunit/Integration/Parser/PropertyLinkParserFunctionParityTest.php
@@ -6,6 +6,7 @@ use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\ParserOptions;
 use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
+use SMW\ParserData;
 use SMW\Tests\TestEnvironment;
 
 /**
@@ -66,15 +67,85 @@ class PropertyLinkParserFunctionParityTest extends TestCase {
 		];
 	}
 
+	/**
+	 * A caption is display text and must not annotate. The annotation syntax
+	 * hands its caption to InTextAnnotationParser, which never rescans it, but
+	 * a parser function returns wikitext that InTextAnnotationParser scans
+	 * afterwards, so annotation syntax in a caption reaches that scan unless it
+	 * is neutralized first.
+	 *
+	 * @dataProvider captionWithAnnotationSyntaxProvider
+	 */
+	public function testCaptionDoesNotAnnotate( string $wikitext ) {
+		$this->assertNotContains(
+			'Bar',
+			$this->propertyKeys( $wikitext ),
+			'a caption must not store an annotation of its own'
+		);
+	}
+
+	/**
+	 * @return array<string,array{string}>
+	 */
+	public function captionWithAnnotationSyntaxProvider(): array {
+		return [
+			'annotation' => [ '{{#property_link:Foo|[[Bar::Baz]]}}' ],
+			'annotation with caption' => [ '{{#property_link:Foo|[[Bar::Baz|label]]}}' ],
+			'annotation within text' => [ '{{#property_link:Foo|see [[Bar::Baz]] here}}' ],
+			'nested annotation' => [ '{{#property_link:Foo|[[Foo::[[Bar::Baz]]]]}}' ],
+		];
+	}
+
+	/**
+	 * `[[SMW::off]]` disables annotation processing for the remainder of the
+	 * text, so a caption carrying it would silently discard the annotations of
+	 * an entire page.
+	 */
+	public function testCaptionCannotDisableSubsequentAnnotations() {
+		$this->assertContains(
+			'Baz',
+			$this->propertyKeys( '{{#property_link:Foo|[[SMW::off]]}} [[Baz::Quux]]' ),
+			'a caption must not disable annotation processing for what follows it'
+		);
+	}
+
 	private function parse( string $wikitext ): string {
-		$parser = MediaWikiServices::getInstance()->getParserFactory()->create();
 		$parserOptions = ParserOptions::newFromAnon();
 
-		return $parser->parse(
+		return $this->parserOutput( $wikitext, $parserOptions )
+			->runOutputPipeline( $parserOptions )
+			->getContentHolderText();
+	}
+
+	/**
+	 * @return string[] the keys of the properties annotated by `$wikitext`
+	 */
+	private function propertyKeys( string $wikitext ): array {
+		$title = $this->newTitle();
+		$parserData = new ParserData(
+			$title,
+			$this->parserOutput( $wikitext, ParserOptions::newFromAnon(), $title )
+		);
+
+		$keys = [];
+
+		foreach ( $parserData->getSemanticData()->getProperties() as $property ) {
+			$keys[] = $property->getKey();
+		}
+
+		return $keys;
+	}
+
+	private function parserOutput( string $wikitext, ParserOptions $parserOptions, ?Title $title = null ) {
+		return MediaWikiServices::getInstance()->getParserFactory()->create()->parse(
 			$wikitext,
-			Title::newFromText( 'PropertyLinkParserFunctionParityTest', NS_MAIN ),
+			$title ?? $this->newTitle(),
 			$parserOptions
-		)->runOutputPipeline( $parserOptions )->getContentHolderText();
+		);
+	}
+
+	private function newTitle(): Title {
+		return Title::newFromText( 'PropertyLinkParserFunctionParityTest', NS_MAIN );
 	}
 
 }

--- a/tests/phpunit/Integration/Parser/PropertyLinkParserFunctionParityTest.php
+++ b/tests/phpunit/Integration/Parser/PropertyLinkParserFunctionParityTest.php
@@ -68,12 +68,13 @@ class PropertyLinkParserFunctionParityTest extends TestCase {
 
 	private function parse( string $wikitext ): string {
 		$parser = MediaWikiServices::getInstance()->getParserFactory()->create();
+		$parserOptions = ParserOptions::newFromAnon();
 
 		return $parser->parse(
 			$wikitext,
 			Title::newFromText( 'PropertyLinkParserFunctionParityTest', NS_MAIN ),
-			ParserOptions::newFromAnon()
-		)->getText();
+			$parserOptions
+		)->runOutputPipeline( $parserOptions )->getContentHolderText();
 	}
 
 }

--- a/tests/phpunit/Integration/Parser/PropertyLinkParserFunctionParityTest.php
+++ b/tests/phpunit/Integration/Parser/PropertyLinkParserFunctionParityTest.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace SMW\Tests\Integration\Parser;
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\ParserOptions;
+use MediaWiki\Title\Title;
+use PHPUnit\Framework\TestCase;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * Proves that `{{#property_link:Property}}` renders output identical to the
+ * equivalent `[[Property::@@@]]` annotation syntax. The JSONScript cases
+ * p-0216/p-0466 pin representative fragments with substring assertions; this
+ * test asserts full-output equality, so a divergence introduced into either
+ * path — including the parser-function wrapper, which is not shared code —
+ * is caught even when the shared property-link fragment is unchanged.
+ *
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.2.0
+ */
+class PropertyLinkParserFunctionParityTest extends TestCase {
+
+	private TestEnvironment $testEnvironment;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+	}
+
+	protected function tearDown(): void {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * @dataProvider equivalentSyntaxProvider
+	 */
+	public function testParserFunctionMatchesAnnotationSyntax( string $annotation, string $parserFunction ) {
+		$annotationOutput = $this->parse( $annotation );
+
+		$this->assertStringContainsString(
+			'smw-property',
+			$annotationOutput,
+			'guard: the annotation is expected to render a property link'
+		);
+
+		$this->assertSame(
+			$annotationOutput,
+			$this->parse( $parserFunction )
+		);
+	}
+
+	/**
+	 * @return array<string,array{string,string}>
+	 */
+	public function equivalentSyntaxProvider(): array {
+		return [
+			'plain property' => [ '[[Foo::@@@]]', '{{#property_link:Foo}}' ],
+			'custom caption' => [ '[[Foo::@@@|My caption]]', '{{#property_link:Foo|My caption}}' ],
+			'no-link variant' => [ '[[Modification date::@@@|#]]', '{{#property_link:Modification date|#}}' ],
+			'predefined property with tooltip' => [ '[[Modification date::@@@]]', '{{#property_link:Modification date}}' ],
+		];
+	}
+
+	private function parse( string $wikitext ): string {
+		$parser = MediaWikiServices::getInstance()->getParserFactory()->create();
+
+		return $parser->parse(
+			$wikitext,
+			Title::newFromText( 'PropertyLinkParserFunctionParityTest', NS_MAIN ),
+			ParserOptions::newFromAnon()
+		)->getText();
+	}
+
+}

--- a/tests/phpunit/Unit/Parser/PropertyLinkRendererTest.php
+++ b/tests/phpunit/Unit/Parser/PropertyLinkRendererTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace SMW\Tests\Unit\Parser;
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\ParserOutput;
+use PHPUnit\Framework\TestCase;
+use SMW\Parser\PropertyLinkRenderer;
+use SMW\ParserData;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\Parser\PropertyLinkRenderer
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.2.0
+ */
+class PropertyLinkRendererTest extends TestCase {
+
+	private $testEnvironment;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+	}
+
+	protected function tearDown(): void {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testRendersLinkToPropertyPage() {
+		$this->assertSame(
+			$this->propertyLink( '[[:Property:Foo|Foo]]' ),
+			$this->render( [ 'Foo' ], '@@@', false )
+		);
+	}
+
+	public function testUsesCustomCaptionAsLinkText() {
+		$this->assertSame(
+			$this->propertyLink( '[[:Property:Foo|Foobar]]' ),
+			$this->render( [ 'Foo' ], '@@@', 'Foobar' )
+		);
+	}
+
+	public function testLinksToLastPropertyOfChain() {
+		$this->assertSame(
+			$this->propertyLink( '[[:Property:Baz|Baz]]' ),
+			$this->render( [ 'Foo', 'Baz' ], '@@@', false )
+		);
+	}
+
+	public function testHashCaptionSuppressesLink() {
+		$this->assertSame(
+			'<span class="smw-property nolink">Foo</span>',
+			$this->render( [ 'Foo' ], '@@@', '#' )
+		);
+	}
+
+	public function testLanguageAnnotatedValueUsesPropertyLabelAsCaption() {
+		$this->assertSame(
+			$this->propertyLink( '[[:Property:Foo|Foo]]' ),
+			$this->render( [ 'Foo' ], '@@@en', false )
+		);
+	}
+
+	public function testLanguageAnnotatedValueKeepsCustomCaption() {
+		$this->assertSame(
+			$this->propertyLink( '[[:Property:Foo|Foobar]]' ),
+			$this->render( [ 'Foo' ], '@@@en', 'Foobar' )
+		);
+	}
+
+	public function testValidPropertyWithoutTooltipDoesNotVaryByUserLanguage() {
+		$parserData = $this->newParserData();
+
+		$renderer = new PropertyLinkRenderer( $parserData );
+		$renderer->render( [ 'Foo' ], '@@@', false );
+
+		$this->assertFalse(
+			$parserData->variesByUserLanguage()
+		);
+	}
+
+	public function testInvalidPropertyVariesByUserLanguage() {
+		$parserData = $this->newParserData();
+
+		$renderer = new PropertyLinkRenderer( $parserData );
+		$renderer->render( [ 'Fo%o' ], '@@@', false );
+
+		$this->assertTrue(
+			$parserData->variesByUserLanguage()
+		);
+	}
+
+	private function render( array $properties, string $value, string|false $caption ): string {
+		$renderer = new PropertyLinkRenderer( $this->newParserData() );
+
+		return $renderer->render( $properties, $value, $caption );
+	}
+
+	private function newParserData(): ParserData {
+		return new ParserData(
+			MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __CLASS__, NS_MAIN ),
+			new ParserOutput()
+		);
+	}
+
+	private function propertyLink( string $link ): string {
+		return $this->testEnvironment->replaceNamespaceWithLocalizedText(
+			SMW_NS_PROPERTY,
+			'<span class="smw-property">' . $link . '</span>'
+		);
+	}
+
+}

--- a/tests/phpunit/Unit/ParserFunctionFactoryTest.php
+++ b/tests/phpunit/Unit/ParserFunctionFactoryTest.php
@@ -8,6 +8,7 @@ use SMW\ParserFunctionFactory;
 use SMW\ParserFunctions\AskParserFunction;
 use SMW\ParserFunctions\ConceptParserFunction;
 use SMW\ParserFunctions\DeclareParserFunction;
+use SMW\ParserFunctions\PropertyLinkParserFunction;
 use SMW\ParserFunctions\RecurringEventsParserFunction;
 use SMW\ParserFunctions\SetParserFunction;
 use SMW\ParserFunctions\ShowParserFunction;
@@ -138,6 +139,11 @@ class ParserFunctionFactoryTest extends TestCase {
 			'newDeclareParserFunction'
 		];
 
+		$provider[] = [
+			PropertyLinkParserFunction::class,
+			'newPropertyLinkParserFunction'
+		];
+
 		return $provider;
 	}
 
@@ -175,6 +181,11 @@ class ParserFunctionFactoryTest extends TestCase {
 		$provider[] = [
 			'getDeclareParserFunctionDefinition',
 			'declare'
+		];
+
+		$provider[] = [
+			'getPropertyLinkParserFunctionDefinition',
+			'property_link'
 		];
 
 		return $provider;

--- a/tests/phpunit/Unit/ParserFunctions/PropertyLinkParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/PropertyLinkParserFunctionTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace SMW\Tests\Unit\ParserFunctions;
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\Parser;
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Title\Title;
+use PHPUnit\Framework\TestCase;
+use SMW\Parser\PropertyLinkRenderer;
+use SMW\ParserData;
+use SMW\ParserFunctions\PropertyLinkParserFunction;
+use SMW\Tests\TestEnvironment;
+
+/**
+ * @covers \SMW\ParserFunctions\PropertyLinkParserFunction
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.2.0
+ */
+class PropertyLinkParserFunctionTest extends TestCase {
+
+	private $testEnvironment;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->testEnvironment = new TestEnvironment();
+	}
+
+	protected function tearDown(): void {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
+	}
+
+	public function testCanConstruct() {
+		$parserData = $this->getMockBuilder( ParserData::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$propertyLinkRenderer = $this->getMockBuilder( PropertyLinkRenderer::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->assertInstanceOf(
+			PropertyLinkParserFunction::class,
+			new PropertyLinkParserFunction( $parserData, $propertyLinkRenderer )
+		);
+	}
+
+	public function testRendersPropertyLinkForFirstParameter() {
+		$this->assertSame(
+			$this->propertyLink( '[[:Property:Foo|Foo]]' ),
+			$this->parse( [ 'Foo' ] )
+		);
+	}
+
+	public function testUsesSecondParameterAsCaption() {
+		$this->assertSame(
+			$this->propertyLink( '[[:Property:Foo|Foobar]]' ),
+			$this->parse( [ 'Foo', 'Foobar' ] )
+		);
+	}
+
+	public function testIgnoresAdditionalParameters() {
+		$this->assertSame(
+			$this->propertyLink( '[[:Property:Foo|Foobar]]' ),
+			$this->parse( [ 'Foo', 'Foobar', 'Baz' ] )
+		);
+	}
+
+	public function testHashCaptionSuppressesLink() {
+		$this->assertSame(
+			'<span class="smw-property nolink">Foo</span>',
+			$this->parse( [ 'Foo', '#' ] )
+		);
+	}
+
+	public function testStripsLeadingParserObjectFromParameters() {
+		$parserData = $this->newParserData( NS_MAIN );
+
+		$instance = $this->newInstance( $parserData );
+
+		$this->assertSame(
+			$this->propertyLink( '[[:Property:Foo|Foo]]' ),
+			$instance->parse( [ $this->newParser(), 'Foo' ] )
+		);
+	}
+
+	public function testInvalidPropertyRecordsUserLanguageParserCacheKey() {
+		$this->testEnvironment->withConfiguration( [
+			'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true ],
+			'smwgSetParserCacheKeys' => [ 'userlang' ]
+		] );
+
+		$parserOutput = new ParserOutput();
+		$parserData = new ParserData( $this->newTitle( NS_MAIN ), $parserOutput );
+
+		$this->newInstance( $parserData )->parse( [ 'Fo%o' ] );
+
+		$this->assertContains(
+			'userlang',
+			$parserOutput->getUsedOptions()
+		);
+	}
+
+	public function testInvalidPropertyOnNonSemanticNamespaceDoesNotRecordParserCacheKey() {
+		$this->testEnvironment->withConfiguration( [
+			'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => false ],
+			'smwgSetParserCacheKeys' => [ 'userlang' ]
+		] );
+
+		$parserOutput = new ParserOutput();
+		$parserData = new ParserData( $this->newTitle( NS_MAIN ), $parserOutput );
+
+		$this->newInstance( $parserData )->parse( [ 'Fo%o' ] );
+
+		$this->assertNotContains(
+			'userlang',
+			$parserOutput->getUsedOptions()
+		);
+	}
+
+	private function parse( array $rawParams ): string {
+		return $this->newInstance( $this->newParserData( NS_MAIN ) )->parse( $rawParams );
+	}
+
+	private function newInstance( ParserData $parserData ): PropertyLinkParserFunction {
+		return new PropertyLinkParserFunction(
+			$parserData,
+			new PropertyLinkRenderer( $parserData )
+		);
+	}
+
+	private function newParserData( int $namespace ): ParserData {
+		return new ParserData( $this->newTitle( $namespace ), new ParserOutput() );
+	}
+
+	private function newTitle( int $namespace ): Title {
+		return MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __CLASS__, $namespace );
+	}
+
+	private function newParser(): Parser {
+		$parser = $this->getMockBuilder( Parser::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parser->method( 'getTitle' )
+			->willReturn( $this->newTitle( NS_MAIN ) );
+
+		$parser->method( 'getOutput' )
+			->willReturn( new ParserOutput() );
+
+		return $parser;
+	}
+
+	private function propertyLink( string $link ): string {
+		return $this->testEnvironment->replaceNamespaceWithLocalizedText(
+			SMW_NS_PROPERTY,
+			'<span class="smw-property">' . $link . '</span>'
+		);
+	}
+
+}


### PR DESCRIPTION
For https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5624

Adds a `{{#property_link:}}` parser function that renders a link to a property page, as a dedicated-syntax alternative to the `[[Foo::@@@]]` in-text annotation syntax (https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1855). Intercepting standard `[[…]]` links for annotations is incompatible with where the MediaWiki parser is going (Parsoid), so property links need a syntax that does not depend on it.

- `{{#property_link:Foo}}` renders exactly what `[[Foo::@@@]]` renders
- `{{#property_link:Foo|custom label}}` renders exactly what `[[Foo::@@@|custom label]]` renders, including the `|#` no-link variant

Parity is by construction: the `@@@` link building moved from a private `InTextAnnotationParser` method into a shared `PropertyLinkRenderer` used by both syntaxes. The legacy `@@@` syntax is unchanged.

Notes:

- The `@@@<lang>` language-annotation variant has no parser-function equivalent in this first version.
- The JSONScript cases first pin the legacy behavior (p-0212 additions and the legacy half of p-0466), then mirrored `{{#property_link:}}` cases assert identical strings as the parity proof (p-0215, and p-0466 for a non-English content language). Newly pinned edge cases: nonexistent properties render red links; invalid or empty property names render nothing (both syntaxes agree).
- No new user-facing messages; the i18n surface is the new `property_link` magic word.
- The regenerated JSONScript README index also catches up on a few pre-existing stale entries.