### PR TITLE
Convert smw_hash hex values in batches during update.php

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.1.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.1.md
@@ -17,6 +17,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed the `templatefile` result format leaving templates unexpanded in the downloaded file, and the PHP deprecation notice that corrupted it ([#7055](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7055))
 * Fixed pages with a very large tooltip failing to render with a `pcre.backtrack_limit exhausted` error; the tooltip's `title` attribute is now capped at 1024 characters, so readers without JavaScript see a truncated native tooltip ([#7076](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7076))
 * Fixed a fatal error when a query asked for an inverse property, such as the `?-Has subobject` printout, which stopped the page from being saved or rendered ([#7092](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7092))
+* Fixed `update.php` aborting on wikis with a large entity table, where the `smw_hash` conversion ran as one long database statement that a dropped connection discarded in full; it now converts in batches and resumes where an interrupted run stopped ([#7091](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7091))
 
 ## Upgrading
 

--- a/src/SQLStore/TableBuilder/Examiner/HashField.php
+++ b/src/SQLStore/TableBuilder/Examiner/HashField.php
@@ -3,7 +3,9 @@
 namespace SMW\SQLStore\TableBuilder\Examiner;
 
 use Onoi\MessageReporter\MessageReporterAwareTrait;
+use RuntimeException;
 use SMW\Maintenance\populateHashField;
+use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\SQLStore;
 use SMW\Utils\CliMsgFormatter;
 use Wikimedia\Rdbms\DBError;
@@ -18,6 +20,17 @@ use Wikimedia\Rdbms\RawSQLValue;
 class HashField {
 
 	use MessageReporterAwareTrait;
+
+	/**
+	 * Number of `smw_object_ids` rows one conversion statement covers.
+	 *
+	 * Small enough that a single statement finishes in about a second even
+	 * on a wiki with millions of entities, which is what keeps the migration
+	 * clear of connection and query timeouts.
+	 *
+	 * @since 7.2.1
+	 */
+	public const CONVERSION_BATCH_SIZE = 5000;
 
 	/**
 	 * @var ?PopulateHashField
@@ -51,8 +64,7 @@ class HashField {
 	 * The LENGTH check distinguishes hex (40) from already-converted
 	 * binary (20) and empty values.
 	 *
-	 * Always runs to completion regardless of row count: this is a
-	 * single server-side UPDATE on MySQL/Postgres, and skipping it would
+	 * Always runs to completion regardless of row count: skipping it would
 	 * leave 40-byte hex values that the subsequent ALTER TABLE cannot
 	 * narrow to BINARY(20) without truncation.
 	 *
@@ -62,12 +74,7 @@ class HashField {
 		$cliMsgFormatter = new CliMsgFormatter();
 		$connection = $this->store->getConnection( 'mw.db' );
 
-		$count = (int)$connection->newSelectQueryBuilder()
-			->select( 'COUNT(*)' )
-			->from( SQLStore::ID_TABLE )
-			->where( 'LENGTH(smw_hash) = 40' )
-			->caller( __METHOD__ )
-			->fetchField();
+		[ 'count' => $count, 'first' => $first, 'last' => $last ] = $this->hexRowBounds( $connection );
 
 		if ( $count === 0 ) {
 			return;
@@ -77,65 +84,183 @@ class HashField {
 			$cliMsgFormatter->twoCols( "... converting hex hashes to binary ...", "(rows) $count", 3 )
 		);
 
-		$type = $connection->getType();
-
 		try {
-			if ( $type === 'postgres' ) {
-				$connection->newUpdateQueryBuilder()
-					->update( SQLStore::ID_TABLE )
-					->set( [ 'smw_hash' => new RawSQLValue( "decode(smw_hash, 'hex')" ) ] )
-					->where( [ 'LENGTH(smw_hash) = 40' ] )
-					->caller( __METHOD__ )
-					->execute();
-			} elseif ( $type === 'sqlite' ) {
-				// unhex() requires SQLite 3.38+; fall back to PHP-side conversion
-				$this->migrateHexHashesViaPHP( $connection );
-			} else {
-				$connection->newUpdateQueryBuilder()
-					->update( SQLStore::ID_TABLE )
-					->set( [ 'smw_hash' => new RawSQLValue( 'UNHEX(smw_hash)' ) ] )
-					->where( [ 'LENGTH(smw_hash) = 40' ] )
-					->caller( __METHOD__ )
-					->execute();
-			}
+			$this->convertInBatches( $connection, $cliMsgFormatter, $first, $last );
 		} catch ( DBError $e ) {
 			$this->reportMigrationFailure( $cliMsgFormatter );
 			throw $e;
 		}
+
+		$this->messageReporter->reportMessage( "\n" );
+
+		$this->assertNoHexRowsRemain( $connection, $cliMsgFormatter );
 	}
 
 	/**
-	 * Surface a recovery hint before the raw `DBError` propagates and aborts
-	 * `update.php`. The migration is safe to retry after a partial failure
-	 * because the `LENGTH(smw_hash) = 40` predicate skips already-converted
-	 * rows — the SQLite per-row fallback in particular is not transactional,
-	 * but the idempotent predicate makes that safe.
+	 * How many rows still hold a hex hash, and the `smw_id` range they sit
+	 * in. One scan answers all three: the count drives the report and the
+	 * completeness check, the range bounds the walk. Taking the bounds from
+	 * the hex rows rather than from the table as a whole keeps a resumed run
+	 * proportional to what is left instead of to the whole id space, and it
+	 * skips id ranges that never held a hex hash.
+	 *
+	 * Reads the primary. A lagging replica would under-report and let the
+	 * schema change run against rows that are still hex, and would fail the
+	 * post-conversion check on an upgrade that actually succeeded.
+	 *
+	 * `LENGTH(smw_hash) = 40` cannot use an index, so this scans the whole
+	 * `smw_hash` index. It is the one part of the migration whose duration
+	 * still grows with the table, but it is a read: losing the connection
+	 * here costs no converted rows.
+	 *
+	 * @return array{count:int,first:int,last:int} `first`/`last` are 0 when
+	 *   nothing is left to convert
 	 */
-	private function reportMigrationFailure( CliMsgFormatter $cliMsgFormatter ): void {
+	private function hexRowBounds( Database $connection ): array {
+		$row = $connection->newPrimarySelectQueryBuilder()
+			->select( [ 'rows' => 'COUNT(*)', 'first' => 'MIN(smw_id)', 'last' => 'MAX(smw_id)' ] )
+			->from( SQLStore::ID_TABLE )
+			->where( 'LENGTH(smw_hash) = 40' )
+			->caller( __METHOD__ )
+			->fetchRow();
+
+		return [
+			'count' => (int)$row->rows,
+			'first' => (int)$row->first,
+			'last' => (int)$row->last,
+		];
+	}
+
+	/**
+	 * Before batching, "every hex row was converted" held by construction:
+	 * one unbounded statement could not miss a row. It now depends on the
+	 * `smw_id` walk having covered them all. The caller narrows the column
+	 * to `BINARY(20)` immediately afterwards, which truncates whatever is
+	 * left, so confirm the conversion really is complete and stop the
+	 * upgrade with an explanation if it is not.
+	 */
+	private function assertNoHexRowsRemain( Database $connection, CliMsgFormatter $cliMsgFormatter ): void {
+		$remaining = $this->hexRowBounds( $connection )['count'];
+
+		if ( $remaining === 0 ) {
+			return;
+		}
+
 		$text = [
 			$cliMsgFormatter->red(
-				"\n... hex-to-binary conversion failed; the schema change " .
-				"cannot proceed until this UPDATE succeeds."
+				"... $remaining row(s) still hold a hex `smw_hash` after the conversion."
 			),
-			"Common causes: lock contention on `smw_object_ids`, insufficient " .
-			"disk space, or a restrictive SQL mode. Resolve the underlying " .
-			"database error and re-run `update.php` — already-converted rows " .
-			"are skipped, so the migration is safe to retry.",
+			"The schema change that follows would truncate them, so the upgrade " .
+			"stops here. This happens when rows are written to `smw_object_ids` " .
+			"by an older Semantic MediaWiki while `update.php` runs. Make sure no " .
+			"other process is writing to the wiki and re-run `update.php`: rows " .
+			"converted so far are already committed and are skipped.",
 		];
 
 		$this->messageReporter->reportMessage(
 			"\n" . $cliMsgFormatter->wordwrap( $text ) . "\n"
 		);
+
+		throw new RuntimeException(
+			"$remaining `smw_object_ids` row(s) still hold a hex `smw_hash`; " .
+			"refusing to narrow the column to BINARY(20)."
+		);
 	}
 
 	/**
-	 * Row-by-row hex-to-binary conversion for databases without UNHEX().
+	 * Walks the ID table in `smw_id` ranges, converting one range per
+	 * statement and committing after each.
+	 *
+	 * A single whole-table `UPDATE` rewrites every row and every `smw_hash`
+	 * index entry in one transaction, which on a wiki with over a million
+	 * entities runs for minutes. Anything that drops the connection in that
+	 * window (a proxy timeout, a query killer, the server running out of
+	 * memory) discards the entire conversion, so the next `update.php`
+	 * starts over and fails the same way. Bounded ranges keep each statement
+	 * short and let a failed run resume: the range comes from the rows that
+	 * still hold a hex hash, so a resumed run neither revisits the ids an
+	 * earlier one finished nor, thanks to the `LENGTH(smw_hash) = 40`
+	 * predicate, reconverts a row it happens to meet again.
 	 */
-	private function migrateHexHashesViaPHP( $connection ): void {
-		$rows = $connection->newSelectQueryBuilder()
+	private function convertInBatches(
+		Database $connection,
+		CliMsgFormatter $cliMsgFormatter,
+		int $first,
+		int $last
+	): void {
+		$type = $connection->getType();
+
+		// unhex() requires SQLite 3.38+; fall back to PHP-side conversion
+		$convertsInPHP = $type === 'sqlite';
+
+		$expression = $type === 'postgres'
+			? new RawSQLValue( "decode(smw_hash, 'hex')" )
+			: new RawSQLValue( 'UNHEX(smw_hash)' );
+
+		// Without a ticket `commitAndWaitForReplication` is a no-op. Every
+		// statement still autocommits under `update.php`, but a caller that
+		// holds an open transaction (the web-based updater) would collect the
+		// whole walk into one transaction again, so say so rather than
+		// silently losing the property this migration depends on.
+		$ticket = $connection->getEmptyTransactionTicket( __METHOD__ );
+
+		if ( $ticket === null ) {
+			$this->messageReporter->reportMessage(
+				$cliMsgFormatter->twoCols(
+					"... cannot commit per batch, a transaction is already open ...",
+					"(warning)",
+					3
+				)
+			);
+		}
+
+		$span = $last - $first + 1;
+
+		for ( $start = $first; $start <= $last; $start += self::CONVERSION_BATCH_SIZE ) {
+			$end = min( $start + self::CONVERSION_BATCH_SIZE - 1, $last );
+
+			if ( $convertsInPHP ) {
+				$this->convertRangeViaPHP( $connection, $start, $end );
+			} else {
+				$this->convertRange( $connection, $expression, $start, $end );
+			}
+
+			$connection->commitAndWaitForReplication( __METHOD__, $ticket );
+
+			$this->messageReporter->reportMessage(
+				$cliMsgFormatter->twoColsOverride(
+					"... converting hex hashes to binary ...",
+					// Percentage over the range being walked, so it does not
+					// start near 100% when the remaining rows sit at high ids.
+					$cliMsgFormatter->progressCompact( $end - $first + 1, $span, $end, $last ),
+					3
+				)
+			);
+		}
+	}
+
+	private function convertRange( Database $connection, RawSQLValue $expression, int $start, int $end ): void {
+		$connection->newUpdateQueryBuilder()
+			->update( SQLStore::ID_TABLE )
+			->set( [ 'smw_hash' => $expression ] )
+			->where( [ 'LENGTH(smw_hash) = 40' ] )
+			->andWhere( $connection->expr( 'smw_id', '>=', $start ) )
+			->andWhere( $connection->expr( 'smw_id', '<=', $end ) )
+			->caller( __METHOD__ )
+			->execute();
+	}
+
+	/**
+	 * Row-by-row hex-to-binary conversion for databases without UNHEX(),
+	 * bounded to one `smw_id` range so the result set stays small.
+	 */
+	private function convertRangeViaPHP( Database $connection, int $start, int $end ): void {
+		$rows = $connection->newPrimarySelectQueryBuilder()
 			->select( [ 'smw_id', 'smw_hash' ] )
 			->from( SQLStore::ID_TABLE )
 			->where( 'LENGTH(smw_hash) = 40' )
+			->andWhere( $connection->expr( 'smw_id', '>=', $start ) )
+			->andWhere( $connection->expr( 'smw_id', '<=', $end ) )
 			->caller( __METHOD__ )
 			->fetchResultSet();
 
@@ -147,6 +272,30 @@ class HashField {
 				->caller( __METHOD__ )
 				->execute();
 		}
+	}
+
+	/**
+	 * Surface a recovery hint before the raw `DBError` propagates and aborts
+	 * `update.php`. The migration is safe to retry after a partial failure
+	 * because the `LENGTH(smw_hash) = 40` predicate skips already-converted
+	 * rows, and each batch is committed as it completes.
+	 */
+	private function reportMigrationFailure( CliMsgFormatter $cliMsgFormatter ): void {
+		$text = [
+			$cliMsgFormatter->red(
+				"\n... hex-to-binary conversion failed; the schema change " .
+				"cannot proceed until the conversion completes."
+			),
+			"Common causes: a dropped database connection, lock contention on " .
+			"`smw_object_ids`, insufficient disk space, or a restrictive SQL " .
+			"mode. Resolve the underlying database error and re-run " .
+			"`update.php`: rows converted so far are already committed and " .
+			"are skipped, so the migration resumes where it stopped.",
+		];
+
+		$this->messageReporter->reportMessage(
+			"\n" . $cliMsgFormatter->wordwrap( $text ) . "\n"
+		);
 	}
 
 	/**

--- a/tests/phpunit/Integration/SQLStore/TableBuilder/Examiner/HashFieldIntegrationTest.php
+++ b/tests/phpunit/Integration/SQLStore/TableBuilder/Examiner/HashFieldIntegrationTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace SMW\Tests\Integration\SQLStore\TableBuilder\Examiner;
+
+use Onoi\MessageReporter\MessageReporterFactory;
+use SMW\SQLStore\SQLStore;
+use SMW\SQLStore\TableBuilder\Examiner\HashField;
+use SMW\Tests\SMWIntegrationTestCase;
+use Wikimedia\Rdbms\Platform\ISQLPlatform;
+
+/**
+ * `HashField::migrateHexHashes` converts every hex `smw_hash` to raw binary
+ * just before `update.php` narrows the column to `BINARY(20)`, so a row it
+ * misses is a row the schema change truncates. These tests exercise the
+ * conversion against the database rather than the statements it builds.
+ *
+ * @covers \SMW\SQLStore\TableBuilder\Examiner\HashField
+ * @group semantic-mediawiki
+ * @group Database
+ * @group medium
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.2.1
+ */
+class HashFieldIntegrationTest extends SMWIntegrationTestCase {
+
+	/**
+	 * Window name => `smw_id`, so assertions can name the row they mean.
+	 */
+	private array $ids = [];
+
+	/**
+	 * PHPUnit runs `tearDown()` even when `setUp()` skips, so the restore has
+	 * to know whether the widening actually happened.
+	 */
+	private bool $columnWidened = false;
+
+	/**
+	 * The migration only has work to do while `smw_hash` is still the
+	 * pre-7.0 `VARBINARY(40)`, and the test schema is created at the current
+	 * definition. Widen the column for the duration of the test so hex values
+	 * can be stored at all, then put it back.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+
+		if ( $this->getStore()->getConnection( 'mw.db' )->getType() !== 'mysql' ) {
+			$this->markTestSkipped( 'Column juggling is written for MySQL/MariaDB' );
+		}
+
+		$this->changeHashColumnTo( 'VARBINARY(40)' );
+		$this->columnWidened = true;
+	}
+
+	protected function tearDown(): void {
+		if ( $this->ids !== [] ) {
+			$this->getStore()->getConnection( 'mw.db' )->newDeleteQueryBuilder()
+				->deleteFrom( SQLStore::ID_TABLE )
+				->where( [ 'smw_id' => array_values( $this->ids ) ] )
+				->caller( __METHOD__ )
+				->execute();
+		}
+
+		if ( $this->columnWidened ) {
+			$this->changeHashColumnTo( 'BINARY(20)' );
+		}
+
+		parent::tearDown();
+	}
+
+	private function changeHashColumnTo( string $type ): void {
+		$connection = $this->getStore()->getConnection( 'mw.db' );
+		$table = $connection->tableName( SQLStore::ID_TABLE );
+
+		$connection->query(
+			"ALTER TABLE $table CHANGE `smw_hash` `smw_hash` $type",
+			__METHOD__,
+			ISQLPlatform::QUERY_CHANGE_SCHEMA
+		);
+	}
+
+	public function testConvertsHexRowsSpreadOverSeveralBatches() {
+		$expected = $this->seedRows();
+
+		$this->runMigration();
+
+		$this->assertSame( $expected, $this->readHashes() );
+	}
+
+	public function testLeavesAnEmptyHashAlone() {
+		$this->seedRows();
+
+		$this->runMigration();
+
+		$this->assertNull( $this->readHash( 'empty' ) );
+	}
+
+	public function testSecondRunIsANoOpSoAnInterruptedRunCanResume() {
+		$expected = $this->seedRows();
+
+		$this->runMigration();
+		$this->runMigration();
+
+		$this->assertSame( $expected, $this->readHashes() );
+	}
+
+	/**
+	 * Seeds one hex row per batch window, plus a row an earlier run already
+	 * converted, and returns the raw binary each is expected to hold once the
+	 * migration has run.
+	 *
+	 * @return array<string,string> window name => expected raw binary
+	 */
+	private function seedRows(): array {
+		$base = $this->nextFreeId();
+		$stride = HashField::CONVERSION_BATCH_SIZE;
+
+		// Spacing the rows a full batch apart forces the walk to cross window
+		// boundaries instead of converting everything in one statement.
+		$hex = [
+			'first' => sha1( 'first' ),
+			'second' => sha1( 'second' ),
+			'third' => sha1( 'third' ),
+		];
+
+		$expected = [];
+		$offset = 0;
+
+		foreach ( $hex as $window => $value ) {
+			$this->insertRow( $window, $base + $offset * $stride, $value );
+			$expected[$window] = hex2bin( $value );
+			$offset++;
+		}
+
+		// Rows the conversion has to leave alone, placed *inside* the id range
+		// the walk covers so that they are actually exposed to it: one an
+		// earlier run already converted, one that never had a hash. Only
+		// `LENGTH(smw_hash) = 40` keeps them out of the UPDATE, and converting
+		// 20 raw bytes a second time would destroy the hash.
+		$converted = hex2bin( sha1( 'converted' ) );
+		$this->insertRow( 'converted', $base + 1, $converted );
+		$expected['converted'] = $converted;
+
+		$this->insertRow( 'empty', $base + 2, null );
+
+		return $expected;
+	}
+
+	private function nextFreeId(): int {
+		return (int)$this->getStore()->getConnection( 'mw.db' )->newSelectQueryBuilder()
+			->select( 'MAX(smw_id)' )
+			->from( SQLStore::ID_TABLE )
+			->caller( __METHOD__ )
+			->fetchField() + 1;
+	}
+
+	private function insertRow( string $window, int $id, ?string $hash ): void {
+		$connection = $this->getStore()->getConnection( 'mw.db' );
+
+		$connection->newInsertQueryBuilder()
+			->insertInto( SQLStore::ID_TABLE )
+			->row( [
+				'smw_id' => $id,
+				'smw_namespace' => NS_MAIN,
+				'smw_title' => "HashFieldIntegration$id",
+				'smw_iw' => '',
+				'smw_subobject' => '',
+				'smw_sortkey' => "HashFieldIntegration$id",
+				'smw_hash' => $hash === null ? null : $connection->escape_bytea( $hash ),
+			] )
+			->caller( __METHOD__ )
+			->execute();
+
+		$this->ids[$window] = $id;
+	}
+
+	private function runMigration(): void {
+		$instance = new HashField( $this->getStore() );
+
+		$instance->setMessageReporter(
+			MessageReporterFactory::getInstance()->newSpyMessageReporter()
+		);
+
+		$instance->migrateHexHashes();
+	}
+
+	/**
+	 * @return array<string,string> window name => stored raw binary, for the
+	 *   windows that are expected to hold one
+	 */
+	private function readHashes(): array {
+		$windows = array_diff( array_keys( $this->ids ), [ 'empty' ] );
+
+		return array_combine(
+			$windows,
+			array_map( fn ( string $window ) => $this->readHash( $window ), $windows )
+		);
+	}
+
+	private function readHash( string $window ): ?string {
+		$connection = $this->getStore()->getConnection( 'mw.db' );
+
+		$value = $connection->newSelectQueryBuilder()
+			->select( 'smw_hash' )
+			->from( SQLStore::ID_TABLE )
+			->where( [ 'smw_id' => $this->ids[$window] ] )
+			->caller( __METHOD__ )
+			->fetchField();
+
+		if ( $value === null || $value === false ) {
+			return null;
+		}
+
+		return $connection->unescape_bytea( $value );
+	}
+
+}

--- a/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
+++ b/tests/phpunit/Unit/SQLStore/TableBuilder/Examiner/HashFieldTest.php
@@ -3,6 +3,7 @@
 namespace SMW\Tests\Unit\SQLStore\TableBuilder\Examiner;
 
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use SMW\Maintenance\populateHashField;
 use SMW\MediaWiki\Connection\Database;
 use SMW\SQLStore\SQLStore;
@@ -89,33 +90,62 @@ class HashFieldTest extends TestCase {
 		);
 	}
 
-	public function testMigrateHexHashes_RunsWhenCountExceedsThreshold() {
-		// Regression test for issue #6715: when more than threshold hex
-		// hashes exist, the SQL conversion must still run — otherwise the
-		// subsequent ALTER TABLE BINARY(20) truncates the 40-byte values
-		// and the upgrade fails.
-		$this->connection = $this->getMockBuilder( Database::class )
+	/**
+	 * Builds a Database mock for the migration.
+	 *
+	 * Every read the migration makes goes to the primary: first the hex-row
+	 * count and the id range it spans, then any per-batch reads, then the
+	 * same query again to confirm nothing is left. That last one reports
+	 * zero, which is what the check sees once the batches have run; the queue
+	 * keeps answering zero after it is drained, so adding a read to the
+	 * production code degrades an assertion instead of fataling on a null
+	 * builder.
+	 */
+	private function newConnectionForMigration(
+		int $hexCount,
+		int $lastId,
+		string $type = 'mysql',
+		array $selectQueue = [],
+		?array &$idBounds = null
+	): Database {
+		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$selectBuilder = $this->createMockSelectQueryBuilder(
-			[ (object)[ 'count' => HashField::threshold() + 1 ] ]
+		$exhausted = $this->createMockSelectQueryBuilder(
+			[ (object)[ 'rows' => 0, 'first' => null, 'last' => null ] ]
 		);
 
-		$this->connection->method( 'newSelectQueryBuilder' )
-			->willReturn( $selectBuilder );
+		$queue = array_merge(
+			[ $this->createMockSelectQueryBuilder(
+				[ (object)[ 'rows' => $hexCount, 'first' => 1, 'last' => $lastId ] ]
+			) ],
+			$selectQueue,
+			[ $exhausted ]
+		);
 
-		$this->connection->method( 'getType' )
-			->willReturn( 'mysql' );
-
-		$updateTables = [];
-		$updateSets = [];
-		$updateWheres = [];
-		$this->connection->expects( $this->once() )
-			->method( 'newUpdateQueryBuilder' )
+		$connection->method( 'newPrimarySelectQueryBuilder' )
 			->willReturnCallback(
-				function () use ( &$updateTables, &$updateSets, &$updateWheres ) {
-					return $this->createMockUpdateQueryBuilder( $updateTables, $updateSets, $updateWheres );
+				static function () use ( &$queue, $exhausted ) {
+					return array_shift( $queue ) ?? $exhausted;
+				}
+			);
+
+		// Nothing in the migration reads a replica; a stray call must not
+		// consume a queued answer.
+		$connection->method( 'newSelectQueryBuilder' )
+			->willReturn( $exhausted );
+
+		$connection->method( 'getType' )
+			->willReturn( $type );
+
+		// Record every `expr()` call as a `[ field, operator, value ]` triple
+		// so a test can reconstruct the `smw_id` windows that were asked for.
+		$connection->method( 'expr' )
+			->willReturnCallback(
+				static function ( $field, $operator, $value ) use ( &$idBounds ) {
+					$idBounds[] = [ $field, $operator, $value ];
+					return "$field $operator $value";
 				}
 			);
 
@@ -124,16 +154,57 @@ class HashFieldTest extends TestCase {
 			->getMock();
 
 		$this->store->method( 'getConnection' )
-			->willReturn( $this->connection );
+			->willReturn( $connection );
 
+		return $connection;
+	}
+
+	/**
+	 * Turns recorded bounds into the `[ start, end ]` windows they describe.
+	 */
+	private function idWindowsFrom( array $bounds ): array {
+		return array_map(
+			static function ( array $pair ) {
+				return [ $pair[0][2], $pair[1][2] ];
+			},
+			array_chunk( $bounds, 2 )
+		);
+	}
+
+	private function newInstance(): HashField {
 		$instance = new HashField( $this->store );
 		$instance->setMessageReporter( $this->spyMessageReporter );
-		$instance->migrateHexHashes();
+
+		return $instance;
+	}
+
+	public function testMigrateHexHashes_RunsWhenCountExceedsThreshold() {
+		// Regression test for issue #6715: when more than threshold hex
+		// hashes exist, the SQL conversion must still run — otherwise the
+		// subsequent ALTER TABLE BINARY(20) truncates the 40-byte values
+		// and the upgrade fails.
+		$connection = $this->newConnectionForMigration( HashField::threshold() + 1, 1 );
+
+		$updateTables = [];
+		$updateSets = [];
+		$updateWheres = [];
+
+		$connection->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback(
+				function () use ( &$updateTables, &$updateSets, &$updateWheres ) {
+					return $this->createMockUpdateQueryBuilder( $updateTables, $updateSets, $updateWheres );
+				}
+			);
+
+		$this->newInstance()->migrateHexHashes();
 
 		$this->assertSame( [ SQLStore::ID_TABLE ], $updateTables );
 		$this->assertCount( 1, $updateSets );
 		$this->assertSame( 'UNHEX(smw_hash)', $updateSets[0]['smw_hash']->toSql() );
-		$this->assertSame( [ [ 'LENGTH(smw_hash) = 40' ] ], $updateWheres );
+		$this->assertSame(
+			[ [ 'LENGTH(smw_hash) = 40' ], 'smw_id >= 1', 'smw_id <= 1' ],
+			$updateWheres
+		);
 
 		$this->assertStringContainsString(
 			'converting hex hashes to binary',
@@ -141,20 +212,188 @@ class HashFieldTest extends TestCase {
 		);
 	}
 
-	public function testMigrateHexHashes_EmitsRecoveryHintOnDBError() {
-		$this->connection = $this->getMockBuilder( Database::class )
+	public function testMigrateHexHashes_SplitsConversionIntoBoundedIdRanges() {
+		// Issue #7091: a single whole-table UPDATE runs for minutes on a
+		// large wiki, so a dropped connection rolls back all of it. Convert
+		// in bounded `smw_id` windows instead: consecutive, batch-sized, and
+		// spanning exactly the ids that still hold a hex hash.
+		$lastId = 2 * HashField::CONVERSION_BATCH_SIZE + 1;
+		$bounds = [];
+		$connection = $this->newConnectionForMigration( $lastId, $lastId, idBounds: $bounds );
+
+		$connection->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback(
+				function () {
+					return $this->createMockUpdateQueryBuilder();
+				}
+			);
+
+		$this->newInstance()->migrateHexHashes();
+
+		$windows = $this->idWindowsFrom( $bounds );
+		$starts = array_column( $windows, 0 );
+		$ends = array_column( $windows, 1 );
+
+		$this->assertSame( 1, $starts[0], 'walk starts at the first row needing conversion' );
+		$this->assertSame( $lastId, end( $ends ), 'walk stops at the last one, without overshooting it' );
+
+		$this->assertSame(
+			array_fill( 0, count( $windows ) - 1, HashField::CONVERSION_BATCH_SIZE ),
+			array_map( static fn ( array $w ) => $w[1] - $w[0] + 1, array_slice( $windows, 0, -1 ) ),
+			'every window but the last covers a full batch'
+		);
+
+		$this->assertSame(
+			array_slice( array_map( static fn ( int $e ) => $e + 1, $ends ), 0, -1 ),
+			array_slice( $starts, 1 ),
+			'windows are consecutive, so no id is skipped'
+		);
+	}
+
+	public function testMigrateHexHashes_CommitsAfterEveryBatch() {
+		// Without a commit per batch the whole conversion stays one
+		// transaction, which is what makes a mid-migration disconnect
+		// discard every converted row.
+		$lastId = 2 * HashField::CONVERSION_BATCH_SIZE;
+		$connection = $this->newConnectionForMigration( $lastId, $lastId );
+
+		$connection->method( 'getEmptyTransactionTicket' )
+			->willReturn( 42 );
+
+		// The update builder records the table it targets, so sharing one
+		// array with the commit callback yields the interleaving.
+		$callLog = [];
+
+		$connection->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback(
+				function () use ( &$callLog ) {
+					return $this->createMockUpdateQueryBuilder( $callLog );
+				}
+			);
+
+		$connection->method( 'commitAndWaitForReplication' )
+			->willReturnCallback(
+				static function () use ( &$callLog ) {
+					$callLog[] = 'commit';
+				}
+			);
+
+		$this->newInstance()->migrateHexHashes();
+
+		$this->assertSame(
+			[ SQLStore::ID_TABLE, 'commit', SQLStore::ID_TABLE, 'commit' ],
+			$callLog,
+			'each batch is committed before the next one starts'
+		);
+	}
+
+	public function testMigrateHexHashes_WarnsWhenBatchesCannotBeCommitted() {
+		// A null ticket makes commitAndWaitForReplication a no-op, which
+		// silently restores the single-transaction behaviour being fixed.
+		$connection = $this->newConnectionForMigration( 1, 1 );
+
+		$connection->method( 'getEmptyTransactionTicket' )
+			->willReturn( null );
+
+		$connection->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback(
+				function () {
+					return $this->createMockUpdateQueryBuilder();
+				}
+			);
+
+		$this->newInstance()->migrateHexHashes();
+
+		$this->assertStringContainsString(
+			'cannot commit per batch',
+			$this->spyMessageReporter->getMessagesAsString()
+		);
+	}
+
+	public function testMigrateHexHashes_StopsBeforeSchemaChangeWhenHexRowsSurvive() {
+		// The caller narrows smw_hash to BINARY(20) right after this runs,
+		// which would truncate anything the walk missed.
+		$connection = $this->getMockBuilder( Database::class )
 			->disableOriginalConstructor()
 			->getMock();
 
-		$selectBuilder = $this->createMockSelectQueryBuilder(
-			[ (object)[ 'count' => 1 ] ]
+		// The count stays non-zero after the conversion, as if the walk had
+		// missed rows.
+		$connection->method( 'newPrimarySelectQueryBuilder' )
+			->willReturnCallback(
+				fn () => $this->createMockSelectQueryBuilder(
+					[ (object)[ 'rows' => 3, 'first' => 1, 'last' => 1 ] ]
+				)
+			);
+
+		$connection->method( 'getType' )->willReturn( 'mysql' );
+		$connection->method( 'expr' )
+			->willReturnCallback( static fn ( $f, $o, $v ) => "$f $o $v" );
+
+		$connection->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback(
+				function () {
+					return $this->createMockUpdateQueryBuilder();
+				}
+			);
+
+		$this->store = $this->getMockBuilder( SQLStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->store->method( 'getConnection' )->willReturn( $connection );
+
+		$instance = $this->newInstance();
+
+		$this->expectException( RuntimeException::class );
+		$instance->migrateHexHashes();
+	}
+
+	public function testMigrateHexHashes_UsesPostgresDecode() {
+		$connection = $this->newConnectionForMigration( 1, 1, 'postgres' );
+
+		$updateSets = [];
+
+		$connection->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback(
+				function () use ( &$updateSets ) {
+					return $this->createMockUpdateQueryBuilder( sets: $updateSets );
+				}
+			);
+
+		$this->newInstance()->migrateHexHashes();
+
+		$this->assertSame( "decode(smw_hash, 'hex')", $updateSets[0]['smw_hash']->toSql() );
+	}
+
+	public function testMigrateHexHashes_ConvertsRowsInPhpOnSqlite() {
+		// SQLite gained unhex() only in 3.38, so the conversion happens in
+		// PHP there — one bounded read per window, one update per row.
+		$connection = $this->newConnectionForMigration(
+			1,
+			1,
+			'sqlite',
+			[ $this->createMockSelectQueryBuilder( [ (object)[ 'smw_id' => 7, 'smw_hash' => str_repeat( 'ab', 20 ) ] ] ) ]
 		);
 
-		$this->connection->method( 'newSelectQueryBuilder' )
-			->willReturn( $selectBuilder );
+		$updateSets = [];
+		$updateWheres = [];
 
-		$this->connection->method( 'getType' )
-			->willReturn( 'mysql' );
+		$connection->method( 'newUpdateQueryBuilder' )
+			->willReturnCallback(
+				function () use ( &$updateSets, &$updateWheres ) {
+					return $this->createMockUpdateQueryBuilder( sets: $updateSets, wheres: $updateWheres );
+				}
+			);
+
+		$this->newInstance()->migrateHexHashes();
+
+		$this->assertSame( hex2bin( str_repeat( 'ab', 20 ) ), $updateSets[0]['smw_hash'] );
+		$this->assertSame( [ [ 'smw_id' => 7 ] ], $updateWheres );
+	}
+
+	public function testMigrateHexHashes_EmitsRecoveryHintOnDBError() {
+		$connection = $this->newConnectionForMigration( 1, 1 );
 
 		$dbError = $this->getMockBuilder( DBError::class )
 			->disableOriginalConstructor()
@@ -164,18 +403,10 @@ class HashFieldTest extends TestCase {
 		$updateBuilder->method( 'execute' )
 			->willThrowException( $dbError );
 
-		$this->connection->method( 'newUpdateQueryBuilder' )
+		$connection->method( 'newUpdateQueryBuilder' )
 			->willReturn( $updateBuilder );
 
-		$this->store = $this->getMockBuilder( SQLStore::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$this->store->method( 'getConnection' )
-			->willReturn( $this->connection );
-
-		$instance = new HashField( $this->store );
-		$instance->setMessageReporter( $this->spyMessageReporter );
+		$instance = $this->newInstance();
 
 		try {
 			$instance->migrateHexHashes();
@@ -186,23 +417,21 @@ class HashFieldTest extends TestCase {
 
 		$messages = $this->spyMessageReporter->getMessagesAsString();
 		$this->assertStringContainsString( 'hex-to-binary conversion failed', $messages );
-		$this->assertStringContainsString( 're-run `update.php`', $messages );
+		$this->assertStringContainsString( 'resumes where it stopped', $messages );
 	}
 
 	public function testMigrateHexHashes_NoOpWhenCountIsZero() {
 		$selectBuilder = $this->createMockSelectQueryBuilder(
-			[ (object)[ 'count' => 0 ] ]
+			[ (object)[ 'rows' => 0, 'first' => null, 'last' => null ] ]
 		);
 
-		$this->connection->method( 'newSelectQueryBuilder' )
+		$this->connection->method( 'newPrimarySelectQueryBuilder' )
 			->willReturn( $selectBuilder );
 
 		$this->connection->expects( $this->never() )
 			->method( 'newUpdateQueryBuilder' );
 
-		$instance = new HashField( $this->store );
-		$instance->setMessageReporter( $this->spyMessageReporter );
-		$instance->migrateHexHashes();
+		$this->newInstance()->migrateHexHashes();
 	}
 
 	public function testCheck_Incomplete() {


### PR DESCRIPTION
Fixes https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7091

The hex-to-binary conversion that has to precede the VARBINARY(40) to
BINARY(20) change of `smw_hash` ran as a single whole-table UPDATE. On a wiki
with over a million entities that is a statement running for minutes: it
rewrites every row of `smw_object_ids` and maintains the `smw_hash` index for
each one, in one transaction.

Anything that drops the connection inside that window aborts `update.php` with
`DBQueryDisconnectedError` and "2006 MySQL server has gone away". The statement
then rolls back in full, so the next run starts from scratch and fails the same
way. MediaWiki replays a query after a lost connection only when it failed
within three seconds (`Database::DROPPED_CONN_BLAME_THRESHOLD_SEC`), so a
statement of this length is never recovered.

Walk the ID table in `smw_id` ranges instead, committing after each range and
reporting progress. The `LENGTH(smw_hash) = 40` predicate already made the
conversion idempotent, so committed ranges are skipped and an interrupted run
resumes where it stopped. Each range also stays under MediaWiki's replay
threshold, which turns a transient disconnect into a retry rather than a fatal
error.

Until now "every hex row was converted" held by construction, because one
unbounded statement could not miss a row; it now depends on the walk covering
them all. The caller narrows the column immediately afterwards and would
truncate anything left behind, so count the remaining hex rows once the walk
ends and stop the upgrade with an explanation rather than let the schema change
run. Every read the migration makes goes to the primary, so replication lag can
neither hide rows from the walk nor fail a conversion that actually succeeded.

Measured against a 1,605,632 row `smw_object_ids` on MariaDB 11.2: the
conversion goes from one 328 second statement to about a second per range, and
the whole `update.php` run from 7m48s to 4m10s. Batching is faster
overall, not a trade-off, because InnoDB purges and flushes as it goes instead
of carrying one large undo image into the table copy that follows.

That table copy is unavoidable. MariaDB rejects `ALGORITHM=INPLACE` for this
type change, so the `ALTER TABLE` still rebuilds the table; it is the smaller
half of the migration and gets quicker once the conversion no longer leaves a
large transaction behind.

