### PR TITLE
Fix PostgreSQL failures from unencoded binary smw_hash and uca sort keys

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -22,10 +22,13 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed long-running maintenance scripts (such as `rebuildData`, `rebuildFulltextSearchTable` and `dumpRDF`) exhausting memory on large wikis; MediaWiki's buffered stats samples, which accumulate in process memory for every processed entity and have no flush point on the command line, are now flushed periodically during the rebuild loops ([#7036](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7036))
 * Fixed maintenance scripts and Elasticsearch index rebuilds aborting with a `TypeError`, and faceted search returning incorrect counts, when an entity's stored sort-sequence or value-count map could not be deserialized (for example after the wiki's `$wgSecretKey` was changed); such a map is now treated as empty instead of crashing or miscounting ([#7043](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7043))
 * Fixed a JavaScript error when rendering a property as a link on the client side; the code called `mw.util.wikiGetlink`, which has been removed from MediaWiki core, and now uses `mw.util.getUrl` ([#7047](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7047))
+* Fixed Semantic MediaWiki being unusable on PostgreSQL since 7.0.0, where `update.php`, saving pages and running queries aborted with a `pg_escape_string()` error ([#7049](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7049))
 
 ## Upgrading
 
 No need to run "update.php" or any other migration scripts.
+
+Wikis that set `$smwgEntityCollation` to a `uca-*` value should run `php extensions/SemanticMediaWiki/maintenance/updateEntityCollation.php` once after upgrading so that previously stored sort keys use the new, consistent encoding. Wikis using the default `identity` collation need no migration.
 
 **Get the new version via Composer:**
 

--- a/maintenance/populateHashField.php
+++ b/maintenance/populateHashField.php
@@ -294,7 +294,7 @@ class populateHashField extends Maintenance {
 			$connection->newUpdateQueryBuilder()
 				->update( SQLStore::ID_TABLE )
 				->set( [
-					'smw_hash' => $hash
+					'smw_hash' => $connection->escape_bytea( $hash )
 				] )
 				->where( [
 					'smw_id' => $row->smw_id

--- a/src/MediaWiki/Collator.php
+++ b/src/MediaWiki/Collator.php
@@ -78,6 +78,20 @@ class Collator {
 	}
 
 	/**
+	 * Storage-safe sort key: the collation sort key of `$text`, armored so the
+	 * result is always valid UTF-8 (see `armor`).
+	 *
+	 * For `uca-*` collations the raw sort key is a binary blob that cannot be
+	 * stored in a text column such as Postgres `TEXT` (#7049); for the other
+	 * collations `armor` is a no-op and the value is returned unchanged.
+	 *
+	 * @since 7.2.0
+	 */
+	public function armoredSortKey( string $text ): string {
+		return $this->armor( $this->getSortKey( $text ) );
+	}
+
+	/**
 	 * @since 3.0
 	 */
 	public function getFirstLetter( string $text ): string {

--- a/src/SQLStore/EntityStore/AuxiliaryFields.php
+++ b/src/SQLStore/EntityStore/AuxiliaryFields.php
@@ -82,7 +82,7 @@ class AuxiliaryFields {
 			}
 
 			$cache->save( (string)$row->smw_id, $map );
-			$countMaps[$hashMap[$row->smw_hash]] = [ $row->smw_id => $map ];
+			$countMaps[$hashMap[(string)$this->connection->unescape_bytea( $row->smw_hash )]] = [ $row->smw_id => $map ];
 		}
 
 		return new FieldList( $countMaps );
@@ -138,7 +138,7 @@ class AuxiliaryFields {
 			->select( [ 't.smw_id', 't.smw_hash', 'p.smw_countmap' ] )
 			->from( SQLStore::ID_TABLE, 't' )
 			->join( SQLStore::ID_AUXILIARY_TABLE, 'p', 'p.smw_id=t.smw_id' )
-			->where( [ 't.smw_hash' => $hashes ] )
+			->where( [ 't.smw_hash' => array_map( [ $this->connection, 'escape_bytea' ], $hashes ) ] )
 			->caller( __METHOD__ )
 			->fetchResultSet();
 	}

--- a/src/SQLStore/EntityStore/CacheWarmer.php
+++ b/src/SQLStore/EntityStore/CacheWarmer.php
@@ -150,7 +150,7 @@ class CacheWarmer {
 				'smw_sort'
 			] )
 			->from( SQLStore::ID_TABLE )
-			->where( [ 'smw_hash' => $hashList ] )
+			->where( [ 'smw_hash' => array_map( [ $connection, 'escape_bytea' ], $hashList ) ] )
 			->caller( __METHOD__ )
 			->fetchResultSet();
 		foreach ( $rows as $row ) {

--- a/src/SQLStore/EntityStore/EntityIdFinder.php
+++ b/src/SQLStore/EntityStore/EntityIdFinder.php
@@ -134,7 +134,7 @@ class EntityIdFinder {
 			}
 
 			// Prevent any irregularities caused by a delayed, or redirect update
-			if ( $row->smw_hash !== $sha1 && $iw !== SMW_SQL3_SMWREDIIW ) {
+			if ( $this->connection->unescape_bytea( $row->smw_hash ) !== $sha1 && $iw !== SMW_SQL3_SMWREDIIW ) {
 				$this->deferHashUpdate( $id, $sha1 );
 			}
 		} else { // inconsistent DB; just recover somehow
@@ -214,7 +214,7 @@ class EntityIdFinder {
 			}
 
 			// Prevent any irregularities caused by a delayed, or redirect update
-			if ( $row->smw_hash !== $sha1 && $iw !== SMW_SQL3_SMWREDIIW ) {
+			if ( $this->connection->unescape_bytea( $row->smw_hash ) !== $sha1 && $iw !== SMW_SQL3_SMWREDIIW ) {
 				$this->deferHashUpdate( $id, $sha1 );
 			}
 		} else {
@@ -285,7 +285,7 @@ class EntityIdFinder {
 		$update = static function () use ( $connection, $id, $sha1, $caller ): void {
 			$connection->newUpdateQueryBuilder()
 				->update( SQLStore::ID_TABLE )
-				->set( [ 'smw_hash' => $sha1 ] )
+				->set( [ 'smw_hash' => $connection->escape_bytea( $sha1 ) ] )
 				->where( [ 'smw_id' => $id ] )
 				->caller( $caller )
 				->execute();

--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -631,8 +631,8 @@ class EntityIdManager {
 					'smw_iw' => $iw,
 					'smw_subobject' => $subobjectName,
 					'smw_sortkey' => $sortkey,
-					'smw_sort' => $collator->getSortKey( $sortkey ),
-					'smw_hash' => $this->computeSha1( [ $title, (int)$namespace, $iw, $subobjectName ] ),
+					'smw_sort' => $collator->armoredSortKey( $sortkey ),
+					'smw_hash' => $db->escape_bytea( $this->computeSha1( [ $title, (int)$namespace, $iw, $subobjectName ] ) ),
 					'smw_touched' => $db->timestamp(),
 				] )
 				->caller( __METHOD__ )
@@ -734,7 +734,7 @@ class EntityIdManager {
 
 		if ( $title instanceof WikiPage ) {
 			$cond = [
-				'smw_hash' => $title->getSha1(),
+				'smw_hash' => $connection->escape_bytea( $title->getSha1() ),
 			];
 		} elseif ( is_int( $title ) ) {
 			$cond = [

--- a/src/SQLStore/EntityStore/IdChanger.php
+++ b/src/SQLStore/EntityStore/IdChanger.php
@@ -82,7 +82,7 @@ class IdChanger {
 				'smw_subobject' => $row->smw_subobject,
 				'smw_sortkey' => $row->smw_sortkey,
 				'smw_sort' => $row->smw_sort,
-				'smw_hash' => IdCacheManager::computeSha1( $hash )
+				'smw_hash' => $connection->escape_bytea( IdCacheManager::computeSha1( $hash ) )
 			] )
 			->caller( __METHOD__ )
 			->execute();

--- a/src/SQLStore/EntityStore/IdEntityFinder.php
+++ b/src/SQLStore/EntityStore/IdEntityFinder.php
@@ -89,7 +89,7 @@ class IdEntityFinder {
 			$dataItem->setOption( 'sort', $row->smw_sort );
 		}
 
-		if ( !$this->idCacheManager->hasCache( $row->smw_hash ) ) {
+		if ( !$this->idCacheManager->hasCache( $this->store->getConnection( 'mw.db' )->unescape_bytea( $row->smw_hash ) ) ) {
 			$sortkey = $row->smw_sort === null ? '' : $row->smw_sortkey;
 
 			$this->idCacheManager->setCache(

--- a/src/SQLStore/Lookup/ByGroupPropertyValuesLookup.php
+++ b/src/SQLStore/Lookup/ByGroupPropertyValuesLookup.php
@@ -182,6 +182,10 @@ class ByGroupPropertyValuesLookup {
 			$pid = $entityIdManager->getSMWPropertyID( $property );
 		}
 
+		// smw_hash is stored as raw binary; escape each value so it is a valid
+		// bytea literal on Postgres (no-op on other backends).
+		$subjects = array_map( [ $connection, 'escape_bytea' ], $subjects );
+
 		if ( $isIdField ) {
 			$res = $connection->newSelectQueryBuilder()
 				->select( $fields )

--- a/src/SQLStore/Lookup/DisplayTitleLookup.php
+++ b/src/SQLStore/Lookup/DisplayTitleLookup.php
@@ -56,13 +56,13 @@ class DisplayTitleLookup {
 				] )
 				->from( SQLStore::ID_TABLE )
 				->where( [
-					'smw_hash' => array_keys( $chunk )
+					'smw_hash' => array_map( [ $connection, 'escape_bytea' ], array_keys( $chunk ) )
 				] )
 				->caller( __METHOD__ )
 				->fetchResultSet();
 
 			foreach ( $rows as $row ) {
-				$hashes[$row->smw_hash] = $row->smw_id;
+				$hashes[$connection->unescape_bytea( $row->smw_hash )] = $row->smw_id;
 			}
 
 			foreach ( $chunk as $sha1 => $dataItem ) {

--- a/src/SQLStore/Lookup/MonolingualTextLookup.php
+++ b/src/SQLStore/Lookup/MonolingualTextLookup.php
@@ -247,11 +247,11 @@ class MonolingualTextLookup {
 
 		// Is it a Monolingual representation?
 		if ( $subject->isSubEntityOf( SMW_SUBENTITY_MONOLINGUAL ) ) {
-			$qb->where( [ 'o0.smw_hash' => $subject->getSha1() ] );
+			$qb->where( [ 'o0.smw_hash' => $connection->escape_bytea( $subject->getSha1() ) ] );
 		} else {
 			// We don't have a _ML entity reference hence we add a JOIN to find
 			// such entity
-			$qb->where( [ 'o1.smw_hash' => $subject->getSha1() ] );
+			$qb->where( [ 'o1.smw_hash' => $connection->escape_bytea( $subject->getSha1() ) ] );
 
 			$qb->join( SQLStore::ID_TABLE, 'o1', 't0.s_id=o1.smw_id' );
 		}

--- a/src/SQLStore/QueryDependency/DependencyLinksValidator.php
+++ b/src/SQLStore/QueryDependency/DependencyLinksValidator.php
@@ -111,7 +111,7 @@ class DependencyLinksValidator {
 			->join( SQLStore::ID_TABLE, 'p', [ 's_id=p.smw_id' ] )
 			->join( SQLStore::ID_TABLE, 'v', [ 'o_id=v.smw_id' ] )
 			->where( [
-				'p.smw_hash' => $subject->getSha1(),
+				'p.smw_hash' => $connection->escape_bytea( $subject->getSha1() ),
 				$connection->expr( 'p.smw_iw', '!=', SMW_SQL3_SMWIW_OUTDATED ),
 				$connection->expr( 'p.smw_iw', '!=', SMW_SQL3_SMWDELETEIW ),
 			] )

--- a/src/SQLStore/TableBuilder/Examiner/HashField.php
+++ b/src/SQLStore/TableBuilder/Examiner/HashField.php
@@ -142,7 +142,7 @@ class HashField {
 		foreach ( $rows as $row ) {
 			$connection->newUpdateQueryBuilder()
 				->update( SQLStore::ID_TABLE )
-				->set( [ 'smw_hash' => hex2bin( $row->smw_hash ) ] )
+				->set( [ 'smw_hash' => hex2bin( (string)$row->smw_hash ) ] )
 				->where( [ 'smw_id' => $row->smw_id ] )
 				->caller( __METHOD__ )
 				->execute();

--- a/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
+++ b/src/SQLStore/TableBuilder/Examiner/PredefinedProperties.php
@@ -76,6 +76,13 @@ class PredefinedProperties {
 	private function doUpdate( Property $property, $id ): void {
 		$connection = $this->store->getConnection( DB_PRIMARY );
 
+		// `escape_bytea`/`unescape_bytea` live on SMW's connection wrapper, not
+		// on the raw `DB_PRIMARY` handle used for the queries here. They are
+		// connection-independent (a pure `\x`+hex transform on Postgres, a
+		// no-op elsewhere), so a separate wrapper handle can safely encode the
+		// binary `smw_hash` value.
+		$byteaConnection = $this->store->getConnection( 'mw.db' );
+
 		// Try to find the ID for a non-fixed predefined property
 		if ( $id === null ) {
 			$row = $connection->newSelectQueryBuilder()
@@ -123,6 +130,11 @@ class PredefinedProperties {
 				'smw_rev' => null,
 				'smw_touched' => $connection->timestamp( '1970-01-01 00:00:00' )
 			];
+		} else {
+			// smw_hash is stored as raw binary; on Postgres a read returns an
+			// escaped bytea literal, so normalise it back to raw binary before
+			// it is re-escaped on write below.
+			$row->smw_hash = $byteaConnection->unescape_bytea( $row->smw_hash );
 		}
 
 		$connection->newReplaceQueryBuilder()
@@ -135,9 +147,9 @@ class PredefinedProperties {
 				'smw_iw' => $iw,
 				'smw_subobject' => '',
 				'smw_sortkey' => $label,
-				'smw_sort' => Collator::singleton()->getSortKey( $label ?? '' ),
+				'smw_sort' => Collator::singleton()->armoredSortKey( $label ?? '' ),
 				'smw_proptable_hash' => $row->smw_proptable_hash,
-				'smw_hash' => $row->smw_hash,
+				'smw_hash' => $byteaConnection->escape_bytea( $row->smw_hash ),
 				'smw_rev' => $row->smw_rev,
 				'smw_touched' => $row->smw_touched
 			] )

--- a/src/SQLStore/TableFieldUpdater.php
+++ b/src/SQLStore/TableFieldUpdater.php
@@ -65,7 +65,7 @@ class TableFieldUpdater {
 			->update( SQLStore::ID_TABLE )
 			->set( [
 				'smw_sortkey' => mb_strcut( $searchKey, 0, 255 ),
-				'smw_sort'    => substr( $this->collator->getSortKey( $searchKey ), 0, 255 ),
+				'smw_sort'    => substr( $this->collator->armoredSortKey( $searchKey ), 0, 255 ),
 				'smw_touched' => $connection->timestamp()
 			] )
 			->where( [ 'smw_id' => $id ] )
@@ -115,7 +115,7 @@ class TableFieldUpdater {
 			->update( SQLStore::ID_TABLE )
 			->set( [
 				'smw_iw' => $iw,
-				'smw_hash' => $hash
+				'smw_hash' => $connection->escape_bytea( $hash )
 			] )
 			->where( [
 				'smw_id' => $sid

--- a/tests/phpunit/Unit/MediaWiki/CollatorTest.php
+++ b/tests/phpunit/Unit/MediaWiki/CollatorTest.php
@@ -101,6 +101,65 @@ class CollatorTest extends TestCase {
 		);
 	}
 
+	/**
+	 * The raw ICU sort key of a uca-* collation is a binary blob that is not
+	 * valid UTF-8, so it cannot be stored in a Postgres TEXT column. The
+	 * armored form must be storable (valid UTF-8, no NUL bytes).
+	 *
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7049
+	 */
+	public function testArmoredSortKeyOnUCAIsStorable() {
+		if ( !extension_loaded( 'intl' ) ) {
+			$this->markTestSkipped( 'Skipping because intl (ICU) is not available.' );
+		}
+
+		$instance = Collator::singleton( 'uca-default' );
+
+		// Reproduces #7049: for a uca-* collation ICU emits a binary sort key
+		// that is not valid UTF-8 (holds for Latin text across ICU versions).
+		// The armored value asserted below is what makes it storable.
+		$this->assertFalse(
+			mb_check_encoding( $instance->getSortKey( 'Has type' ), 'UTF-8' )
+		);
+
+		$armored = $instance->armoredSortKey( 'Has type' );
+
+		$this->assertTrue( mb_check_encoding( $armored, 'UTF-8' ) );
+		$this->assertStringNotContainsString( "\0", $armored );
+	}
+
+	/**
+	 * Armoring preserves the bitwise order of the raw sort keys, so a DB-side
+	 * ORDER BY on the stored value keeps collation order.
+	 */
+	public function testArmoredSortKeyPreservesOrderOnUCA() {
+		if ( !extension_loaded( 'intl' ) ) {
+			$this->markTestSkipped( 'Skipping because intl (ICU) is not available.' );
+		}
+
+		$instance = Collator::singleton( 'uca-default' );
+
+		foreach ( [ [ 'apple', 'banana' ], [ 'Zoo', 'apple' ], [ 'aa', 'ab' ] ] as [ $a, $b ] ) {
+			$rawCmp = strcmp( $instance->getSortKey( $a ), $instance->getSortKey( $b ) ) <=> 0;
+			$armoredCmp = strcmp( $instance->armoredSortKey( $a ), $instance->armoredSortKey( $b ) ) <=> 0;
+
+			$this->assertSame( $rawCmp, $armoredCmp, "order mismatch for '$a' vs '$b'" );
+		}
+	}
+
+	/**
+	 * For non-binary collations (identity/uppercase/numeric) the sort key is
+	 * already valid text, so armoring is a no-op and the value is unchanged.
+	 */
+	public function testArmoredSortKeyIsPlainForIdentityCollation() {
+		$instance = Collator::singleton( 'identity' );
+
+		$this->assertSame(
+			'Foo bar',
+			$instance->armoredSortKey( 'Foo bar' )
+		);
+	}
+
 	public function uppercaseProvider() {
 		$provider[] = [
 			'',

--- a/tests/phpunit/Unit/SQLStore/EntityStore/AuxiliaryFieldsTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/AuxiliaryFieldsTest.php
@@ -57,6 +57,9 @@ class AuxiliaryFieldsTest extends TestCase {
 			->with( AuxiliaryFields::COUNTMAP_CACHE_ID )
 			->willReturn( $this->cache );
 
+		$this->connection->method( 'escape_bytea' )->willReturnArgument( 0 );
+		$this->connection->method( 'unescape_bytea' )->willReturnArgument( 0 );
+
 		$subjects = [ WikiPage::newFromText( 'Foo' ) ];
 
 		$row = [
@@ -132,7 +135,8 @@ class AuxiliaryFieldsTest extends TestCase {
 	public function testPrefetchFieldListTreatsEmptyByteaAsEmptyMapWithoutWarning() {
 		// PostgreSQL's unescape_bytea() returns '' (not null) for a NULL column,
 		// so an empty count map must be recognised as empty rather than run
-		// through uncompress() and reported as a deserialization failure.
+		// through uncompress() and reported as a deserialization failure. The
+		// non-null smw_hash in the same row still decodes to its own value.
 		$this->idCacheManager->expects( $this->any() )
 			->method( 'get' )
 			->with( AuxiliaryFields::COUNTMAP_CACHE_ID )
@@ -140,7 +144,7 @@ class AuxiliaryFieldsTest extends TestCase {
 
 		$this->connection->expects( $this->any() )
 			->method( 'unescape_bytea' )
-			->willReturn( '' );
+			->willReturnCallback( static fn ( $value ) => $value === null ? '' : $value );
 
 		$subjects = [ WikiPage::newFromText( 'Foo' ) ];
 

--- a/tests/phpunit/Unit/SQLStore/EntityStore/CacheWarmerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/CacheWarmerTest.php
@@ -81,6 +81,8 @@ class CacheWarmerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$connection->method( 'escape_bytea' )->willReturnArgument( 0 );
+
 		$whereConditions = [];
 		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions );
 
@@ -159,6 +161,8 @@ class CacheWarmerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$connection->method( 'escape_bytea' )->willReturnArgument( 0 );
+
 		$whereConditions = [];
 		$qb = $this->createMockSelectQueryBuilder( [ (object)$row ], $whereConditions );
 
@@ -200,6 +204,8 @@ class CacheWarmerTest extends TestCase {
 		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$connection->method( 'escape_bytea' )->willReturnArgument( 0 );
 
 		$this->store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdChangerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdChangerTest.php
@@ -49,6 +49,8 @@ class IdChangerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$this->connection->method( 'escape_bytea' )->willReturnArgument( 0 );
+
 		$this->store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
 			->setMethods( [ 'getConnection', 'getPropertyTables' ] )

--- a/tests/phpunit/Unit/SQLStore/TableFieldUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableFieldUpdaterTest.php
@@ -41,7 +41,7 @@ class TableFieldUpdaterTest extends TestCase {
 			->getMock();
 
 		$collator->expects( $this->once() )
-			->method( 'getSortKey' )
+			->method( 'armoredSortKey' )
 			->willReturn( 'Foo' );
 
 		$capturedTables = [];
@@ -191,6 +191,7 @@ class TableFieldUpdaterTest extends TestCase {
 			->getMock();
 
 		$connection->method( 'newUpdateQueryBuilder' )->willReturn( $updateBuilder );
+		$connection->method( 'escape_bytea' )->willReturnArgument( 0 );
 
 		$store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()


### PR DESCRIPTION
## Problem

On PostgreSQL, `update.php`, saving pages and running queries abort with:

```
ValueError: pg_escape_string(): Argument #2 ($string) Escaping string failed
```

Two independent binary values are written to PostgreSQL without binary encoding:

1. **`smw_hash`** became a raw 20-byte binary SHA-1 in 7.0.0 (#6588), stored in a `BYTEA` column. Raw binary has to be passed through `bytea` encoding, otherwise MediaWiki's `DBConnRef` routes it through `pg_escape_string`, which rejects the non-UTF-8 bytes. This affects every `smw_hash` write and every hash lookup (entity creation, the `update.php` predefined-property setup, dependency validation, monolingual/group/display-title lookups, cache warming), so it is independent of the collation and breaks the default `identity` setup as well.

2. **`smw_sort`** holds the collation sort key. For `uca-*` entity collations this is a raw binary ICU key that is likewise not valid UTF-8, and it was written to `smw_sort` unarmored. On MySQL the column is `VARBINARY` so the bytes are tolerated; on PostgreSQL it is `TEXT`, which aborts the statement. (The same unarmored key also breaks `#ask` cursor pagination on MySQL, where the stored value is `json_encode`d.)

## Fix

- Add `Collator::armoredSortKey()` (the collation sort key, armored) and use it at the three `smw_sort` write paths. `armor()` is a no-op for non-`uca` collations, so `identity`/`uppercase`/`numeric` are unchanged, and it preserves byte order, so `ORDER BY smw_sort` is unaffected.
- Encode `smw_hash` with `escape_bytea()` on writes and `WHERE` values and decode reads with `unescape_bytea()` throughout the SQL store and `populateHashField.php`. Both helpers are no-ops on non-PostgreSQL backends, so MySQL/SQLite behaviour and the stored bytes are unchanged.

## Verification

Reproduced the reported crash on PostgreSQL 15 with `$smwgEntityCollation = 'uca-default-u-kn'` and confirmed the fix end to end: `update.php` completes, pages save, `#ask` queries return correct results, and `rebuildData.php` completes. Also confirmed the crash reproduces with the default `identity` collation (the `smw_hash` path) and is fixed there too. The unit test suite passes.

## Upgrading

Wikis that set `$smwgEntityCollation` to a `uca-*` value should run `updateEntityCollation.php` once after upgrading, so the previously stored sort keys are rewritten in the armored encoding. Wikis on the default `identity` collation need no migration.
