### PR TITLE
Add missing smw-paramdesc-cursor message

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -75,6 +75,7 @@
 	"validator-type-class-SMWParamSource": "text",
 	"smw-paramdesc-limit": "The maximum number of results to return",
 	"smw-paramdesc-offset": "The offset of the first result",
+	"smw-paramdesc-cursor": "The cursor token as provided by a previous page of results, used instead of \"offset\" to continue the pagination",
 	"smw-paramdesc-headers": "Display the headers/property names",
 	"smw-paramdesc-mainlabel": "The label to give to the main page name",
 	"smw-paramdesc-link": "Show values as links",

--- a/i18n/qqq.json
+++ b/i18n/qqq.json
@@ -98,6 +98,7 @@
 	"validator-type-class-SMWParamSource": "This is the description of the \"source\" parameter for [https://semantic-mediawiki.org/wiki/Help:Inline_queries#Standard_parameters_for_inline_queries inline queries].\n{{Identical|Text}}",
 	"smw-paramdesc-limit": "This is the description of the \"limit\" parameter for [https://semantic-mediawiki.org/wiki/Help:Inline_queries#Standard_parameters_for_inline_queries inline queries].",
 	"smw-paramdesc-offset": "This is the description of the \"offset\" parameter for [https://semantic-mediawiki.org/wiki/Help:Inline_queries#Standard_parameters_for_inline_queries inline queries].",
+	"smw-paramdesc-cursor": "This is the description of the \"cursor\" parameter for [https://semantic-mediawiki.org/wiki/Help:Inline_queries#Standard_parameters_for_inline_queries inline queries].",
 	"smw-paramdesc-headers": "This is the description of the \"headers\" parameter for [https://semantic-mediawiki.org/wiki/Help:Inline_queries#Standard_parameters_for_inline_queries inline queries].",
 	"smw-paramdesc-mainlabel": "This is the description of the \"mainlabel\" parameter for [https://semantic-mediawiki.org/wiki/Help:Inline_queries#Standard_parameters_for_inline_queries inline queries].",
 	"smw-paramdesc-link": "This is the description of the \"link\" parameter for [https://semantic-mediawiki.org/wiki/Help:Inline_queries#Standard_parameters_for_inline_queries inline queries].",


### PR DESCRIPTION
Fixes https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7059

`DefaultParamDefinition` assigns every base query parameter the message key `smw-paramdesc-<name>`. The `cursor` parameter introduced with keyset pagination never got its message, so Special:Ask renders the raw key ⧼smw-paramdesc-cursor⧽ in the options panel.

> <sub>AI-authored — Claude Code, `Fable 5 (max)`; ask from @kghbln, no revisions; diff not yet human-reviewed; both i18n files JSON-validated, wording matched to the sibling limit/offset entries; rendering not exercised locally (no MediaWiki in the authoring sandbox), banana checker runs on CI.</sub>
