### PR TITLE
Add 'property_link' translation to SemanticMediaWiki

### DIFF
--- a/i18n/extra/SemanticMediaWiki.magic.php
+++ b/i18n/extra/SemanticMediaWiki.magic.php
@@ -318,6 +318,7 @@ $magicWords['pt'] = [
 	'set' => [ 0, 'definir' ],
 	'set_recurring_event' => [ 0, 'definir_evento_recorrente' ],
 	'declare' => [ 0, 'declarar' ],
+	'property_link' => [ 0, 'link_de_propriedade' ],
 	'SMW_NOFACTBOX' => [ 0, '__SEMCAIXADEFATOS__' ],
 	'SMW_SHOWFACTBOX' => [ 0, '__EXIBIRCAIXADEFATOS__' ],
 ];
@@ -333,6 +334,7 @@ $magicWords['pt-br'] = [
 	'set' => [ 0, 'definir' ],
 	'set_recurring_event' => [ 0, 'definir_evento_recorrente' ],
 	'declare' => [ 0, 'declarar' ],
+	'property_link' => [ 0, 'link_de_propriedade' ],
 	'SMW_NOFACTBOX' => [ 0, '__SEMCAIXADEFATOS__' ],
 	'SMW_SHOWFACTBOX' => [ 0, '__EXIBIRCAIXADEFATOS__' ],
 ];


### PR DESCRIPTION
In Portuguese and Brazilian Portuguese.