### PR TITLE
Fix property and category pages permanently locked by change propagation

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.1.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.1.md
@@ -7,7 +7,9 @@ This is a [patch release](../RELEASE-POLICY.md). Thus, it contains only bug fixe
 Like SMW 7.2.0, this version is compatible with MediaWiki 1.43 up to 1.46 and PHP 8.1 up to 8.5.
 For more detailed information, see the [compatibility matrix](../COMPATIBILITY.md#compatibility).
 
-## Changes
+## Bug fixes
+
+* Fixed property and category pages sometimes remaining permanently locked for a change propagation update even when no such update was pending, leaving them uneditable; affected pages are editable again, and routine category changes such as setting a parent category no longer trigger the lock ([#4344](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4344))
 
 ## Upgrading
 

--- a/src/MediaWiki/Hooks/ArticleViewHeader.php
+++ b/src/MediaWiki/Hooks/ArticleViewHeader.php
@@ -84,7 +84,14 @@ class ArticleViewHeader implements ArticleViewHeaderHook {
 			$subject
 		);
 
-		if ( $semanticData->hasProperty( new Property( Property::TYPE_CHANGE_PROP ) ) ) {
+		// The `_CHGPRO` marker only reflects an active lock while a change
+		// propagation is genuinely pending. A dispatch job that failed or was
+		// lost can leave the marker behind with no pending job, which used to
+		// show the lock banner indefinitely (#4344), so cross-check the job queue.
+		if (
+			$semanticData->hasProperty( new Property( Property::TYPE_CHANGE_PROP ) ) &&
+			ChangePropagationDispatchJob::hasPendingJobs( $subject )
+		) {
 			$severity = $this->settings->get( 'smwgChangePropagationProtection' ) ? 'error' : 'warning';
 
 			$message .= $this->message(

--- a/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
+++ b/src/MediaWiki/Jobs/ChangePropagationDispatchJob.php
@@ -79,8 +79,11 @@ class ChangePropagationDispatchJob extends Job {
 	 *
 	 * Excluded as constraint-adjacent (stored _ERRT may depend):
 	 * _PVAL/_PVUC/_PVALI/_PVAP/_PREC.
+	 *
+	 * Public so `ChangePropagationNotifier` can share the same classification when
+	 * deciding whether a diff needs the `_CHGPRO` lock at all (#4344).
 	 */
-	private const SHALLOW_SET = [ '_SUBC', '_SUBP', '_PDESC', '_PPLB' ];
+	public const SHALLOW_SET = [ '_SUBC', '_SUBP', '_PDESC', '_PPLB' ];
 
 	/**
 	 * @since 3.0

--- a/src/Property/ChangePropagationNotifier.php
+++ b/src/Property/ChangePropagationNotifier.php
@@ -218,6 +218,15 @@ class ChangePropagationNotifier {
 			return;
 		}
 
+		// Hierarchy/display-only changes (e.g. `_SUBC`, `_SUBP`) are resolved at
+		// query time and do not affect dependents' stored data, so there is
+		// nothing to protect against while propagation runs. Dispatch the
+		// reprocessing job (done above) but skip the `_CHGPRO` marker so the page
+		// is never locked for such a diff (#4344).
+		if ( $this->isShallowOnlyDiff() ) {
+			return;
+		}
+
 		$previous = $this->store->getSemanticData(
 			$semanticData->getSubject()
 		);
@@ -237,6 +246,25 @@ class ChangePropagationNotifier {
 		);
 
 		$semanticData = $previous;
+	}
+
+	/**
+	 * Whether every diffing key only affects data that is resolved at query time
+	 * (see ChangePropagationDispatchJob::SHALLOW_SET), in which case no `_CHGPRO`
+	 * lock is required.
+	 */
+	private function isShallowOnlyDiff(): bool {
+		if ( $this->diffKeys === [] ) {
+			return false;
+		}
+
+		foreach ( $this->diffKeys as $key ) {
+			if ( !in_array( $key, ChangePropagationDispatchJob::SHALLOW_SET, true ) ) {
+				return false;
+			}
+		}
+
+		return true;
 	}
 
 }

--- a/src/Property/DeclarationExaminer/ChangePropagationExaminer.php
+++ b/src/Property/DeclarationExaminer/ChangePropagationExaminer.php
@@ -75,7 +75,14 @@ class ChangePropagationExaminer extends DeclarationExaminer {
 			$this->semanticData = $semanticData;
 		}
 
-		if ( $semanticData->hasProperty( new Property( Property::TYPE_CHANGE_PROP ) ) ) {
+		// The `_CHGPRO` marker only reflects an active lock while a change
+		// propagation is genuinely pending. A dispatch job that failed or was
+		// lost can leave the marker behind with no pending job, which used to
+		// lock the page indefinitely (#4344), so cross-check the job queue.
+		if (
+			$semanticData->hasProperty( new Property( Property::TYPE_CHANGE_PROP ) ) &&
+			ChangePropagationDispatchJob::hasPendingJobs( $subject )
+		) {
 			$this->isChangePropagation( $property );
 		} else {
 			$this->checkForPendingChangePropagationDispatchJob( $property );

--- a/src/Protection/ProtectionValidator.php
+++ b/src/Protection/ProtectionValidator.php
@@ -10,6 +10,7 @@ use SMW\DataItems\WikiPage;
 use SMW\EntityCache;
 use SMW\Listener\ChangeListener\ChangeListeners\PropertyChangeListener;
 use SMW\Listener\ChangeListener\ChangeRecord;
+use SMW\MediaWiki\Jobs\ChangePropagationDispatchJob;
 use SMW\MediaWiki\PageCreator;
 use SMW\MediaWiki\PermissionManager;
 use SMW\Store;
@@ -234,7 +235,13 @@ class ProtectionValidator {
 			return false;
 		}
 
-		return $this->checkProtection( $subject, new Property( '_CHGPRO' ) );
+		// The `_CHGPRO` marker only reflects an active lock while a change
+		// propagation is genuinely pending. A dispatch job that failed or was
+		// lost can leave the marker behind with no pending job, which used to
+		// lock the page indefinitely (#4344). Cross-check the job queue and
+		// treat a marker without any pending job as stale.
+		return $this->checkProtection( $subject, new Property( '_CHGPRO' ) )
+			&& ChangePropagationDispatchJob::hasPendingJobs( $subject );
 	}
 
 	/**

--- a/tests/phpunit/Unit/MediaWiki/Hooks/ArticleViewHeaderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Hooks/ArticleViewHeaderTest.php
@@ -17,6 +17,7 @@ use SMW\NamespaceExaminer;
 use SMW\Settings;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\Store;
+use SMW\Tests\TestEnvironment;
 use WikiPage as MwWikiPage;
 
 /**
@@ -35,6 +36,8 @@ class ArticleViewHeaderTest extends TestCase {
 	private $settings;
 	private $dependencyValidator;
 	private $dependencyValidatorFactory;
+	private $jobQueue;
+	private $testEnvironment;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -56,6 +59,18 @@ class ArticleViewHeaderTest extends TestCase {
 
 		$this->dependencyValidatorFactory = $this->createMock( DependencyValidatorFactory::class );
 		$this->dependencyValidatorFactory->method( 'newFor' )->willReturn( $this->dependencyValidator );
+
+		$this->jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->testEnvironment = new TestEnvironment();
+		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
+	}
+
+	protected function tearDown(): void {
+		$this->testEnvironment->tearDown();
+		parent::tearDown();
 	}
 
 	private function newInstance(): ArticleViewHeader {
@@ -107,6 +122,8 @@ class ArticleViewHeaderTest extends TestCase {
 
 		$this->store->method( 'getSemanticData' )->willReturn( $semanticData );
 
+		$this->jobQueue->method( 'hasPendingJob' )->willReturn( true );
+
 		$output = $this->createMock( OutputPage::class );
 		$output->expects( $this->once() )->method( 'addHTML' );
 
@@ -127,6 +144,54 @@ class ArticleViewHeaderTest extends TestCase {
 		$this->newInstance()->onArticleViewHeader( $page, $outputDone, $useParserCache );
 
 		$this->assertFalse( $useParserCache );
+	}
+
+	public function testStaleChangePropagationMarkerUsesParserCacheOnCategory() {
+		$subject = WikiPage::newFromText( __METHOD__, NS_CATEGORY );
+		$property = new Property( Property::TYPE_CHANGE_PROP );
+
+		$this->namespaceExaminer->method( 'isSemanticEnabled' )->willReturn( true );
+
+		$this->settings->method( 'get' )
+			->willReturnMap( [
+				[ 'smwgChangePropagationWatchlist', [ '_SUBC' ] ],
+				[ 'smwgChangePropagationProtection', false ],
+			] );
+
+		$semanticData = $this->getMockBuilder( SemanticData::class )
+			->setConstructorArgs( [ WikiPage::newFromText( 'Foo' ) ] )
+			->getMock();
+
+		$semanticData->method( 'hasProperty' )
+			->with( $property )
+			->willReturn( true );
+
+		$this->store->method( 'getSemanticData' )->willReturn( $semanticData );
+
+		// #4344: the `_CHGPRO` marker lingers but no dispatch job is pending, so
+		// no lock banner is shown and the parser cache remains usable.
+		$this->jobQueue->method( 'hasPendingJob' )->willReturn( false );
+		$this->jobQueue->method( 'getQueueSize' )->willReturn( 0 );
+
+		$output = $this->createMock( OutputPage::class );
+
+		$context = $this->createMock( RequestContext::class );
+		$context->method( 'getOutput' )->willReturn( $output );
+
+		$wikiPage = $this->createMock( MwWikiPage::class );
+		$wikiPage->method( 'makeParserOptions' )->willReturn( $this->createMock( ParserOptions::class ) );
+
+		$page = $this->createMock( Article::class );
+		$page->method( 'getTitle' )->willReturn( $subject->getTitle() );
+		$page->method( 'getContext' )->willReturn( $context );
+		$page->method( 'getPage' )->willReturn( $wikiPage );
+
+		$outputDone = '';
+		$useParserCache = '';
+
+		$this->newInstance()->onArticleViewHeader( $page, $outputDone, $useParserCache );
+
+		$this->assertTrue( $useParserCache );
 	}
 
 	public function testProcessOnNoCategory() {

--- a/tests/phpunit/Unit/Property/ChangePropagationNotifierTest.php
+++ b/tests/phpunit/Unit/Property/ChangePropagationNotifierTest.php
@@ -355,6 +355,67 @@ class ChangePropagationNotifierTest extends TestCase {
 		$this->assertTrue( $capturedJob->getParameter( 'isTypePropagation' ) );
 	}
 
+	public function testShallowOnlyDiffDispatchesJobWithoutPlantingChangePropagationMarker() {
+		// #4344: a hierarchy-only change (e.g. _SUBC) is resolved at query time
+		// and does not affect dependents' stored data. The reprocessing job is
+		// still dispatched, but no `_CHGPRO` marker is planted, so the page is
+		// never locked for it.
+		$matchingBlob = new Blob( 'same-value' );
+		$this->mockedStoreValues = [ $matchingBlob ];
+
+		$subject = new WikiPage( __METHOD__, NS_CATEGORY );
+
+		$capturedJob = null;
+
+		$jobQueueGroup = $this->getMockBuilder( '\JobQueueGroup' )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'lazyPush' ] )
+			->getMock();
+		$jobQueueGroup->expects( $this->atLeastOnce() )
+			->method( 'lazyPush' )
+			->willReturnCallback( static function ( $job ) use ( &$capturedJob ) {
+				$capturedJob = $job;
+			} );
+		$this->testEnvironment->registerObject( 'JobQueueGroup', $jobQueueGroup );
+
+		$store = $this->getMockBuilder( Store::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'getPropertyValues', 'getSemanticData' ] )
+			->getMockForAbstractClass();
+
+		$innerSemanticData = $this->getMockBuilder( SemanticData::class )
+			->setConstructorArgs( [ WikiPage::newFromText( 'Foo' ) ] )
+			->getMock();
+
+		// No `_CHGPRO` marker (or any postponed data) must be planted onto the
+		// stored data for a shallow-only diff.
+		$innerSemanticData->expects( $this->never() )
+			->method( 'addPropertyObjectValue' );
+
+		$store->method( 'getSemanticData' )->willReturn( $innerSemanticData );
+		$store->method( 'getPropertyValues' )
+			->willReturnCallback( [ $this, 'doComparePropertyValuesOnCallback' ] );
+
+		$semanticData = $this->getMockBuilder( SemanticData::class )
+			->setConstructorArgs( [ WikiPage::newFromText( 'Foo' ) ] )
+			->getMock();
+		$semanticData->method( 'getSubject' )->willReturn( $subject );
+		// New values: only _SUBC differs; all other watched keys match.
+		$semanticData->method( 'getPropertyValues' )
+			->willReturnCallback( static function ( Property $property ) use ( $matchingBlob ) {
+				return $property->getKey() === '_SUBC'
+					? [ new Blob( 'different-subc' ) ]
+					: [ $matchingBlob ];
+			} );
+
+		$instance = new ChangePropagationNotifier( $store, $this->serializerFactory );
+		$instance->setPropertyList( [ '_SUBC' ] );
+		$instance->checkAndNotify( $semanticData );
+
+		$this->assertNotNull( $capturedJob );
+		$this->assertSame( [ '_SUBC' ], $capturedJob->getParameter( 'diffKeys' ) );
+	}
+
 	/**
 	 * Returns an array of DataItem and simulates an alternating
 	 * existencance of return values ('_LIST')

--- a/tests/phpunit/Unit/Property/DeclarationExaminer/ChangePropagationExaminerTest.php
+++ b/tests/phpunit/Unit/Property/DeclarationExaminer/ChangePropagationExaminerTest.php
@@ -85,6 +85,10 @@ class ChangePropagationExaminerTest extends TestCase {
 			->method( 'getSemanticData' )
 			->willReturn( $semanticData );
 
+		$this->jobQueue->expects( $this->any() )
+			->method( 'hasPendingJob' )
+			->willReturn( true );
+
 		$instance = new ChangePropagationExaminer(
 			$this->declarationExaminer,
 			$this->store,
@@ -102,6 +106,53 @@ class ChangePropagationExaminerTest extends TestCase {
 
 		$this->assertTrue(
 			$instance->isLocked()
+		);
+	}
+
+	public function testStaleChangePropagationMarkerIsNotLocked() {
+		$dataItemFactory = new DataItemFactory();
+		$subject = $dataItemFactory->newDIWikiPage( 'Test', NS_MAIN );
+
+		$semanticData = new SemanticData(
+			$subject
+		);
+
+		$semanticData->addPropertyObjectValue(
+			$dataItemFactory->newDIProperty( '_CHGPRO' ),
+			$dataItemFactory->newDIBlob( '...' )
+		);
+
+		$this->store->expects( $this->any() )
+			->method( 'getSemanticData' )
+			->willReturn( $semanticData );
+
+		// #4344: the `_CHGPRO` marker lingers but no dispatch job is pending, so
+		// the page must not be reported as locked.
+		$this->jobQueue->expects( $this->any() )
+			->method( 'hasPendingJob' )
+			->willReturn( false );
+
+		$this->jobQueue->expects( $this->any() )
+			->method( 'getQueueSize' )
+			->willReturn( 0 );
+
+		$instance = new ChangePropagationExaminer(
+			$this->declarationExaminer,
+			$this->store,
+			$this->semanticData
+		);
+
+		$instance->check(
+			$dataItemFactory->newDIProperty( 'Bar' )
+		);
+
+		$this->assertFalse(
+			$instance->isLocked()
+		);
+
+		$this->assertStringNotContainsString(
+			'change-propagation-locked',
+			$instance->getMessagesAsString()
 		);
 	}
 

--- a/tests/phpunit/Unit/Protection/ProtectionValidatorTest.php
+++ b/tests/phpunit/Unit/Protection/ProtectionValidatorTest.php
@@ -34,6 +34,7 @@ class ProtectionValidatorTest extends TestCase {
 	private $entityCache;
 	private $permissionManager;
 	private $pageCreator;
+	private $jobQueue;
 	private $testEnvironment;
 
 	protected function setUp(): void {
@@ -58,7 +59,12 @@ class ProtectionValidatorTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
+		$this->jobQueue = $this->getMockBuilder( '\SMW\MediaWiki\JobQueue' )
+			->disableOriginalConstructor()
+			->getMock();
+
 		$this->testEnvironment = new TestEnvironment();
+		$this->testEnvironment->registerObject( 'JobQueue', $this->jobQueue );
 	}
 
 	protected function tearDown(): void {
@@ -227,6 +233,72 @@ class ProtectionValidatorTest extends TestCase {
 		$this->entityCache->expects( $this->once() )
 			->method( 'fetch' )
 			->willReturn( 'yes' );
+
+		$this->jobQueue->expects( $this->any() )
+			->method( 'hasPendingJob' )
+			->willReturn( true );
+
+		$instance = new ProtectionValidator(
+			$this->store,
+			$this->entityCache,
+			$this->permissionManager,
+			$this->pageCreator
+		);
+
+		$this->assertTrue(
+			$instance->hasChangePropagationProtection( $subject->getTitle() )
+		);
+	}
+
+	public function testStaleChangePropagationMarkerDoesNotProtectWhenJobQueueEmpty() {
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', SMW_NS_PROPERTY );
+
+		// The `_CHGPRO` marker is (still) present ...
+		$this->entityCache->expects( $this->any() )
+			->method( 'contains' )
+			->willReturn( true );
+
+		$this->entityCache->expects( $this->any() )
+			->method( 'fetch' )
+			->willReturn( 'yes' );
+
+		// ... but no change propagation job is actually pending (#4344: an orphaned
+		// marker left behind by a failed/lost dispatch job must not lock the page
+		// indefinitely).
+		$this->jobQueue->expects( $this->any() )
+			->method( 'hasPendingJob' )
+			->willReturn( false );
+
+		$this->jobQueue->expects( $this->any() )
+			->method( 'getQueueSize' )
+			->willReturn( 0 );
+
+		$instance = new ProtectionValidator(
+			$this->store,
+			$this->entityCache,
+			$this->permissionManager,
+			$this->pageCreator
+		);
+
+		$this->assertFalse(
+			$instance->hasChangePropagationProtection( $subject->getTitle() )
+		);
+	}
+
+	public function testChangePropagationProtectionAppliesWhileJobPending() {
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', SMW_NS_PROPERTY );
+
+		$this->entityCache->expects( $this->any() )
+			->method( 'contains' )
+			->willReturn( true );
+
+		$this->entityCache->expects( $this->any() )
+			->method( 'fetch' )
+			->willReturn( 'yes' );
+
+		$this->jobQueue->expects( $this->any() )
+			->method( 'hasPendingJob' )
+			->willReturn( true );
 
 		$instance = new ProtectionValidator(
 			$this->store,


### PR DESCRIPTION
## Problem

Property and category pages can become permanently locked for a change propagation update ("This page is locked to prevent accidental data modification while a change propagation update is run", or shown as edit protection) even when the job queue is empty. This has been reported across many releases and still reproduces on 7.2.0.

Fixes #4344.

## Root cause

The lock is driven by the stored `_CHGPRO` ("Change propagation") property on the page. This marker has no expiry and is removed only when the change-propagation dispatch/update job chain runs to completion. If that job is lost or fails, the marker is orphaned, and because the three places that read it treat its mere presence as an active lock, without checking whether any change propagation is actually still pending, the page stays locked forever. This is independent of the cache configuration, which is why it reproduces even with caching disabled.

## Fix

- **Lift the lock when no related job is pending.** The three readers of the marker (the edit-permission check in `ProtectionValidator`, the "locked" declaration message in `ChangePropagationExaminer`, and the category banner in `ArticleViewHeader`) now cross-check the job queue: a `_CHGPRO` marker only locks the page while a matching change-propagation job is pending. An orphaned marker is treated as stale, so affected pages become editable again on the next view and the marker clears on the next edit.
- **Do not lock for hierarchy-only changes.** Diffs that only touch query-time-resolved keys (`_SUBC`, `_SUBP`, `_PDESC`, `_PPLB`), for example giving a category a parent category, no longer plant the marker at all. The reprocessing job is still dispatched; there is simply nothing to protect against, so the page is never locked for such a change.

## Known limitation

The pending-job check is global per job type, not per subject. On a busy wiki whose change-propagation queue rarely empties, a page with an orphaned marker can therefore remain locked while unrelated change-propagation jobs are queued; the lock clears once the queue drains. The reported failure, a permanent lock with an empty queue, is fully resolved. There is also a narrow, pre-existing race in the opposite direction: during the brief window between an edit and the dispatch job registering, the lock now rests on the job-queue read, so a momentarily stale-low queue size could allow an edit during genuine propagation. The practical risk is low and the marker set by the dispatch covers the following window.

## Related, not addressed here

The large-property dispatch failure that can create these orphaned markers in the first place (a dispatch job exhausting memory or exceeding `max_allowed_packet` on a property used by hundreds of thousands of pages) is a separate scalability issue and is left for a follow-up.

## Testing

- Unit tests for each reader: an orphaned marker with an empty queue does not lock, while an in-progress propagation still does; plus a test that a hierarchy-only diff dispatches the job without planting the marker.
- Verified end to end on a MediaWiki 1.43 install: a page with an orphaned marker and an empty queue is editable, and a page with a genuinely queued dispatch job remains locked.
