### PR TITLE
Keep noparse unchanged when #set displays a value

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -9,7 +9,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 ## New features and enhancements
 
-* Added the `+display` option to the `#set` parser function, so a value can be stored and shown in one call without inline annotation syntax. The option attaches to the immediately preceding property assignment like `+sep` does and renders the value the way the corresponding inline annotation would: `+display` or `+display=link` produce the linked, formatted value, `+display=text` the formatted value without a link ([#5624](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5624))
+* Added the `+display` option to the `#set` parser function, so a value can be stored and shown in one call without inline annotation syntax. The option follows a property assignment like `+sep` does and shows the values stored for that property, rendered the way the corresponding inline annotation would: `+display` or `+display=link` produce the linked, formatted value, `+display=text` the formatted value without a link ([#5624](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5624))
 * Added `SMW\MediaWiki\Outputs::requireJsConfigVar()` so extensions can register JavaScript configuration variables through the SMW output mechanism, alongside modules, styles and head items, instead of emitting inline scripts ([#7028](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7028))
 
 ## Bug fixes

--- a/src/ParserFunctions/SetParserFunction.php
+++ b/src/ParserFunctions/SetParserFunction.php
@@ -157,7 +157,7 @@ class SetParserFunction {
 
 		$html = $this->templateRenderer->render() . $displayText . $errorHtml;
 
-		return [ $html, 'noparse' => $template === '' && $displayText === '', 'isHTML' => false ];
+		return [ $html, 'noparse' => $template === '', 'isHTML' => false ];
 	}
 
 	/**

--- a/tests/phpunit/Integration/JSONScript/TestCases/p-0214.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/p-0214.json
@@ -121,6 +121,10 @@
 		{
 			"page": "Example/P0214/17",
 			"contents": "{{#subobject: |Has text=x |+display }}"
+		},
+		{
+			"page": "Example/P0214/18",
+			"contents": "{{#set: |Has text={{{1}}} |+display }}"
 		}
 	],
 	"tests": [
@@ -536,6 +540,33 @@
 				],
 				"not-contain": [
 					"title=\"Display target page\""
+				]
+			}
+		},
+		{
+			"type": "parser",
+			"about": "#17 an unresolved template argument in a displayed value is shown as stored, not expanded against the #set arguments",
+			"subject": "Example/P0214/18",
+			"assert-store": {
+				"semantic-data": {
+					"strictPropertyValueMatch": false,
+					"propertyCount": 3,
+					"propertyKeys": [
+						"Has_text",
+						"_SKEY",
+						"_MDAT"
+					],
+					"propertyValues": [
+						"{{{1}}}"
+					]
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"{{{1}}}"
+				],
+				"not-contain": [
+					"+display"
 				]
 			}
 		}

--- a/tests/phpunit/Unit/ParserFunctions/SetParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/SetParserFunctionTest.php
@@ -208,7 +208,7 @@ class SetParserFunctionTest extends TestCase {
 		);
 
 		$this->assertSame(
-			[ 0 => '[[:Bar|bar]]', 'noparse' => false, 'isHTML' => false ],
+			[ 0 => '[[:Bar|bar]]', 'noparse' => true, 'isHTML' => false ],
 			$result
 		);
 	}
@@ -221,8 +221,32 @@ class SetParserFunctionTest extends TestCase {
 		);
 
 		$this->assertSame(
-			[ 0 => 'bar', 'noparse' => false, 'isHTML' => false ],
+			[ 0 => 'bar', 'noparse' => true, 'isHTML' => false ],
 			$result
+		);
+	}
+
+	/**
+	 * `noparse` must not depend on whether a value is displayed. Returning
+	 * `noparse => false` makes the Parser preprocess the result in a child
+	 * frame built from the `#set` call's own arguments, which expands any
+	 * `{{{n}}}` left in a stored value against those arguments (#7040).
+	 * Link markup renders either way, so the flag can stay at its legacy value.
+	 */
+	public function testDisplayDoesNotFlipNoParse() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', '+display' ], true )
+		);
+
+		// A value has to reach the output for the flag to be under test at all
+		$this->assertNotSame(
+			'',
+			$result[0]
+		);
+		$this->assertTrue(
+			$result['noparse']
 		);
 	}
 
@@ -261,6 +285,72 @@ class SetParserFunctionTest extends TestCase {
 
 		$this->assertSame(
 			'b',
+			$result[0]
+		);
+	}
+
+	/**
+	 * The option is scoped to the property of the assignment it follows, not to
+	 * that assignment alone, because the parameter processor merges repeated
+	 * assignments of one property into a single value list before `#set` sees
+	 * them. Pinned so the scope is a documented choice rather than an accident.
+	 */
+	public function testDisplayAppliesToEveryValueOfARepeatedProperty() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=a', 'Foo=b', '+display=text' ], true )
+		);
+
+		$this->assertSame(
+			'a, b',
+			$result[0]
+		);
+	}
+
+	public function testLastDisplayModeWinsForARepeatedProperty() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray(
+				[ 'Foo=a', '+display=link', 'Foo=b', '+display=text' ],
+				true
+			)
+		);
+
+		$this->assertSame(
+			'a, b',
+			$result[0]
+		);
+	}
+
+	public function testDisplayModeIsCaseInsensitive() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', '+display=TEXT' ], true )
+		);
+
+		$this->assertSame(
+			'bar',
+			$result[0]
+		);
+	}
+
+	/**
+	 * `@json` assignments are expanded into their property names only after the
+	 * display option has been keyed to the literal `@json` parameter, so the
+	 * option matches no property and is silently ignored.
+	 */
+	public function testDisplayIsIgnoredForJsonAssignments() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ '@json={"Foo":"bar"}', '+display' ], true )
+		);
+
+		$this->assertSame(
+			'',
 			$result[0]
 		);
 	}
