### PR TITLE
Add client-side backoff and termination guard to page-purge reload

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -583,35 +583,34 @@
 		}
 	},
 	"QUnitTestModule": {
-		"ext.smw.tests": {
-			"scripts": [
-				"tests/qunit/smw/ext.smw.test.js",
-				"tests/qunit/smw/data/ext.smw.dataItem.wikiPage.test.js",
-				"tests/qunit/smw/data/ext.smw.dataItem.uri.test.js",
-				"tests/qunit/smw/data/ext.smw.dataItem.time.test.js",
-				"tests/qunit/smw/data/ext.smw.dataItem.property.test.js",
-				"tests/qunit/smw/data/ext.smw.dataItem.unknown.test.js",
-				"tests/qunit/smw/data/ext.smw.dataItem.number.test.js",
-				"tests/qunit/smw/data/ext.smw.dataItem.text.test.js",
-				"tests/qunit/smw/data/ext.smw.dataValue.quantity.test.js",
-				"tests/qunit/smw/data/ext.smw.data.test.js",
-				"tests/qunit/smw/api/ext.smw.api.test.js",
-				"tests/qunit/smw/query/ext.smw.query.test.js",
-				"tests/qunit/smw/util/ext.smw.localtime.test.js"
-			],
-			"dependencies": [
-				"mediawiki.language.months",
-				"ext.smw",
-				"ext.smw.tooltip",
-				"ext.smw.query",
-				"ext.smw.data",
-				"ext.smw.api",
-				"ext.smw.localtime"
-			],
-			"position": "top",
-			"localBasePath": "",
-			"remoteExtPath": "SemanticMediaWiki"
-		}
+		"scripts": [
+			"tests/qunit/smw/ext.smw.test.js",
+			"tests/qunit/smw/data/ext.smw.dataItem.wikiPage.test.js",
+			"tests/qunit/smw/data/ext.smw.dataItem.uri.test.js",
+			"tests/qunit/smw/data/ext.smw.dataItem.time.test.js",
+			"tests/qunit/smw/data/ext.smw.dataItem.property.test.js",
+			"tests/qunit/smw/data/ext.smw.dataItem.unknown.test.js",
+			"tests/qunit/smw/data/ext.smw.dataItem.number.test.js",
+			"tests/qunit/smw/data/ext.smw.dataItem.text.test.js",
+			"tests/qunit/smw/data/ext.smw.dataValue.quantity.test.js",
+			"tests/qunit/smw/data/ext.smw.data.test.js",
+			"tests/qunit/smw/api/ext.smw.api.test.js",
+			"tests/qunit/smw/query/ext.smw.query.test.js",
+			"tests/qunit/smw/util/ext.smw.localtime.test.js",
+			"tests/qunit/smw/util/ext.smw.util.purge.test.js"
+		],
+		"dependencies": [
+			"mediawiki.language.months",
+			"ext.smw",
+			"ext.smw.purge",
+			"ext.smw.tooltip",
+			"ext.smw.query",
+			"ext.smw.api",
+			"ext.smw.localtime"
+		],
+		"position": "top",
+		"localBasePath": "",
+		"remoteExtPath": "SemanticMediaWiki"
 	},
 	"SpecialPages": {
 		"ExportRDF": "SMW\\MediaWiki\\Specials\\SpecialOWLExport",
@@ -894,10 +893,12 @@
 			"scripts": "smw/util/ext.smw.util.purge.js",
 			"messages": [
 				"smw-purge-failed",
-				"smw-purge-update-dependencies"
+				"smw-purge-update-dependencies",
+				"smw-purge-update-dependencies-timeout"
 			],
 			"dependencies": [
-				"mediawiki.api"
+				"mediawiki.api",
+				"mediawiki.storage"
 			]
 		},
 		"ext.smw.vtabs.styles": {

--- a/i18n/de.json
+++ b/i18n/de.json
@@ -258,6 +258,7 @@
 	"smw-special-wantedproperties-template": "$1 ($2 {{PLURAL:$2|Vorkommen}})",
 	"smw_purge": "Neu laden",
 	"smw-purge-update-dependencies": "Diese Seite wird automatisch neu geladen, um sicherzustellen, dass alle Informationen aktuell sind. Das kann einen Moment dauern und mehr als einmal passieren.",
+	"smw-purge-update-dependencies-timeout": "Semantic MediaWiki verarbeitet für diese Seite noch immer Aktualisierungen. Dies dauert länger als erwartet; die angezeigten Informationen sind möglicherweise noch nicht vollständig aktuell. Ein manuelles Neuladen zu einem späteren Zeitpunkt kann helfen.",
 	"smw-purge-failed": "Die aktuelle Seite konnte von Semantic MediaWiki nicht neu geladen werden.",
 	"types": "Datentypen",
 	"smw_types_docu": "Dies ist eine [https://www.semantic-mediawiki.org/wiki/Help:List_of_datatypes Liste aller Datentypen], die Attributen zugewiesen werden können. Jeder [https://www.semantic-mediawiki.org/wiki/Help:Datatype Datentyp] beschreibt eindeutige Merkmale zur Datenspeicherung und -anzeige eines Datenwerts für ein Attribut, dem der entsprechende Datentyp zugeordnet wurde.",

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -228,6 +228,7 @@
 	"smw-special-wantedproperties-template": "$1 ($2 {{PLURAL:$2|use|uses}})",
 	"smw_purge": "Refresh",
 	"smw-purge-update-dependencies": "This page is being reloaded to ensure all information is up to date. This may take a moment and may happen more than once.",
+	"smw-purge-update-dependencies-timeout": "Semantic MediaWiki is still processing updates for this page. This is taking longer than expected; the information shown may not be fully up to date yet. Performing a manual refresh later may help.",
 	"smw-purge-failed": "Semantic MediaWiki tried to purge the page but failed",
 	"types": "Types",
 	"smw_types_docu": "List of [https://www.semantic-mediawiki.org/wiki/Help:List_of_datatypes available datatypes] with each [https://www.semantic-mediawiki.org/wiki/Help:Datatype type] representing a unique set of attributes to describe a value in terms of storage and display characteristics that are hereditary to an assigned property.",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -251,6 +251,7 @@
 	"smw-special-wantedproperties-template": "This is the message on [[Special:WantedProperties]] showing the name of the property without an assigned data type and how often it is used in the wiki.\n\nParameters:\n* $1 holds the name of the wanted property.\n* $2 holds the number of values annotated with the wanted property.",
 	"smw_purge": "{{doc-actionlink}}\nThis is the label of a tab of an action item for the content area.\n{{Identical|Refresh}}",
 	"smw-purge-update-dependencies": "This is an informatory message in a balloon informing about the automatic purge of the page triggered by the annotation query marker.",
+	"smw-purge-update-dependencies-timeout": "This is an informatory message in a balloon shown when the automatic reload triggered by the annotation query marker (see [[mediawiki:Smw-purge-update-dependencies/en|smw-purge-update-dependencies]]) has been retried for a while without the underlying data becoming up to date, so the client stops auto-reloading.",
 	"smw-purge-failed": "This is an error/warning message. Please translate consistent to {{msg-mw|smw_purge}}.",
 	"types": "{{doc-special|Types}}\n{{Identical|Type}}",
 	"smw_types_docu": "This is the introductory message at the top of [[Special:Types]].",

--- a/res/smw/util/ext.smw.util.purge.js
+++ b/res/smw/util/ext.smw.util.purge.js
@@ -15,50 +15,165 @@
 /*global jQuery, mediaWiki, smw */
 /*jslint white: true */
 
-( function( $, mw ) {
+( function ( $, mw ) {
 
 	'use strict';
 
-	var purge = function( context ) {
+	mw.smw = mw.smw || {};
 
-		var forcelinkupdate = false;
+	// Ceiling on the total time spent auto-reloading via a `.page-purge`
+	// element (#7044). Once exceeded, stop reloading and notify instead.
+	var MAX_RETRY_MS = 120000;
 
-		if ( context.data( 'title' ) ) {
-			var title = context.data( 'title' );
-		} else {
-			var title = mw.config.get( 'wgPageName' );
-		}
+	// Backoff sequence (ms) between successive auto-reloads; the last value
+	// repeats for any further attempt.
+	var BACKOFF_SEQUENCE = [ 1000, 3000, 7000, 15000, 30000 ];
 
-		if ( context.data( 'msg' ) ) {
-			mw.notify( mw.msg( context.data( 'msg' ) ), { type: 'info', autoHide: false } );
-		};
+	var purge = {
+		/**
+		 * @param {string} title
+		 * @return {string}
+		 */
+		storageKey: function ( title ) {
+			return 'mw-smw-purge-retry-' + title;
+		},
 
-		if ( context.data( 'forcelinkupdate' ) ) {
-			forcelinkupdate = context.data( 'forcelinkupdate' );
-		};
+		/**
+		 * @param {string} title
+		 * @return {Object} { attempts: number, startTime: number }
+		 */
+		getRetryState: function ( title ) {
+			var raw = mw.storage.session.get( purge.storageKey( title ) );
+			var state;
 
-		var postArgs = { action: 'purge', titles: title, forcelinkupdate: forcelinkupdate };
+			try {
+				state = raw ? JSON.parse( raw ) : null;
+			} catch ( e ) {
+				state = null;
+			}
 
-		new mw.Api().post( postArgs ).then( function () {
+			if ( !state || typeof state.attempts !== 'number' || typeof state.startTime !== 'number' ) {
+				state = { attempts: 0, startTime: Date.now() };
+			}
+
+			return state;
+		},
+
+		/**
+		 * @param {string} title
+		 * @param {Object} state
+		 */
+		setRetryState: function ( title, state ) {
+			mw.storage.session.set( purge.storageKey( title ), JSON.stringify( state ) );
+		},
+
+		/**
+		 * @param {string} title
+		 */
+		clearRetryState: function ( title ) {
+			mw.storage.session.remove( purge.storageKey( title ) );
+		},
+
+		/**
+		 * @param {number} attempts number of auto-reloads already performed
+		 * @return {number} delay in ms before the next reload
+		 */
+		computeBackoff: function ( attempts ) {
+			var index = Math.min( attempts, BACKOFF_SEQUENCE.length - 1 );
+			return BACKOFF_SEQUENCE[ index ];
+		},
+
+		/**
+		 * Decide, for an auto-triggered (`.page-purge`) purge, whether another
+		 * reload attempt is still within the retry budget.
+		 *
+		 * @param {string} title
+		 * @return {Object} { allowed: boolean, delay: number, state: Object }
+		 */
+		nextAttempt: function ( title ) {
+			var state = purge.getRetryState( title );
+			var elapsed = Date.now() - state.startTime;
+
+			if ( elapsed >= MAX_RETRY_MS ) {
+				return { allowed: false, delay: 0, state: state };
+			}
+
+			return { allowed: true, delay: purge.computeBackoff( state.attempts ), state: state };
+		},
+
+		/**
+		 * Indirection point so tests can substitute a stub, since
+		 * `window.location.reload` cannot be reassigned directly in all
+		 * environments.
+		 */
+		reload: function () {
 			location.reload();
-		}, function () {
-			mw.notify( mw.msg( 'smw-purge-failed' ), { type: 'error' } );
-		} );
-	}
+		},
+
+		/**
+		 * @param {jQuery} context
+		 * @param {boolean} isAutoTriggered whether this purge originates from
+		 *  a `.page-purge` element rather than a user click
+		 */
+		run: function ( context, isAutoTriggered ) {
+
+			var forcelinkupdate = false;
+			var title = context.data( 'title' ) || mw.config.get( 'wgPageName' );
+
+			if ( context.data( 'forcelinkupdate' ) ) {
+				forcelinkupdate = context.data( 'forcelinkupdate' );
+			}
+
+			var attempt = isAutoTriggered ?
+				purge.nextAttempt( title ) :
+				{ allowed: true, delay: 0, state: null };
+
+			if ( !attempt.allowed ) {
+				purge.clearRetryState( title );
+				mw.notify( mw.msg( 'smw-purge-update-dependencies-timeout' ), { type: 'info', autoHide: false } );
+				return;
+			}
+
+			if ( context.data( 'msg' ) ) {
+				mw.notify( mw.msg( context.data( 'msg' ) ), { type: 'info', autoHide: false } );
+			}
+
+			var postArgs = { action: 'purge', titles: title, forcelinkupdate: forcelinkupdate };
+
+			new mw.Api().post( postArgs ).then( function () {
+				if ( isAutoTriggered ) {
+					purge.setRetryState( title, {
+						attempts: attempt.state.attempts + 1,
+						startTime: attempt.state.startTime
+					} );
+
+					setTimeout( function () {
+						purge.reload();
+					}, attempt.delay );
+				} else {
+					purge.reload();
+				}
+			}, function () {
+				mw.notify( mw.msg( 'smw-purge-failed' ), { type: 'error' } );
+			} );
+		}
+	};
+
+	mw.smw.purge = purge;
 
 	// JS is loaded, now remove the "soft" disabled functionality
-	$( "#ca-purge" ).removeClass( 'is-disabled' );
+	$( '#ca-purge' ).removeClass( 'is-disabled' );
 
 	// Observed on the chameleon skin
-	$( "#ca-purge a" ).removeClass( 'is-disabled' );
+	$( '#ca-purge a' ).removeClass( 'is-disabled' );
 
-	$( "#ca-purge a, .purge" ).on( 'click', function ( e ) {
-		purge( $( this ) );
+	$( '#ca-purge a, .purge' ).on( 'click', function ( e ) {
+		purge.run( $( this ), false );
 		e.preventDefault();
 	} );
 
-	$( ".page-purge" ).each( function () {
-		purge( $( this ) );
+	$( '.page-purge' ).each( function () {
+		purge.run( $( this ), true );
 	} );
 
 }( jQuery, mediaWiki ) );

--- a/res/smw/util/ext.smw.util.purge.js
+++ b/res/smw/util/ext.smw.util.purge.js
@@ -142,6 +142,15 @@
 
 			new mw.Api().post( postArgs ).then( function () {
 				if ( isAutoTriggered ) {
+					var elapsed = Date.now() - attempt.state.startTime;
+					var remaining = MAX_RETRY_MS - elapsed;
+
+					if ( remaining <= attempt.delay ) {
+						purge.clearRetryState( title );
+						mw.notify( mw.msg( 'smw-purge-update-dependencies-timeout' ), { type: 'info', autoHide: false } );
+						return;
+					}
+
 					purge.setRetryState( title, {
 						attempts: attempt.state.attempts + 1,
 						startTime: attempt.state.startTime
@@ -156,24 +165,41 @@
 			}, function () {
 				mw.notify( mw.msg( 'smw-purge-failed' ), { type: 'error' } );
 			} );
+		},
+
+		/**
+		 * @param {jQuery} $content
+		 */
+		init: function ( $content ) {
+			// JS is loaded, now remove the "soft" disabled functionality
+			$content.find( '#ca-purge' ).removeClass( 'is-disabled' );
+
+			// Observed on the chameleon skin
+			$content.find( '#ca-purge a' ).removeClass( 'is-disabled' );
+
+			$content.find( '#ca-purge a, .purge' ).on( 'click', function ( e ) {
+				purge.run( $( this ), false );
+				e.preventDefault();
+			} );
+
+			var $pagePurge = $content.find( '.page-purge' );
+
+			if ( !$pagePurge.length ) {
+				// Dependencies are current again; drop any stale retry state so
+				// a later, unrelated outdated-dependency event for this title
+				// starts with a fresh retry window instead of inheriting an old
+				// startTime.
+				purge.clearRetryState( mw.config.get( 'wgPageName' ) );
+			}
+
+			$pagePurge.each( function () {
+				purge.run( $( this ), true );
+			} );
 		}
 	};
 
 	mw.smw.purge = purge;
 
-	// JS is loaded, now remove the "soft" disabled functionality
-	$( '#ca-purge' ).removeClass( 'is-disabled' );
-
-	// Observed on the chameleon skin
-	$( '#ca-purge a' ).removeClass( 'is-disabled' );
-
-	$( '#ca-purge a, .purge' ).on( 'click', function ( e ) {
-		purge.run( $( this ), false );
-		e.preventDefault();
-	} );
-
-	$( '.page-purge' ).each( function () {
-		purge.run( $( this ), true );
-	} );
+	purge.init( $( document ) );
 
 }( jQuery, mediaWiki ) );

--- a/tests/phpunit/Unit/DependencyValidatorTest.php
+++ b/tests/phpunit/Unit/DependencyValidatorTest.php
@@ -180,6 +180,25 @@ class DependencyValidatorTest extends TestCase {
 		);
 	}
 
+	public function testHasLikelyOutdatedDependencies_RemainsTrueAcrossRepeatedChecks() {
+		// #7044: markTitle/hasLikelyOutdatedDependencies intentionally has no
+		// reset or expiry (by design, see #6882's "Out of scope" note). This
+		// means a client that keeps reloading a title with outdated
+		// dependencies will keep observing `true` here on every repeated
+		// view/request until the underlying update job runs and a fresh view
+		// no longer calls markTitle(). Bounding the number of client reloads
+		// is therefore the client's responsibility (ext.smw.util.purge.js).
+		$subject = WikiPage::newFromText( 'Foo' );
+		$title = $subject->getTitle();
+
+		$instance = $this->newInstance();
+		$instance->markTitle( $title );
+
+		$this->assertTrue( $instance->hasLikelyOutdatedDependencies( $title ) );
+		$this->assertTrue( $instance->hasLikelyOutdatedDependencies( $title ) );
+		$this->assertTrue( $instance->hasLikelyOutdatedDependencies( $title ) );
+	}
+
 	public function testCanKeepParserCache_NoCache() {
 		$this->entityCache->expects( $this->once() )
 			->method( 'contains' )

--- a/tests/phpunit/Unit/PostProcHandlerTest.php
+++ b/tests/phpunit/Unit/PostProcHandlerTest.php
@@ -282,6 +282,73 @@ class PostProcHandlerTest extends TestCase {
 	}
 
 	/**
+	 * Reproduces the server-side condition behind #7044: as long as
+	 * `hasLikelyOutdatedDependencies` remains true for a title (e.g. the
+	 * update job backlog has not caught up yet), every subsequent view of
+	 * that title keeps emitting the `.page-purge` div, one per request/reload.
+	 * The client is therefore solely responsible for bounding how many
+	 * reloads it performs (see ext.smw.util.purge.js).
+	 */
+	public function testPurgePageOnQueryDependency_RepeatedOnSuccessiveViews() {
+		$this->parserOutput->expects( $this->any() )
+			->method( 'getExtensionData' )
+			->with( PostProcHandler::POST_EDIT_UPDATE )
+			->willReturn( [ 'Bar' ] );
+
+		$instance = new PostProcHandler(
+			$this->parserOutput,
+			$this->cache
+		);
+
+		$instance->setOptions(
+			[
+				'purge-page' => [ 'on-outdated-query-dependency' => true ]
+			]
+		);
+
+		$title = $this->createMock( Title::class );
+
+		$dependencyLinksValidator = $this->createMock( DependencyLinksValidator::class );
+		$namespaceExaminer = $this->createMock( NamespaceExaminer::class );
+		$entityCache = $this->createMock( EntityCache::class );
+		$eventDispatcher = $this->createMock( EventDispatcher::class );
+		$dependencyValidator = new DependencyValidator(
+			$namespaceExaminer,
+			$dependencyLinksValidator,
+			$entityCache,
+			'',
+			3600,
+			$eventDispatcher
+		);
+		// Simulates the dependency remaining outdated across several distinct
+		// requests (e.g. the update job has not run yet by the time of the
+		// next reload).
+		$dependencyValidator->markTitle( $title );
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'getPrefixedDBKey' )
+			->willReturn( 'Foo' );
+
+		$title->expects( $this->atLeastOnce() )
+			->method( 'getNamespace' )
+			->willReturn( NS_MAIN );
+
+		$webRequest = $this->createMock( WebRequest::class );
+
+		// First view: emits the purge div (this is the same behaviour already
+		// covered by testPurgePageOnQueryDependency).
+		$firstHtml = $instance->getHtml( $title, $webRequest );
+
+		// A second, independent view of the same title (simulating the reload
+		// the client just performed) still finds the dependency outdated and
+		// therefore emits the purge div again, unbounded on the server side.
+		$secondHtml = $instance->getHtml( $title, $webRequest );
+
+		$this->assertStringContainsString( 'page-purge', $firstHtml );
+		$this->assertStringContainsString( 'page-purge', $secondHtml );
+	}
+
+	/**
 	 * @dataProvider validPropertyKeyProvider
 	 */
 	public function testGetHtmlOnCookieAndValidChangeDiff( $key ) {

--- a/tests/qunit/smw/util/ext.smw.util.purge.test.js
+++ b/tests/qunit/smw/util/ext.smw.util.purge.test.js
@@ -1,0 +1,210 @@
+/**
+ * QUnit coverage for ext.smw.util.purge.js (#7044).
+ *
+ * @licence GNU GPL v2 or later
+ */
+( function () {
+	'use strict';
+
+	QUnit.module( 'ext.smw.util.purge', QUnit.newMwEnvironment( {
+		afterEach: function () {
+			mw.smw.purge.clearRetryState( 'Foo' );
+		}
+	} ) );
+
+	QUnit.test( 'storageKey builds a title-scoped key', function ( assert ) {
+		assert.strictEqual(
+			mw.smw.purge.storageKey( 'Foo' ),
+			'mw-smw-purge-retry-Foo'
+		);
+	} );
+
+	QUnit.test( 'getRetryState returns a fresh state when nothing is stored', function ( assert ) {
+		var state = mw.smw.purge.getRetryState( 'Foo' );
+
+		assert.strictEqual( state.attempts, 0, 'no attempts recorded yet' );
+		assert.strictEqual( typeof state.startTime, 'number', 'startTime is set' );
+	} );
+
+	QUnit.test( 'getRetryState returns a fresh state on corrupt storage', function ( assert ) {
+		mw.storage.session.set( mw.smw.purge.storageKey( 'Foo' ), 'not-json' );
+
+		var state = mw.smw.purge.getRetryState( 'Foo' );
+
+		assert.strictEqual( state.attempts, 0 );
+	} );
+
+	QUnit.test( 'setRetryState persists attempts and startTime', function ( assert ) {
+		mw.smw.purge.setRetryState( 'Foo', { attempts: 2, startTime: 12345 } );
+
+		var state = mw.smw.purge.getRetryState( 'Foo' );
+
+		assert.strictEqual( state.attempts, 2 );
+		assert.strictEqual( state.startTime, 12345 );
+	} );
+
+	QUnit.test( 'clearRetryState removes the stored state', function ( assert ) {
+		mw.smw.purge.setRetryState( 'Foo', { attempts: 2, startTime: 12345 } );
+		mw.smw.purge.clearRetryState( 'Foo' );
+
+		var state = mw.smw.purge.getRetryState( 'Foo' );
+
+		assert.strictEqual( state.attempts, 0, 'state was reset, not merely re-read' );
+	} );
+
+	QUnit.test( 'computeBackoff increases with attempts and then plateaus', function ( assert ) {
+		assert.strictEqual( mw.smw.purge.computeBackoff( 0 ), 1000 );
+		assert.strictEqual( mw.smw.purge.computeBackoff( 1 ), 3000 );
+		assert.strictEqual( mw.smw.purge.computeBackoff( 2 ), 7000 );
+
+		var last = mw.smw.purge.computeBackoff( 4 );
+		assert.strictEqual( mw.smw.purge.computeBackoff( 100 ), last, 'plateaus at the last configured delay' );
+	} );
+
+	QUnit.test( 'nextAttempt allows a reload within the retry budget', function ( assert ) {
+		mw.smw.purge.setRetryState( 'Foo', { attempts: 1, startTime: Date.now() } );
+
+		var attempt = mw.smw.purge.nextAttempt( 'Foo' );
+
+		assert.strictEqual( attempt.allowed, true );
+		assert.strictEqual( attempt.delay, mw.smw.purge.computeBackoff( 1 ) );
+	} );
+
+	QUnit.test( 'nextAttempt denies a reload once the retry budget is exceeded', function ( assert ) {
+		// startTime far enough in the past to exceed the fixed retry ceiling.
+		mw.smw.purge.setRetryState( 'Foo', { attempts: 5, startTime: Date.now() - 121000 } );
+
+		var attempt = mw.smw.purge.nextAttempt( 'Foo' );
+
+		assert.strictEqual( attempt.allowed, false );
+	} );
+
+	QUnit.test( 'run() on a click-triggered purge reloads immediately on success', function ( assert ) {
+		var done = assert.async();
+		var reloadCalled = false;
+		var originalReload = mw.smw.purge.reload;
+		var originalApi = mw.Api;
+
+		mw.smw.purge.reload = function () {
+			reloadCalled = true;
+		};
+
+		mw.Api = function () {};
+		mw.Api.prototype.post = function () {
+			return $.Deferred().resolve( {} ).promise();
+		};
+
+		var $context = $( '<a>' ).attr( 'href', '#' );
+
+		mw.smw.purge.run( $context, false );
+
+		setTimeout( function () {
+			assert.strictEqual( reloadCalled, true, 'reload was called without delay' );
+
+			mw.smw.purge.reload = originalReload;
+			mw.Api = originalApi;
+			done();
+		}, 0 );
+	} );
+
+	QUnit.test( 'run() on a click-triggered purge notifies on failure and does not reload', function ( assert ) {
+		var done = assert.async();
+		var reloadCalled = false;
+		var originalReload = mw.smw.purge.reload;
+		var originalApi = mw.Api;
+
+		mw.smw.purge.reload = function () {
+			reloadCalled = true;
+		};
+
+		mw.Api = function () {};
+		mw.Api.prototype.post = function () {
+			return $.Deferred().reject().promise();
+		};
+
+		var $context = $( '<a>' ).attr( 'href', '#' );
+
+		mw.smw.purge.run( $context, false );
+
+		setTimeout( function () {
+			assert.strictEqual( reloadCalled, false, 'no reload on a failed purge request' );
+
+			mw.smw.purge.reload = originalReload;
+			mw.Api = originalApi;
+			done();
+		}, 0 );
+	} );
+
+	QUnit.test( 'run() auto-triggered (.page-purge) delays the reload using the backoff', function ( assert ) {
+		var done = assert.async();
+		var reloadCalled = false;
+		var originalReload = mw.smw.purge.reload;
+		var originalApi = mw.Api;
+		var originalSetTimeout = window.setTimeout;
+		var capturedDelay = null;
+
+		mw.smw.purge.reload = function () {
+			reloadCalled = true;
+		};
+
+		window.setTimeout = function ( fn, delay ) {
+			capturedDelay = delay;
+			return originalSetTimeout( fn, 0 );
+		};
+
+		mw.Api = function () {};
+		mw.Api.prototype.post = function () {
+			return $.Deferred().resolve( {} ).promise();
+		};
+
+		var $context = $( '<div>' ).addClass( 'page-purge' ).data( 'title', 'Foo' );
+
+		mw.smw.purge.run( $context, true );
+
+		setTimeout( function () {
+			assert.strictEqual( capturedDelay, 1000, 'first auto-retry uses the initial backoff delay' );
+			assert.strictEqual( reloadCalled, true, 'reload still happens after the delay' );
+
+			var state = mw.smw.purge.getRetryState( 'Foo' );
+			assert.strictEqual( state.attempts, 1, 'attempt counter was incremented' );
+
+			mw.smw.purge.reload = originalReload;
+			mw.Api = originalApi;
+			window.setTimeout = originalSetTimeout;
+			done();
+		}, 10 );
+	} );
+
+	QUnit.test( 'run() auto-triggered stops reloading once the retry budget is exceeded', function ( assert ) {
+		var reloadCalled = false;
+		var notifyCalled = false;
+		var originalReload = mw.smw.purge.reload;
+		var originalNotify = mw.notify;
+
+		mw.smw.purge.reload = function () {
+			reloadCalled = true;
+		};
+
+		mw.notify = function ( msg, opt ) {
+			if ( opt && opt.type === 'info' ) {
+				notifyCalled = true;
+			}
+		};
+
+		mw.smw.purge.setRetryState( 'Foo', { attempts: 5, startTime: Date.now() - 121000 } );
+
+		var $context = $( '<div>' ).addClass( 'page-purge' ).data( 'title', 'Foo' );
+
+		mw.smw.purge.run( $context, true );
+
+		assert.strictEqual( reloadCalled, false, 'no further reload once the ceiling is exceeded' );
+		assert.strictEqual( notifyCalled, true, 'a low-key notice is shown instead' );
+
+		var state = mw.smw.purge.getRetryState( 'Foo' );
+		assert.strictEqual( state.attempts, 0, 'retry state was reset' );
+
+		mw.smw.purge.reload = originalReload;
+		mw.notify = originalNotify;
+	} );
+
+}() );

--- a/tests/qunit/smw/util/ext.smw.util.purge.test.js
+++ b/tests/qunit/smw/util/ext.smw.util.purge.test.js
@@ -7,6 +7,9 @@
 	'use strict';
 
 	QUnit.module( 'ext.smw.util.purge', QUnit.newMwEnvironment( {
+		config: {
+			wgPageName: 'Foo'
+		},
 		afterEach: function () {
 			mw.smw.purge.clearRetryState( 'Foo' );
 		}
@@ -161,7 +164,7 @@
 
 		mw.smw.purge.run( $context, true );
 
-		setTimeout( function () {
+		originalSetTimeout( function () {
 			assert.strictEqual( capturedDelay, 1000, 'first auto-retry uses the initial backoff delay' );
 			assert.strictEqual( reloadCalled, true, 'reload still happens after the delay' );
 
@@ -173,6 +176,53 @@
 			window.setTimeout = originalSetTimeout;
 			done();
 		}, 10 );
+	} );
+
+	QUnit.test( 'run() auto-triggered stops reloading when the scheduled delay would exceed the ceiling', function ( assert ) {
+		var done = assert.async();
+		var reloadCalled = false;
+		var notifyCalled = false;
+		var originalReload = mw.smw.purge.reload;
+		var originalNotify = mw.notify;
+		var originalApi = mw.Api;
+
+		mw.smw.purge.reload = function () {
+			reloadCalled = true;
+		};
+
+		mw.notify = function ( msg, opt ) {
+			if ( opt && opt.type === 'info' ) {
+				notifyCalled = true;
+			}
+		};
+
+		mw.Api = function () {};
+		mw.Api.prototype.post = function () {
+			return $.Deferred().resolve( {} ).promise();
+		};
+
+		// 1 attempt so far => next backoff is computeBackoff( 1 ) = 3000ms.
+		// startTime far enough in the past that only ~1000ms of budget is
+		// left, less than the scheduled 3000ms delay: eligible at request
+		// time, but the reload itself would land past the ceiling.
+		mw.smw.purge.setRetryState( 'Foo', { attempts: 1, startTime: Date.now() - 119000 } );
+
+		var $context = $( '<div>' ).addClass( 'page-purge' ).data( 'title', 'Foo' );
+
+		mw.smw.purge.run( $context, true );
+
+		setTimeout( function () {
+			assert.strictEqual( reloadCalled, false, 'no reload scheduled past the ceiling' );
+			assert.strictEqual( notifyCalled, true, 'a low-key notice is shown instead' );
+
+			var state = mw.smw.purge.getRetryState( 'Foo' );
+			assert.strictEqual( state.attempts, 0, 'retry state was reset' );
+
+			mw.smw.purge.reload = originalReload;
+			mw.notify = originalNotify;
+			mw.Api = originalApi;
+			done();
+		}, 0 );
 	} );
 
 	QUnit.test( 'run() auto-triggered stops reloading once the retry budget is exceeded', function ( assert ) {
@@ -205,6 +255,43 @@
 
 		mw.smw.purge.reload = originalReload;
 		mw.notify = originalNotify;
+	} );
+
+	QUnit.test( 'init() clears stale retry state once the page-purge marker is gone', function ( assert ) {
+		mw.smw.purge.setRetryState( 'Foo', { attempts: 3, startTime: Date.now() - 90000 } );
+
+		var $content = $( '<div>' );
+
+		mw.smw.purge.init( $content );
+
+		var state = mw.smw.purge.getRetryState( 'Foo' );
+		assert.strictEqual( state.attempts, 0, 'stale attempts were dropped' );
+	} );
+
+	QUnit.test( 'init() leaves retry state untouched while a page-purge marker is present', function ( assert ) {
+		var originalReload = mw.smw.purge.reload;
+		var originalApi = mw.Api;
+
+		mw.smw.purge.reload = function () {};
+		mw.Api = function () {};
+		mw.Api.prototype.post = function () {
+			// Never resolves; only init()'s synchronous effects are under test.
+			return $.Deferred().promise();
+		};
+
+		mw.smw.purge.setRetryState( 'Foo', { attempts: 3, startTime: Date.now() - 90000 } );
+
+		var $content = $( '<div>' ).append(
+			$( '<div>' ).addClass( 'page-purge' ).data( 'title', 'Foo' )
+		);
+
+		mw.smw.purge.init( $content );
+
+		var state = mw.smw.purge.getRetryState( 'Foo' );
+		assert.strictEqual( state.attempts, 3, 'existing retry state is preserved, not cleared' );
+
+		mw.smw.purge.reload = originalReload;
+		mw.Api = originalApi;
 	} );
 
 }() );


### PR DESCRIPTION
## Summary

The `@annotation`-driven page-purge reload (`res/smw/util/ext.smw.util.purge.js`) reloaded immediately and unconditionally on every `.page-purge` element found in the DOM, with no client-side rate limiting. If the server kept emitting the purge div across successive reloads — e.g. because the referencing query's `_ASK` entity hadn't received a fresh `smw_touched` yet, or the update job backlog hadn't caught up — the browser would reload repeatedly and immediately, producing a visible, unbounded "flicker" loop.

This mirrors #6882, which fixed the *sibling* non-`@annotation` cache-rejection path and explicitly scoped this `@annotation`/`PostProcHandler`/`purge.js` path as a separate, out-of-scope mechanism. This PR is that separate fix. `DependencyValidator::markTitle()`/`hasLikelyOutdatedDependencies()` remain in use by design, unchanged — only the client's reload behavior changes.

## Changes

- **`res/smw/util/ext.smw.util.purge.js`**: exposes its logic under `mw.smw.purge` (mirroring the existing `mw.smw.localtime` pattern) so it can be unit tested. Adds:
  - `getRetryState`/`setRetryState`/`clearRetryState` — per-title retry bookkeeping in `mw.storage.session`.
  - `computeBackoff` — an increasing delay sequence (1s → 3s → 7s → 15s → 30s, then plateauing) between auto-reload attempts.
  - `nextAttempt` — decides whether another auto-reload is still within a fixed 2-minute retry ceiling.
  - `reload` — a small indirection so tests can stub the actual `location.reload()` call.
  - `run()` now applies the above only for the auto-triggered (`.page-purge`) path; a user-initiated click-to-purge (`#ca-purge`/`.purge`) still reloads immediately, unchanged.
  - Once the retry ceiling is exceeded, the client stops reloading and shows a low-key `mw.notify(..., { type: 'info' })` notice (new message `smw-purge-update-dependencies-timeout`) instead of treating it as an error — the data usually does arrive eventually via the job queue.
- **`tests/qunit/smw/util/ext.smw.util.purge.test.js`** (new): QUnit coverage for the retry-state helpers, the backoff sequence, the retry-budget decision, and `run()`'s click-triggered vs. auto-triggered behavior (including the termination-guard path).
- **`tests/phpunit/Unit/PostProcHandlerTest.php`** / **`tests/phpunit/Unit/DependencyValidatorTest.php`**: new tests documenting the server-side condition that motivates the client fix — `hasLikelyOutdatedDependencies()` has no reset/expiry by design, so it (and therefore the emitted `.page-purge` div) stays `true` across as many successive requests/reloads as it takes for the underlying dependency to actually become fresh. Bounding the number of reloads is therefore solely the client's responsibility.
- **`i18n/en.json`** / **`i18n/qqq.json`**: new `smw-purge-update-dependencies-timeout` message.
- **`extension.json`**: fixes `QUnitTestModule` being structurally invalid — it was wrapped in a spurious `"ext.smw.tests"` key instead of the module definition sitting directly under `QUnitTestModule` (MediaWiki's `ExtensionProcessor` auto-derives the RL module name as `test.{extension-name}` and only recognizes the un-wrapped form), and it depended on a non-existent `"ext.smw.data"` module. This was a necessary prerequisite for the new QUnit tests (and, it turns out, every pre-existing QUnit test in this repo) to load and run at all — see **#7045** for the full detail on the broader JS-test-infrastructure gap this surfaced (CI never runs JS tests, no `package.json`, `NODE_JS` disabled in the `Makefile`, plus a few further pre-existing, unrelated QUnit failures now visible for the first time).

## Test plan

- [x] `composer test` (lint, phpcs, phan, phpunit:unit, phpunit:integration) passes in a local `make install`'d container — 7319/7319 unit tests pass (7 pre-existing, unrelated skips).
- [x] New `PostProcHandlerTest`/`DependencyValidatorTest` cases pass.
- [x] New QUnit tests verified locally via Docker + Playwright against `Special:JavaScriptTest/qunit?component=SemanticMediaWiki`: the pure retry-state/backoff/budget logic (8 of the 12 new tests) passes directly; the remaining 4 `run()` tests initially failed only because `window.location.reload` is non-reassignable in that environment, fixed by introducing the `mw.smw.purge.reload` indirection point (a test-mockability change, not a logic change).
- [ ] Manual verification of the actual flicker-loop scenario (`#set +@annotation` query + `$smwgEnabledQueryDependencyLinksStore = true` + a persistently-outdated dependency) is left to reviewers with a live wiki, since reproducing the update-job-backlog timing reliably in an automated test is impractical.

Closes #7044
Follow-up filed as #7045