### PR TITLE
Restore template expansion for queries resolved outside a page parse

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.1.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.1.md
@@ -12,6 +12,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed property and category pages sometimes reporting the wrong Semantic MediaWiki protection status, where a page's change-propagation lock and its "Is edit protected" status could be confused for one another ([#4344](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4344))
 * Fixed property and category pages sometimes remaining permanently locked for a change propagation update even when no such update was pending, leaving them uneditable; affected pages are editable again, and routine category changes such as setting a parent category no longer trigger the lock ([#4344](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4344))
 * Fixed change propagation failing to complete for a property or category connected to a very large number of pages, where selecting the affected pages could exhaust the available memory ([#4344](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4344))
+* Fixed the `templatefile` result format leaving templates unexpanded in the downloaded file, and the PHP deprecation notice that corrupted it ([#7055](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7055))
 
 ## Upgrading
 

--- a/src/Parser/RecursiveTextProcessor.php
+++ b/src/Parser/RecursiveTextProcessor.php
@@ -190,7 +190,7 @@ class RecursiveTextProcessor {
 	 */
 	public function recursivePreprocess( $text ): string {
 		// not during parsing, no preprocessing needed, still protect the result
-		if ( !$this->parser || !$this->parser->getOptions() || !$this->parser->getPage() ) {
+		if ( $this->parser->getOptions() === null ) {
 			return $this->recursiveAnnotation ? $text : '[[SMW::off]]' . $text . '[[SMW::on]]';
 		}
 
@@ -226,7 +226,7 @@ class RecursiveTextProcessor {
 	 */
 	public function recursiveTagParse( $text ) {
 		$this->recursionDepth++;
-		$isValid = $this->parser->getOptions() && $this->parser->getPage();
+		$isValid = $this->parser->getOptions() !== null;
 
 		if ( $this->recursionDepth <= $this->maxRecursionDepth && $isValid ) {
 			$text = $this->parser->recursiveTagParse( $text );

--- a/tests/phpunit/Integration/Parser/RecursiveTextProcessorIntegrationTest.php
+++ b/tests/phpunit/Integration/Parser/RecursiveTextProcessorIntegrationTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace SMW\Tests\Integration\Parser;
+
+use MediaWiki\MediaWikiServices;
+use MediaWiki\Parser\Parser;
+use PHPUnit\Framework\TestCase;
+use SMW\MediaWiki\Template\TemplateExpander;
+use SMW\Parser\RecursiveTextProcessor;
+
+/**
+ * @covers \SMW\Parser\RecursiveTextProcessor
+ * @group semantic-mediawiki
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.2.1
+ */
+class RecursiveTextProcessorIntegrationTest extends TestCase {
+
+	public function testRecursivePreprocessExpandsTextOnAParserPrimedWithoutAPage() {
+		$parser = $this->newParserPrimedWithoutAPage();
+
+		$instance = new RecursiveTextProcessor( $parser );
+		$instance->uniqid();
+
+		$this->assertSame(
+			'[[SMW::off]]5[[SMW::on]]',
+			$instance->recursivePreprocess( '{{formatnum:5}}' )
+		);
+	}
+
+	/**
+	 * A file export runs its templates through TemplateExpander, which feeds the
+	 * parser's own placeholder title back into Parser::preprocess. That sets the
+	 * parser options while leaving the page unset, which is the state issue #7055
+	 * was reported against.
+	 */
+	private function newParserPrimedWithoutAPage(): Parser {
+		$parser = MediaWikiServices::getInstance()->getParserFactory()->create();
+
+		( new TemplateExpander( $parser ) )->expand( 'Foo' );
+
+		$this->assertNotNull(
+			$parser->getOptions(),
+			'expected TemplateExpander to have set the parser options'
+		);
+
+		$this->assertTrue(
+			$parser->getTitle()->isSpecial( 'Badtitle' ),
+			'expected the parser to be left without a page'
+		);
+
+		return $parser;
+	}
+
+}

--- a/tests/phpunit/Unit/Parser/RecursiveTextProcessorTest.php
+++ b/tests/phpunit/Unit/Parser/RecursiveTextProcessorTest.php
@@ -4,7 +4,6 @@ namespace SMW\Tests\Unit\Parser;
 
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\ParserOutput;
-use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
 use SMW\Parser\RecursiveTextProcessor;
 use SMW\ParserData;
@@ -23,7 +22,6 @@ class RecursiveTextProcessorTest extends TestCase {
 	private $parser;
 	private $parserOptions;
 	private $parserOutput;
-	private $title;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -43,10 +41,6 @@ class RecursiveTextProcessorTest extends TestCase {
 		$this->parserOutput->expects( $this->any() )
 			->method( 'getHeadItems' )
 			->willReturn( [] );
-
-		$this->title = $this->getMockBuilder( Title::class )
-			->disableOriginalConstructor()
-			->getMock();
 	}
 
 	public function testCanConstruct() {
@@ -57,10 +51,6 @@ class RecursiveTextProcessorTest extends TestCase {
 	}
 
 	public function testRecursivePreprocess_NO_RecursiveAnnotation() {
-		$this->parser->expects( $this->atLeastOnce() )
-			->method( 'getPage' )
-			->willReturn( $this->title );
-
 		$this->parser->expects( $this->atLeastOnce() )
 			->method( 'getOptions' )
 			->willReturn( $this->parserOptions );
@@ -91,10 +81,6 @@ class RecursiveTextProcessorTest extends TestCase {
 			->willReturn( $this->parserOutput );
 
 		$this->parser->expects( $this->atLeastOnce() )
-			->method( 'getPage' )
-			->willReturn( $this->title );
-
-		$this->parser->expects( $this->atLeastOnce() )
 			->method( 'getOptions' )
 			->willReturn( $this->parserOptions );
 
@@ -121,10 +107,6 @@ class RecursiveTextProcessorTest extends TestCase {
 			->willReturn( $this->parserOutput );
 
 		$this->parser->expects( $this->atLeastOnce() )
-			->method( 'getPage' )
-			->willReturn( $this->title );
-
-		$this->parser->expects( $this->atLeastOnce() )
 			->method( 'getOptions' )
 			->willReturn( $this->parserOptions );
 
@@ -146,10 +128,6 @@ class RecursiveTextProcessorTest extends TestCase {
 	}
 
 	public function testRecursivePreprocess_WITH_RecursiveAnnotation() {
-		$this->parser->expects( $this->atLeastOnce() )
-			->method( 'getPage' )
-			->willReturn( $this->title );
-
 		$this->parser->expects( $this->atLeastOnce() )
 			->method( 'getOptions' )
 			->willReturn( $this->parserOptions );
@@ -191,11 +169,27 @@ class RecursiveTextProcessorTest extends TestCase {
 		);
 	}
 
-	public function testRecursiveTagParse() {
+	public function testRecursivePreprocessExpandsTemplatesWhenParserHasNoPageContext() {
 		$this->parser->expects( $this->atLeastOnce() )
-			->method( 'getPage' )
-			->willReturn( $this->title );
+			->method( 'getOptions' )
+			->willReturn( $this->parserOptions );
 
+		$this->parser->expects( $this->once() )
+			->method( 'replaceVariables' )
+			->with( '{{Foo}}' )
+			->willReturn( 'Expanded' );
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$this->assertSame(
+			'[[SMW::off]]Expanded[[SMW::on]]',
+			$instance->recursivePreprocess( '{{Foo}}' )
+		);
+	}
+
+	public function testRecursiveTagParse() {
 		$this->parser->expects( $this->atLeastOnce() )
 			->method( 'getOptions' )
 			->willReturn( $this->parserOptions );
@@ -228,6 +222,29 @@ class RecursiveTextProcessorTest extends TestCase {
 		$instance->recursiveTagParse( 'Foo' );
 	}
 
+	public function testRecursiveTagParseUsesTheParserWhenParserHasNoPageContext() {
+		$this->parser->expects( $this->atLeastOnce() )
+			->method( 'getOptions' )
+			->willReturn( $this->parserOptions );
+
+		$this->parser->expects( $this->once() )
+			->method( 'recursiveTagParse' )
+			->with( '{{Foo}}' )
+			->willReturn( 'Expanded' );
+
+		$this->parser->expects( $this->never() )
+			->method( 'parse' );
+
+		$instance = new RecursiveTextProcessor(
+			$this->parser
+		);
+
+		$this->assertSame(
+			'Expanded',
+			$instance->recursiveTagParse( '{{Foo}}' )
+		);
+	}
+
 	public function testExpandTemplate() {
 		$this->parser->expects( $this->once() )
 			->method( 'preprocess' )
@@ -241,10 +258,6 @@ class RecursiveTextProcessorTest extends TestCase {
 	}
 
 	public function testRecursivePreprocess_ExceededRecursion() {
-		$this->parser->expects( $this->atLeastOnce() )
-			->method( 'getPage' )
-			->willReturn( $this->title );
-
 		$this->parser->expects( $this->atLeastOnce() )
 			->method( 'getOptions' )
 			->willReturn( $this->parserOptions );


### PR DESCRIPTION
Fixes https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7055

`RecursiveTextProcessor` bails out of preprocessing when the parser it was handed has no page context. That
happens whenever a query is resolved outside a page parse, for example a `templatefile` download from
`Special:Ask`, because `ResultPrinter::copyParser()` hands out the shared main parser and `TemplateExpander`
primes it with the `Special:Badtitle/Missing` placeholder. Template calls come back unexpanded, and a
`Parser::getPage without a Title set` deprecation notice is written into the response body, which corrupts
file downloads.

That clause has only been live since #6735. It was written as `!$this->parser->getTitle()`, and
`Parser::getTitle()` has a non-nullable `Title` return type across the whole supported MediaWiki range, so it
was always false. #6735 was right that the condition was impossible, but replaced it with
`!$this->parser->getPage()` rather than removing it, which turned a dead branch into a live one.

Removing the clause leaves the parser options check that has been doing the real work all along, and restores
the behaviour of 6.0.1 and every release before it. The leading `!$this->parser` test goes with it, since the
property is typed `Parser` and always assigned in the constructor. Only the export path changes; rendering a
query on a page, and `format=template` on `Special:Ask`, produce identical output before and after.

The unit tests pin the guard condition, and the integration test pins the state it exists for by priming a
real parser through `TemplateExpander` exactly as the file export does. Both fail without the production
change.

This removes the notice SMW itself was emitting, but expansion on a page-less parser can still reach
`Parser::addTrackingCategory()` and `Parser::msg()`, which call `Parser::getPage()` unconditionally, so
content that trips a tracking category or a parser limit still produces the same notice from core.
`ResultPrinter::copyParser()` returning the wiki's shared main parser is the underlying defect and is left
for a separate change.

Supersedes #7072, which removes the notice by reading the page through the deprecated `Parser::getTitle()`
accessor but leaves the branch live, so templates stay unexpanded. Thanks to @jaideraf for the report and for
tracking the notice down to the accessor.

