### PR TITLE
Security fixes for 7.2.0

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -17,6 +17,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 * Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where a crafted `sep` parameter was inserted unescaped into table output ([GHSA-7xv3-gf2g-498h](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-7xv3-gf2g-498h))
 * Fixed an open redirect in `Special:URIResolver` where a crafted pretty URI could redirect visitors to an external host ([GHSA-hw3m-8j5x-94ff](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-hw3m-8j5x-94ff))
+* Fixed a cross-site scripting (XSS) vulnerability in `Special:SearchByProperty` where crafted `property` or `value` parameters were reflected unescaped into validation error messages and the result heading ([GHSA-59xw-qv23-j3rc](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-59xw-qv23-j3rc))
 
 ## Bug fixes
 

--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -16,6 +16,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 ## Security fixes
 
 * Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where a crafted `sep` parameter was inserted unescaped into table output ([GHSA-7xv3-gf2g-498h](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-7xv3-gf2g-498h))
+* Fixed an open redirect in `Special:URIResolver` where a crafted pretty URI could redirect visitors to an external host ([GHSA-hw3m-8j5x-94ff](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-hw3m-8j5x-94ff))
 
 ## Bug fixes
 

--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -20,6 +20,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed a cross-site scripting (XSS) vulnerability in `Special:SearchByProperty` where crafted `property` or `value` parameters were reflected unescaped into validation error messages and the result heading ([GHSA-59xw-qv23-j3rc](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-59xw-qv23-j3rc))
 * Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where crafted query values were reflected unescaped into the `format=debug` query debug output ([GHSA-q5fm-9mx6-44f4](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-q5fm-9mx6-44f4))
 * Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where a crafted `mainlabel` or property label was reflected unescaped into plain table headers (`headers=plain`) ([GHSA-3jp5-3h47-28qf](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-3jp5-3h47-28qf))
+* Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where a crafted `cursor` pagination token was reflected unescaped into query error messages ([GHSA-cx86-7xwp-w9wf](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-cx86-7xwp-w9wf))
 
 ## Bug fixes
 

--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -16,11 +16,11 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 ## Security fixes
 
 * Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where a crafted `sep` parameter was inserted unescaped into table output ([GHSA-7xv3-gf2g-498h](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-7xv3-gf2g-498h))
-* Fixed an open redirect in `Special:URIResolver` where a crafted pretty URI could redirect visitors to an external host ([GHSA-hw3m-8j5x-94ff](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-hw3m-8j5x-94ff))
-* Fixed a cross-site scripting (XSS) vulnerability in `Special:SearchByProperty` where crafted `property` or `value` parameters were reflected unescaped into validation error messages and the result heading ([GHSA-59xw-qv23-j3rc](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-59xw-qv23-j3rc))
 * Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where crafted query values were reflected unescaped into the `format=debug` query debug output ([GHSA-q5fm-9mx6-44f4](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-q5fm-9mx6-44f4))
 * Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where a crafted `mainlabel` or property label was reflected unescaped into plain table headers (`headers=plain`) ([GHSA-3jp5-3h47-28qf](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-3jp5-3h47-28qf))
 * Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where a crafted `cursor` pagination token was reflected unescaped into query error messages ([GHSA-cx86-7xwp-w9wf](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-cx86-7xwp-w9wf))
+* Fixed a cross-site scripting (XSS) vulnerability in `Special:SearchByProperty` where crafted `property` or `value` parameters were reflected unescaped into validation error messages and the result heading ([GHSA-59xw-qv23-j3rc](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-59xw-qv23-j3rc))
+* Fixed an open redirect in `Special:URIResolver` where a crafted pretty URI could redirect visitors to an external host ([GHSA-hw3m-8j5x-94ff](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-hw3m-8j5x-94ff))
 
 ## Bug fixes
 

--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -18,6 +18,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where a crafted `sep` parameter was inserted unescaped into table output ([GHSA-7xv3-gf2g-498h](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-7xv3-gf2g-498h))
 * Fixed an open redirect in `Special:URIResolver` where a crafted pretty URI could redirect visitors to an external host ([GHSA-hw3m-8j5x-94ff](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-hw3m-8j5x-94ff))
 * Fixed a cross-site scripting (XSS) vulnerability in `Special:SearchByProperty` where crafted `property` or `value` parameters were reflected unescaped into validation error messages and the result heading ([GHSA-59xw-qv23-j3rc](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-59xw-qv23-j3rc))
+* Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where crafted query values were reflected unescaped into the `format=debug` query debug output ([GHSA-q5fm-9mx6-44f4](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-q5fm-9mx6-44f4))
 
 ## Bug fixes
 

--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -19,6 +19,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed an open redirect in `Special:URIResolver` where a crafted pretty URI could redirect visitors to an external host ([GHSA-hw3m-8j5x-94ff](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-hw3m-8j5x-94ff))
 * Fixed a cross-site scripting (XSS) vulnerability in `Special:SearchByProperty` where crafted `property` or `value` parameters were reflected unescaped into validation error messages and the result heading ([GHSA-59xw-qv23-j3rc](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-59xw-qv23-j3rc))
 * Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where crafted query values were reflected unescaped into the `format=debug` query debug output ([GHSA-q5fm-9mx6-44f4](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-q5fm-9mx6-44f4))
+* Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where a crafted `mainlabel` or property label was reflected unescaped into plain table headers (`headers=plain`) ([GHSA-3jp5-3h47-28qf](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-3jp5-3h47-28qf))
 
 ## Bug fixes
 

