### PR TITLE
Fix IdChanger recomputing smw_hash from the title instead of the namespace

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -23,6 +23,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed maintenance scripts and Elasticsearch index rebuilds aborting with a `TypeError`, and faceted search returning incorrect counts, when an entity's stored sort-sequence or value-count map could not be deserialized (for example after the wiki's `$wgSecretKey` was changed); such a map is now treated as empty instead of crashing or miscounting ([#7043](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7043))
 * Fixed a JavaScript error when rendering a property as a link on the client side; the code called `mw.util.wikiGetlink`, which has been removed from MediaWiki core, and now uses `mw.util.getUrl` ([#7047](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7047))
 * Fixed Semantic MediaWiki being unusable on PostgreSQL since 7.0.0, where `update.php`, saving pages and running queries aborted with a `pg_escape_string()` error ([#7049](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7049))
+* Fixed an incorrect `smw_hash` being stored when moving an entity in a non-zero namespace (such as a category or property), which could break hash-based lookups for the moved entity ([#7051](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7051))
 
 ## Upgrading
 

--- a/src/SQLStore/EntityStore/IdChanger.php
+++ b/src/SQLStore/EntityStore/IdChanger.php
@@ -67,7 +67,7 @@ class IdChanger {
 
 		$hash = [
 			$row->smw_title,
-			(int)$row->smw_title,
+			(int)$row->smw_namespace,
 			$row->smw_iw,
 			$row->smw_subobject
 		];

--- a/tests/phpunit/Unit/SQLStore/EntityStore/IdChangerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/IdChangerTest.php
@@ -168,6 +168,78 @@ class IdChangerTest extends TestCase {
 		);
 	}
 
+	public function testMove_UsesNamespaceForHash() {
+		// smw_hash must be recomputed from the entity's namespace. Using
+		// (int)$row->smw_title (which is 0 for any non-numeric title) instead
+		// would store a wrong hash for entities in a non-zero namespace and
+		// break hash-based lookups after a move.
+		$namespace = NS_CATEGORY;
+		$row = [
+			'smw_id' => 42,
+			'smw_title' => 'Foo',
+			'smw_namespace' => $namespace,
+			'smw_iw' => '',
+			'smw_subobject' => '',
+			'smw_sortkey' => 'FOO',
+			'smw_sort' => 'FOO',
+			'smw_hash' => sha1( json_encode( [ 'Foo', $namespace, '', '' ] ), true )
+		];
+
+		$selectBuilder = $this->createMockSelectQueryBuilder( [ (object)$row ] );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $selectBuilder );
+
+		$this->connection->expects( $this->once() )
+			->method( 'nextSequenceValue' )
+			->willReturn( 1 );
+
+		$insertTables = $insertRows = [];
+		$insertBuilder = $this->createMockInsertQueryBuilder( $insertTables, $insertRows );
+
+		$this->connection->expects( $this->once() )
+			->method( 'newInsertQueryBuilder' )
+			->willReturn( $insertBuilder );
+
+		$this->connection->expects( $this->once() )
+			->method( 'insertId' )
+			->willReturn( 9999 );
+
+		$deleteTables = $deleteWheres = [];
+		$deleteBuilder = $this->createMockDeleteQueryBuilder( $deleteTables, $deleteWheres );
+
+		$this->connection->expects( $this->any() )
+			->method( 'newDeleteQueryBuilder' )
+			->willReturn( $deleteBuilder );
+
+		$updateBuilder = $this->createMockUpdateQueryBuilder();
+
+		$this->connection->expects( $this->any() )
+			->method( 'newUpdateQueryBuilder' )
+			->willReturn( $updateBuilder );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyTables' )
+			->willReturnOnConsecutiveCalls( [] );
+
+		$this->jobFactory->expects( $this->once() )
+			->method( 'newUpdateJob' )
+			->willReturn( $this->updateJob );
+
+		$instance = new IdChanger(
+			$this->store,
+			$this->jobFactory
+		);
+
+		$instance->move( 42, 0 );
+
+		$this->assertSame(
+			[ [ 'smw_id' => 1 ] + $row ],
+			$insertRows
+		);
+	}
+
 	public function testMove_Target() {
 		$row = [
 			'smw_id' => 42,


### PR DESCRIPTION
## Problem

`IdChanger::move()` recomputes an entity's `smw_hash` when moving it to a new ID, but built the hash payload with `(int)$row->smw_title` in the namespace position:

```php
$hash = [
    $row->smw_title,
    (int)$row->smw_title,   // namespace slot
    $row->smw_iw,
    $row->smw_subobject
];
```

`(int)` of a non-numeric title is `0`, so the recomputed hash always used namespace `0`. For an entity in a non-zero namespace (category, property, ...) this stores an `smw_hash` that does not match the one computed everywhere else from the real namespace, breaking hash-based lookups for the moved entity.

## Fix

Use `(int)$row->smw_namespace`, matching every other `computeSha1([title, namespace, iw, subobject])` call. `$row->smw_namespace` is already selected and used in the same INSERT.

Added a regression test (`IdChangerTest::testMove_UsesNamespaceForHash`) that moves an entity in `NS_CATEGORY` and asserts the stored `smw_hash` is derived from the namespace; it fails on the old code and passes with the fix.

Spotted during review of #7050.
