### PR TITLE
Stream change-propagation subject selection on large properties

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.1.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.1.md
@@ -11,6 +11,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 * Fixed property and category pages sometimes reporting the wrong Semantic MediaWiki protection status, where a page's change-propagation lock and its "Is edit protected" status could be confused for one another ([#4344](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4344))
 * Fixed property and category pages sometimes remaining permanently locked for a change propagation update even when no such update was pending, leaving them uneditable; affected pages are editable again, and routine category changes such as setting a parent category no longer trigger the lock ([#4344](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4344))
+* Fixed change propagation failing to complete for a property or category connected to a very large number of pages, where selecting the affected pages could exhaust the available memory ([#4344](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4344))
 
 ## Upgrading
 

--- a/src/SQLStore/Lookup/ChangePropagationEntityLookup.php
+++ b/src/SQLStore/Lookup/ChangePropagationEntityLookup.php
@@ -5,8 +5,10 @@ namespace SMW\SQLStore\Lookup;
 use RuntimeException;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
+use SMW\Enum;
 use SMW\IteratorFactory;
 use SMW\Iterators\AppendIterator;
+use SMW\RequestOptions;
 use SMW\Store;
 
 /**
@@ -70,9 +72,11 @@ class ChangePropagationEntityLookup {
 	public function findByProperty( Property $property ) {
 		$dataItems = [];
 		$appendIterator = $this->iteratorFactory->newAppendIterator();
+		$requestOptions = $this->newSuspendedCacheWarmupOptions();
 
 		$res = $this->store->getAllPropertySubjects(
-			$property
+			$property,
+			$requestOptions
 		);
 
 		$appendIterator->add(
@@ -87,7 +91,8 @@ class ChangePropagationEntityLookup {
 
 		$dataItems = $this->store->getPropertySubjects(
 			new Property( Property::TYPE_ERROR ),
-			$property->getCanonicalDiWikiPage()
+			$property->getCanonicalDiWikiPage(),
+			$requestOptions
 		);
 
 		$appendIterator->add(
@@ -106,11 +111,12 @@ class ChangePropagationEntityLookup {
 	 */
 	public function findByCategory( WikiPage $category ) {
 		$appendIterator = $this->iteratorFactory->newAppendIterator();
+		$requestOptions = $this->newSuspendedCacheWarmupOptions();
 
 		$property = new Property( '_INST' );
 
 		$appendIterator->add(
-			$this->store->getPropertySubjects( $property, $category )
+			$this->store->getPropertySubjects( $property, $category, $requestOptions )
 		);
 
 		// Only direct antecedents
@@ -121,11 +127,24 @@ class ChangePropagationEntityLookup {
 
 		foreach ( $dataItems as $dataItem ) {
 			$appendIterator->add(
-				$this->store->getPropertySubjects( $property, $dataItem )
+				$this->store->getPropertySubjects( $property, $dataItem, $requestOptions )
 			);
 		}
 
 		return $appendIterator;
+	}
+
+	/**
+	 * The dispatch only serialises subject hashes into chunked job params and
+	 * never resolves per-item id/sortkey caches, so keep the result set lazy and
+	 * skip warmUpCache, which would otherwise materialise the entire subject set
+	 * at once for a heavily used property or category (#4344).
+	 */
+	private function newSuspendedCacheWarmupOptions(): RequestOptions {
+		$requestOptions = new RequestOptions();
+		$requestOptions->setOption( Enum::SUSPEND_CACHE_WARMUP, true );
+
+		return $requestOptions;
 	}
 
 	private function fetchOtherReferencesOnTypePropagation( Property $property ) {

--- a/tests/phpunit/Unit/SQLStore/Lookup/ChangePropagationEntityLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/Lookup/ChangePropagationEntityLookupTest.php
@@ -5,8 +5,10 @@ namespace SMW\Tests\Unit\SQLStore\Lookup;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
+use SMW\Enum;
 use SMW\IteratorFactory;
 use SMW\Iterators\AppendIterator;
+use SMW\RequestOptions;
 use SMW\SQLStore\Lookup\ChangePropagationEntityLookup;
 use SMW\SQLStore\PropertyTableInfoFetcher;
 use SMW\SQLStore\SQLStore;
@@ -67,6 +69,79 @@ class ChangePropagationEntityLookupTest extends TestCase {
 			'Iterator',
 			$instance->findByProperty( $property )
 		);
+	}
+
+	public function testFindByPropertySuspendsCacheWarmup(): void {
+		$property = new Property( 'Foo' );
+
+		$this->iteratorFactory->expects( $this->any() )
+			->method( 'newAppendIterator' )
+			->willReturn( $this->appendIterator );
+
+		// The dispatch discovery must keep the subject iterator lazy (suspend
+		// warmUpCache), otherwise a property attached to a very large number of
+		// subjects materialises the whole set at once (#4344).
+		$captured = null;
+		$this->store->expects( $this->once() )
+			->method( 'getAllPropertySubjects' )
+			->willReturnCallback( static function ( $p, $opts = null ) use ( &$captured ) {
+				$captured = $opts;
+				return [];
+			} );
+
+		// The error-reference lookup on the same discovery must be suspended too.
+		$capturedForError = null;
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->willReturnCallback( static function ( $p, $s = null, $opts = null ) use ( &$capturedForError ) {
+				$capturedForError = $opts;
+				return [];
+			} );
+
+		$instance = new ChangePropagationEntityLookup(
+			$this->store,
+			$this->iteratorFactory
+		);
+
+		$instance->findByProperty( $property );
+
+		foreach ( [ $captured, $capturedForError ] as $opts ) {
+			$this->assertInstanceOf( RequestOptions::class, $opts );
+			$this->assertTrue( $opts->getOption( Enum::SUSPEND_CACHE_WARMUP ) );
+		}
+	}
+
+	public function testFindByCategorySuspendsCacheWarmup(): void {
+		$category = new WikiPage( 'Foo', NS_CATEGORY );
+
+		$this->iteratorFactory->expects( $this->any() )
+			->method( 'newAppendIterator' )
+			->willReturn( $this->appendIterator );
+
+		$captured = [];
+		$this->store->expects( $this->any() )
+			->method( 'getPropertySubjects' )
+			->willReturnCallback( static function ( $p, $s = null, $opts = null ) use ( &$captured ) {
+				$captured[] = $opts;
+				return [];
+			} );
+
+		$this->store->expects( $this->any() )
+			->method( 'getPropertyValues' )
+			->willReturn( [ WikiPage::newFromText( 'Bar' ) ] );
+
+		$instance = new ChangePropagationEntityLookup(
+			$this->store,
+			$this->iteratorFactory
+		);
+
+		$instance->findByCategory( $category );
+
+		$this->assertNotEmpty( $captured );
+		foreach ( $captured as $opts ) {
+			$this->assertInstanceOf( RequestOptions::class, $opts );
+			$this->assertTrue( $opts->getOption( Enum::SUSPEND_CACHE_WARMUP ) );
+		}
 	}
 
 	public function testFindByProperty_TypePropagation() {


### PR DESCRIPTION
## Problem

When a property (or category) is connected to a very large number of pages, changing its specification (for example its type) can make the change-propagation dispatch job exhaust the available memory, so the propagation never completes. This is the failure mode behind the large-property reports on #4344.

## Root cause

`ChangePropagationEntityLookup` selects the affected subjects via `getAllPropertySubjects()` / `getPropertySubjects()` **without a `RequestOptions`**. `EntityLookup::getPropertySubjects()` therefore skips its `SUSPEND_CACHE_WARMUP` short-circuit and eagerly runs `warmUpCache()`, which drains the deliberately-lazy subject iterator and materialises the entire set (every affected subject) into memory at once. For a property attached to hundreds of thousands of pages this exhausts memory before the dispatch can chunk the work.

## Fix

Pass a `RequestOptions` with `SUSPEND_CACHE_WARMUP` set, exactly as the sibling `UpdateDispatcherJob` already does for the same call. The result then stays a lazy iterator and the dispatch's existing chunked streaming processes the subjects a chunk at a time. Skipping the cache warmup is inert for this consumer, which only reads each subject's hash and serialises it into the chunked job parameters (it never resolves the per-item id/sortkey caches that `warmUpCache` pre-populates).

## Scope

- This targets the memory-exhaustion path, which the investigation found to be the dominant failure. The permanent-lock symptom that a stuck change-propagation marker used to cause is handled separately by the self-healing change in the related #4344 work.
- Batching the remaining shared lookup queries (`CacheWarmer` / `IdEntityFinder` `IN (...)`) is deliberately left out: those sit on the general read path and warrant their own change with performance validation. They are no longer reached from the dispatch path once the warmup is suspended.

## A note on reproduction

The crash only manifests for a property connected to a very large number of pages, which is not reproducible in a unit or development environment, so the fix rests on the verified mechanism rather than a local repro. Verified on a MediaWiki 1.43 install that a normal change-propagation cycle still discovers all affected subjects (the `count()`-then-chunk two-pass over the now-lazy iterator is intact) and completes without regression.

## Testing

- Unit tests assert that both `findByProperty` and `findByCategory` pass a `RequestOptions` carrying `SUSPEND_CACHE_WARMUP` to the store lookups.
- The existing dispatch integration test continues to exercise the full discover -> commit -> per-entity update chain.
