### PR TITLE
Cache entity protection status per property

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.1.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.1.md
@@ -7,7 +7,9 @@ This is a [patch release](../RELEASE-POLICY.md). Thus, it contains only bug fixe
 Like SMW 7.2.0, this version is compatible with MediaWiki 1.43 up to 1.46 and PHP 8.1 up to 8.5.
 For more detailed information, see the [compatibility matrix](../COMPATIBILITY.md#compatibility).
 
-## Changes
+## Bug fixes
+
+* Fixed property and category pages sometimes reporting the wrong Semantic MediaWiki protection status, where a page's change-propagation lock and its "Is edit protected" status could be confused for one another ([#4344](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4344))
 
 ## Upgrading
 

--- a/src/Protection/ProtectionValidator.php
+++ b/src/Protection/ProtectionValidator.php
@@ -81,7 +81,9 @@ class ProtectionValidator {
 				$record->get( 'row.s_id' )
 			);
 
-			$key = $this->entityCache->makeCacheKey( 'protection', $subject->getHash() );
+			// Target the `_CHGPRO`-specific slot written by checkProtection() (this
+			// listener only ever handles the `_CHGPRO` property).
+			$key = $this->entityCache->makeCacheKey( 'protection', $subject->getHash(), '_CHGPRO' );
 
 			// If the change is an insert type then the `Change propagation` property
 			// was added hence use this as a short cut to store the state avoiding
@@ -300,7 +302,10 @@ class ProtectionValidator {
 			$property = new Property( '_EDIP' );
 		}
 
-		$key = $this->entityCache->makeCacheKey( 'protection', $subject->getHash() );
+		// The property must be part of the key: `checkProtection()` is called for
+		// both `_CHGPRO` (change-propagation lock) and `_EDIP` (edit protection),
+		// and a shared slot let one concern's cached result be read for the other.
+		$key = $this->entityCache->makeCacheKey( 'protection', $subject->getHash(), $property->getKey() );
 		$hasProtection = false;
 
 		if ( $this->entityCache->contains( $key ) ) {

--- a/tests/phpunit/Unit/Protection/ProtectionValidatorTest.php
+++ b/tests/phpunit/Unit/Protection/ProtectionValidatorTest.php
@@ -16,6 +16,7 @@ use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\SQLStore;
 use SMW\Store;
 use SMW\Tests\TestEnvironment;
+use Wikimedia\ObjectCache\HashBagOStuff;
 use WikiPage;
 
 /**
@@ -262,6 +263,70 @@ class ProtectionValidatorTest extends TestCase {
 		);
 	}
 
+	public function testEditProtectionCacheIsNotPoisonedByChangePropagationCheck() {
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', SMW_NS_PROPERTY );
+
+		// The page carries no `_CHGPRO` (no change propagation) but is edit
+		// protected (`_EDIP` = true).
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyValues' )
+			->willReturnCallback( function ( $subj, $property ) {
+				return $property->getKey() === '_EDIP'
+					? [ $this->dataItemFactory->newDIBoolean( true ) ]
+					: [];
+			} );
+
+		// Use a real cache so the two protection checks share (or, once fixed, do
+		// not share) the same slot.
+		$realEntityCache = new EntityCache( new HashBagOStuff() );
+
+		$instance = new ProtectionValidator(
+			$this->store,
+			$realEntityCache,
+			$this->permissionManager,
+			$this->pageCreator
+		);
+
+		// A change-propagation check runs first and caches its own (`_CHGPRO`)
+		// result; it must not poison the unrelated edit-protection (`_EDIP`)
+		// lookup for the same page.
+		$instance->hasChangePropagationProtection( $subject->getTitle() );
+
+		$this->assertTrue(
+			$instance->hasProtection( $subject->getTitle() )
+		);
+	}
+
+	public function testChangePropagationCacheIsNotPoisonedByEditProtectionCheck() {
+		$subject = $this->dataItemFactory->newDIWikiPage( 'Foo', SMW_NS_PROPERTY );
+
+		// The page is edit protected (`_EDIP` = true) but has no `_CHGPRO`.
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyValues' )
+			->willReturnCallback( function ( $subj, $property ) {
+				return $property->getKey() === '_EDIP'
+					? [ $this->dataItemFactory->newDIBoolean( true ) ]
+					: [];
+			} );
+
+		$realEntityCache = new EntityCache( new HashBagOStuff() );
+
+		$instance = new ProtectionValidator(
+			$this->store,
+			$realEntityCache,
+			$this->permissionManager,
+			$this->pageCreator
+		);
+
+		// An edit-protection check runs first and caches its (`_EDIP`) result; it
+		// must not make the unrelated change-propagation check report a lock.
+		$instance->hasProtection( $subject->getTitle() );
+
+		$this->assertFalse(
+			$instance->hasChangePropagationProtection( $subject->getTitle() )
+		);
+	}
+
 	public function testSetGetCreateProtectionRight() {
 		$instance = new ProtectionValidator(
 			$this->store,
@@ -498,7 +563,7 @@ class ProtectionValidatorTest extends TestCase {
 
 		$this->entityCache->expects( $this->once() )
 			->method( 'delete' )
-			->with( $this->stringContains( 'smw:entity:d5c5aca7d29a32ea16a0331dac164ac4' ) );
+			->with( $this->stringContains( 'smw:entity:ea54787292d320f8940f3447754fae22' ) );
 
 		$changeRecord = new ChangeRecord(
 			[
@@ -537,7 +602,7 @@ class ProtectionValidatorTest extends TestCase {
 
 		$this->entityCache->expects( $this->once() )
 			->method( 'save' )
-			->with( $this->stringContains( 'smw:entity:d5c5aca7d29a32ea16a0331dac164ac4' ) );
+			->with( $this->stringContains( 'smw:entity:ea54787292d320f8940f3447754fae22' ) );
 
 		$changeRecord = new ChangeRecord(
 			[


### PR DESCRIPTION
## Problem

`ProtectionValidator::checkProtection()` caches its result in the entity cache under a key built only from the subject (`makeCacheKey('protection', $subject->getHash())`). But the method is called for two different properties with different meanings:

- `_CHGPRO`, the change-propagation lock (via `hasChangePropagationProtection()`)
- `_EDIP`, the "Is edit protected" status (via `hasProtection()` / `hasEditProtection()`)

On property and category pages both checks run within a single edit-permission flow, so whichever runs first populates the shared slot and the second reads it back, returning the other concern's result. For example, on a page with no pending change propagation, the `_CHGPRO` check caches "no protection" and a subsequent `_EDIP` check then reports the page as unprotected at the Semantic MediaWiki layer, even when it is marked "Is edit protected".

## Scope of impact

This affects Semantic MediaWiki's own protection checks and the messages driven by them. It does not change actual edit access: when a page is marked "Is edit protected", `EditProtectionUpdater` applies native MediaWiki `page_restrictions`, and MediaWiki core enforces that independently of this cache. Verified on MediaWiki 1.43: an unprivileged user is still blocked (with core's `protectedpagetext`) even with the Semantic MediaWiki check poisoned. So this is a correctness fix, not an access-control bypass.

## Fix

Include the property key in the cache key so each protection is cached independently, and target the `_CHGPRO`-specific key from the change-propagation invalidation listener so invalidation still lands on the right entry.

## Testing

- A regression test using a real cache asserts that a `_CHGPRO` check no longer poisons the `_EDIP` lookup for the same page.
- Existing `invalidateCache` expectations updated for the new (property-specific) key.

## Note

Found while investigating #4344; it is an independent defect in the same subsystem and is not required for that fix.
