### PR TITLE
Cap the length of the tooltip title attribute

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.1.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.1.md
@@ -13,6 +13,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed property and category pages sometimes remaining permanently locked for a change propagation update even when no such update was pending, leaving them uneditable; affected pages are editable again, and routine category changes such as setting a parent category no longer trigger the lock ([#4344](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4344))
 * Fixed change propagation failing to complete for a property or category connected to a very large number of pages, where selecting the affected pages could exhaust the available memory ([#4344](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/4344))
 * Fixed the `templatefile` result format leaving templates unexpanded in the downloaded file, and the PHP deprecation notice that corrupted it ([#7055](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7055))
+* Fixed pages with a very large tooltip failing to render with a `pcre.backtrack_limit exhausted` error; the tooltip's `title` attribute is now capped at 1024 characters, so readers without JavaScript see a truncated native tooltip ([#7076](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7076))
 
 ## Upgrading
 

--- a/src/Formatters/Highlighter.php
+++ b/src/Formatters/Highlighter.php
@@ -71,6 +71,14 @@ class Highlighter {
 	 */
 	const TYPE_REFERENCE = 10;
 
+	/**
+	 * Upper bound for the `title` attribute. A browser truncates the native
+	 * tooltip well before this, while an attribute that grows with the content
+	 * makes MediaWiki's HTML tidy step exhaust `pcre.backtrack_limit` and abort
+	 * the whole page (#7076).
+	 */
+	private const MAX_TITLE_LENGTH = 1024;
+
 	private ?array $options = null;
 
 	/**
@@ -343,11 +351,17 @@ class Highlighter {
 			$content = Message::get( [ 'smw-parse', $content ], Message::PARSE, $language );
 		}
 
-		return strip_tags(
+		$title = strip_tags(
 			htmlspecialchars_decode(
 				str_replace( [ "[", '&#160;', "&#10;", "\n", "&#39;", "'" ], [ "&#91;", ' ', '', '', '' ], $content ),
 			)
 		);
+
+		if ( mb_strlen( $title ) > self::MAX_TITLE_LENGTH ) {
+			$title = mb_substr( $title, 0, self::MAX_TITLE_LENGTH - 2 ) . ' …';
+		}
+
+		return $title;
 	}
 
 }

--- a/tests/phpunit/Unit/Formatters/HighlighterTest.php
+++ b/tests/phpunit/Unit/Formatters/HighlighterTest.php
@@ -92,6 +92,55 @@ class HighlighterTest extends TestCase {
 		);
 	}
 
+	public function testOversizedTitleIsTruncatedWithAnEllipsis() {
+		$this->assertSame(
+			str_repeat( 'a', 1022 ) . ' …',
+			$this->titleAttributeOf( $this->htmlForContent( str_repeat( 'a', 2000 ) ) )
+		);
+	}
+
+	public function testOversizedTitleIsTruncatedByCharactersNotBytes() {
+		$this->assertSame(
+			str_repeat( '日本語 ', 255 ) . '日本' . ' …',
+			$this->titleAttributeOf( $this->htmlForContent( str_repeat( '日本語 ', 500 ) ) )
+		);
+	}
+
+	public function testTitleAttributeKeepsShortContentIntact() {
+		$content = 'Property Foo has an invalid value.';
+
+		$this->assertSame(
+			$content,
+			$this->titleAttributeOf( $this->htmlForContent( $content ) )
+		);
+	}
+
+	public function testOversizedContentRemainsAvailableForTheTooltip() {
+		$content = str_repeat( 'lorem ipsum ', 50000 );
+
+		$this->assertStringContainsString(
+			'<span class="smwttcontent">' . $content . '</span>',
+			$this->htmlForContent( $content )
+		);
+	}
+
+	private function htmlForContent( string $content ): string {
+		$instance = Highlighter::factory( Highlighter::TYPE_TEXT );
+
+		$instance->setContent( [
+			'caption' => ' … ',
+			'content' => $content
+		] );
+
+		return $instance->getHtml();
+	}
+
+	private function titleAttributeOf( string $html ): string {
+		preg_match( '/ title="([^"]*)"/', $html, $matches );
+
+		return $matches[1] ?? '';
+	}
+
 	public function getTypeDataProvider() {
 		return [
 			[ '', Highlighter::TYPE_NOTYPE ],


### PR DESCRIPTION
For https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7076

`Highlighter` copied the entire tooltip content into the `title` attribute of the element it wraps, so the attribute grew with the content. A tooltip holding a large value, such as a long text value or a validation error quoting the offending input, produced an attribute of several hundred kilobytes.

MediaWiki's HTML tidy step tokenizes a quoted attribute value at a cost of one PCRE unit per character once the value contains an HTML entity, and SMW's messages quote the offending input, so the entity sits at the start of the value. Past roughly half a million characters the tokenizer exhausts `pcre.backtrack_limit` and the page fails to render. Output that reaches MediaWiki's sanitizer first is escaped instead, leaving the raw markup visible as text on the page.

The attribute serves readers without JavaScript, for whom a browser truncates the native tooltip well before this length anyway. Cap it at 1024 characters. Everyone else is unaffected: the tooltip renders from the element body, which is untouched.

## Why the attribute is expensive

Remex matches a quoted attribute value with

```
" ( [^"&\r\0]*+ ( (?: &(?:amp|apos|lt|gt|quot|nbsp); | [^"&\r\0] )*+ ) ( [^"]*+ ) ) "?
```

The cheap prefix stops at the first `&`. If that `&` begins one of those six entities, the middle group takes over and costs one PCRE match unit per character until the closing quote. `pcre.backtrack_limit` defaults to 1,000,000, and SMW's markup costs about two units per character of tooltip content.

`Highlighter::title()` is the single choke point: `{{#info:}}`, the validation errors from `smwfEncodeMessages()` and `MessageFormatter`, `StringValueFormatter`'s abbreviation of long text values, and property description tooltips all pass through it.

## Measured effect

Tokenizer cost of the HTML that `{{#set:Has text=…}}` produces, measured by bisecting the lowest `pcre.backtrack_limit` at which `RemexHtml\Tokenizer` completes:

| value length | before | after |
| --- | --- | --- |
| 100 KB | 200,374 | 2,062 |
| 400 KB | 800,372 | 2,062 |
| 600 KB | 1,200,374 | 2,062 |

Linear in the content before, constant after. The emitted HTML also halves for these pages, since the value is no longer written out twice.

## Notes for reviewers

- **Only reachable where PCRE JIT is not in use.** With JIT enabled the same markup survives 10 MB, which is why CI never sees this. The reporter's install evidently runs the interpreter.
- **Not a regression.** `git diff 6.0.1:includes/Highlighter.php 7.2.0:src/Formatters/Highlighter.php` is namespace and type-hint churn only. Filed as "For" rather than "Fixes" because the reporter's page is unknown, so it is worth their confirmation before closing.
- **Truncation uses `mb_substr` rather than `Normalizer::reduceLengthTo()`.** The helper computes its cut point with a byte offset from `strrpos()` and then passes it back as a character count, so it overshoots on multibyte input: asked for 1022 characters it returns 1852 for Cyrillic, 2793 for Japanese and 3314 for emoji. That is a separate bug in the helper, which `TextSanitizer` and `StringValueFormatter` also use; it is left alone here. `testOversizedTitleIsTruncatedByCharactersNotBytes` fails against the helper and passes against `mb_substr`.
- **No test at the tokenizer level.** Feeding the output to Remex would pass vacuously on a JIT-enabled CI, so the tests pin the attribute contract instead.

Considered, omitted: `TableResultPrinter` puts the full `_txt` sort key into `data-order` on every cell, and `ReferenceValueFormatter` builds its own `smw-highlighter` element with an uncapped `title` and `data-content`. Both are the same class of unbounded attribute and both reach the tokenizer without passing MediaWiki's sanitizer, but neither goes through `Highlighter`, and both need far more contrived content to matter. Better as separate changes.

## Verification

- New tests fail before the change and pass after
- Unit suite green: 7,369 tests, 14,979 assertions
- `composer analyze` clean, phan clean
- Browser check on MediaWiki 1.43: the tooltip still opens with its full content, the `title` attribute is removed by tippy on init as before, no console errors. A page carrying a 600 KB value, which renders the raw `<span class="smw-highlighter" …>` markup as visible text on master, now renders a normal tooltip icon.
