### PR TITLE
Removed 'doc_values' from 'text_*' fields

### DIFF
--- a/data/elastic/smw-data-icu.json
+++ b/data/elastic/smw-data-icu.json
@@ -220,13 +220,11 @@
 				},
 				"text_copy": {
 					"type": "text",
-					"analyzer": "nfkc_cf_normalized",
-					"doc_values": false
+					"analyzer": "nfkc_cf_normalized"
 				},
 				"text_raw": {
 					"type": "text",
-					"analyzer": "nfkc_cf_normalized",
-					"doc_values": false
+					"analyzer": "nfkc_cf_normalized"
 				},
 				"subject.title": {
 					"type": "text",


### PR DESCRIPTION
Removed 'doc_values' property from 'text_copy' and 'text_raw' fields. Not supported by field types 'text' and 'annotated_text'.