### PR TITLE
7.2.0 release

### DIFF
--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -24,8 +24,17 @@ Increases of minimum requirements are indicated in bold.
         <th>Notes</th>
     </tr>
     <tr>
-        <th><a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki_7.1.0">7.1.x</a></th>
+        <th><a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki_7.2.0">7.2.x</a></th>
         <td><strong>Stable release</strong></td>
+        <td>2026-07-17</td>
+        <td>2026-07-17</td>
+        <td>8.1 - 8.5</td>
+        <td>1.43 - 1.46</td>
+        <td></td>
+    </tr>
+    <tr>
+        <th><a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki_7.1.0">7.1.x</a></th>
+        <td>Obsolete release</td>
         <td>2026-07-09</td>
         <td>2026-07-09</td>
         <td>8.1 - 8.5</td>
@@ -390,6 +399,12 @@ Note that MS SQL Server and Oracle are not supported as database backends.
         <th>Elasticsearch</th>
         <th>OpenSearch</th>
         <th>Notes</th>
+    </tr>
+    <tr>
+        <th><a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki_7.2.0">7.2.x</a></th>
+        <td>7.10.2</td>
+        <td>1.3.x+</td>
+        <td></td>
     </tr>
     <tr>
         <th><a href="https://www.semantic-mediawiki.org/wiki/Semantic_MediaWiki_7.1.0">7.1.x</a></th>

--- a/docs/releasenotes/RELEASE-NOTES-7.2.0.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.0.md
@@ -1,6 +1,6 @@
 # Semantic MediaWiki 7.2.0
 
-Released on TBD.
+Released on July 17, 2026.
 
 This is a [minor release](../RELEASE-POLICY.md). Thus, it contains no breaking changes, only new features and fixes.
 

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticMediaWiki",
-	"version": "7.2.0-alpha",
+	"version": "7.2.0",
 	"author": [
 		"[https://korrekt.org Markus Krötzsch]",
 		"[https://EntropyWins.wtf/mediawiki Jeroen De Dauw]",


### PR DESCRIPTION
Prepares the 7.2.0 release:

* Drop the `-alpha` suffix in `extension.json` (`7.2.0-alpha` to `7.2.0`)
* Set the release date in the 7.2.0 release notes
* Mark 7.2.x as the stable release in the compatibility matrix and move 7.1.x to obsolete

Merge with "Squash and merge".
