### PR TITLE
EntityLookup: cast inverse-property lookup result to array

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.1.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.1.md
@@ -16,6 +16,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed Elasticsearch and OpenSearch sort keys losing characters on wikis that set `$smwgEntityCollation` to a `uca-*` value, which made entries that differ only in a number sort as if that number were absent ([#7079](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7079))
 * Fixed the `templatefile` result format leaving templates unexpanded in the downloaded file, and the PHP deprecation notice that corrupted it ([#7055](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7055))
 * Fixed pages with a very large tooltip failing to render with a `pcre.backtrack_limit exhausted` error; the tooltip's `title` attribute is now capped at 1024 characters, so readers without JavaScript see a truncated native tooltip ([#7076](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7076))
+* Fixed a fatal error when a query asked for an inverse property, such as the `?-Has subobject` printout, which stopped the page from being saved or rendered ([#7092](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7092))
 
 ## Upgrading
 

--- a/src/EntityLookup.php
+++ b/src/EntityLookup.php
@@ -63,7 +63,7 @@ interface EntityLookup {
 	 * @param Property $property
 	 * @param RequestOptions|null $requestOptions
 	 *
-	 * @return DataItem[]|array|Iterator
+	 * @return DataItem[]
 	 */
 	public function getPropertyValues( ?WikiPage $subject, Property $property, ?RequestOptions $requestOptions = null );
 

--- a/src/SQLStore/EntityStore/EntityLookup.php
+++ b/src/SQLStore/EntityStore/EntityLookup.php
@@ -229,6 +229,14 @@ class EntityLookup implements IEntityLookup {
 		if ( $property->isInverse() ) { // inverses are working differently
 			$noninverse = new Property( $property->getKey(), false );
 			$result = $this->getPropertySubjects( $noninverse, $subject, $requestOptions );
+
+			// getPropertySubjects() may return a MappingIterator (e.g. when
+			// PropertySubjectsLookup::fetchFromTable() wraps its result, or
+			// SUSPEND_CACHE_WARMUP short-circuits before an array cast), but
+			// this method is typed to always return an array.
+			if ( !is_array( $result ) ) {
+				$result = iterator_to_array( $result );
+			}
 		} elseif ( $subject !== null ) { // subject given, use semantic data cache
 			$sortKey = '';
 			$sid = $idTable->getSMWPageIDandSort(

--- a/tests/phpunit/Unit/SQLStore/EntityStore/EntityLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/EntityLookupTest.php
@@ -228,11 +228,11 @@ class EntityLookupTest extends TestCase {
 		$instance->getPropertyValues( $subject, $property );
 	}
 
-	public function testGetPropertyValues_Property_Inverse_ReturnsArray_WhenLookupReturnsMappingIterator() {
+	public function testGetPropertyValues_Property_Inverse_ConvertsLookupIteratorToArray() {
 		// PropertySubjectsLookup::fetchFromTable() always wraps its result in a
-		// MappingIterator (see PropertySubjectsLookup::fetchFromTable), never a
-		// plain array. getPropertyValues() is typed `: array` and must convert
-		// the inverse-property branch's result before returning it.
+		// MappingIterator, never a plain array, while getPropertyValues() is
+		// typed `: array`. The inverse-property branch has to materialise the
+		// iterator, keeping the mapped items and their order intact.
 		$property = new Property( 'Bar', true );
 		$subject = new WikiPage( 'Foo', NS_MAIN );
 
@@ -254,7 +254,10 @@ class EntityLookupTest extends TestCase {
 
 		$this->propertySubjectsLookup->expects( $this->once() )
 			->method( 'fetchFromTable' )
-			->willReturn( new MappingIterator( [], static fn ( $x ) => $x ) );
+			->willReturn( new MappingIterator(
+				[ 'One', 'Two', 'Three' ],
+				static fn ( string $title ) => new WikiPage( $title, NS_MAIN )
+			) );
 
 		$instance = new EntityLookup(
 			$this->store,
@@ -263,7 +266,14 @@ class EntityLookupTest extends TestCase {
 
 		$result = $instance->getPropertyValues( $subject, $property );
 
-		$this->assertIsArray( $result );
+		$this->assertEquals(
+			[
+				new WikiPage( 'One', NS_MAIN ),
+				new WikiPage( 'Two', NS_MAIN ),
+				new WikiPage( 'Three', NS_MAIN )
+			],
+			$result
+		);
 	}
 
 	public function testGetPropertyValues_Subject_Null() {

--- a/tests/phpunit/Unit/SQLStore/EntityStore/EntityLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/EntityLookupTest.php
@@ -196,36 +196,26 @@ class EntityLookupTest extends TestCase {
 		$instance->getPropertyValues( $subject, $property );
 	}
 
-	public function testGetPropertyValues_Property_Inverse() {
+	public function testGetPropertyValues_Property_Inverse_UnregisteredProperty() {
+		// The lookup is never reached for a property without an ID, so this is
+		// the one inverse path that genuinely yields a plain array.
 		$property = new Property( 'Bar', true );
 		$subject = new WikiPage( 'Foo', NS_MAIN );
 
-		$propTable = $this->getMockBuilder( PropertyTableDefinition::class )
-			->disableOriginalConstructor()
-			->getMock();
-
 		$this->idTable->expects( $this->once() )
 			->method( 'getSMWPropertyID' )
-			->willReturn( 42 );
+			->willReturn( 0 );
 
 		$this->store->expects( $this->once() )
 			->method( 'findPropertyTableID' )
 			->willReturn( '_foo' );
-
-		$this->store->expects( $this->once() )
-			->method( 'getPropertyTables' )
-			->willReturn( [ '_foo' => $propTable ] );
-
-		$this->propertySubjectsLookup->expects( $this->once() )
-			->method( 'fetchFromTable' )
-			->willReturn( [] );
 
 		$instance = new EntityLookup(
 			$this->store,
 			$this->factory
 		);
 
-		$instance->getPropertyValues( $subject, $property );
+		$this->assertSame( [], $instance->getPropertyValues( $subject, $property ) );
 	}
 
 	public function testGetPropertyValues_Property_Inverse_ConvertsLookupIteratorToArray() {
@@ -328,16 +318,18 @@ class EntityLookupTest extends TestCase {
 			->method( 'getPropertyTables' )
 			->willReturn( [ '_foo' => $propTable ] );
 
+		$subjects = new MappingIterator( [ 'One', 'Two' ], static fn ( string $title ) => new WikiPage( $title, NS_MAIN ) );
+
 		$this->propertySubjectsLookup->expects( $this->once() )
 			->method( 'fetchFromTable' )
-			->willReturn( [] );
+			->willReturn( $subjects );
 
 		$instance = new EntityLookup(
 			$this->store,
 			$this->factory
 		);
 
-		$instance->getPropertySubjects( $property, $subject );
+		$this->assertSame( $subjects, $instance->getPropertySubjects( $property, $subject ) );
 	}
 
 	public function testGetAllPropertySubjects() {
@@ -359,16 +351,18 @@ class EntityLookupTest extends TestCase {
 			->method( 'getPropertyTables' )
 			->willReturn( [ '_foo' => $propTable ] );
 
+		$subjects = new MappingIterator( [ 'One', 'Two' ], static fn ( string $title ) => new WikiPage( $title, NS_MAIN ) );
+
 		$this->propertySubjectsLookup->expects( $this->once() )
 			->method( 'fetchFromTable' )
-			->willReturn( [] );
+			->willReturn( $subjects );
 
 		$instance = new EntityLookup(
 			$this->store,
 			$this->factory
 		);
 
-		$instance->getAllPropertySubjects( $property );
+		$this->assertSame( $subjects, $instance->getAllPropertySubjects( $property ) );
 	}
 
 	public function testGetInProperties() {

--- a/tests/phpunit/Unit/SQLStore/EntityStore/EntityLookupTest.php
+++ b/tests/phpunit/Unit/SQLStore/EntityStore/EntityLookupTest.php
@@ -5,6 +5,7 @@ namespace SMW\Tests\Unit\SQLStore\EntityStore;
 use PHPUnit\Framework\TestCase;
 use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
+use SMW\Iterators\MappingIterator;
 use SMW\SQLStore\EntityStore\CachingSemanticDataLookup;
 use SMW\SQLStore\EntityStore\EntityIdManager;
 use SMW\SQLStore\EntityStore\EntityLookup;
@@ -225,6 +226,44 @@ class EntityLookupTest extends TestCase {
 		);
 
 		$instance->getPropertyValues( $subject, $property );
+	}
+
+	public function testGetPropertyValues_Property_Inverse_ReturnsArray_WhenLookupReturnsMappingIterator() {
+		// PropertySubjectsLookup::fetchFromTable() always wraps its result in a
+		// MappingIterator (see PropertySubjectsLookup::fetchFromTable), never a
+		// plain array. getPropertyValues() is typed `: array` and must convert
+		// the inverse-property branch's result before returning it.
+		$property = new Property( 'Bar', true );
+		$subject = new WikiPage( 'Foo', NS_MAIN );
+
+		$propTable = $this->getMockBuilder( PropertyTableDefinition::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->idTable->expects( $this->once() )
+			->method( 'getSMWPropertyID' )
+			->willReturn( 42 );
+
+		$this->store->expects( $this->once() )
+			->method( 'findPropertyTableID' )
+			->willReturn( '_foo' );
+
+		$this->store->expects( $this->once() )
+			->method( 'getPropertyTables' )
+			->willReturn( [ '_foo' => $propTable ] );
+
+		$this->propertySubjectsLookup->expects( $this->once() )
+			->method( 'fetchFromTable' )
+			->willReturn( new MappingIterator( [], static fn ( $x ) => $x ) );
+
+		$instance = new EntityLookup(
+			$this->store,
+			$this->factory
+		);
+
+		$result = $instance->getPropertyValues( $subject, $property );
+
+		$this->assertIsArray( $result );
 	}
 
 	public function testGetPropertyValues_Subject_Null() {


### PR DESCRIPTION
Fixes #7092

## Summary

- `getPropertyValues()` is typed to return `array`, but its inverse-property branch assigns it the return value of `getPropertySubjects()`, which can be a `MappingIterator` (since `PropertySubjectsLookup::fetchFromTable()` always wraps its result in one).
- This raises a `TypeError` in production whenever an inverse property (e.g. `?-Has subobject`) is queried and the lookup takes its normal iterator path — reproduced by asking for an inverse property on a page with a matching result set.
- Cast the result to an array right after the assignment, only when it isn't already one.

## Test plan

- Added `testGetPropertyValues_Property_Inverse_ReturnsArray_WhenLookupReturnsMappingIterator`, which mocks `PropertySubjectsLookup::fetchFromTable()` returning a real `MappingIterator` (rather than a plain array, as the pre-existing `testGetPropertyValues_Property_Inverse` test does) — this reproduces the exact production `TypeError` before the fix, and passes after it.
- Ran the full `tests/phpunit/Unit/SQLStore/EntityStore/` suite (203 tests, 434 assertions) — all green, no regressions.