### PR TITLE
Add +display option to the #set parser function

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -9,6 +9,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 ## New features and enhancements
 
+* Added the `+display` option to the `#set` parser function, so a value can be stored and shown in one call without inline annotation syntax. The option attaches to the immediately preceding property assignment like `+sep` does and renders the value the way the corresponding inline annotation would: `+display` or `+display=link` produce the linked, formatted value, `+display=text` the formatted value without a link ([#5624](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5624))
 * Added `SMW\MediaWiki\Outputs::requireJsConfigVar()` so extensions can register JavaScript configuration variables through the SMW output mechanism, alongside modules, styles and head items, instead of emitting inline scripts ([#7028](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7028))
 
 ## Bug fixes

--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -9,7 +9,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 ## New features and enhancements
 
-* Added the `+display` option to the `#set` parser function, so a value can be stored and shown in one call without inline annotation syntax. The option attaches to the immediately preceding property assignment like `+sep` does and renders the value the way the corresponding inline annotation would: `+display` or `+display=link` produce the linked, formatted value, `+display=text` the formatted value without a link ([#5624](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5624))
+* Added the `+display` option to the `#set` parser function, so a value can be stored and shown in one call without inline annotation syntax. The option follows a property assignment like `+sep` does and shows the values stored for that property, rendered the way the corresponding inline annotation would: `+display` or `+display=link` produce the linked, formatted value, `+display=text` the formatted value without a link ([#5624](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5624))
 * Added `SMW\MediaWiki\Outputs::requireJsConfigVar()` so extensions can register JavaScript configuration variables through the SMW output mechanism, alongside modules, styles and head items, instead of emitting inline scripts ([#7028](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7028))
 
 ## Bug fixes

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -953,6 +953,8 @@
 	"smw-format-list-other-fields-close": ")",
 	"smw-category-invalid-redirect-target": "Category \"$1\" contains an invalid redirect target to a non-category namespace.",
 	"smw-parser-function-expensive-execution-limit": "The parser function has reached the limit for expensive executions (see configuration parameter [https://www.semantic-mediawiki.org/wiki/Help:$smwgQExpensiveExecutionLimit <code>$smwgQExpensiveExecutionLimit</code>]).",
+	"smw-parser-function-set-display-invalid-mode": "\"$1\" is not a supported \"+display\" mode (supported modes are \"link\" and \"text\"). The value was annotated but is not shown.",
+	"smw-parser-function-set-display-template-conflict": "The \"+display\" option cannot be combined with the \"template\" parameter. The values were annotated but \"+display\" was ignored.",
 	"smw-postproc-queryref": "Semantic MediaWiki is refreshing the current page on the condition of some required query post processing.",
 	"apihelp-smwinfo-summary": "API module to retrieve information about Semantic MediaWiki statistics and other meta information.",
 	"apihelp-ask-summary": "API module to query Semantic MediaWiki using the ask language.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -906,6 +906,8 @@
 	"smw-format-list-other-fields-close": "{{Optional}}\n\nSeparator closing the group of other values, e.g. the ) in 'MAIN VALUE (OTHER VALUES)'",
 	"smw-category-invalid-redirect-target": "This is an error message.\n\nParamters:\n* $1 - holds the name of the category",
 	"smw-parser-function-expensive-execution-limit": "This is an explanatory message.",
+	"smw-parser-function-set-display-invalid-mode": "Warning shown when the \"+display\" option of the #set parser function is used with an unsupported mode. The annotation is still stored, only the display of the value is skipped.\n\nParameter:\n* $1 - the unsupported mode value as given by the user",
+	"smw-parser-function-set-display-template-conflict": "Error shown when a single #set parser function call combines the \"+display\" option with the \"template\" parameter, which are mutually exclusive. The template output is still rendered and the annotations are stored; only \"+display\" is ignored.",
 	"smw-postproc-queryref": "This is an informatory message.",
 	"apihelp-smwinfo-summary": "This is an informatory message describing and API module.",
 	"apihelp-ask-summary": "This is an informatory message describing and API module.",

--- a/src/ParameterProcessorFactory.php
+++ b/src/ParameterProcessorFactory.php
@@ -14,27 +14,29 @@ class ParameterProcessorFactory {
 	 * @since 1.9
 	 *
 	 * @param array $parameters
+	 * @param bool $captureDisplayOptions
 	 *
 	 * @return ParserParameterProcessor
 	 */
-	public static function newFromArray( array $parameters ): ParserParameterProcessor {
+	public static function newFromArray( array $parameters, bool $captureDisplayOptions = false ): ParserParameterProcessor {
 		$instance = new self();
-		return $instance->newParserParameterProcessor( $parameters );
+		return $instance->newParserParameterProcessor( $parameters, $captureDisplayOptions );
 	}
 
 	/**
 	 * @since 2.3
 	 *
 	 * @param array $parameters
+	 * @param bool $captureDisplayOptions
 	 *
 	 * @return ParserParameterProcessor
 	 */
-	public function newParserParameterProcessor( array $parameters ): ParserParameterProcessor {
+	public function newParserParameterProcessor( array $parameters, bool $captureDisplayOptions = false ): ParserParameterProcessor {
 		if ( isset( $parameters[0] ) && is_object( $parameters[0] ) ) {
 			array_shift( $parameters );
 		}
 
-		return new ParserParameterProcessor( $parameters );
+		return new ParserParameterProcessor( $parameters, $captureDisplayOptions );
 	}
 
 }

--- a/src/ParserFunctionFactory.php
+++ b/src/ParserFunctionFactory.php
@@ -410,7 +410,7 @@ class ParserFunctionFactory {
 			);
 
 			return $setParserFunction->parse(
-				ParameterProcessorFactory::newFromArray( func_get_args() )
+				ParameterProcessorFactory::newFromArray( func_get_args(), true )
 			);
 		};
 

--- a/src/ParserFunctions/SetParserFunction.php
+++ b/src/ParserFunctions/SetParserFunction.php
@@ -157,7 +157,7 @@ class SetParserFunction {
 
 		$html = $this->templateRenderer->render() . $displayText . $errorHtml;
 
-		return [ $html, 'noparse' => $template === '' && $displayText === '', 'isHTML' => false ];
+		return [ $html, 'noparse' => $template === '', 'isHTML' => false ];
 	}
 
 	/**

--- a/src/ParserFunctions/SetParserFunction.php
+++ b/src/ParserFunctions/SetParserFunction.php
@@ -2,8 +2,10 @@
 
 namespace SMW\ParserFunctions;
 
+use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\DataValueFactory;
+use SMW\DataValues\DataValue;
 use SMW\Formatters\MessageFormatter;
 use SMW\MediaWiki\Renderer\WikitextTemplateRenderer;
 use SMW\MediaWiki\StripMarkerDecoder;
@@ -25,6 +27,9 @@ use SMW\ParserParameterProcessor;
  * @author mwjames
  */
 class SetParserFunction {
+
+	private const DISPLAY_LINK = 'link';
+	private const DISPLAY_TEXT = 'text';
 
 	private ?StripMarkerDecoder $stripMarkerDecoder = null;
 
@@ -71,16 +76,25 @@ class SetParserFunction {
 			unset( $parametersToArray['template'] );
 		}
 
+		$displayModes = $this->determineDisplayModes(
+			$parameters->getDisplayOptions(),
+			$template
+		);
+
 		$annotationProcessor = new AnnotationProcessor(
 			$this->parserData->getSemanticData(),
 			DataValueFactory::getInstance()
 		);
+
+		$displayParts = [];
 
 		foreach ( $parametersToArray as $property => $values ) {
 
 			$last = count( $values ) - 1; // -1 because the key starts with 0
 
 			foreach ( $values as $key => $value ) {
+
+				$origValue = $value;
 
 				if ( $this->stripMarkerDecoder !== null ) {
 					$value = $this->stripMarkerDecoder->decode( $value );
@@ -99,6 +113,14 @@ class SetParserFunction {
 
 				$this->messageFormatter->addFromArray( $dataValue->getErrors() );
 
+				if ( isset( $displayModes[$property] ) ) {
+					$displayPart = $this->renderDisplayValue( $displayModes[$property], $dataValue, $origValue, $value );
+
+					if ( $displayPart !== null ) {
+						$displayParts[] = $displayPart;
+					}
+				}
+
 				$this->addFieldsToTemplate(
 					$template,
 					$dataValue,
@@ -110,15 +132,114 @@ class SetParserFunction {
 			}
 		}
 
+		if ( $this->parserData->variesByUserLanguage() ) {
+			// Bridge the flag recorded during rendering into the parser cache
+			// key, as the inline annotation path does; without this the value
+			// would be cached regardless of the viewer's interface language
+			$this->parserData->addExtraParserKey( 'userlang' );
+		}
+
 		$this->parserData->copyToParserOutput();
 
 		$annotationProcessor->release();
 
-		$html = $this->templateRenderer->render() . $this->messageFormatter
+		$displayText = implode( ', ', $displayParts );
+
+		$errorHtml = $this->messageFormatter
 			->addFromArray( $parameters->getErrors() )
 			->getHtml();
 
-		return [ $html, 'noparse' => $template === '', 'isHTML' => false ];
+		if ( $displayText !== '' ) {
+			// Encode `:` so the error output cannot form annotations or comment
+			// blocks when the result is parsed, as the inline annotation path does
+			$errorHtml = str_replace( ':', '&#58;', $errorHtml );
+		}
+
+		$html = $this->templateRenderer->render() . $displayText . $errorHtml;
+
+		return [ $html, 'noparse' => $template === '' && $displayText === '', 'isHTML' => false ];
+	}
+
+	/**
+	 * @param array<string, string> $displayOptions
+	 *
+	 * @return array<string, string> property name => self::DISPLAY_LINK|self::DISPLAY_TEXT
+	 */
+	private function determineDisplayModes( array $displayOptions, string $template ): array {
+		if ( $displayOptions === [] ) {
+			return [];
+		}
+
+		if ( $template !== '' ) {
+			$this->messageFormatter->addFromKey( 'smw-parser-function-set-display-template-conflict' );
+			return [];
+		}
+
+		$modes = [];
+
+		foreach ( $displayOptions as $property => $option ) {
+			$mode = $option === '' ? self::DISPLAY_LINK : strtolower( $option );
+
+			if ( $mode === self::DISPLAY_LINK || $mode === self::DISPLAY_TEXT ) {
+				$modes[$property] = $mode;
+			} else {
+				$this->messageFormatter->addFromKey( 'smw-parser-function-set-display-invalid-mode', $option );
+			}
+		}
+
+		return $modes;
+	}
+
+	private function renderDisplayValue( string $mode, DataValue $dataValue, string $origValue, $decodedValue ): ?string {
+		if ( !$dataValue->isValid() ) {
+			// An invalid value renders a localized error, so the output is not
+			// cache-stable across languages, as the inline annotation path does
+			$this->parserData->markVariesByUserLanguage();
+			return null;
+		}
+
+		// A changed value signals a strip marker; return the raw original so
+		// the standard Parser restores the stripped content, as the inline
+		// annotation path does
+		if ( $origValue !== $decodedValue ) {
+			return $origValue;
+		}
+
+		if ( $mode === self::DISPLAY_TEXT ) {
+			$wikiText = $dataValue->getShortWikiText();
+		} else {
+			$wikiText = $dataValue->getShortWikiText( true );
+			$this->addFileUsage( $dataValue );
+		}
+
+		// getShortWikiText() records user-language output while formatting (e.g.
+		// a unit-conversion tooltip), so this must be checked after rendering,
+		// mirroring the inline annotation path
+		if ( $dataValue->hasUserLanguageOutput() ) {
+			$this->parserData->markVariesByUserLanguage();
+		}
+
+		return $wikiText;
+	}
+
+	/**
+	 * Records a file referenced through a displayed property value as a
+	 * dependency of the parsed page, mirroring the inline annotation path
+	 * (#6141): an embedded image registers this link through its `[[File:...]]`
+	 * markup, but a non-image file is rendered as a plain link whose dependency
+	 * would otherwise be missing.
+	 */
+	private function addFileUsage( DataValue $dataValue ): void {
+		$dataItem = $dataValue->getDataItem();
+
+		if (
+			$dataItem instanceof WikiPage &&
+			$dataItem->getNamespace() === NS_FILE &&
+			$dataItem->getInterwiki() === '' &&
+			$dataItem->getSubobjectName() === ''
+		) {
+			$this->parserData->getOutput()->addImage( $dataItem->getDBkey() );
+		}
 	}
 
 	private function addFieldsToTemplate( $template, $dataValue, $property, $value, bool $isLastElement, &$count ): string {

--- a/src/ParserParameterProcessor.php
+++ b/src/ParserParameterProcessor.php
@@ -26,10 +26,15 @@ class ParserParameterProcessor {
 
 	private array $errors = [];
 
+	private bool $captureDisplayOptions;
+
+	private array $displayOptions = [];
+
 	/**
 	 * @since 1.9
 	 */
-	public function __construct( array $rawParameters = [] ) {
+	public function __construct( array $rawParameters = [], bool $captureDisplayOptions = false ) {
+		$this->captureDisplayOptions = $captureDisplayOptions;
 		$this->rawParameters = $rawParameters;
 		$this->parameters = $this->doMap( $rawParameters );
 	}
@@ -59,6 +64,19 @@ class ParserParameterProcessor {
 	 */
 	public function getFirstParameter(): ?string {
 		return $this->first;
+	}
+
+	/**
+	 * Display modes captured from `+display` options, keyed by the property
+	 * name they attach to, verbatim and unvalidated. Only populated when the
+	 * processor was constructed with display option capture enabled.
+	 *
+	 * @since 7.2.0
+	 *
+	 * @return array<string, string>
+	 */
+	public function getDisplayOptions(): array {
+		return $this->displayOptions;
 	}
 
 	/**
@@ -178,6 +196,7 @@ class ParserParameterProcessor {
 		while ( key( $params ) !== null ) {
 
 			$pipe = false;
+			$display = null;
 			$values = [];
 
 			// Only strings are allowed for processing
@@ -189,7 +208,7 @@ class ParserParameterProcessor {
 			$currentElement = explode( '=', trim( current( $params ) ), 2 );
 
 			// Looking to the next element for comparison
-			$separator = $this->lookAheadOnNextElement( $params, $pipe );
+			$separator = $this->lookAheadOnNextElement( $params, $pipe, $display );
 
 			// First named parameter
 			if ( count( $currentElement ) == 1 && $previousProperty === null ) {
@@ -224,30 +243,52 @@ class ParserParameterProcessor {
 			if ( $pipe ) {
 				$results[$currentElement[0]] = [ implode( '|', $results[$currentElement[0]] ) ];
 			}
+
+			if ( $display !== null ) {
+				$this->displayOptions[$currentElement[0]] = $display;
+			}
 		}
 
 		return $this->parseFromJson( $results );
 	}
 
-	private function lookAheadOnNextElement( &$params, bool &$pipe ): string {
+	private function lookAheadOnNextElement( &$params, bool &$pipe, ?string &$display ): string {
 		$separator = '';
 
 		if ( !next( $params ) ) {
 			return $separator;
 		}
 
-		$nextElement = explode( '=', trim( current( $params ) ), 2 );
+		$sepConsumed = false;
 
-		// This allows assignments of type |Has property=Test1,Test2|+sep=,
-		// as a means to support multiple value declaration
-		if ( substr( $nextElement[0], -5 ) === '+sep' ) {
-			$separator = isset( $nextElement[1] ) ? ( $nextElement[1] !== '' ? $nextElement[1] : $this->defaultSeparator ) : $this->defaultSeparator;
-			next( $params );
-		}
+		while ( key( $params ) !== null ) {
+			$current = current( $params );
+			$option = is_string( $current ) ? explode( '=', trim( $current ), 2 ) : [ '' ];
 
-		if ( current( $params ) === '+pipe' ) {
-			$pipe = true;
-			next( $params );
+			if ( $this->captureDisplayOptions && $option[0] === '+display' ) {
+				$display = trim( $option[1] ?? '' );
+				next( $params );
+				continue;
+			}
+
+			// This allows assignments of type |Has property=Test1,Test2|+sep=,
+			// as a means to support multiple value declaration; +sep is never
+			// consumed after +pipe, and at most once per assignment
+			if ( !$sepConsumed && !$pipe && substr( $option[0], -5 ) === '+sep' ) {
+				$separator = isset( $option[1] ) ? ( $option[1] !== '' ? $option[1] : $this->defaultSeparator ) : $this->defaultSeparator;
+				$sepConsumed = true;
+				next( $params );
+				continue;
+			}
+
+			// +pipe is matched against the raw, untrimmed element
+			if ( !$pipe && $current === '+pipe' ) {
+				$pipe = true;
+				next( $params );
+				continue;
+			}
+
+			break;
 		}
 
 		return $separator;

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0214.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0214.json
@@ -121,6 +121,10 @@
 		{
 			"page": "Example/P0214/17",
 			"contents": "{{#subobject: |Has text=x |+display }}"
+		},
+		{
+			"page": "Example/P0214/18",
+			"contents": "{{#set: |Has text={{{1}}} |+display }}"
 		}
 	],
 	"tests": [
@@ -536,6 +540,33 @@
 				],
 				"not-contain": [
 					"title=\"Display target page\""
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#17 an unresolved template argument in a displayed value is shown as stored, not expanded against the #set arguments",
+			"subject": "Example/P0214/18",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_text",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"{{{1}}}"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"{{{1}}}"
+				],
+				"not-contain": [
+					"+display"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0214.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0214.json
@@ -1,0 +1,555 @@
+{
+	"description": "Test `#set` parser with `+display` option to store and show values in one call (#5624, en, `wgContLang=en`, `wgLang=en`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has page",
+			"contents": "[[Has type::Page]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has url",
+			"contents": "[[Has type::URL]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has ext id",
+			"contents": "[[Has type::External identifier]] [[External formatter uri::https://example.org/$1]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has area",
+			"contents": "[[Has type::Quantity]] [[Corresponds to::1 km²]] [[Corresponds to::1000 m²]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has date",
+			"contents": "[[Has type::Date]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has mltext",
+			"contents": "[[Has type::Monolingual text]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has number",
+			"contents": "[[Has type::Number]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has text",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Display target page",
+			"contents": "Just a target page."
+		},
+		{
+			"page": "Shown page",
+			"contents": "Just a target page."
+		},
+		{
+			"namespace": "NS_TEMPLATE",
+			"page": "P0214 Echo",
+			"contents": "TPLSTART-{{{property}}}=={{{value}}}-TPLEND"
+		},
+		{
+			"page": "Example/P0214/1",
+			"contents": "{{#set: Has page=Display target page |+display=link }}"
+		},
+		{
+			"page": "Example/P0214/2",
+			"contents": "{{#set: Has page=File:Example.jpg |+display=link }}"
+		},
+		{
+			"page": "Example/P0214/3",
+			"contents": "{{#set: Has url=http://example.org |+display=link }}"
+		},
+		{
+			"page": "Example/P0214/4",
+			"contents": "{{#set: Has ext id=ABC123 |+display=link }}"
+		},
+		{
+			"page": "Example/P0214/6",
+			"contents": "{{#set: Has area=1000 m² |+display=link }}"
+		},
+		{
+			"page": "Example/P0214/7",
+			"contents": "{{#set: Has date=2020-01-15 |+display=link }}"
+		},
+		{
+			"page": "Example/P0214/8",
+			"contents": "{{#set: Has mltext=Foo@de |+display }}"
+		},
+		{
+			"page": "Example/P0214/9",
+			"contents": "{{#set: Has number=12abc |+display }}"
+		},
+		{
+			"page": "Example/P0214/10",
+			"contents": "{{#set: Has number=1;2;3 |+sep=; |+display }}"
+		},
+		{
+			"page": "Example/P0214/11",
+			"contents": "{{#set: Has text=Silent value | Has page=Shown page |+display=link }}"
+		},
+		{
+			"page": "Example/P0214/12",
+			"contents": "{{#set: Has number=1;2;3 |+display |+sep=; }}"
+		},
+		{
+			"page": "Example/P0214/13",
+			"contents": "{{#set: Has page=Display target page |+display }}"
+		},
+		{
+			"page": "Example/P0214/13b",
+			"contents": "{{#set: Has page=Display target page |+display= }}"
+		},
+		{
+			"page": "Example/P0214/14",
+			"contents": "{{#set: Has page=Display target page |+display=foo }}"
+		},
+		{
+			"page": "Example/P0214/15",
+			"contents": "{{#set: Has page=Shown page |template=P0214 Echo |+display=link }}"
+		},
+		{
+			"page": "Example/P0214/16",
+			"contents": "{{#set: Has page=Display target page |+display=text }}"
+		},
+		{
+			"page": "Example/P0214/17",
+			"contents": "{{#subobject: |Has text=x |+display }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 WikiPage value, +display=link renders the page link and stores the value",
+			"subject": "Example/P0214/1",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_page",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"Display target page"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"title=\"Display target page\">Display target page</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 WikiPage value on a File target, +display=link renders the file link markup and stores the value",
+			"subject": "Example/P0214/2",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 4,
+					"propertyKeys": [
+						"Has_page",
+						"_INST",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"File:Example.jpg"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"typeof=\"mw:Error mw:File\"",
+					"<span class=\"mw-file-element mw-broken-media\">File:Example.jpg</span>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#2 URL value, +display=link renders an external link and stores the value",
+			"subject": "Example/P0214/3",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_url",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"http://example.org"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<a rel=\"nofollow\" class=\"external text\" href=\"http://example.org\">http://example.org</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#3 External identifier value with formatter uri, +display=link renders the formatted link",
+			"subject": "Example/P0214/4",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_ext_id",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"ABC123"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<span class=\"plainlinks smw-eid\"><a rel=\"nofollow\" class=\"external text\" href=\"https://example.org/ABC123\">ABC123</a></span>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#4 Quantity value with unit conversion, +display=link renders the converted value",
+			"subject": "Example/P0214/6",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_area",
+						"_SKEY",
+						"_MDAT"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"1&#160;km²"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#5 Date value, +display=link renders the formatted date",
+			"subject": "Example/P0214/7",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_date",
+						"_SKEY",
+						"_MDAT"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"2020-01-15"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#6 MonolingualText value, bare +display renders the text with language marker",
+			"subject": "Example/P0214/8",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_mltext",
+						"_SKEY",
+						"_MDAT"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"Foo (de)"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#7 Invalid value with +display, error output present, value not shown, store keeps _ERRC",
+			"subject": "Example/P0214/9",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"_ERRC",
+						"_SKEY",
+						"_MDAT"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"&quot;abc&quot; can not be assigned to a declared number type with value 12."
+				],
+				"not-contain": [
+					"12abc"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#8 Multi-value with +sep and +display, all values shown joined and stored",
+			"subject": "Example/P0214/10",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_number",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						1,
+						2,
+						3
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"1, 2, 3"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#9 Per-assignment selectivity, only the assignment carrying +display is shown, both stored",
+			"subject": "Example/P0214/11",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 4,
+					"propertyKeys": [
+						"Has_text",
+						"Has_page",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"Silent value",
+						"Shown page"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"title=\"Shown page\">Shown page</a>"
+				],
+				"not-contain": [
+					"Silent value"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#10 Order robustness, +display before +sep yields the same result",
+			"subject": "Example/P0214/12",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_number",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						1,
+						2,
+						3
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"1, 2, 3"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#11 Bare +display uses link mode",
+			"subject": "Example/P0214/13",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_page",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"Display target page"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"title=\"Display target page\">Display target page</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#12 Empty +display= uses link mode",
+			"subject": "Example/P0214/13b",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_page",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"Display target page"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"title=\"Display target page\">Display target page</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#13 Unknown mode emits a warning, value not shown, annotation stored",
+			"subject": "Example/P0214/14",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_page",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"Display target page"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"&quot;foo&quot; is not a supported &quot;+display&quot; mode (supported modes are &quot;link&quot; and &quot;text&quot;). The value was annotated but is not shown."
+				],
+				"not-contain": [
+					"title=\"Display target page\">Display target page</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#14 template conflict emits an error, template output still present, display suppressed, store intact",
+			"subject": "Example/P0214/15",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_page",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"Shown page"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"The &quot;+display&quot; option cannot be combined with the &quot;template&quot; parameter. The values were annotated but &quot;+display&quot; was ignored.",
+					"TPLSTART-Has page==Shown page-TPLEND"
+				],
+				"not-contain": [
+					"title=\"Shown page\">Shown page</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#15 #subobject ignores the +display token and swallows it as a literal value",
+			"subject": "Example/P0214/17#_8e85294faaf5f3634cfe3f67f35926b1",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 2,
+					"propertyKeys": [
+						"Has_text",
+						"_SKEY"
+					],
+					"propertyValues": [
+						"x",
+						"+display"
+					]
+				}
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#16 +display=text renders the value without a link",
+			"subject": "Example/P0214/16",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_page",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"Display target page"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"Display target page"
+				],
+				"not-contain": [
+					"title=\"Display target page\""
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0215.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0215.json
@@ -1,0 +1,102 @@
+{
+	"description": "Test `#set` parser with `+display` option on a keyword formatter schema and on strip-marker values (#5624, `smwgCompactLinkSupport`, `SMW_PARSER_UNSTRIP`)",
+	"setup": [
+		{
+			"namespace": "SMW_NS_SCHEMA",
+			"page": "Keyword link formatter schema",
+			"contents": {
+				"import-from": "/../Fixtures/p-0459-keyword-formatter-schema.json"
+			}
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has keyword",
+			"contents": "[[Has type::Keyword]] [[Formatter schema::Keyword link formatter schema]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has description",
+			"contents": "[[Has type::Text]]"
+		},
+		{
+			"page": "Example/P0215/1",
+			"contents": "{{#set: Has keyword=KW1 |+display=link }}"
+		},
+		{
+			"page": "Example/P0215/2",
+			"contents": "{{#set: Has description=<nowiki>Contains nowiki tag</nowiki> |+display }}"
+		}
+	],
+	"tests": [
+		{
+			"type": "parser",
+			"about": "#0 Keyword value with a link-formatter schema, +display=link renders the compact formatter link",
+			"subject": "Example/P0215/1",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_keyword",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"KW1"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6S1cxLTVELTVEL2Zvcm1hdD1saXN0\" title=\"Special:Ask/cl:LTVCLTVCSGFzLTIwa2V5d29yZDo6S1cxLTVELTVEL2Zvcm1hdD1saXN0\">KW1</a>"
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#1 Strip-marker value with +display, the value is shown (unlike plain #set) and stored escaped",
+			"subject": "Example/P0215/2",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_description",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"&lt;nowiki&gt;Contains nowiki tag&lt;/nowiki&gt;"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"Contains nowiki tag"
+				]
+			}
+		}
+	],
+	"settings": {
+		"wgContLang": "en",
+		"wgLang": "en",
+		"smwgParserFeatures": [
+			"unstrip",
+			"strict"
+		],
+		"smwgCompactLinkSupport": true,
+		"smwgNamespacesWithSemanticLinks": {
+			"NS_MAIN": true,
+			"SMW_NS_PROPERTY": true,
+			"SMW_NS_SCHEMA": true
+		},
+		"smwgPageSpecialProperties": [
+			"_MDAT"
+		]
+	},
+	"meta": {
+		"version": "2",
+		"is-incomplete": false,
+		"debug": false
+	}
+}

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0455.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0455.json
@@ -133,6 +133,11 @@
 						"&lt;nowiki&gt;Contains nowiki tag&lt;/nowiki&gt;"
 					]
 				}
+			},
+			"assert-output": {
+				"not-contain": [
+					"Contains nowiki tag"
+				]
 			}
 		},
 		{
@@ -152,6 +157,11 @@
 						"&lt;pre&gt;Contains pre tag&lt;/pre&gt;"
 					]
 				}
+			},
+			"assert-output": {
+				"not-contain": [
+					"Contains pre tag"
+				]
 			}
 		},
 		{
@@ -171,6 +181,11 @@
 						"&lt;nowiki&gt;&lt;code&gt;&#x007B;&#x007B;#ask&#58; &#x005B;&#x005B;Has strip&#58;&#58;Markers]] }}&lt;/code&gt;&lt;/nowiki&gt;"
 					]
 				}
+			},
+			"assert-output": {
+				"not-contain": [
+					"Has strip::Markers"
+				]
 			}
 		},
 		{

--- a/tests/phpunit/Integration/ParserFunctions/SetParserFunctionDisplayUserLanguageDBIntegrationTest.php
+++ b/tests/phpunit/Integration/ParserFunctions/SetParserFunctionDisplayUserLanguageDBIntegrationTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace SMW\Tests\Integration\ParserFunctions;
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\ParserOutput;
+use MediaWiki\Title\Title;
+use SMW\Formatters\MessageFormatter;
+use SMW\MediaWiki\Renderer\WikitextTemplateRenderer;
+use SMW\ParameterProcessorFactory;
+use SMW\ParserFunctions\SetParserFunction;
+use SMW\Services\ServicesFactory;
+use SMW\Tests\SMWIntegrationTestCase;
+
+/**
+ * Guards that a displayed `#set` value fragments the parser cache by the
+ * viewer's interface language exactly like the equivalent inline annotation,
+ * so a page rendered in one language is not served from cache to viewers of
+ * another. Requires a real store because the user-language flag is only set
+ * while a typed value (e.g. a unit-converting quantity) is being rendered.
+ *
+ * @covers \SMW\ParserFunctions\SetParserFunction
+ * @group semantic-mediawiki
+ * @group Database
+ * @group medium
+ *
+ * @license GPL-2.0-or-later
+ */
+class SetParserFunctionDisplayUserLanguageDBIntegrationTest extends SMWIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->testEnvironment->withConfiguration( [
+			'smwgNamespacesWithSemanticLinks' => [ NS_MAIN => true, SMW_NS_PROPERTY => true ],
+			'smwgSetParserCacheKeys' => [ 'userlang' ],
+		] );
+	}
+
+	public function testDisplayingAUnitConvertingQuantityMarksTheParserCacheAsUserLanguageDependent() {
+		$this->testEnvironment->getUtilityFactory()->newPageCreator()
+			->createPage( Title::newFromText( 'Has area', SMW_NS_PROPERTY ) )
+			->doEdit( '[[Has type::Quantity]] [[Corresponds to::1 km²]] [[Corresponds to::1000 m²]]' );
+
+		$parserOutput = $this->displayValue( 'Has area=1000 m²' );
+
+		$this->assertContains(
+			'userlang',
+			$parserOutput->getUsedOptions()
+		);
+	}
+
+	public function testDisplayingAPlainPageValueDoesNotMarkTheParserCacheAsUserLanguageDependent() {
+		$parserOutput = $this->displayValue( 'Has somewhere=Target page' );
+
+		$this->assertNotContains(
+			'userlang',
+			$parserOutput->getUsedOptions()
+		);
+	}
+
+	private function displayValue( string $assignment ): ParserOutput {
+		$parserOutput = new ParserOutput();
+
+		$parserData = ServicesFactory::getInstance()->newParserData(
+			Title::newFromText( __CLASS__ ),
+			$parserOutput
+		);
+
+		$setParserFunction = new SetParserFunction(
+			$parserData,
+			new MessageFormatter( MediaWikiServices::getInstance()->getContentLanguage() ),
+			new WikitextTemplateRenderer()
+		);
+
+		$setParserFunction->parse(
+			ParameterProcessorFactory::newFromArray( [ $assignment, '+display=link' ], true )
+		);
+
+		return $parserOutput;
+	}
+
+}

--- a/tests/phpunit/Unit/ParameterProcessorFactoryTest.php
+++ b/tests/phpunit/Unit/ParameterProcessorFactoryTest.php
@@ -42,6 +42,15 @@ class ParameterProcessorFactoryTest extends TestCase {
 		);
 	}
 
+	public function testObjectFirstParameterIsShiftedButRemainingParametersAreKept() {
+		$instance = ParameterProcessorFactory::newFromArray( [ new stdClass, 'Foo=1' ] );
+
+		$this->assertSame(
+			[ 'Foo=1' ],
+			$instance->getRaw()
+		);
+	}
+
 	public function testNewFromArray() {
 		$parameter = [
 			'La' => 'Lu'

--- a/tests/phpunit/Unit/ParserFunctions/SetParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/SetParserFunctionTest.php
@@ -208,7 +208,7 @@ class SetParserFunctionTest extends TestCase {
 		);
 
 		$this->assertSame(
-			[ 0 => '[[:Bar|bar]]', 'noparse' => false, 'isHTML' => false ],
+			[ 0 => '[[:Bar|bar]]', 'noparse' => true, 'isHTML' => false ],
 			$result
 		);
 	}
@@ -221,8 +221,32 @@ class SetParserFunctionTest extends TestCase {
 		);
 
 		$this->assertSame(
-			[ 0 => 'bar', 'noparse' => false, 'isHTML' => false ],
+			[ 0 => 'bar', 'noparse' => true, 'isHTML' => false ],
 			$result
+		);
+	}
+
+	/**
+	 * `noparse` must not depend on whether a value is displayed. Returning
+	 * `noparse => false` makes the Parser preprocess the result in a child
+	 * frame built from the `#set` call's own arguments, which expands any
+	 * `{{{n}}}` left in a stored value against those arguments (#7040).
+	 * Link markup renders either way, so the flag can stay at its legacy value.
+	 */
+	public function testDisplayDoesNotFlipNoParse() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', '+display' ], true )
+		);
+
+		// A value has to reach the output for the flag to be under test at all
+		$this->assertNotSame(
+			'',
+			$result[0]
+		);
+		$this->assertTrue(
+			$result['noparse']
 		);
 	}
 
@@ -261,6 +285,72 @@ class SetParserFunctionTest extends TestCase {
 
 		$this->assertSame(
 			'b',
+			$result[0]
+		);
+	}
+
+	/**
+	 * The option is scoped to the property of the assignment it follows, not to
+	 * that assignment alone, because the parameter processor merges repeated
+	 * assignments of one property into a single value list before `#set` sees
+	 * them. Pinned so the scope is a documented choice rather than an accident.
+	 */
+	public function testDisplayAppliesToEveryValueOfARepeatedProperty() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=a', 'Foo=b', '+display=text' ], true )
+		);
+
+		$this->assertSame(
+			'a, b',
+			$result[0]
+		);
+	}
+
+	public function testLastDisplayModeWinsForARepeatedProperty() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray(
+				[ 'Foo=a', '+display=link', 'Foo=b', '+display=text' ],
+				true
+			)
+		);
+
+		$this->assertSame(
+			'a, b',
+			$result[0]
+		);
+	}
+
+	public function testDisplayModeIsCaseInsensitive() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', '+display=TEXT' ], true )
+		);
+
+		$this->assertSame(
+			'bar',
+			$result[0]
+		);
+	}
+
+	/**
+	 * `@json` assignments are expanded into their property names only after the
+	 * display option has been keyed to the literal `@json` parameter, so the
+	 * option matches no property and is silently ignored.
+	 */
+	public function testDisplayIsIgnoredForJsonAssignments() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ '@json={"Foo":"bar"}', '+display' ], true )
+		);
+
+		$this->assertSame(
+			'',
 			$result[0]
 		);
 	}
@@ -348,7 +438,11 @@ class SetParserFunctionTest extends TestCase {
 			'RAW',
 			$result[0]
 		);
-		$this->assertFalse(
+		// `noparse` only controls whether the Parser preprocesses the result in
+		// a child frame, so it has no bearing on how a strip marker in the
+		// output is handled; the legacy value stands here as it does for every
+		// other displayed value (#7040)
+		$this->assertTrue(
 			$result['noparse']
 		);
 	}

--- a/tests/phpunit/Unit/ParserFunctions/SetParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/SetParserFunctionTest.php
@@ -4,9 +4,13 @@ namespace SMW\Tests\Unit\ParserFunctions;
 
 use MediaWiki\MediaWikiServices;
 use MediaWiki\Parser\ParserOutput;
+use PHPUnit\Framework\MockObject\Rule\InvocationOrder;
 use PHPUnit\Framework\TestCase;
+use SMW\DataItems\WikiPage as DIWikiPage;
+use SMW\DataModel\SemanticData;
 use SMW\Formatters\MessageFormatter;
 use SMW\MediaWiki\Renderer\WikitextTemplateRenderer;
+use SMW\MediaWiki\StripMarkerDecoder;
 use SMW\ParameterProcessorFactory;
 use SMW\ParserData;
 use SMW\ParserFunctions\SetParserFunction;
@@ -169,6 +173,358 @@ class SetParserFunctionTest extends TestCase {
 			$expected,
 			$parserData->getSemanticData()
 		);
+	}
+
+	public function testParseWithoutTemplateReturnsNoParseTripleWithMessageHtml() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( 'HTML-OUTPUT' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar' ] )
+		);
+
+		$this->assertSame(
+			[ 0 => 'HTML-OUTPUT', 'noparse' => true, 'isHTML' => false ],
+			$result
+		);
+	}
+
+	public function testParseWithTemplateReturnsParseableResult() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', 'template=FooTemplate' ] )
+		);
+
+		$this->assertFalse(
+			$result['noparse']
+		);
+	}
+
+	public function testDisplayLinkModeRendersLinkedValue() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', '+display=link' ], true )
+		);
+
+		$this->assertSame(
+			[ 0 => '[[:Bar|bar]]', 'noparse' => false, 'isHTML' => false ],
+			$result
+		);
+	}
+
+	public function testDisplayTextModeRendersUnlinkedValue() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', '+display=text' ], true )
+		);
+
+		$this->assertSame(
+			[ 0 => 'bar', 'noparse' => false, 'isHTML' => false ],
+			$result
+		);
+	}
+
+	public function testBareDisplayDefaultsToLinkMode() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', '+display' ], true )
+		);
+
+		$this->assertSame(
+			'[[:Bar|bar]]',
+			$result[0]
+		);
+	}
+
+	public function testDisplayJoinsMultipleValuesInInputOrder() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=a;b', '+sep=;', '+display=text' ], true )
+		);
+
+		$this->assertSame(
+			'a, b',
+			$result[0]
+		);
+	}
+
+	public function testDisplayRendersOnlyTheFlaggedAssignment() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=a', 'Bar=b', '+display=text' ], true )
+		);
+
+		$this->assertSame(
+			'b',
+			$result[0]
+		);
+	}
+
+	public function testInvalidValueIsNotDisplayed() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		// '+bad' contains a character from the invalid property character list,
+		// producing an invalid DataValue that must never render
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ '+bad=x', '+display' ], true )
+		);
+
+		$this->assertSame(
+			[ 0 => '', 'noparse' => true, 'isHTML' => false ],
+			$result
+		);
+	}
+
+	public function testUnknownDisplayModeAddsWarningAndDisplaysNothing() {
+		$messageFormatter = $this->newMessageFormatterExpectingKey(
+			'smw-parser-function-set-display-invalid-mode',
+			'foo'
+		);
+
+		$instance = new SetParserFunction(
+			$this->newParserData(),
+			$messageFormatter,
+			$this->newTemplateRendererMock()
+		);
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', '+display=foo' ], true )
+		);
+
+		$this->assertSame(
+			[ 0 => '', 'noparse' => true, 'isHTML' => false ],
+			$result
+		);
+	}
+
+	public function testDisplayCombinedWithTemplateAddsConflictErrorAndKeepsTemplateOutput() {
+		$messageFormatter = $this->newMessageFormatterExpectingKey(
+			'smw-parser-function-set-display-template-conflict'
+		);
+
+		$instance = new SetParserFunction(
+			$this->newParserData(),
+			$messageFormatter,
+			new WikitextTemplateRenderer()
+		);
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', '+display', 'template=FooTemplate' ], true )
+		);
+
+		$this->assertFalse(
+			$result['noparse']
+		);
+		$this->assertStringContainsString(
+			'FooTemplate',
+			$result[0]
+		);
+		$this->assertStringNotContainsString(
+			'[[:Bar',
+			$result[0]
+		);
+	}
+
+	public function testStripMarkerValueDisplaysTheRawOriginal() {
+		$stripMarkerDecoder = $this->getMockBuilder( StripMarkerDecoder::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$stripMarkerDecoder->method( 'decode' )->willReturn( 'DECODED' );
+
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+		$instance->setStripMarkerDecoder( $stripMarkerDecoder );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=RAW', '+display' ], true )
+		);
+
+		$this->assertSame(
+			'RAW',
+			$result[0]
+		);
+		$this->assertFalse(
+			$result['noparse']
+		);
+	}
+
+	public function testInvalidDisplayedValueMarksVariesByUserLanguage() {
+		$parserData = $this->newParserDataMockExpectingVariesByUserLanguage( $this->once() );
+
+		$instance = new SetParserFunction(
+			$parserData,
+			$this->newMessageFormatterMock(),
+			$this->newTemplateRendererMock()
+		);
+
+		$instance->parse(
+			ParameterProcessorFactory::newFromArray( [ '+bad=x', '+display' ], true )
+		);
+	}
+
+	public function testValidDisplayedValueWithoutUserLanguageOutputDoesNotMarkVariesByUserLanguage() {
+		$parserData = $this->newParserDataMockExpectingVariesByUserLanguage( $this->never() );
+
+		$instance = new SetParserFunction(
+			$parserData,
+			$this->newMessageFormatterMock(),
+			$this->newTemplateRendererMock()
+		);
+
+		$instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', '+display' ], true )
+		);
+	}
+
+	public function testDisplayedFileValueRegistersFileUsage() {
+		$parserOutput = new ParserOutput();
+
+		$instance = $this->newSetParserFunctionForParserOutput( $parserOutput );
+
+		$instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=File:Example.png', '+display' ], true )
+		);
+
+		$this->assertArrayHasKey(
+			'Example.png',
+			$parserOutput->getImages()
+		);
+	}
+
+	public function testDisplayedFileValueInTextModeDoesNotRegisterFileUsage() {
+		$parserOutput = new ParserOutput();
+
+		$instance = $this->newSetParserFunctionForParserOutput( $parserOutput );
+
+		$instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=File:Example.png', '+display=text' ], true )
+		);
+
+		$this->assertSame(
+			[],
+			$parserOutput->getImages()
+		);
+	}
+
+	public function testErrorHtmlColonsAreEncodedWhenDisplayValuesAreShown() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( 'Warn:ing' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', '+display=text' ], true )
+		);
+
+		$this->assertSame(
+			'barWarn&#58;ing',
+			$result[0]
+		);
+	}
+
+	public function testErrorHtmlIsNotEncodedWithoutDisplayOutput() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( 'Warn:ing' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar' ], true )
+		);
+
+		$this->assertSame(
+			[ 0 => 'Warn:ing', 'noparse' => true, 'isHTML' => false ],
+			$result
+		);
+	}
+
+	private function newSetParserFunctionWithHtmlOutput( string $html ): SetParserFunction {
+		$parserData = ApplicationFactory::getInstance()->newParserData(
+			MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __CLASS__ ),
+			new ParserOutput()
+		);
+
+		$messageFormatter = $this->getMockBuilder( MessageFormatter::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$messageFormatter->method( 'addFromArray' )->willReturnSelf();
+		$messageFormatter->method( 'getHtml' )->willReturn( $html );
+
+		$templateRenderer = $this->getMockBuilder( WikitextTemplateRenderer::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		return new SetParserFunction(
+			$parserData,
+			$messageFormatter,
+			$templateRenderer
+		);
+	}
+
+	private function newSetParserFunctionForParserOutput( ParserOutput $parserOutput ): SetParserFunction {
+		$parserData = ApplicationFactory::getInstance()->newParserData(
+			MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __CLASS__ ),
+			$parserOutput
+		);
+
+		return new SetParserFunction(
+			$parserData,
+			$this->newMessageFormatterMock(),
+			$this->newTemplateRendererMock()
+		);
+	}
+
+	private function newParserData(): ParserData {
+		return ApplicationFactory::getInstance()->newParserData(
+			MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __CLASS__ ),
+			new ParserOutput()
+		);
+	}
+
+	private function newParserDataMockExpectingVariesByUserLanguage( InvocationOrder $expected ): ParserData {
+		$semanticData = new SemanticData(
+			DIWikiPage::newFromText( __CLASS__ )
+		);
+
+		$parserData = $this->getMockBuilder( ParserData::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$parserData->method( 'getSemanticData' )->willReturn( $semanticData );
+		$parserData->method( 'canUse' )->willReturn( false );
+
+		$parserData->expects( $expected )
+			->method( 'markVariesByUserLanguage' );
+
+		return $parserData;
+	}
+
+	private function newMessageFormatterExpectingKey( string $key, string ...$params ): MessageFormatter {
+		$messageFormatter = $this->newMessageFormatterMock();
+
+		$messageFormatter->expects( $this->once() )
+			->method( 'addFromKey' )
+			->with( $key, ...$params )
+			->willReturnSelf();
+
+		return $messageFormatter;
+	}
+
+	private function newMessageFormatterMock(): MessageFormatter {
+		$messageFormatter = $this->getMockBuilder( MessageFormatter::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$messageFormatter->method( 'addFromArray' )->willReturnSelf();
+		$messageFormatter->method( 'getHtml' )->willReturn( '' );
+
+		return $messageFormatter;
+	}
+
+	private function newTemplateRendererMock(): WikitextTemplateRenderer {
+		return $this->getMockBuilder( WikitextTemplateRenderer::class )
+			->disableOriginalConstructor()
+			->getMock();
 	}
 
 	public function setParserProvider() {

--- a/tests/phpunit/Unit/ParserFunctions/SubobjectParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/SubobjectParserFunctionTest.php
@@ -137,6 +137,20 @@ class SubobjectParserFunctionTest extends TestCase {
 		);
 	}
 
+	public function testDisplayTokensAreStoredAsUnchangedJunkParameters() {
+		// #subobject never opts in to +display capture, so with default construction
+		// the tokens are ordinary junk: bare '+display' continues the preceding
+		// property as a value, while '+display=link' is an invalid property name
+		// (contains '+') and is recorded as an _ERRC error container.
+		$this->setupInstanceAndAssertSemanticData(
+			[ '', 'Foo=bar', '+display', '+display=link' ],
+			[
+				'propertyCount' => 2,
+				'propertyKeys' => [ 'Foo', '_ERRC' ],
+			]
+		);
+	}
+
 	public function testSubobjectIdStabilityForFixedSetOfParameters() {
 		$parameters = [
 			'Foo=Bar'

--- a/tests/phpunit/Unit/ParserParameterProcessorTest.php
+++ b/tests/phpunit/Unit/ParserParameterProcessorTest.php
@@ -151,6 +151,292 @@ class ParserParameterProcessorTest extends TestCase {
 		);
 	}
 
+	public function testBareTokensContinuePrecedingProperty() {
+		$instance = new ParserParameterProcessor( [ 'Foo=1', '2', '3' ] );
+
+		$this->assertSame(
+			[ 'Foo' => [ '1', '2', '3' ] ],
+			$instance->toArray()
+		);
+	}
+
+	public function testFirstBareTokenBecomesFirstParameterWithSpacesConvertedToUnderscores() {
+		$instance = new ParserParameterProcessor( [ 'Bar baz', 'Foo=1' ] );
+
+		$this->assertSame(
+			'Bar_baz',
+			$instance->getFirstParameter()
+		);
+	}
+
+	public function testBareSepUsesDefaultCommaSeparator() {
+		$instance = new ParserParameterProcessor( [ 'Foo=1,2', '+sep' ] );
+
+		$this->assertSame(
+			[ 'Foo' => [ '1', '2' ] ],
+			$instance->toArray()
+		);
+	}
+
+	public function testSepWithExplicitValueUsesThatSeparator() {
+		$instance = new ParserParameterProcessor( [ 'Foo=1;2', '+sep=;' ] );
+
+		$this->assertSame(
+			[ 'Foo' => [ '1', '2' ] ],
+			$instance->toArray()
+		);
+	}
+
+	public function testSepWithEmptyValueFallsBackToDefaultComma() {
+		$instance = new ParserParameterProcessor( [ 'Foo=1,2', '+sep=' ] );
+
+		$this->assertSame(
+			[ 'Foo' => [ '1', '2' ] ],
+			$instance->toArray()
+		);
+	}
+
+	public function testTrailingSepIsConsumedWithoutAffectingOtherAssignments() {
+		$instance = new ParserParameterProcessor( [ 'Foo=1', 'Bar=2', '+sep' ] );
+
+		$this->assertSame(
+			[ 'Foo' => [ '1' ], 'Bar' => [ '2' ] ],
+			$instance->toArray()
+		);
+	}
+
+	public function testBarePipeTokenIsConsumed() {
+		$instance = new ParserParameterProcessor( [ 'Foo=a', '+pipe' ] );
+
+		$this->assertSame(
+			[ 'Foo' => [ 'a' ] ],
+			$instance->toArray()
+		);
+	}
+
+	public function testPipeTokenWithWhitespaceIsNotConsumedAndBecomesValue() {
+		// +pipe is compared against the raw, untrimmed look-ahead token, so a
+		// padded ' +pipe ' does not match and falls through to the bare-token rule.
+		$instance = new ParserParameterProcessor( [ 'Foo=a', ' +pipe ' ] );
+
+		$this->assertSame(
+			[ 'Foo' => [ 'a', '+pipe' ] ],
+			$instance->toArray()
+		);
+	}
+
+	public function testSepFollowedByPipeAreBothConsumedAndValuesPipeJoined() {
+		$instance = new ParserParameterProcessor( [ 'Foo=1;2', '+sep=;', '+pipe' ] );
+
+		$this->assertSame(
+			[ 'Foo' => [ '1|2' ] ],
+			$instance->toArray()
+		);
+	}
+
+	public function testPipeFollowedBySepLeavesSepAsLiteralJunkKey() {
+		// +sep is only ever inspected before +pipe, so once +pipe is consumed the
+		// trailing +sep=; is not recognized and lands as its own literal key.
+		$instance = new ParserParameterProcessor( [ 'Foo=a', '+pipe', '+sep=;' ] );
+
+		$this->assertSame(
+			[ 'Foo' => [ 'a' ], '+sep' => [ ';' ] ],
+			$instance->toArray()
+		);
+	}
+
+	public function testValidJsonObjectMergesKeysWrappingScalarsAndEmptyStrings() {
+		$instance = new ParserParameterProcessor(
+			[ '@json={"Has one":"1","Has empty":"","Has many":["a","b"]}' ]
+		);
+
+		$this->assertSame(
+			[
+				'Has one' => [ '1' ],
+				'Has empty' => [],
+				'Has many' => [ 'a', 'b' ],
+			],
+			$instance->toArray()
+		);
+	}
+
+	public function testMalformedJsonIsKeptVerbatimAndReportsError() {
+		$instance = new ParserParameterProcessor( [ '@json={ Foo }' ] );
+
+		$this->assertSame(
+			[ '@json' => [ '{ Foo }' ] ],
+			$instance->toArray()
+		);
+		$this->assertNotEmpty(
+			$instance->getErrors()
+		);
+	}
+
+	public function testNonStringParameterIsSkipped() {
+		$instance = new ParserParameterProcessor( [ 42, 'Foo=1' ] );
+
+		$this->assertSame(
+			[ 'Foo' => [ '1' ] ],
+			$instance->toArray()
+		);
+	}
+
+	public function testDisplayOptionWithValueBecomesOwnJunkKey() {
+		// Default construction does not capture +display: with a value it is parsed
+		// as an ordinary (junk) property assignment.
+		$instance = new ParserParameterProcessor( [ 'Foo=x', '+display=link' ] );
+
+		$this->assertSame(
+			[ 'Foo' => [ 'x' ], '+display' => [ 'link' ] ],
+			$instance->toArray()
+		);
+	}
+
+	public function testBareDisplayTokenIsSwallowedAsValueOfPrecedingProperty() {
+		// Default construction does not capture +display: a bare token continues
+		// the preceding property just like any other bare token.
+		$instance = new ParserParameterProcessor( [ 'Foo=x', '+display' ] );
+
+		$this->assertSame(
+			[ 'Foo' => [ 'x', '+display' ] ],
+			$instance->toArray()
+		);
+	}
+
+	public function testDisplayOptionsAreEmptyByDefault() {
+		$instance = new ParserParameterProcessor( [ 'Foo=x', '+display' ] );
+
+		$this->assertSame(
+			[],
+			$instance->getDisplayOptions()
+		);
+	}
+
+	public function testDisplayOptionIsCapturedForPrecedingPropertyWhenEnabled() {
+		$instance = new ParserParameterProcessor( [ 'Foo=x', '+display=link' ], true );
+
+		$this->assertSame(
+			[ 'Foo' => [ 'x' ] ],
+			$instance->toArray()
+		);
+		$this->assertSame(
+			[ 'Foo' => 'link' ],
+			$instance->getDisplayOptions()
+		);
+	}
+
+	public function testBareDisplayOptionIsCapturedAsEmptyMode() {
+		$instance = new ParserParameterProcessor( [ 'Foo=x', '+display' ], true );
+
+		$this->assertSame(
+			[ 'Foo' => [ 'x' ] ],
+			$instance->toArray()
+		);
+		$this->assertSame(
+			[ 'Foo' => '' ],
+			$instance->getDisplayOptions()
+		);
+	}
+
+	public function testDisplayOptionWithEmptyValueIsCapturedAsEmptyMode() {
+		$instance = new ParserParameterProcessor( [ 'Foo=x', '+display=' ], true );
+
+		$this->assertSame(
+			[ 'Foo' => '' ],
+			$instance->getDisplayOptions()
+		);
+	}
+
+	public function testDisplayOptionModeValueIsTrimmed() {
+		$instance = new ParserParameterProcessor( [ 'Foo=x', '+display= link ' ], true );
+
+		$this->assertSame(
+			[ 'Foo' => 'link' ],
+			$instance->getDisplayOptions()
+		);
+	}
+
+	public function testUnknownDisplayModeIsCapturedVerbatim() {
+		$instance = new ParserParameterProcessor( [ 'Foo=x', '+display=foo' ], true );
+
+		$this->assertSame(
+			[ 'Foo' => 'foo' ],
+			$instance->getDisplayOptions()
+		);
+	}
+
+	public function testRepeatedDisplayOptionOnOneAssignmentLastOneWins() {
+		$instance = new ParserParameterProcessor( [ 'Foo=x', '+display=link', '+display=text' ], true );
+
+		$this->assertSame(
+			[ 'Foo' => 'text' ],
+			$instance->getDisplayOptions()
+		);
+	}
+
+	public function testDisplayOptionBeforeSepAppliesToSameAssignment() {
+		$instance = new ParserParameterProcessor( [ 'Foo=1;2', '+display=link', '+sep=;' ], true );
+
+		$this->assertSame(
+			[ 'Foo' => [ '1', '2' ] ],
+			$instance->toArray()
+		);
+		$this->assertSame(
+			[ 'Foo' => 'link' ],
+			$instance->getDisplayOptions()
+		);
+	}
+
+	public function testDisplayOptionAfterSepAppliesToSameAssignment() {
+		$instance = new ParserParameterProcessor( [ 'Foo=1;2', '+sep=;', '+display=link' ], true );
+
+		$this->assertSame(
+			[ 'Foo' => [ '1', '2' ] ],
+			$instance->toArray()
+		);
+		$this->assertSame(
+			[ 'Foo' => 'link' ],
+			$instance->getDisplayOptions()
+		);
+	}
+
+	public function testDisplayOptionAppliesOnlyToPrecedingAssignment() {
+		$instance = new ParserParameterProcessor( [ 'Foo=a', 'Bar=b', '+display=link' ], true );
+
+		$this->assertSame(
+			[ 'Bar' => 'link' ],
+			$instance->getDisplayOptions()
+		);
+	}
+
+	public function testDisplayOptionForMultiElementAssignmentAttachesToProperty() {
+		$instance = new ParserParameterProcessor( [ 'Foo=1', '2', '+display=text' ], true );
+
+		$this->assertSame(
+			[ 'Foo' => [ '1', '2' ] ],
+			$instance->toArray()
+		);
+		$this->assertSame(
+			[ 'Foo' => 'text' ],
+			$instance->getDisplayOptions()
+		);
+	}
+
+	public function testDisplayOptionDoesNotUnlockSepAfterPipe() {
+		// The legacy rule that +sep is never consumed after +pipe still applies
+		// when a +display option sits between them.
+		$instance = new ParserParameterProcessor( [ 'Foo=a', '+pipe', '+display', '+sep=;' ], true );
+
+		$this->assertSame(
+			[ 'Foo' => [ 'a' ], '+sep' => [ ';' ] ],
+			$instance->toArray()
+		);
+		$this->assertSame(
+			[ 'Foo' => '' ],
+			$instance->getDisplayOptions()
+		);
+	}
+
 	public function parametersDataProvider() {
 		// {{#...:
 		// |Has test 1=One


### PR DESCRIPTION
Implements the display option requested in #5624.

+display attaches to the immediately preceding property assignment like +sep/+pipe and renders the stored value the way the corresponding inline annotation would: bare +display, +display= and +display=link produce the linked, formatted value; +display=text the unlinked one. Multiple values are joined with ", ".

Capture is enabled at construction time and only by the #set definition, so #subobject and #set_recurring_event parsing is unchanged even when a +display token appears. Without the option, #set parsing and output stay byte-identical, guarded by a characterization suite that pins the shared ParserParameterProcessor behavior (bare tokens, +sep/+pipe variants and their order quirks, @json handling, non-string parameters) and the exact #set return contract.

Invalid values are never displayed; unknown modes produce a warning; template= and +display are mutually exclusive. The display path mirrors the inline annotation path for strip markers (raw original returned for unstripping), file usage registration, and parser-cache user-language handling: a value whose rendering depends on the viewer's interface language (a unit-conversion tooltip, a localized error) marks the output with the 'userlang' extra parser key, as InTextAnnotationParser and AskParserFunction already do, so cached renderings do not leak another user's language. #set returns noparse=false when at least one value displays, with the same `:` encoding protection for error output that the inline path uses.

JSONScript cases cover the datatype matrix (page, file target, URL, external identifier with formatter URI, keyword formatter schema, quantity unit conversion, date, monolingual text), the link/text/bare/empty modes, multi-value +sep in both option orders, per-assignment selectivity, invalid values, the unknown-mode warning, the template= conflict, strip-marker values, and the #subobject guard; a DB integration test asserts the user-language parser-cache fragmentation.