### PR TITLE
Stop a #set +display value from annotating

### DIFF
--- a/src/Parser/LinksEncoder.php
+++ b/src/Parser/LinksEncoder.php
@@ -64,6 +64,34 @@ class LinksEncoder {
 	}
 
 	/**
+	 * Strips the annotation syntax from text that re-enters the wikitext
+	 * stream ahead of InTextAnnotationParser, so that it cannot annotate.
+	 *
+	 * A parser function returns its result while the Parser expands templates,
+	 * which is before InTextAnnotationParser scans the page, so text a parser
+	 * function passes through reaches that scan: `[[Bar::Baz]]` would store an
+	 * annotation of its own and `[[SMW::off]]` would discard the annotations of
+	 * everything that follows it. The `[[Foo::Bar]]` syntax needs none of this,
+	 * as InTextAnnotationParser consumes its text itself and never rescans it.
+	 *
+	 * @since 7.2.0
+	 */
+	public static function neutralizeAnnotation( string $text ): string {
+		// removeAnnotation() reduces an annotation to the text it displays and
+		// leaves ordinary links alone, but unwraps one level at a time, so
+		// repeat it to reduce a value that is an annotation in its own right.
+		// It never lengthens the text, hence this settles.
+		do {
+			$previous = $text;
+			$text = self::removeAnnotation( $text );
+		} while ( $text !== $previous );
+
+		// Some shapes are deliberately left intact by removeAnnotation (#1747),
+		// so encode the brackets of whatever it did not reduce.
+		return (string)self::obfuscateAnnotation( $text );
+	}
+
+	/**
 	 * @since 2.5
 	 */
 	public static function obfuscateAnnotation( string $text ): ?string {

--- a/src/ParserFunctions/PropertyLinkParserFunction.php
+++ b/src/ParserFunctions/PropertyLinkParserFunction.php
@@ -40,7 +40,8 @@ class PropertyLinkParserFunction {
 		$caption = array_shift( $rawParams ) ?? false;
 
 		if ( $caption !== false ) {
-			$caption = $this->neutralizeAnnotations( $caption );
+			// A caption is display text and must not annotate
+			$caption = LinksEncoder::neutralizeAnnotation( $caption );
 		}
 
 		$result = $this->propertyLinkRenderer->render( [ $property ], '@@@', $caption );
@@ -57,25 +58,6 @@ class PropertyLinkParserFunction {
 		}
 
 		return $result;
-	}
-
-	/**
-	 * A caption is display text and must not annotate. `[[Foo::@@@|caption]]`
-	 * hands its caption to InTextAnnotationParser, which never rescans it, but
-	 * this function returns wikitext before InTextAnnotationParser runs, so an
-	 * unhandled caption would reach that scan: `[[Bar::Baz]]` would store an
-	 * annotation of its own and `[[SMW::off]]` would discard the annotations of
-	 * everything that follows it on the page.
-	 *
-	 * removeAnnotation() reduces an annotation to the text it displays, leaving
-	 * ordinary links alone; obfuscateAnnotation() then encodes the brackets of
-	 * whatever remains, since removeAnnotation() unwraps only the outermost
-	 * annotation and would otherwise expose a nested one.
-	 */
-	private function neutralizeAnnotations( string $caption ): string {
-		return (string)LinksEncoder::obfuscateAnnotation(
-			LinksEncoder::removeAnnotation( $caption )
-		);
 	}
 
 	/**

--- a/src/ParserFunctions/SetParserFunction.php
+++ b/src/ParserFunctions/SetParserFunction.php
@@ -10,6 +10,7 @@ use SMW\Formatters\MessageFormatter;
 use SMW\MediaWiki\Renderer\WikitextTemplateRenderer;
 use SMW\MediaWiki\StripMarkerDecoder;
 use SMW\Parser\AnnotationProcessor;
+use SMW\Parser\LinksEncoder;
 use SMW\ParserData;
 use SMW\ParserParameterProcessor;
 
@@ -117,7 +118,7 @@ class SetParserFunction {
 					$displayPart = $this->renderDisplayValue( $displayModes[$property], $dataValue, $origValue, $value );
 
 					if ( $displayPart !== null ) {
-						$displayParts[] = $displayPart;
+						$displayParts[] = LinksEncoder::neutralizeAnnotation( $displayPart );
 					}
 				}
 
@@ -145,15 +146,15 @@ class SetParserFunction {
 
 		$displayText = implode( ', ', $displayParts );
 
-		$errorHtml = $this->messageFormatter
-			->addFromArray( $parameters->getErrors() )
-			->getHtml();
-
-		if ( $displayText !== '' ) {
-			// Encode `:` so the error output cannot form annotations or comment
-			// blocks when the result is parsed, as the inline annotation path does
-			$errorHtml = str_replace( ':', '&#58;', $errorHtml );
-		}
+		// A warning names the input it rejected, so the error output carries
+		// user input into the stream just as a displayed value does and has to
+		// be neutralized unconditionally: gating this on a displayed value
+		// leaves the warning for an unknown `+display` mode able to annotate.
+		$errorHtml = LinksEncoder::neutralizeAnnotation(
+			$this->messageFormatter
+				->addFromArray( $parameters->getErrors() )
+				->getHtml()
+		);
 
 		$html = $this->templateRenderer->render() . $displayText . $errorHtml;
 

--- a/tests/phpunit/Unit/Parser/LinksEncoderTest.php
+++ b/tests/phpunit/Unit/Parser/LinksEncoderTest.php
@@ -44,6 +44,44 @@ class LinksEncoderTest extends TestCase {
 	}
 
 	/**
+	 * @dataProvider neutralizeAnnotationProvider
+	 */
+	public function testNeutralizeAnnotation( string $text, string $expected ) {
+		$this->assertSame(
+			$expected,
+			LinksEncoder::neutralizeAnnotation( $text )
+		);
+	}
+
+	/**
+	 * @return array<string,array{string,string}>
+	 */
+	public function neutralizeAnnotationProvider(): array {
+		return [
+			'annotation reduces to its value' => [ '[[Bar::Baz]]', 'Baz' ],
+			'annotation reduces to its caption' => [ '[[Bar::Baz|label]]', 'label' ],
+			'annotation within text' => [ 'see [[Age::42]] here', 'see 42 here' ],
+			'subobject annotation' => [ '[[Bar:=Baz]]', 'Baz' ],
+			'annotation off switch is dropped' => [ '[[SMW::off]]', '' ],
+			'annotation on switch is dropped' => [ '[[SMW::on]]', '' ],
+			// a value that is an annotation in its own right is reduced too
+			'nested annotation' => [ '[[Foo::[[Bar::Baz]]]]', 'Baz' ],
+			'deeply nested annotation' => [ '[[A::[[B::[[C::D]]]]]]', 'D' ],
+			// removeAnnotation() leaves this shape intact (#1747), so the
+			// brackets are encoded instead of reduced
+			'annotation that is not reduced is obfuscated' => [ '[[Bar|x::Baz]]', '&#91;&#91;Bar|x::Baz]]' ],
+			// an annotation cannot be smuggled past the match by encoding it
+			'encoded annotation' => [ '%5B%5BBar::Baz%5D%5D', 'Baz' ],
+			'link is left alone' => [ '[[Some page]]', '[[Some page]]' ],
+			'piped link is left alone' => [ '[[Some page|label]]', '[[Some page|label]]' ],
+			'namespaced link is left alone' => [ '[[Category:Foo]]', '[[Category:Foo]]' ],
+			'external link is left alone' => [ '[http://example.org e]', '[http://example.org e]' ],
+			'text is left alone' => [ 'plain text', 'plain text' ],
+			'empty text' => [ '', '' ],
+		];
+	}
+
+	/**
 	 * @dataProvider stripTextWithAnnotationProvider
 	 */
 	public function testStrip( $text, $expectedRemoval, $expectedObscuration ) {

--- a/tests/phpunit/Unit/ParserFunctions/SetParserFunctionTest.php
+++ b/tests/phpunit/Unit/ParserFunctions/SetParserFunctionTest.php
@@ -370,6 +370,58 @@ class SetParserFunctionTest extends TestCase {
 		);
 	}
 
+	/**
+	 * A displayed value re-enters the wikitext stream, where
+	 * InTextAnnotationParser scans it. Annotation syntax carried by a value
+	 * must not survive into the output: `[[Bar::Baz]]` would store an
+	 * annotation the `#set` never declared, and `[[SMW::off]]` would discard
+	 * the annotations of everything that follows it on the page. `Text` is a
+	 * predefined property of type Text, whose values render as given.
+	 *
+	 * @dataProvider displayedValueWithAnnotationSyntaxProvider
+	 */
+	public function testDisplayedValueDoesNotCarryAnnotationSyntax( string $value, string $expected ) {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ "Text=$value", '+display=text' ], true )
+		);
+
+		$this->assertSame( $expected, $result[0] );
+	}
+
+	/**
+	 * @return array<string,array{string,string}>
+	 */
+	public function displayedValueWithAnnotationSyntaxProvider(): array {
+		return [
+			'annotation' => [ '[[Bar::Baz]]', 'Baz' ],
+			'annotation with caption' => [ '[[Bar::Baz|label]]', 'label' ],
+			'annotation within text' => [ 'see [[Age::42]] here', 'see 42 here' ],
+			'nested annotation' => [ '[[Foo::[[Bar::Baz]]]]', 'Baz' ],
+			'annotation off switch' => [ '[[SMW::off]]', '' ],
+			'link is left alone' => [ '[[Some page]]', '[[Some page]]' ],
+			'text is left alone' => [ 'plain text', 'plain text' ],
+		];
+	}
+
+	/**
+	 * The warning names the mode it rejected, so an unknown mode reaches the
+	 * output as given and has to be neutralized like a displayed value.
+	 */
+	public function testUnknownDisplayModeDoesNotCarryAnnotationSyntaxIntoTheWarning() {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( '<span>[[Bar::Baz]] [[SMW::off]]</span>' );
+
+		$result = $instance->parse(
+			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', '+display=[[Bar::Baz]]' ], true )
+		);
+
+		$this->assertSame(
+			'<span>Baz </span>',
+			$result[0]
+		);
+	}
+
 	public function testUnknownDisplayModeAddsWarningAndDisplaysNothing() {
 		$messageFormatter = $this->newMessageFormatterExpectingKey(
 			'smw-parser-function-set-display-invalid-mode',
@@ -505,30 +557,34 @@ class SetParserFunctionTest extends TestCase {
 		);
 	}
 
-	public function testErrorHtmlColonsAreEncodedWhenDisplayValuesAreShown() {
-		$instance = $this->newSetParserFunctionWithHtmlOutput( 'Warn:ing' );
+	/**
+	 * The error output names the input it rejected, so it carries user input
+	 * into the stream whether or not a value is displayed and is neutralized in
+	 * both cases. A colon that cannot form an annotation is left alone, so a
+	 * URL in an error survives.
+	 *
+	 * @dataProvider errorHtmlProvider
+	 *
+	 * @param string[] $parameters
+	 */
+	public function testErrorHtmlIsNeutralized( array $parameters, string $expected ) {
+		$instance = $this->newSetParserFunctionWithHtmlOutput( 'Warn:ing [[Bar::Baz]]' );
 
 		$result = $instance->parse(
-			ParameterProcessorFactory::newFromArray( [ 'Foo=bar', '+display=text' ], true )
+			ParameterProcessorFactory::newFromArray( $parameters, true )
 		);
 
-		$this->assertSame(
-			'barWarn&#58;ing',
-			$result[0]
-		);
+		$this->assertSame( $expected, $result[0] );
 	}
 
-	public function testErrorHtmlIsNotEncodedWithoutDisplayOutput() {
-		$instance = $this->newSetParserFunctionWithHtmlOutput( 'Warn:ing' );
-
-		$result = $instance->parse(
-			ParameterProcessorFactory::newFromArray( [ 'Foo=bar' ], true )
-		);
-
-		$this->assertSame(
-			[ 0 => 'Warn:ing', 'noparse' => true, 'isHTML' => false ],
-			$result
-		);
+	/**
+	 * @return array<string,array{string[],string}>
+	 */
+	public function errorHtmlProvider(): array {
+		return [
+			'with a displayed value' => [ [ 'Foo=bar', '+display=text' ], 'barWarn:ing Baz' ],
+			'without a displayed value' => [ [ 'Foo=bar' ], 'Warn:ing Baz' ],
+		];
 	}
 
 	private function newSetParserFunctionWithHtmlOutput( string $html ): SetParserFunction {


### PR DESCRIPTION
`#set` returns its result while the Parser expands templates, which is before `InTextAnnotationParser` scans the page. A value shown by `+display` therefore re-enters the wikitext stream and is read as wikitext a second time, so annotation syntax carried by a value takes effect:

| Wikitext (`Property:Text` is the predefined Text property) | Annotations stored |
| --- | --- |
| `{{#set:Text=[[Bar::Baz]]\|+display=text}}` | `Bar=Baz`, which the `#set` never declared |
| `{{#set:Text=[[SMW::off]]\|+display=text}} [[Baz::Quux]]` | `Baz=Quux` is **dropped** |
| `{{#set:Text=use [[Age::42]] syntax\|+display=text}}` | `Age=42` |

The inline annotation syntax does none of this, as `InTextAnnotationParser` consumes its own text and never rescans it. `#set` without `+display` is unaffected too, so the divergence appears exactly where `+display` promises to render a value the way the corresponding annotation would.

Two things make this worth fixing rather than documenting. The third case needs no crafted input, only prose that happens to contain the syntax, so a value can quietly become data nobody asked for. And the second silently discards the annotations of everything after it on the page, which loses data with no error. All three are reachable through a template parameter, which is where `#set` is normally used.

Only properties whose values render as given are affected (Text, Keyword, Code, External identifier, Monolingual text). Page-typed and undeclared properties are not, because their value renders as a link whose leading colon cannot start an annotation, and Number or Boolean values are rejected before they display.

## Fix

Annotations in a displayed value are reduced to the text they display, so `see [[Age::42]] here` still reads as `see 42 here`, and the brackets of anything that cannot be reduced are encoded. Ordinary links, external links and namespaced links are left alone.

The error output needs the same treatment, because a warning names the input it rejected: `{{#set:Text=x|+display=[[Bar::Baz]]}}` stored `Bar=Baz` through the message for an unknown mode. Its `:` encoding was already there for this reason but ran only when a value displayed, which is the one case where that warning cannot appear. Neutralizing unconditionally also stops the encoding from reaching colons that never formed an annotation, such as a URL inside an error.

The caption of `{{#property_link:}}` is neutralized the same way and now shares the helper.

## Scope

The `|template=` path passes values into a template that reaches the same scan, so `{{#set:Text=[[SMW::off]]|template=T}}` drops later annotations as well. That behaviour predates both `+display` and `#property_link` by roughly a decade, and changing it would alter what long-standing templates render, so it is left alone here and is worth its own issue.

No release note: `+display` is new in the unreleased 7.2.0, so no released version renders any of this.

## Testing

`LinksEncoderTest` covers the reduction itself, including nesting, the encoded-bracket bypass, and the shapes that are deliberately left intact. `SetParserFunctionTest` covers the displayed value and the unknown-mode warning against the predefined Text property. Verified end-to-end against a wiki: `Baz=Quux` now survives every case above, no `Bar` or `Age` is stored, and an ordinary displayed value still renders.