@@ -348,7 +438,11 @@ class SetParserFunctionTest extends TestCase {
 			'RAW',
 			$result[0]
 		);
-		$this->assertFalse(
+		// `noparse` only controls whether the Parser preprocesses the result in
+		// a child frame, so it has no bearing on how a strip marker in the
+		// output is handled; the legacy value stands here as it does for every
+		// other displayed value (#7040)
+		$this->assertTrue(
 			$result['noparse']
 		);
 	}


### PR DESCRIPTION
Follow-up to #7040, targeting that branch rather than master. Review findings from reading and exercising the branch against a live wiki.

## `noparse` flips when a value is displayed

`#set` returns `noparse => false` as soon as `+display` produces output. That flag only decides whether the Parser preprocesses the result, and preprocessing marks the result as a child object, so `Parser::braceSubstitution()` expands the returned text in a child frame built from the `#set` call's own arguments (`$args = $piece['parts']`).

Any `{{{n}}}` left in a stored value is then resolved against those arguments instead of being shown. On a page containing

```
{{#set: Has text={{{1}}} |+display}}
```

the stored value is `{{{1}}}` and the rendered output is `+display`, the option token itself. Confirmed on a live 1.43 wiki. The spelling of the option decides the outcome: bare `+display` occupies numbered argument 1, while `+display=text` is a named argument and leaves slot 1 empty, so the same call renders differently depending on which form was used.

The flag is not needed to display values. Link markup in a parser function result is rendered by the later link pass regardless of `noparse`, which gates only template re-expansion. Verified both ways on a live wiki: with the legacy expression restored, `{{#set: Has page=Some page |+display}}` still renders the page link, and `{{{1}}}` renders as stored.

The new `p-0214` case fails on the current branch and passes with the change.

## `+display` is scoped to the property, not the assignment

The release note states the option "attaches to the immediately preceding property assignment like `+sep` does". It does not, because the parameter processor merges repeated assignments of one property into a single value list before `#set` sees them, and the option is keyed by property name:

```
{{#set: |Has author=Alice |Has author=Bob |+display}}
```

renders `Alice, Bob` rather than `Bob`, and

```
{{#set: |Has author=Alice |+display=link |Has author=Bob |+display=text}}
```

silently resolves to `text` for both values. `+sep` and `+pipe` do not behave this way because they are locals rebuilt on each iteration.

Re-keying alone cannot fix this: the continuation form `|Has author=Alice |Bob |+display` produces an identical parameter array and should display both, so the two cases are indistinguishable downstream. A per-assignment scope would need the option to record the value range it covers.

Since repeating a property inside one `#set` is unidiomatic, this reads as an acceptable limitation rather than a blocker, so this changes the release note to describe the real scope and adds tests pinning it. Happy to attempt a per-assignment implementation instead if you would rather have the documented semantics.

Every existing test of the contract uses distinct property names, which is why the current suite passes.

## Also covered

Two behaviours had no coverage, so a change to either would go unnoticed:

* mode case-folding (`+display=TEXT`); removing the `strtolower()` call keeps the whole suite green today
* `+display` on an `@json` assignment, which is silently ignored because the option is keyed to the literal `@json` parameter that `parseFromJson()` then removes

Both are pinned as-is, not changed.

## Not addressed here

**The `:` guard.** `str_replace( ':', '&#58;', $errorHtml )` is gated on `$displayText !== ''`, which was presumably chosen to match the `noparse` flip that this changes, leaving the gate without a rationale. Worth noting that the guard stops SMW annotations forming (`[[Has author&#58;&#58;Jane]]` does not annotate) but not MediaWiki category links, since Title normalisation decodes the entity: `[[Category&#58;Evil]]` still categorises. The comment says the encoding is applied "as the inline annotation path does", but `InTextAnnotationParser` encodes the value and appends the error text raw, which is the inverse. Left as-is to keep this focused.

Separately, and not a problem with this branch: `{{#set: Has number=[[Category:Evil]]}}` already categorises a page through the error message on master, with no `+display` involved.

## Checked and correct

Noting these because they were the parts most worth doubting:

* The strip-marker path is right. With `SMW_PARSER_UNSTRIP` enabled, `{{#set: Has text=<nowiki>x</nowiki> |+display=text}}` renders `x`, matching `[[Has text::<nowiki>x</nowiki>]]` exactly. With the feature off both render the raw marker, so `+display` tracks the inline path in either configuration. The one gap is coverage: the PR description mentions JSONScript covering strip-marker values, but `p-0214` has no such case and the unit test mocks the decoder, so only the return value is asserted, never the rendering. A case with `smwgParserFeatures: ["unstrip"]` as in `p-0455` would close that.
* The `lookAheadOnNextElement()` rewrite is behaviour-preserving. Running the pre- and post-change classes side by side over 49 parameter arrays gives identical results on 47; the two differences are inputs where the old code raised a `TypeError` from `trim()` on a non-string and the new `is_string()` guard handles it, so nothing can depend on the old behaviour. The `!$sepConsumed` and `!$pipe` guards reproduce the legacy quirks exactly, including `+sep` never being consumed after `+pipe`.

## Verification

Run against MW 1.43 / PHP 8.2 in a dedicated container off this branch:

* `SetParserFunction`, `ParserParameterProcessor`, `ParameterProcessorFactory`, `SubobjectParserFunction`, recurring events: 220 tests, 347 assertions
* JSONScript `p-0210`, `p-0214`, `p-0215`, `p-0455`: 298 assertions
* `SetParserFunctionDisplayUserLanguageDBIntegrationTest`
* `composer analyze` clean, no warnings; `phan` clean
