### PR TITLE
Make Elasticsearch sort keys independent of the indexing path

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.1.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.1.md
@@ -12,10 +12,16 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed property and category pages sometimes reporting the wrong Semantic MediaWiki protection status, where a page's change-propagation lock and its "Is edit protected" status could be confused for one another ([#4344](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4344))
 * Fixed property and category pages sometimes remaining permanently locked for a change propagation update even when no such update was pending, leaving them uneditable; affected pages are editable again, and routine category changes such as setting a parent category no longer trigger the lock ([#4344](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4344))
 * Fixed change propagation failing to complete for a property or category connected to a very large number of pages, where selecting the affected pages could exhaust the available memory ([#4344](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4344))
+* Fixed Elasticsearch and OpenSearch queries sorted by a Page-datatype property returning results in several independently sorted blocks ([#7079](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7079))
+* Fixed Elasticsearch and OpenSearch sort keys losing characters on wikis that set `$smwgEntityCollation` to a `uca-*` value, which made entries that differ only in a number sort as if that number were absent ([#7079](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7079))
 
 ## Upgrading
 
-No need to run "update.php" or any other migration scripts.
+No need to run "update.php".
+
+Wikis using Elasticsearch or OpenSearch should run `php maintenance/run.php SemanticMediaWiki:rebuildElasticIndex --only-update` once after upgrading, so that documents indexed before the upgrade are rewritten with the corrected sort keys. It re-indexes in place, without creating new indices or a rollover. Until it has run, the sorting problems listed above persist for every page that is not edited in the meantime.
+
+Note that sorting by a Page-datatype property now orders by the value page's name on Elasticsearch and OpenSearch. Where a value page sets `{{DEFAULTSORT:}}`, results that were last indexed by `rebuildElasticIndex` ordered by that sort key instead, and will change position. The storage back-end continues to order by the sort key.
 
 **Get the new version via Composer:**
 

--- a/src/Elastic/Indexer/DocumentCreator.php
+++ b/src/Elastic/Indexer/DocumentCreator.php
@@ -124,7 +124,7 @@ class DocumentCreator {
 		);
 
 		$data = [
-			'subject' => $this->makeSubject( $subject )
+			'subject' => $this->makeSubject( $subject, $subject->getSortKey() )
 		];
 
 		$rev_id = $semanticData->getExtensionData( 'revision_id' );
@@ -202,16 +202,22 @@ class DocumentCreator {
 					$values["dat_raw"][] = $dataItem->getSerialization();
 				} elseif ( $type === DataItem::TYPE_WIKIPAGE ) {
 
+					[ $oid, $valueSortKey ] = $this->store->getObjectIds()->findIdAndSortKey( $dataItem );
+
 					// T:P0434 (reference, record chain sorting)
 					// Used for `compatibilityMode`
-					$values["$fieldType"][] = mb_convert_encoding( $dataItem->getSortKey(), 'UTF-8', 'UTF-8' );
-
-					$oid = (int)$this->store->getObjectIds()->getSMWPageID(
-						$dataItem->getDBKey(),
-						$dataItem->getNamespace(),
-						$dataItem->getInterwiki(),
-						$dataItem->getSubobjectName(),
-						true
+					//
+					// #7079 The readable title rather than `getSortKey()`. The
+					// parse path leaves the sort key of a value unset so it
+					// falls back to the DB key, while the SQLStore read path
+					// substitutes the collated `smw_sort` value. This field is
+					// copied to `text_copy` and backs `sort=<Page property>`, so
+					// it has to hold text, and it has to hold the same text no
+					// matter which path produced the data.
+					$values["$fieldType"][] = mb_convert_encoding(
+						str_replace( '_', ' ', $dataItem->getDBKey() ),
+						'UTF-8',
+						'UTF-8'
 					);
 
 					if ( !isset( $values["wpgID"] ) ) {
@@ -239,9 +245,18 @@ class DocumentCreator {
 					if ( !$document->hasSubDocumentById( $oid ) &&
 						$dataItem instanceof WikiPage
 					) {
-						$document->addSubDocument(
-							$this->newHead( $oid, $dataItem, Document::TYPE_UPSERT )
-						);
+						// #7079 This stub is merged into the referenced page's own
+						// document, so its sort key has to be the one the store
+						// recorded for that page. Where the store has none, fall
+						// back to the page name rather than to the referencing
+						// item, whose sort key depends on the path that produced
+						// the data.
+						$document->addSubDocument( $this->newHead(
+							$oid,
+							$dataItem,
+							$valueSortKey !== '' ? $valueSortKey : str_replace( '_', ' ', $dataItem->getDBKey() ),
+							Document::TYPE_UPSERT
+						) );
 					}
 				} elseif ( $type === DataItem::TYPE_BLOB ) {
 
@@ -278,31 +293,31 @@ class DocumentCreator {
 		return $document;
 	}
 
-	private function newHead( int $id, WikiPage $subject, string $type ): Document {
-		return new Document( $id, [ 'subject' => $this->makeSubject( $subject ) ], $type );
+	private function newHead( int $id, WikiPage $subject, string $sortKey, string $type ): Document {
+		return new Document( $id, [ 'subject' => $this->makeSubject( $subject, $sortKey ) ], $type );
 	}
 
-	private function makeSubject( WikiPage $subject ): array {
+	private function makeSubject( WikiPage $subject, string $sortKey ): array {
 		$title = $subject->getDBKey();
 
 		if ( $subject->getNamespace() !== SMW_NS_PROPERTY || !str_starts_with( $title ?? '', '_' ) ) {
 			$title = str_replace( '_', ' ', $title );
 		}
 
-		$sort = $subject->getSortKey();
-		$sort = Collator::singleton()->getSortKey( $sort );
+		// #7079 Armoring keeps the collated key valid UTF-8 while preserving its
+		// order. It replaces a raw sort key whose non-UTF-8 bytes the conversion
+		// below turned into `?`, collapsing distinct `uca-*` keys onto each other
+		// and dropping their numeric component from the ordering. The `sort`
+		// option is no longer consulted: only the SQLStore read path sets it, and
+		// it already holds a collated value.
+		//
+		// `str_replace` mirrors `WikiPage::setSortKey` and is idempotent, so a
+		// sort key taken straight from `smw_sortkey` is normalised the same way
+		// as one that passed through the data item.
+		$sort = Collator::singleton()->armoredSortKey( str_replace( '_', ' ', $sortKey ) );
 
-		// Use collated sort field if available
-		if ( $subject->getOption( 'sort', '' ) !== '' ) {
-			$sort = $subject->getOption( 'sort' );
-		}
-
-		// This may loose some non valif UTF-8 characters as it is required by ES
-		// to be strict UTF-8 otherwise the ES indexer will fail with a serialization
-		// error because ES only allows UTF-8 but when the collator applies something
-		// like `uca-default-u-kn` it can produce characters not valid for/by
-		// ES hence the sorting compared to the SQLStore will be different (given
-		// the DB stores the byte representation)
+		// Elasticsearch rejects a document that is not strict UTF-8, and a
+		// collation is free to emit anything
 		$sort = mb_convert_encoding( $sort, 'UTF-8', 'UTF-8' );
 
 		return [

--- a/src/Elastic/Indexer/Indexer.php
+++ b/src/Elastic/Indexer/Indexer.php
@@ -293,24 +293,17 @@ class Indexer {
 	private function makeSubject( WikiPage $subject ): array {
 		$title = $subject->getDBKey();
 
-		if ( $subject->getNamespace() !== SMW_NS_PROPERTY || $title[0] !== '_' ) {
+		if ( $subject->getNamespace() !== SMW_NS_PROPERTY || !str_starts_with( $title ?? '', '_' ) ) {
 			$title = str_replace( '_', ' ', $title );
 		}
 
-		$sort = $subject->getSortKey();
-		$sort = Collator::singleton()->getSortKey( $sort );
+		// #7079 Keep in step with `DocumentCreator::makeSubject`: `create`
+		// replaces the whole document, so a value derived differently here would
+		// undo what `DocumentCreator` wrote.
+		$sort = Collator::singleton()->armoredSortKey( $subject->getSortKey() );
 
-		// Use collated sort field if available
-		if ( $subject->getOption( 'sort', '' ) !== '' ) {
-			$sort = $subject->getOption( 'sort' );
-		}
-
-		// This may loose some non valif UTF-8 characters as it is required by ES
-		// to be strict UTF-8 otherwise the ES indexer will fail with a serialization
-		// error because ES only allows UTF-8 but when the collator applies something
-		// like `uca-default-u-kn` it can produce characters not valid for/by
-		// ES hence the sorting compared to the SQLStore will be different (given
-		// the DB stores the byte representation)
+		// Elasticsearch rejects a document that is not strict UTF-8, and a
+		// collation is free to emit anything
 		$sort = mb_convert_encoding( $sort, 'UTF-8', 'UTF-8' );
 
 		return [

--- a/src/MediaWiki/Collator.php
+++ b/src/MediaWiki/Collator.php
@@ -71,10 +71,21 @@ class Collator {
 	/**
 	 * @since 3.0
 	 *
-	 * The output could be a binary string, it can be armored with the method `armor`.
+	 * The output could be a binary string, it can be armored with the method
+	 * `armor`. Input the collation cannot process is returned unchanged.
 	 */
 	public function getSortKey( string $text ): string {
-		return $this->collation->getSortKey( $text );
+		$sortKey = $this->collation->getSortKey( $text );
+
+		// `IcuCollation` delegates to intl, which returns `false` for input it
+		// cannot convert to UTF-16 — most notably a sort key it produced itself.
+		// Without weak mode coercing that to an empty string, every affected
+		// entity would compare equal to every other one.
+		if ( $sortKey === false ) {
+			return $text;
+		}
+
+		return $sortKey;
 	}
 
 	/**
@@ -108,7 +119,9 @@ class Collator {
 	 * @since 3.0
 	 */
 	public function isIdentical( string $old, string $new ): bool {
-		return $this->collation->getSortKey( $old ) === $this->collation->getSortKey( $new );
+		// Through `getSortKey` so that input the collation rejects compares on
+		// its own text instead of every such value comparing equal
+		return $this->getSortKey( $old ) === $this->getSortKey( $new );
 	}
 
 }

--- a/src/SQLStore/EntityStore/EntityIdManager.php
+++ b/src/SQLStore/EntityStore/EntityIdManager.php
@@ -545,6 +545,31 @@ class EntityIdManager {
 	}
 
 	/**
+	 * The ID of an entity together with the `smw_sortkey` recorded for it,
+	 * without creating an ID for an entity that has none. Callers that need
+	 * both get them from the single lookup `getSMWPageID` already performs.
+	 *
+	 * @since 7.2.1
+	 *
+	 * @return array{0:int,1:string} ID (0 when unknown) and sort key
+	 */
+	public function findIdAndSortKey( WikiPage $dataItem, bool $canonical = true ): array {
+		$sortKey = '';
+
+		$id = $this->getSMWPageIDandSort(
+			$dataItem->getDBKey(),
+			$dataItem->getNamespace(),
+			$dataItem->getInterwiki(),
+			$dataItem->getSubobjectName(),
+			$sortKey,
+			$canonical
+		);
+
+		// A cache miss leaves the by-reference sort key as `false`
+		return [ $id, is_string( $sortKey ) ? $sortKey : '' ];
+	}
+
+	/**
 	 * Find the numeric ID used for the page of the given title, namespace,
 	 * interwiki, and subobjectName. If $canonical is set to true,
 	 * redirects are taken into account to find the canonical alias ID for

--- a/tests/phpunit/Unit/Elastic/Indexer/DocumentCreatorTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/DocumentCreatorTest.php
@@ -28,11 +28,21 @@ use SMW\SQLStore\SQLStore;
 class DocumentCreatorTest extends TestCase {
 
 	private $store;
+	private string $entityCollation;
 
 	protected function setUp(): void {
 		$this->store = $this->getMockBuilder( SQLStore::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		// The indexed sort key depends on the collation, so pin it instead of
+		// inheriting whatever the wiki running the suite happens to configure
+		$this->entityCollation = $GLOBALS['smwgEntityCollation'];
+		$GLOBALS['smwgEntityCollation'] = 'identity';
+	}
+
+	protected function tearDown(): void {
+		$GLOBALS['smwgEntityCollation'] = $this->entityCollation;
 	}
 
 	public function testCanConstruct() {
@@ -64,6 +74,10 @@ class DocumentCreatorTest extends TestCase {
 		$entityIdManager->expects( $this->any() )
 			->method( 'getSMWPageID' )
 			->willReturn( 42 );
+
+		$entityIdManager->expects( $this->any() )
+			->method( 'findIdAndSortKey' )
+			->willReturn( [ 42, 'Duck, Donald' ] );
 
 		$entityIdManager->expects( $this->any() )
 			->method( 'getSMWPropertyID' )
@@ -130,6 +144,10 @@ class DocumentCreatorTest extends TestCase {
 			->willReturn( 42 );
 
 		$entityIdManager->expects( $this->any() )
+			->method( 'findIdAndSortKey' )
+			->willReturn( [ 42, 'Duck, Donald' ] );
+
+		$entityIdManager->expects( $this->any() )
 			->method( 'getSMWPropertyID' )
 			->willReturn( 1001 );
 
@@ -184,6 +202,10 @@ class DocumentCreatorTest extends TestCase {
 			->willReturn( 42 );
 
 		$entityIdManager->expects( $this->any() )
+			->method( 'findIdAndSortKey' )
+			->willReturn( [ 42, 'Duck, Donald' ] );
+
+		$entityIdManager->expects( $this->any() )
 			->method( 'getSMWPropertyID' )
 			->willReturn( 1001 );
 
@@ -218,6 +240,191 @@ class DocumentCreatorTest extends TestCase {
 			Document::class,
 			$instance->newFromSemanticData( $semanticData )
 		);
+	}
+
+	/**
+	 * The parse path (page save) leaves a page value's sort key unset, so it
+	 * falls back to the DB key, while the SQLStore read path replaces it with
+	 * the collated `smw_sort` value. The indexed field has to be the same
+	 * either way, otherwise `sort=<Page property>` orders one half of the index
+	 * against the other. See #7079.
+	 */
+	public function testPageValueFieldDoesNotDependOnHowSemanticDataWasProduced() {
+		$fromParse = WikiPage::newFromText( 'Donald Duck 1998 01' );
+
+		$fromStore = WikiPage::newFromText( 'Donald Duck 1998 01' );
+		$fromStore->setSortKey( 'CKT5Aq4n135JBpy445EK11040HC1tC3S2m' );
+
+		$this->assertSame(
+			[ 'Donald Duck 1998 01' ],
+			$this->newDocument( $fromParse )->getData()['P:1001']['wpgField']
+		);
+
+		$this->assertSame(
+			$this->newDocument( $fromParse )->getData()['P:1001']['wpgField'],
+			$this->newDocument( $fromStore )->getData()['P:1001']['wpgField']
+		);
+	}
+
+	/**
+	 * `IdEntityFinder` carries the already collated `smw_sort` value as a `sort`
+	 * option, so preferring it produced a different encoding from the freshly
+	 * collated one used on the parse path. See #7079.
+	 */
+	public function testSubjectSortKeyDoesNotDependOnHowSemanticDataWasProduced() {
+		$fromParse = WikiPage::newFromText( 'Foo' );
+		$fromParse->setSortKey( 'Duck, Donald' );
+
+		$fromStore = WikiPage::newFromText( 'Foo' );
+		$fromStore->setSortKey( 'Duck, Donald' );
+		$fromStore->setOption( 'sort', 'CKT5Aq4n135JBpy445EK11040HC1tC3S2m' );
+
+		$value = WikiPage::newFromText( 'Bar' );
+
+		$this->assertSame(
+			'Duck, Donald',
+			$this->newDocument( $value, $fromParse )->getData()['subject']['sortkey']
+		);
+
+		$this->assertSame(
+			$this->newDocument( $value, $fromParse )->getData()['subject']['sortkey'],
+			$this->newDocument( $value, $fromStore )->getData()['subject']['sortkey']
+		);
+	}
+
+	/**
+	 * A `uca-*` collation emits a binary sort key whose bytes are not valid
+	 * UTF-8 on their own. Passing it through `mb_convert_encoding` replaced
+	 * those bytes with `?` and collapsed distinct keys onto each other, which
+	 * silently dropped the numeric component from the ordering. See #7079.
+	 */
+	public function testSubjectSortKeysStayDistinctAndOrderedUnderAUcaCollation() {
+		if ( !extension_loaded( 'intl' ) ) {
+			$this->markTestSkipped( 'Skipping because intl (ICU) is not available.' );
+		}
+
+		$GLOBALS['smwgEntityCollation'] = 'uca-default-u-kn';
+		$sortKeys = [];
+
+		foreach ( [ '2000', '1998', '1999' ] as $year ) {
+			$sortKeys[$year] = $this->newDocument(
+				WikiPage::newFromText( 'Bar' ),
+				WikiPage::newFromText( "Donald Duck 01 ($year)" )
+			)->getData()['subject']['sortkey'];
+		}
+
+		// Guards the collapse itself: mangling made all three byte-identical,
+		// and an ordering assertion alone passes on three equal values
+		$this->assertCount( 3, array_unique( $sortKeys ) );
+
+		$sorted = array_values( $sortKeys );
+		sort( $sorted, SORT_STRING );
+
+		$this->assertSame(
+			[ $sortKeys['1998'], $sortKeys['1999'], $sortKeys['2000'] ],
+			$sorted
+		);
+	}
+
+	/**
+	 * The stub document is merged into the referenced page's own document, so
+	 * the two have to agree on the sort key rather than merely happening to
+	 * produce the same value from different sources. See #7079.
+	 */
+	public function testUpsertHeadAndOwnDocumentAgreeOnTheSortKey() {
+		$subject = WikiPage::newFromText( 'Bar' );
+		$subject->setSortKey( 'Duck, Donald' );
+
+		$ownDocument = $this->newDocument( WikiPage::newFromText( 'Irrelevant' ), $subject );
+		$head = $this->newDocument( WikiPage::newFromText( 'Bar' ) )->getSubDocumentById( 42 );
+
+		$this->assertSame(
+			$ownDocument->getData()['subject']['sortkey'],
+			$head->getData()['subject']['sortkey']
+		);
+	}
+
+	/**
+	 * Without a recorded sort key the stub must not fall back to the sort key of
+	 * the item that referenced it, which is the page title on the parse path and
+	 * the collated value on the SQLStore read path. See #7079.
+	 */
+	public function testUpsertHeadFallsBackToThePageNameWhenTheStoreHasNoSortKey() {
+		$value = WikiPage::newFromText( 'Bar' );
+		$value->setSortKey( 'CKT5Aq4n135JBpy445EK11040HC1tC3S2m' );
+
+		$document = $this->newDocument( $value, null, [ 42, '' ] );
+
+		$this->assertSame(
+			'Bar',
+			$document->getSubDocumentById( 42 )->getData()['subject']['sortkey']
+		);
+	}
+
+	/**
+	 * The stub document created for a page that is only referenced as a value
+	 * is merged into that page's own document, so it has to carry the sort key
+	 * the store recorded for that page rather than one derived from the
+	 * referencing annotation. See #7079.
+	 */
+	public function testUpsertHeadCarriesTheStoredSortKeyOfTheReferencedPage() {
+		$value = WikiPage::newFromText( 'Bar' );
+		$value->setSortKey( 'CKT5Aq4n135JBpy445EK11040HC1tC3S2m' );
+
+		$document = $this->newDocument( $value );
+
+		$this->assertSame(
+			'Duck, Donald',
+			$document->getSubDocumentById( 42 )->getData()['subject']['sortkey']
+		);
+	}
+
+	private function newDocument( WikiPage $value, ?WikiPage $subject = null, ?array $idAndSortKey = null ): Document {
+		$subject ??= WikiPage::newFromText( 'Foo' );
+		$property = new Property( 'FooProp' );
+
+		$entityIdManager = $this->getMockBuilder( EntityIdManager::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$entityIdManager->expects( $this->any() )
+			->method( 'getSMWPageID' )
+			->willReturn( 42 );
+
+		$entityIdManager->expects( $this->any() )
+			->method( 'findIdAndSortKey' )
+			->willReturn( $idAndSortKey ?? [ 42, 'Duck, Donald' ] );
+
+		$entityIdManager->expects( $this->any() )
+			->method( 'getSMWPropertyID' )
+			->willReturn( 1001 );
+
+		$this->store->expects( $this->any() )
+			->method( 'getObjectIds' )
+			->willReturn( $entityIdManager );
+
+		$semanticData = $this->getMockBuilder( SemanticData::class )
+			->setConstructorArgs( [ $subject ] )
+			->getMock();
+
+		$semanticData->expects( $this->any() )
+			->method( 'getSubject' )
+			->willReturn( $subject );
+
+		$semanticData->expects( $this->any() )
+			->method( 'getProperties' )
+			->willReturn( [ $property ] );
+
+		$semanticData->expects( $this->any() )
+			->method( 'getPropertyValues' )
+			->with( $property )
+			->willReturn( [ $value ] );
+
+		$semanticData->expects( $this->any() )
+			->method( 'getSubSemanticData' )
+			->willReturn( [] );
+
+		return ( new DocumentCreator( $this->store ) )->newFromSemanticData( $semanticData );
 	}
 
 	public function dataItemsProvider() {

--- a/tests/phpunit/Unit/Elastic/Indexer/IndexerTest.php
+++ b/tests/phpunit/Unit/Elastic/Indexer/IndexerTest.php
@@ -35,6 +35,7 @@ class IndexerTest extends TestCase {
 	private $testEnvironment;
 	private TitleFactory $titleFactory;
 	private RevisionLookup $revisionLookup;
+	private string $entityCollation;
 
 	protected function setUp(): void {
 		$this->testEnvironment = new TestEnvironment();
@@ -80,9 +81,15 @@ class IndexerTest extends TestCase {
 		$this->revisionLookup = $this->getMockBuilder( RevisionLookup::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		// The indexed sort key depends on the collation, so pin it instead of
+		// inheriting whatever the wiki running the suite happens to configure
+		$this->entityCollation = $GLOBALS['smwgEntityCollation'];
+		$GLOBALS['smwgEntityCollation'] = 'identity';
 	}
 
 	protected function tearDown(): void {
+		$GLOBALS['smwgEntityCollation'] = $this->entityCollation;
 		$this->testEnvironment->tearDown();
 		parent::tearDown();
 	}
@@ -122,6 +129,43 @@ class IndexerTest extends TestCase {
 		$this->connection->expects( $this->once() )
 			->method( 'index' )
 			->with( $expected )
+			->willReturn( true );
+
+		$instance = new Indexer(
+			$this->store,
+			$this->bulk,
+			$this->titleFactory,
+			$this->revisionLookup
+		);
+
+		$instance->setLogger( $this->logger );
+		$instance->create( $subject, [] );
+	}
+
+	/**
+	 * `create` replaces the whole document, so it has to derive the sort key the
+	 * same way `DocumentCreator` does. Preferring the already collated `sort`
+	 * option set by the SQLStore read path made the two disagree. See #7079.
+	 */
+	public function testCreateIgnoresTheCollatedSortOptionSetByTheSqlReadPath() {
+		$subject = WikiPage::newFromText( 'Foo' );
+		$subject->setId( 42 );
+		$subject->setOption( 'sort', 'CKT5Aq4n135JBpy445EK11040HC1tC3S2m' );
+
+		$this->connection->expects( $this->any() )
+			->method( 'ping' )
+			->willReturn( true );
+
+		$this->connection->expects( $this->any() )
+			->method( 'getIndexName' )
+			->with( 'data' )
+			->willReturn( '_index_abc' );
+
+		$this->connection->expects( $this->once() )
+			->method( 'index' )
+			->with( $this->callback(
+				static fn ( array $params ) => $params['body']['subject']['sortkey'] === 'Foo'
+			) )
 			->willReturn( true );
 
 		$instance = new Indexer(

--- a/tests/phpunit/Unit/MediaWiki/CollatorTest.php
+++ b/tests/phpunit/Unit/MediaWiki/CollatorTest.php
@@ -148,6 +148,28 @@ class CollatorTest extends TestCase {
 	}
 
 	/**
+	 * ICU rejects input it cannot convert to UTF-16, notably a sort key it
+	 * produced itself. Returning the untouched input keeps such a value
+	 * comparable instead of collapsing every affected entity onto the empty
+	 * string.
+	 *
+	 * @see https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7079
+	 */
+	public function testSortKeyFallsBackToTheInputWhenTheCollationRejectsIt() {
+		if ( !extension_loaded( 'intl' ) ) {
+			$this->markTestSkipped( 'Skipping because intl (ICU) is not available.' );
+		}
+
+		$instance = Collator::singleton( 'uca-default' );
+		$sortKey = $instance->getSortKey( 'Has type' );
+
+		$this->assertSame(
+			$sortKey,
+			$instance->getSortKey( $sortKey )
+		);
+	}
+
+	/**
 	 * For non-binary collations (identity/uppercase/numeric) the sort key is
 	 * already valid text, so armoring is a no-op and the value is unchanged.
 	 */

--- a/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityIdManagerTest.php
@@ -320,6 +320,43 @@ class EntityIdManagerTest extends TestCase {
 	}
 
 	/**
+	 * The Elasticsearch indexer needs an entity's recorded sort key alongside
+	 * its ID, and must not mint an ID for an entity that has none. See #7079.
+	 */
+	public function testFindIdAndSortKeyReturnsTheRecordedSortKey() {
+		$selectRow = new stdClass;
+		$selectRow->smw_id = 9999;
+		$selectRow->smw_sort = '';
+		$selectRow->smw_sortkey = 'Duck, Donald';
+		$selectRow->smw_proptable_hash = serialize( 'Foo' );
+		$selectRow->smw_hash = '___hash___';
+
+		$qb = $this->createMockSelectQueryBuilder( [ $selectRow ] );
+		$this->connection->expects( $this->any() )
+			->method( 'newSelectQueryBuilder' )
+			->willReturn( $qb );
+
+		$instance = $this->newEntityIdManager();
+
+		$this->assertSame(
+			[ 9999, 'Duck, Donald' ],
+			$instance->findIdAndSortKey( new WikiPage( 'Foo', NS_MAIN ) )
+		);
+	}
+
+	private function newEntityIdManager(): EntityIdManager {
+		$store = $this->getMockBuilder( SQLStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->any() )
+			->method( 'getConnection' )
+			->willReturn( $this->connection );
+
+		return new EntityIdManager( $store, $this->factory, $this->settings );
+	}
+
+	/**
 	 * @dataProvider pageIdandSortProvider
 	 */
 	public function testMakeSMWPageID( $parameters ) {


### PR DESCRIPTION
Make Elasticsearch sort keys independent of the indexing path

Fixes https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7079

The document written for an entity depended on which code path produced its
SemanticData, so an index held several mutually incomparable encodings of the
same sort key at once. Results were returned in consecutive blocks, each
correctly sorted but starting over from the beginning, and a null edit moved a
page from one block to another.

Two fields diverged. `P:<pid>.wpgField`, which `sort=<Page property>` orders
on, was written from the value's `getSortKey()`: the parse path leaves that
unset so it fell back to the page name, while the SQLStore read path
substitutes the collated `smw_sort` value. It now always holds the page name.
That field is also copied to `text_copy` and is the match target for page
conditions, so it has to hold text; a collated key there cannot match. The
consequence is that Elasticsearch now orders such queries by the value page's
name rather than by its sort key, which is what the parse path has always
produced and what the release notes describe. Ordering by the collation key
needs a sort sub-field of its own, and with it a mapping change.

`subject.sortkey` was collated with `Collator::getSortKey()` and then passed
through `mb_convert_encoding()`, unless the SQLStore read path had supplied an
already collated value as a `sort` option. For a `uca-*` collation the raw key
is binary, so that conversion replaced its non-UTF-8 bytes with `?`. Under
`uca-default-u-kn` this destroys the weight of a multi-digit number while
leaving small numbers intact, which is why entries differing only in a year
sorted as if the year were absent. Both paths now use
`Collator::armoredSortKey()`, which is order preserving and, for every
collation other than `uca-*`, returns what the old expression returned.

The stub document created for a page that is only referenced as a value is
merged into that page's own document, where it had been overwriting the page's
own sort key on a last-writer-wins basis. It now carries the sort key the store
recorded, taken from the lookup that was already being performed, and falls
back to the page name rather than to the referencing item.

`Collator::getSortKey()` returned an empty string whenever intl rejected its
input, notably a sort key intl produced itself, collapsing the ordering of
every affected entity. It now falls back to the input, and `isIdentical()`
goes through it so the two cannot disagree.

Elasticsearch and OpenSearch users should run
`SemanticMediaWiki:rebuildElasticIndex --only-update` once, so documents
indexed before the upgrade are rewritten.