--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -33,6 +33,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed a JavaScript error when rendering a property as a link on the client side; the code called `mw.util.wikiGetlink`, which has been removed from MediaWiki core, and now uses `mw.util.getUrl` ([#7047](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7047))
 * Fixed Semantic MediaWiki being unusable on PostgreSQL since 7.0.0, where `update.php`, saving pages and running queries aborted with a `pg_escape_string()` error ([#7049](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7049))
 * Fixed an incorrect `smw_hash` being stored when moving an entity in a non-zero namespace (such as a category or property), which could break hash-based lookups for the moved entity ([#7051](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7051))
+* Fixed `Special:Ask` remote and raw requests (those using the `request_type` parameter) aborting with a fatal error on PHP 8.5 ([#7052](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7052))
 
 ## Upgrading
 

--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -13,6 +13,10 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Added `SMW\MediaWiki\Outputs::requireJsConfigVar()` so extensions can register JavaScript configuration variables through the SMW output mechanism, alongside modules, styles and head items, instead of emitting inline scripts ([#7028](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7028))
 * Added the `{{#property_link:}}` parser function for linking to a property page from running text: `{{#property_link:Foo}}` and `{{#property_link:Foo|custom label}}` render the same output as the `[[Foo::@@@]]` and `[[Foo::@@@|custom label]]` annotation syntax, providing a dedicated syntax that does not rely on intercepting `[[…]]` links ([#5624](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5624), [#1855](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/1855))
 
+## Security fixes
+
+* Fixed a cross-site scripting (XSS) vulnerability in `Special:Ask` where a crafted `sep` parameter was inserted unescaped into table output ([GHSA-7xv3-gf2g-498h](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-7xv3-gf2g-498h))
+
 ## Bug fixes
 
 * Fixed a query showing incorrect printout values when the same property is requested through different printout contexts, such as a direct and an inverse printout or the same property with different sort options ([#7026](https://github.com/SemanticMediaWiki/SemanticMediaWiki/pull/7026))

--- a/src/MediaWiki/Specials/SearchByProperty/PageBuilder.php
+++ b/src/MediaWiki/Specials/SearchByProperty/PageBuilder.php
@@ -57,6 +57,17 @@ class PageBuilder {
 	}
 
 	/**
+	 * Encode attacker-influenced text (reflected property/value input and the
+	 * error messages derived from it) before it is placed into the HTML output.
+	 * The result flows into `Xml::tags()`/`addParagraph()`, which do not escape,
+	 * and validation error text can carry unescaped user input (e.g. via the
+	 * `Message::encode()` range roundtrip), so it must be treated as untrusted.
+	 */
+	private function escapeMessage( string $text ): string {
+		return htmlspecialchars( $text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+	}
+
+	/**
 	 * @since 2.1
 	 */
 	public function getHtml(): string {
@@ -133,11 +144,13 @@ class PageBuilder {
 
 		// #1728
 		if ( !$this->pageRequestOptions->property->isValid() ) {
-			return [ ProcessingErrorMsgHandler::getMessagesAsString( $this->pageRequestOptions->property->getErrors() ), '', 0 ];
+			$errors = ProcessingErrorMsgHandler::getMessagesAsString( $this->pageRequestOptions->property->getErrors() );
+			return [ $this->escapeMessage( $errors ), '', 0 ];
 		}
 
 		if ( $this->pageRequestOptions->valueString !== '' && !$this->pageRequestOptions->value->isValid() ) {
-			return [ ProcessingErrorMsgHandler::getMessagesAsString( $this->pageRequestOptions->value->getErrors() ), '', 0 ];
+			$errors = ProcessingErrorMsgHandler::getMessagesAsString( $this->pageRequestOptions->value->getErrors() );
+			return [ $this->escapeMessage( $errors ), '', 0 ];
 		}
 
 		// Find out where the subject is used in connection with a query
@@ -164,7 +177,7 @@ class PageBuilder {
 		$resultMessage = $this->msg(
 			$resultMessageKey,
 			$this->pageRequestOptions->property->getShortHTMLText( $this->linker ),
-			$this->pageRequestOptions->value->getShortHTMLText( $this->linker ) )->text();
+			$this->escapeMessage( (string)$this->pageRequestOptions->value->getWikiValue() ) )->text();
 
 		if ( $exactCount > 0 ) {
 			$resultList = $this->makeResultList( $exactResults, $this->pageRequestOptions->limit, true );

--- a/src/MediaWiki/Specials/SpecialAsk.php
+++ b/src/MediaWiki/Specials/SpecialAsk.php
@@ -289,11 +289,20 @@ class SpecialAsk extends SpecialPage {
 		$printer = null;
 
 		if ( $this->queryString !== '' ) {
-			[ $result, $res, $duration ] = $this->fetchResults(
+			$fetched = $this->fetchResults(
 				$printer,
 				$queryobj,
 				$urlArgs
 			);
+
+			// A remote request (request_type) prints its output directly, disables
+			// the OutputPage, and returns the print() status (an int) rather than
+			// the [ result, res, duration ] triple. Destructuring that int is a
+			// fatal on PHP 8.5 ("Cannot use int as array"), so only unpack an
+			// actual result and leave the already emitted response untouched.
+			if ( is_array( $fetched ) ) {
+				[ $result, $res, $duration ] = $fetched;
+			}
 		}
 
 		if ( $printer !== null && $printer->isExportFormat() ) {

--- a/src/MediaWiki/Specials/SpecialURIResolver.php
+++ b/src/MediaWiki/Specials/SpecialURIResolver.php
@@ -74,9 +74,41 @@ class SpecialURIResolver extends SpecialPage {
 					SkinComponentUtils::makeSpecialUrl( 'ExportRDF', [ 'xmlmime' => 'rdf' ] )
 				);
 			} else {
-				$out->redirect( $title->getFullURL(), '303' );
+				$targetUrl = $title->getFullURL();
+
+				// Validate the resolved target before redirecting: a malformed
+				// authority-like title can make getFullURL() point off-host,
+				// which would turn the resolver into an open redirect.
+				if ( $this->isLocalRedirectTarget( $targetUrl ) ) {
+					$out->redirect( $targetUrl, '303' );
+				} else {
+					$out->showErrorPage( 'badtitle', 'badtitletext' );
+				}
 			}
 		}
+	}
+
+	/**
+	 * Whether a resolved redirect target is safe to hand to the browser: it must
+	 * resolve to the current host and must not carry userinfo. The final URL is
+	 * validated at the sink rather than the input path, so authority-like paths
+	 * cannot smuggle a foreign host past normalisation.
+	 */
+	private function isLocalRedirectTarget( string $url ): bool {
+		$urlUtils = MediaWikiServices::getInstance()->getUrlUtils();
+
+		$targetBits = $urlUtils->parse( (string)$urlUtils->expand( $url, PROTO_CURRENT ) );
+		$serverBits = $urlUtils->parse( (string)$urlUtils->expand( '/', PROTO_CURRENT ) );
+
+		if ( $targetBits === null || $serverBits === null ) {
+			return false;
+		}
+
+		$targetHost = $targetBits['host'] ?? '';
+		$serverHost = $serverBits['host'] ?? '';
+
+		// Host comparison only; port is intentionally out of scope.
+		return $targetHost !== '' && $serverHost !== '' && strcasecmp( $targetHost, $serverHost ) === 0;
 	}
 
 	/**

--- a/src/Query/DebugFormatter.php
+++ b/src/Query/DebugFormatter.php
@@ -68,7 +68,7 @@ class DebugFormatter {
 		if ( $query instanceof Query ) {
 			$preEntries = [];
 			$description = $query->getDescription();
-			$queryString = str_replace( '[', '&#91;', $description->getQueryString() ?? '' );
+			$queryString = str_replace( '[', '&#91;', htmlspecialchars( $description->getQueryString() ?? '', ENT_QUOTES ) );
 
 			$preEntries['ASK Query'] = '<div class="smwpre">' . $queryString . '</div>';
 			$entries = array_merge( $preEntries, $entries );
@@ -81,7 +81,7 @@ class DebugFormatter {
 			);
 
 			foreach ( $queryErrors as $error ) {
-				$errors .= $error . '<br />';
+				$errors .= $this->escape( (string)$error ) . '<br />';
 			}
 
 			if ( $errors === '' ) {
@@ -137,7 +137,7 @@ class DebugFormatter {
 			foreach ( $res as $row ) {
 
 				if ( isset( $row->EXPLAIN ) ) {
-					return '<div class="smwpre">' . $row->EXPLAIN . '</div>';
+					return '<div class="smwpre">' . $this->escape( $row->EXPLAIN ) . '</div>';
 				}
 
 				$possible_keys = $row->possible_keys;
@@ -151,17 +151,17 @@ class DebugFormatter {
 					$ref = implode( ', ', explode( ',', $ref ) );
 				}
 
-				$output .= "<tr style='vertical-align: top;'><td>" . $row->id .
-				"</td><td>" . $row->select_type .
-				"</td><td>" . $row->table .
-				"</td><td>" . $row->type .
-				"</td><td>" . $possible_keys .
-				"</td><td>" . $row->key .
-				"</td><td>" . $row->key_len .
-				"</td><td>" . $ref .
-				"</td><td>" . $row->rows .
-				"</td><td>" . ( $row->filtered ?? '' ) .
-				"</td><td>" . $row->Extra . "</td></tr>";
+				$output .= "<tr style='vertical-align: top;'><td>" . $this->escape( $row->id ) .
+				"</td><td>" . $this->escape( $row->select_type ) .
+				"</td><td>" . $this->escape( $row->table ) .
+				"</td><td>" . $this->escape( $row->type ) .
+				"</td><td>" . $this->escape( $possible_keys ) .
+				"</td><td>" . $this->escape( $row->key ) .
+				"</td><td>" . $this->escape( $row->key_len ) .
+				"</td><td>" . $this->escape( $ref ) .
+				"</td><td>" . $this->escape( $row->rows ) .
+				"</td><td>" . $this->escape( $row->filtered ?? '' ) .
+				"</td><td>" . $this->escape( $row->Extra ) . "</td></tr>";
 			}
 
 			$output .= '</table></div>';
@@ -172,7 +172,10 @@ class DebugFormatter {
 
 			foreach ( $res as $row ) {
 				foreach ( $row as $key => $value ) {
-					$output .= str_replace( [ ' ', '->' ], [ '&nbsp;', '└── ' ], $value ) . '<br>';
+					// Escape < and & (leaving > intact) so the -> tree-branch
+					// substitution below still matches while markup is neutralised.
+					$safeValue = str_replace( [ '&', '<' ], [ '&amp;', '&lt;' ], $value ?? '' );
+					$output .= str_replace( [ ' ', '->' ], [ '&nbsp;', '└── ' ], $safeValue ) . '<br>';
 				}
 			}
 
@@ -194,7 +197,7 @@ class DebugFormatter {
 				}
 
 				$marker = $k === $last ? '└──' : '├──';
-				$plan .= "<div style='margin-left:15px;'>$marker [" . $row->id . '] `' . $row->detail . "`</div>";
+				$plan .= "<div style='margin-left:15px;'>$marker [" . $this->escape( $row->id ) . '] `' . $this->escape( $row->detail ) . "`</div>";
 			}
 
 			if ( $plan === '' ) {
@@ -245,6 +248,7 @@ class DebugFormatter {
 	 * @return string
 	 */
 	public function prettifySQL( $sql, $alias ): string {
+		$sql = $this->escape( $sql );
 		$matches = [];
 		$i = 0;
 
@@ -302,6 +306,13 @@ class DebugFormatter {
 		}
 
 		return '<div class="smwpre">' . $sql . '</div>';
+	}
+
+	/**
+	 * Escape a value for output in an HTML element-content context.
+	 */
+	private function escape( string|int|float|null $value ): string {
+		return htmlspecialchars( (string)( $value ?? '' ), ENT_QUOTES );
 	}
 
 }

--- a/src/Query/Processor/QueryCreator.php
+++ b/src/Query/Processor/QueryCreator.php
@@ -246,10 +246,10 @@ class QueryCreator implements QueryContext {
 		if ( $payloadSortProp !== null ) {
 			$payloadProps = is_array( $payloadSortProp ) ? $payloadSortProp : [ $payloadSortProp ];
 			if ( $payloadProps !== $customSortKeys ) {
-				$payloadDesc = is_array( $payloadSortProp )
+				$payloadDesc = htmlspecialchars( (string)( is_array( $payloadSortProp )
 					? implode( ',', $payloadSortProp )
-					: $payloadSortProp;
-				$requestDesc = implode( ',', $customSortKeys );
+					: $payloadSortProp ), ENT_QUOTES );
+				$requestDesc = htmlspecialchars( implode( ',', $customSortKeys ), ENT_QUOTES );
 				$query->addErrors( [
 					"Cursor was minted for `sort=$payloadDesc` but the request specifies `sort=$requestDesc`. The cursor anchor has no meaning under a different sort; re-issue without `cursor=` or align the `sort=` parameter."
 				] );
@@ -278,8 +278,8 @@ class QueryCreator implements QueryContext {
 				count( $requestSortOrders )
 			);
 			if ( $payloadSortOrders !== $requestSortOrders ) {
-				$payloadDesc = implode( ',', $payloadSortOrders );
-				$requestDesc = implode( ',', $requestSortOrders );
+				$payloadDesc = htmlspecialchars( implode( ',', $payloadSortOrders ), ENT_QUOTES );
+				$requestDesc = htmlspecialchars( implode( ',', $requestSortOrders ), ENT_QUOTES );
 				$query->addErrors( [
 					"Cursor was minted for `order=$payloadDesc` but the request specifies `order=$requestDesc`. The cursor anchor seeks in the wrong direction under the new order; re-issue without `cursor=` or align the `order=` parameter."
 				] );

--- a/src/Query/ResultPrinters/TableResultPrinter.php
+++ b/src/Query/ResultPrinters/TableResultPrinter.php
@@ -144,6 +144,20 @@ class TableResultPrinter extends ResultPrinter {
 				// #2702 Use a fixed output on a requested plain printout
 				$mode = $this->isHTML && $isPlain ? SMW_OUTPUT_WIKI : $outputMode;
 				$text = $pr->getText( $mode, ( $isPlain ? null : $this->mLinker ) );
+
+				// getText( SMW_OUTPUT_WIKI ) returns the label unescaped and HtmlTable
+				// emits header content verbatim into <th>, so a user-controlled plain
+				// header (e.g. mainlabel) is escaped here. Non-plain HTML is escaped by
+				// the formatter; inline wikitext output is sanitised by the parser.
+				//
+				// In this branch $mode is SMW_OUTPUT_WIKI with a null linker, so getText()
+				// returns the raw label; Phan cannot narrow the mode and over-taints it as
+				// already escaped via the HTML formatter path, hence the suppression.
+				if ( $this->isHTML && $isPlain ) {
+					// @phan-suppress-next-line SecurityCheck-DoubleEscaped
+					$text = htmlspecialchars( (string)$text, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
+				}
+
 				$headerList[] = $pr->getCanonicalLabel();
 				// $attributes['class'] is a CSS class built from the (stripped) column
 				// label; HtmlTable escapes attributes once. Phan over-taints it via the

--- a/src/Query/ResultPrinters/TableResultPrinter.php
+++ b/src/Query/ResultPrinters/TableResultPrinter.php
@@ -390,10 +390,42 @@ class TableResultPrinter extends ResultPrinter {
 		} elseif ( !$isSubject && $sep === 'ol' && count( $values ) > 1 ) {
 			$html = '<ol><li>' . implode( '</li><li>', $values ) . '</li></ol>';
 		} else {
-			$html = implode( $this->params['sep'], $values );
+			$html = implode( $this->getValueSeparator( $outputMode ), $values );
 		}
 
 		return $html;
+	}
+
+	/**
+	 * Returns the separator placed between the multiple values of a table cell.
+	 *
+	 * Only wiki output (inline `#ask`) is sanitised downstream by the parser,
+	 * so there the raw value is returned unchanged and legitimate wikitext
+	 * separators keep working. Every other output mode is emitted straight into
+	 * the response and bypasses the parser's tag sanitisation: HTML output
+	 * (`Special:Ask`), RAW output (`Special:Ask` with `request_type=raw`, used
+	 * by remote requests) and FILE output all land in an HTML context where a
+	 * user-supplied `sep` would allow HTML/script injection. In those modes the
+	 * value is escaped, allowlisting only the `<br>` line-break variants that
+	 * are the intended separator markup.
+	 *
+	 * If the renderer ever gains richer separator semantics, keep this
+	 * allowlist explicit rather than widening the allowed HTML surface.
+	 *
+	 * @since 7.2.0
+	 */
+	private function getValueSeparator( int $outputMode ): string {
+		$sep = $this->params['sep'];
+
+		if ( $outputMode === SMW_OUTPUT_WIKI ) {
+			return $sep;
+		}
+
+		if ( preg_match( '#^\s*<br\s*/?>\s*$#i', $sep ) ) {
+			return $sep;
+		}
+
+		return htmlspecialchars( $sep, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/QueryEngine.php
+++ b/src/SQLStore/QueryEngine/QueryEngine.php
@@ -234,9 +234,9 @@ class QueryEngine implements QueryEngineInterface, LoggerAwareInterface {
 		$auxtables = '';
 
 		foreach ( $this->querySegmentListProcessor->getExecutedQueries() as $table => $log ) {
-			$auxtables .= "<li>Temporary table $table";
+			$auxtables .= '<li>Temporary table ' . htmlspecialchars( (string)$table, ENT_QUOTES );
 			foreach ( $log as $q ) {
-				$auxtables .= "<br />&#160;&#160;<tt>$q</tt>";
+				$auxtables .= '<br />&#160;&#160;<tt>' . htmlspecialchars( (string)$q, ENT_QUOTES ) . '</tt>';
 			}
 			$auxtables .= '</li>';
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/special-ask-0008.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/special-ask-0008.json
@@ -58,7 +58,7 @@
 			},
 			"assert-output": {
 				"to-contain": [
-					"<thead><th>&nbsp;</th><th class=\"Modified-label-for-text\">Modified <i>label</i> for text</th></thead>",
+					"<thead><th>&nbsp;</th><th class=\"Modified-label-for-text\">Modified &lt;i&gt;label&lt;/i&gt; for text</th></thead>",
 					"<a href=.* title=\"Example/SA0008/1\">Example/SA0008/1</a>",
 					"<a href=.* title=\"Example/SA0008/2\">Example/SA0008/2</a>"
 				]

--- a/tests/phpunit/Integration/JSONScript/TestCases/special-ask-0012.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/special-ask-0012.json
@@ -9,6 +9,10 @@
 		{
 			"page": "Example/SA0012/1",
 			"contents": "[[Has page extra::123]] [[Category:SA0012]]"
+		},
+		{
+			"page": "Example/SA0012/XSS",
+			"contents": "[[Has page extra::Alpha]] [[Has page extra::Beta]] [[Category:SA0012XSS]]"
 		}
 	],
 	"tests": [
@@ -162,6 +166,59 @@
 					"<a href=.*Property:Has_page_extra\" title=\"Property:Has page extra\">Has page extra</a></th><th class=\"Foo\">Foo</th>",
 					"<tr data-row-number=\"1\" class=\"row-odd\"><td class=\"Has-page-extra smwtype_wpg\" data-sort-value=\"123\">",
 					"<td class=\"Foo smwtype_wpg\">Example/SA0012/1</td>"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#7 (XSS payload in the sep parameter is escaped in HTML output)",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"limit": "10",
+						"offset": "0",
+						"mainlabel": "-",
+						"format": "table",
+						"sep": "\"><x id=X tabindex=1 onfocus=a=0||alert,a(0||document.domain)>"
+					},
+					"q": "[[Category:SA0012XSS]]",
+					"po": "?Has page extra"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"&quot;&gt;&lt;x id=X tabindex=1 onfocus=a=0||alert,a(0||document.domain)&gt;"
+				],
+				"not-contain": [
+					"<x id=X tabindex=1 onfocus=a=0||alert,a(0||document.domain)>"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#8 (XSS payload in the sep parameter is escaped for request_type=raw output)",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"limit": "10",
+						"offset": "0",
+						"mainlabel": "-",
+						"format": "table",
+						"sep": "\"><x id=X tabindex=1 onfocus=a=0||alert,a(0||document.domain)>"
+					},
+					"q": "[[Category:SA0012XSS]]",
+					"po": "?Has page extra",
+					"request_type": "raw"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"&quot;&gt;&lt;x id=X tabindex=1 onfocus=a=0||alert,a(0||document.domain)&gt;"
+				],
+				"not-contain": [
+					"<x id=X tabindex=1 onfocus=a=0||alert,a(0||document.domain)>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/JSONScript/TestCases/special-ask-0012.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/special-ask-0012.json
@@ -221,6 +221,61 @@
 					"<x id=X tabindex=1 onfocus=a=0||alert,a(0||document.domain)>"
 				]
 			}
+		},
+		{
+			"type": "special",
+			"about": "#9 (headers=plain, XSS payload in mainlabel is escaped)",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"limit": "10",
+						"offset": "0",
+						"headers": "plain",
+						"mainlabel": "<img src=x onerror=alert() >",
+						"format": "table"
+					},
+					"q": "[[Category:SA0012]]",
+					"po": "?Has page extra"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<table class=\"sortable wikitable smwtable\">",
+					"<th.*>&lt;img src=x onerror=alert() &gt;</th>",
+					"<th class=\"Has-page-extra\">Has page extra</th>"
+				],
+				"not-contain": [
+					"<img src=x onerror=alert() >"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#10 (headers=plain, XSS payload in a property label is escaped)",
+			"special-page": {
+				"page": "Ask",
+				"request-parameters": {
+					"p": {
+						"limit": "10",
+						"offset": "0",
+						"headers": "plain",
+						"mainlabel": "-",
+						"format": "table"
+					},
+					"q": "[[Category:SA0012]]",
+					"po": "?Has page extra=<img src=x onerror=alert() >"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"<table class=\"sortable wikitable smwtable\">",
+					"<th.*>&lt;img src=x onerror=alert() &gt;</th>"
+				],
+				"not-contain": [
+					"<img src=x onerror=alert() >"
+				]
+			}
 		}
 	],
 	"settings": {

--- a/tests/phpunit/Integration/JSONScript/TestCases/special-search-by-property-0001.json
+++ b/tests/phpunit/Integration/JSONScript/TestCases/special-search-by-property-0001.json
@@ -22,6 +22,16 @@
 			"contents": "[[Has type::Telephone number]]"
 		},
 		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has boolean",
+			"contents": "[[Has type::Boolean]]"
+		},
+		{
+			"namespace": "SMW_NS_PROPERTY",
+			"page": "Has eid",
+			"contents": "[[Has type::External identifier]] [[External formatter uri::http://example.org/$1]]"
+		},
+		{
 			"page": "Example/S0001/1",
 			"contents": "[[Has text::S0001]]"
 		},
@@ -565,6 +575,66 @@
 					"<small>(-25)</small>",
 					"value=\"P-20-25\"",
 					"value=\"-25\""
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#23 reflected value error is html-escaped (invalid Boolean value, `%3C`/`%3E` strip_tags bypass, GHSA-59xw-qv23-j3rc)",
+			"special-page": {
+				"page": "SearchByProperty",
+				"query-parameters": "",
+				"request-parameters": {
+					"property": "Has boolean",
+					"value": "%3Escript%3Calert(1)%3E/script%3C"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"&lt;script&gt;alert(1)&lt;/script&gt;"
+				],
+				"not-contain": [
+					"<script>alert(1)"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#24 reflected property error is html-escaped (invalid property, `%3C`/`%3E` strip_tags bypass, GHSA-59xw-qv23-j3rc)",
+			"special-page": {
+				"page": "SearchByProperty",
+				"query-parameters": "",
+				"request-parameters": {
+					"property": "%3Escript%3Calert(2)%3E/script%3C",
+					"value": ""
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"&lt;script&gt;alert(2)&lt;/script&gt;"
+				],
+				"not-contain": [
+					"<script>alert(2)"
+				]
+			}
+		},
+		{
+			"type": "special",
+			"about": "#25 reflected valid value is html-escaped in the result message (External identifier, GHSA-59xw-qv23-j3rc)",
+			"special-page": {
+				"page": "SearchByProperty",
+				"query-parameters": "",
+				"request-parameters": {
+					"property": "Has eid",
+					"value": "<h1>zzz</h1>"
+				}
+			},
+			"assert-output": {
+				"to-contain": [
+					"&lt;h1&gt;zzz&lt;/h1&gt;"
+				],
+				"not-contain": [
+					"<h1>zzz</h1>"
 				]
 			}
 		}

--- a/tests/phpunit/Integration/MediaWiki/Specials/SpecialURIResolverTest.php
+++ b/tests/phpunit/Integration/MediaWiki/Specials/SpecialURIResolverTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace SMW\Tests\Integration\MediaWiki\Specials;
+
+use MediaWiki\Interwiki\ClassicInterwikiLookup;
+use MediaWiki\MainConfigNames;
+use MediaWiki\MediaWikiServices;
+use SMW\MediaWiki\Specials\SpecialURIResolver;
+use SMW\Tests\SMWIntegrationTestCase;
+
+/**
+ * @covers \SMW\MediaWiki\Specials\SpecialURIResolver
+ * @group semantic-mediawiki
+ * @group Database
+ *
+ * @license GPL-2.0-or-later
+ */
+class SpecialURIResolverTest extends SMWIntegrationTestCase {
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		// Register an interwiki prefix whose target resolves off-host, so that
+		// Title::getFullURL() produces a foreign redirect target. Overriding the
+		// config (rather than resetting the lookup alone) rebuilds the title
+		// parser so the prefix is recognised during parsing.
+		$this->overrideConfigValue(
+			MainConfigNames::InterwikiCache,
+			ClassicInterwikiLookup::buildCdbHash( [
+				[
+					'iw_prefix' => 'offsitewiki',
+					'iw_url' => 'https://evil.example/$1',
+					'iw_api' => '',
+					'iw_wikiid' => '',
+					'iw_local' => 0,
+					'iw_trans' => 0,
+				],
+			] )
+		);
+	}
+
+	private function newInstance(): SpecialURIResolver {
+		// A non-RDF Accept header keeps execution on the canonical-redirect path.
+		$_SERVER['HTTP_ACCEPT'] = 'text/html';
+
+		$instance = new SpecialURIResolver();
+		$instance->getContext()->setTitle(
+			MediaWikiServices::getInstance()->getTitleFactory()->newFromText( 'Special:URIResolver' )
+		);
+
+		return $instance;
+	}
+
+	private function serverHost(): string {
+		$urlUtils = MediaWikiServices::getInstance()->getUrlUtils();
+
+		return $urlUtils->parse( (string)$urlUtils->expand( '/', PROTO_CURRENT ) )['host'] ?? '';
+	}
+
+	public function testExecuteRejectsOffHostInterwikiRedirect() {
+		$instance = $this->newInstance();
+
+		// Decodes to "offsitewiki:Foo"; getFullURL() resolves to the foreign
+		// host https://evil.example/Foo.
+		$instance->execute( 'offsitewiki-3AFoo' );
+
+		$this->assertSame(
+			'',
+			$instance->getOutput()->getRedirect(),
+			'an off-host interwiki target must not be redirected to'
+		);
+	}
+
+	public function testExecuteRedirectsLocalTitleOnHost() {
+		$instance = $this->newInstance();
+
+		$instance->execute( 'Foo' );
+
+		$redirect = $instance->getOutput()->getRedirect();
+
+		$this->assertNotSame( '', $redirect, 'a local title must still redirect' );
+		$this->assertStringContainsString( $this->serverHost(), $redirect );
+	}
+
+}

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialURIResolverTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialURIResolverTest.php
@@ -6,6 +6,7 @@ use MediaWiki\MediaWikiServices;
 use PHPUnit\Framework\TestCase;
 use SMW\MediaWiki\Specials\SpecialURIResolver;
 use SMW\Tests\TestEnvironment;
+use Wikimedia\TestingAccessWrapper;
 
 /**
  * @covers \SMW\MediaWiki\Specials\SpecialURIResolver
@@ -44,6 +45,52 @@ class SpecialURIResolverTest extends TestCase {
 		$this->assertStringContainsString(
 			'https://www.w3.org/2001/tag/issues.html#httpRange-14',
 			$instance->getOutput()->getHTML()
+		);
+	}
+
+	private function serverHost(): string {
+		$urlUtils = MediaWikiServices::getInstance()->getUrlUtils();
+
+		return $urlUtils->parse( (string)$urlUtils->expand( '/', PROTO_CURRENT ) )['host'] ?? '';
+	}
+
+	public function testIsLocalRedirectTargetAllowsSameHost() {
+		$instance = TestingAccessWrapper::newFromObject( new SpecialURIResolver() );
+
+		$this->assertTrue(
+			$instance->isLocalRedirectTarget( 'http://' . $this->serverHost() . '/index.php/Foo' )
+		);
+	}
+
+	public function testIsLocalRedirectTargetRejectsDifferentHost() {
+		$instance = TestingAccessWrapper::newFromObject( new SpecialURIResolver() );
+
+		$this->assertFalse(
+			$instance->isLocalRedirectTarget( 'https://evil.example/index.php/Foo' )
+		);
+	}
+
+	public function testIsLocalRedirectTargetRejectsProtocolRelativeOffHost() {
+		$instance = TestingAccessWrapper::newFromObject( new SpecialURIResolver() );
+
+		$this->assertFalse(
+			$instance->isLocalRedirectTarget( '//evil.example/index.php/Foo' )
+		);
+	}
+
+	public function testIsLocalRedirectTargetRejectsUnparsableUrl() {
+		$instance = TestingAccessWrapper::newFromObject( new SpecialURIResolver() );
+
+		$this->assertFalse(
+			$instance->isLocalRedirectTarget( 'http://' )
+		);
+	}
+
+	public function testIsLocalRedirectTargetAllowsMixedCaseHost() {
+		$instance = TestingAccessWrapper::newFromObject( new SpecialURIResolver() );
+
+		$this->assertTrue(
+			$instance->isLocalRedirectTarget( 'http://' . strtoupper( $this->serverHost() ) . '/x' )
 		);
 	}
 

--- a/tests/phpunit/Unit/Query/DebugFormatterTest.php
+++ b/tests/phpunit/Unit/Query/DebugFormatterTest.php
@@ -101,6 +101,111 @@ class DebugFormatterTest extends TestCase {
 		);
 	}
 
+	public function testBuildHTMLEscapesQueryStringMarkup() {
+		$description = $this->getMockBuilder( Description::class )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$description->expects( $this->any() )
+			->method( 'getQueryString' )
+			->willReturn( '[[Has text::<script>alert(1)</script>]]' );
+
+		$query = $this->getMockBuilder( Query::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getDescription' )
+			->willReturn( $description );
+
+		$query->expects( $this->any() )
+			->method( 'getErrors' )
+			->willReturn( [] );
+
+		$instance = new DebugFormatter();
+		$html = $instance->buildHTML( [], $query );
+
+		$this->assertStringNotContainsString( '<script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+	}
+
+	public function testBuildHTMLEscapesRawErrorMarkup() {
+		$description = $this->getMockBuilder( Description::class )
+			->disableOriginalConstructor()
+			->getMockForAbstractClass();
+
+		$query = $this->getMockBuilder( Query::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$query->expects( $this->any() )
+			->method( 'getDescription' )
+			->willReturn( $description );
+
+		$query->expects( $this->any() )
+			->method( 'getErrors' )
+			->willReturn( [ '<script>alert(1)</script>' ] );
+
+		$instance = new DebugFormatter();
+		$html = $instance->buildHTML( [], $query );
+
+		$this->assertStringNotContainsString( '<script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+	}
+
+	public function testPrettifySQLEscapesMarkup() {
+		$instance = new DebugFormatter();
+
+		$sql = "SELECT * FROM t0 WHERE t0.smw_title = '<script>alert(1)</script>'";
+		$html = $instance->prettifySQL( $sql, 't0' );
+
+		$this->assertStringNotContainsString( '<script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+	}
+
+	public function testPrettifyExplainEscapesPostgresValueMarkup() {
+		$instance = new DebugFormatter( 'postgres' );
+
+		$res = [ [ 'QUERY PLAN' => "Filter: (smw_title = '<script>alert(1)</script>'::text)" ] ];
+		$html = $instance->prettifyExplain( $res );
+
+		$this->assertStringNotContainsString( '<script', $html );
+		$this->assertStringContainsString( '&lt;script', $html );
+	}
+
+	public function testPrettifyExplainEscapesMysqlColumnMarkup() {
+		$instance = new DebugFormatter( 'mysql' );
+
+		$row = [
+			'id' => '1', 'select_type' => 'SIMPLE', 'table' => 't0', 'type' => 'ref',
+			'possible_keys' => '', 'key' => '', 'key_len' => '', 'ref' => '',
+			'rows' => '1', 'filtered' => '100', 'Extra' => '<script>alert(1)</script>'
+		];
+
+		$html = $instance->prettifyExplain( [ (object)$row ] );
+
+		$this->assertStringNotContainsString( '<script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+	}
+
+	public function testPrettifyExplainEscapesMysqlExplainColumnMarkup() {
+		$instance = new DebugFormatter( 'mysql' );
+
+		$html = $instance->prettifyExplain( [ (object)[ 'EXPLAIN' => '<script>alert(1)</script>' ] ] );
+
+		$this->assertStringNotContainsString( '<script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+	}
+
+	public function testPrettifyExplainEscapesSqliteDetailMarkup() {
+		$instance = new DebugFormatter( 'sqlite' );
+
+		$html = $instance->prettifyExplain( [ (object)[ 'id' => 0, 'detail' => '<script>alert(1)</script>' ] ] );
+
+		$this->assertStringNotContainsString( '<script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;', $html );
+	}
+
 	public function sqlExplainFormatProvider() {
 		$row = [
 			'id' => '',

--- a/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
+++ b/tests/phpunit/Unit/Query/Processor/QueryCreatorTest.php
@@ -221,6 +221,28 @@ class QueryCreatorTest extends TestCase {
 		);
 	}
 
+	public function testCursorSortPropMismatchErrorEscapesMarkup(): void {
+		$instance = new QueryCreator(
+			ApplicationFactory::getInstance()->getQueryFactory()
+		);
+
+		// base64url of {"v":1,"sort":"value","sort_prop":"<script>alert(1)</script>","id":42}
+		$token = 'eyJ2IjogMSwgInNvcnQiOiAidmFsdWUiLCAic29ydF9wcm9wIjogIjxzY3JpcHQ-YWxlcnQoMSk8L3NjcmlwdD4iLCAiaWQiOiA0Mn0';
+
+		$query = $instance->create(
+			'[[Foo::Bar]]',
+			[
+				'sort'   => [ 'DifferentProperty' ],
+				'cursor' => $token,
+			]
+		);
+
+		$errors = implode( ' ', $query->getErrors() );
+
+		$this->assertStringNotContainsString( '<script>', $errors );
+		$this->assertStringContainsString( '&lt;script&gt;', $errors );
+	}
+
 	public function testCursorParamWithEmptyPayloadIsAcceptedForAnySingleSort(): void {
 		// Bootstrap case: a cursor with no `sort_prop` (the
 		// `{"v":1}` empty-payload bootstrap from Phase 3 spike)

--- a/tests/phpunit/Unit/Query/ResultPrinters/TableResultPrinterTest.php
+++ b/tests/phpunit/Unit/Query/ResultPrinters/TableResultPrinterTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Unit\Query\ResultPrinters;
 
 use PHPUnit\Framework\TestCase;
 use SMW\Query\QueryResult;
+use SMW\Query\ResultPrinters\ResultPrinter;
 use SMW\Query\ResultPrinters\TableResultPrinter;
 
 /**
@@ -45,6 +46,61 @@ class TableResultPrinterTest extends TestCase {
 		$instance = new TableResultPrinter( 'table' );
 
 		$this->assertFalse( $instance->dependsOnUserLanguage() );
+	}
+
+	/**
+	 * @dataProvider valueSeparatorProvider
+	 */
+	public function testValueSeparatorEscapesHtmlOutput( string $sep, int $outputMode, string $expected ) {
+		$instance = new TableResultPrinter( 'table' );
+
+		$params = new \ReflectionProperty( ResultPrinter::class, 'params' );
+		$params->setAccessible( true );
+		$params->setValue( $instance, [ 'sep' => $sep ] );
+
+		$method = new \ReflectionMethod( TableResultPrinter::class, 'getValueSeparator' );
+		$method->setAccessible( true );
+
+		$this->assertSame( $expected, $method->invoke( $instance, $outputMode ) );
+	}
+
+	public static function valueSeparatorProvider(): iterable {
+		// HTML output (Special:Ask): raw markup would be an XSS sink, so the
+		// separator is escaped, allowlisting only the <br> line-break variants.
+		yield 'html escapes script' => [
+			"<script>alert('x')</script>", SMW_OUTPUT_HTML,
+			'&lt;script&gt;alert(&#039;x&#039;)&lt;/script&gt;',
+		];
+		yield 'html escapes attribute breakout' => [
+			'"><img src=x onerror=alert(1)>', SMW_OUTPUT_HTML,
+			'&quot;&gt;&lt;img src=x onerror=alert(1)&gt;',
+		];
+		yield 'html keeps <br>' => [ '<br>', SMW_OUTPUT_HTML, '<br>' ];
+		yield 'html keeps <br/>' => [ '<br/>', SMW_OUTPUT_HTML, '<br/>' ];
+		yield 'html keeps <br />' => [ '<br />', SMW_OUTPUT_HTML, '<br />' ];
+		yield 'html keeps <BR> case-insensitively' => [ '<BR>', SMW_OUTPUT_HTML, '<BR>' ];
+
+		// Wiki output (inline #ask): the surrounding parser sanitises the
+		// result and escaping would corrupt legitimate wikitext, so the raw
+		// separator is preserved unchanged.
+		yield 'wiki passes script through' => [
+			"<script>alert('x')</script>", SMW_OUTPUT_WIKI,
+			"<script>alert('x')</script>",
+		];
+		yield 'wiki passes <br> through' => [ '<br>', SMW_OUTPUT_WIKI, '<br>' ];
+
+		// RAW output (Special:Ask request_type=raw, used by remote requests)
+		// and FILE output are also emitted into an HTML context without parser
+		// sanitisation, so they must escape exactly like HTML output.
+		yield 'raw escapes script' => [
+			"<script>alert('x')</script>", SMW_OUTPUT_RAW,
+			'&lt;script&gt;alert(&#039;x&#039;)&lt;/script&gt;',
+		];
+		yield 'raw keeps <br>' => [ '<br>', SMW_OUTPUT_RAW, '<br>' ];
+		yield 'file escapes script' => [
+			"<script>alert('x')</script>", SMW_OUTPUT_FILE,
+			'&lt;script&gt;alert(&#039;x&#039;)&lt;/script&gt;',
+		];
 	}
 
 }


### PR DESCRIPTION
Bundles the reflected-XSS and open-redirect fixes for the 7.2.0 release, each as its own commit, together with a Security fixes section in the release notes.

* Escape the table `sep` separator in `Special:Ask` HTML, raw and file output (GHSA-7xv3-gf2g-498h)
* Prevent an open redirect in `Special:URIResolver` (GHSA-hw3m-8j5x-94ff)
* Escape reflected `property` and `value` text in `Special:SearchByProperty` (GHSA-59xw-qv23-j3rc)
* Escape user-controlled values in the `format=debug` query debug output (GHSA-q5fm-9mx6-44f4)
* Escape plain table headers (`headers=plain`) in HTML output (GHSA-3jp5-3h47-28qf)
* Escape forged `cursor` token values reflected into query error messages (GHSA-cx86-7xwp-w9wf)

Please merge with "Rebase and merge" so the fixes stay as individual commits on master.
