### PR TITLE
Replace in-text annotations in foaf/owl property pages

### DIFF
--- a/data/import/properties/foaf.homepage.txt
+++ b/data/import/properties/foaf.homepage.txt
@@ -1,4 +1,4 @@
-* [[Imported from::foaf:homepage]]
-* [[Property description::URL of the homepage of something, which is a general web resource.@en]] 
+* {{#set: Imported from=foaf:homepage|+display}}
+* {{#set: Has property description=URL of the homepage of something, which is a general web resource.@en|+display}}
 
 [[Category:Imported vocabulary]] {{DISPLAYTITLE:foaf:homepage}}

--- a/data/import/properties/foaf.homepage.txt
+++ b/data/import/properties/foaf.homepage.txt
@@ -1,4 +1,4 @@
 * {{#set: Imported from=foaf:homepage|+display}}
-* {{#set: Has property description=URL of the homepage of something, which is a general web resource.@en|+display}}
+* {{#set: Property description=URL of the homepage of something, which is a general web resource.@en|+display}}
 
 [[Category:Imported vocabulary]] {{DISPLAYTITLE:foaf:homepage}}

--- a/data/import/properties/foaf.knows.txt
+++ b/data/import/properties/foaf.knows.txt
@@ -1,4 +1,4 @@
 * {{#set: Imported from=foaf:knows|+display}}
-* {{#set: Has property description=A person known by this person (indicating some level of reciprocated interaction between the parties).@en|+display}}
+* {{#set: Property description=A person known by this person (indicating some level of reciprocated interaction between the parties).@en|+display}}
 
 [[Category:Imported vocabulary]] {{DISPLAYTITLE:foaf:knows}}

--- a/data/import/properties/foaf.knows.txt
+++ b/data/import/properties/foaf.knows.txt
@@ -1,4 +1,4 @@
-* [[Imported from::foaf:knows]]
-* [[Property description::A person known by this person (indicating some level of reciprocated interaction between the parties).@en]]
+* {{#set: Imported from=foaf:knows|+display}}
+* {{#set: Has property description=A person known by this person (indicating some level of reciprocated interaction between the parties).@en|+display}}
 
 [[Category:Imported vocabulary]] {{DISPLAYTITLE:foaf:knows}}

--- a/data/import/properties/foaf.name.txt
+++ b/data/import/properties/foaf.name.txt
@@ -1,4 +1,4 @@
-* [[Imported from::foaf:name]]
-* [[Property description::A name for some thing or agent.@en]]
+* {{#set: Imported from=foaf:name|+display}}
+* {{#set: Has property description=A name for some thing or agent.@en|+display}}
 
 [[Category:Imported vocabulary]] {{DISPLAYTITLE:foaf:name}}

--- a/data/import/properties/foaf.name.txt
+++ b/data/import/properties/foaf.name.txt
@@ -1,4 +1,4 @@
 * {{#set: Imported from=foaf:name|+display}}
-* {{#set: Has property description=A name for some thing or agent.@en|+display}}
+* {{#set: Property description=A name for some thing or agent.@en|+display}}
 
 [[Category:Imported vocabulary]] {{DISPLAYTITLE:foaf:name}}

--- a/data/import/properties/owl.differentFrom.txt
+++ b/data/import/properties/owl.differentFrom.txt
@@ -1,4 +1,4 @@
 * {{#set: Imported from=owl:differentFrom|+display}}
-* {{#set: Has property description=The property that determines that two given individuals are different.@en|+display}}
+* {{#set: Property description=The property that determines that two given individuals are different.@en|+display}}
 
 [[Category:Imported vocabulary]] {{DISPLAYTITLE:owl:differentFrom}}

--- a/data/import/properties/owl.differentFrom.txt
+++ b/data/import/properties/owl.differentFrom.txt
@@ -1,4 +1,4 @@
-* [[Imported from::owl:differentFrom]]
-* [[Property description::The property that determines that two given individuals are different.@en]]
+* {{#set: Imported from=owl:differentFrom|+display}}
+* {{#set: Has property description=The property that determines that two given individuals are different.@en|+display}}
 
 [[Category:Imported vocabulary]] {{DISPLAYTITLE:owl:differentFrom}}


### PR DESCRIPTION
Given the uncertain future of in-text annotations in the long run, replace annotations with `#set`, using the new `+display` option to print a value representation.
