### PR TITLE
WikitextTemplateRenderer: guard against nullness

### DIFF
--- a/src/MediaWiki/Renderer/WikitextTemplateRenderer.php
+++ b/src/MediaWiki/Renderer/WikitextTemplateRenderer.php
@@ -36,10 +36,7 @@ class WikitextTemplateRenderer {
 		$this->template .= '{{' . $templateName;
 
 		foreach ( $this->fields as $key => $value ) {
-			if ( $value === null ) {
-				continue;
-			}
-			$this->template .= "\n|$key=" . str_replace( '|', '{{!}}', $value );
+			$this->template .= "\n|$key=" . str_replace( '|', '{{!}}', $value ?? "" );
 		}
 
 		$this->template .= '}}';

--- a/src/MediaWiki/Renderer/WikitextTemplateRenderer.php
+++ b/src/MediaWiki/Renderer/WikitextTemplateRenderer.php
@@ -36,6 +36,9 @@ class WikitextTemplateRenderer {
 		$this->template .= '{{' . $templateName;
 
 		foreach ( $this->fields as $key => $value ) {
+			if ( $value === null ) {
+				continue;
+			}
 			$this->template .= "\n|$key=" . str_replace( '|', '{{!}}', $value );
 		}
 


### PR DESCRIPTION
It appears that [Semantic Compound Queries](https://github.com/SemanticMediaWiki/SemanticCompoundQueries) may return `null` as a field value, causing PHP to emit a deprecation warning about `str_replace` not accepting types other than string/array as its third argument. 

This patch simply guards against `null` becoming an issue in the future and preserves current behaviour in that either an empty string value or `null` causes an empty template parameter (`|someKey=`) to be printed. (Not printing a template parameter at all may be cleaner, but that's up for discussion)
