### PR TITLE
7.2.1 release

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.1.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.1.md
@@ -1,11 +1,17 @@
 # Semantic MediaWiki 7.2.1
 
-Released on TBD.
+Released on August 18, 2026.
 
-This is a [patch release](../RELEASE-POLICY.md). Thus, it contains only bug fixes, no new features, and no breaking changes.
+This is a [patch release](../RELEASE-POLICY.md). Thus, it contains only security fixes and bug fixes, no new features, and no breaking changes.
 
 Like SMW 7.2.0, this version is compatible with MediaWiki 1.43 up to 1.46 and PHP 8.1 up to 8.5.
 For more detailed information, see the [compatibility matrix](../COMPATIBILITY.md#compatibility).
+
+## Security fixes
+
+* Fixed a cross-site scripting (XSS) vulnerability in `Special:FacetedSearch` where crafted card-state (`cstate`) parameters were reflected unescaped into the search form's hidden inputs ([GHSA-9rcc-pmj8-ffhr](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-9rcc-pmj8-ffhr))
+* Fixed a cross-site scripting (XSS) vulnerability in `Special:FacetedSearch` and `Special:Ask` where a crafted query was reflected unescaped into query error messages
+* Fixed a cross-site scripting (XSS) vulnerability in `Special:Browse` where a crafted subject was reflected unescaped into the invalid-subject error message
 
 ## Bug fixes
 

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "SemanticMediaWiki",
-	"version": "7.2.1-alpha",
+	"version": "7.2.1",
 	"author": [
 		"[https://korrekt.org Markus Krötzsch]",
 		"[https://EntropyWins.wtf/mediawiki Jeroen De Dauw]",

--- a/src/MediaWiki/Specials/Ask/ErrorWidget.php
+++ b/src/MediaWiki/Specials/Ask/ErrorWidget.php
@@ -89,7 +89,10 @@ class ErrorWidget {
 				$value = implode( " ", $value );
 			}
 
-			$errors[] = $value;
+			// Query errors carry request-controlled text (e.g. an unparsed
+			// query chunk) and `Message::encode` can re-introduce angle
+			// brackets past its `strip_tags`, so escape before the raw box.
+			$errors[] = htmlspecialchars( (string)$value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' );
 		}
 
 		if ( count( $errors ) > 1 ) {

--- a/src/MediaWiki/Specials/FacetedSearch/HtmlBuilder.php
+++ b/src/MediaWiki/Specials/FacetedSearch/HtmlBuilder.php
@@ -2,6 +2,7 @@
 
 namespace SMW\MediaWiki\Specials\FacetedSearch;
 
+use MediaWiki\Html\Html;
 use MediaWiki\Html\TemplateParser;
 use MediaWiki\Title\Title;
 use SMW\Localizer\Message;
@@ -129,7 +130,9 @@ class HtmlBuilder {
 		// Remember the "cstate" (aka card state) over the period of one
 		// request by adding hidden elements to the form
 		foreach ( $urlArgs->getArray( 'cstate' ) as $key => $value ) {
-			$hidden .= '<input name="' . "cstate[$key]" . '" type="hidden" value="' . $value . '">';
+			if ( is_scalar( $value ) ) {
+				$hidden .= Html::hidden( "cstate[$key]", $value );
+			}
 		}
 
 		$searchForm = $this->templateParser->processTemplate(

--- a/src/MediaWiki/Specials/FacetedSearch/ResultFetcher.php
+++ b/src/MediaWiki/Specials/FacetedSearch/ResultFetcher.php
@@ -123,7 +123,10 @@ class ResultFetcher {
 				$msg .= Message::decode( $error );
 			}
 
-			return Html::errorBox( $msg );
+			// Query errors carry request-controlled text (e.g. an unparsed
+			// query chunk) and `Message::encode` can re-introduce angle
+			// brackets past its `strip_tags`, so escape before the raw box.
+			return Html::errorBox( htmlspecialchars( $msg, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' ) );
 		}
 
 		if ( $this->queryResult === null ) {

--- a/src/MediaWiki/Specials/SpecialBrowse.php
+++ b/src/MediaWiki/Specials/SpecialBrowse.php
@@ -118,8 +118,15 @@ class SpecialBrowse extends SpecialPage {
 			foreach ( $dataValue->getErrors() as $err ) {
 				$error .= Message::decode( $err, Message::TEXT, Message::USER_LANGUAGE );
 			}
+			// The decoded error carries request-controlled text (the invalid
+			// subject) and `Message::encode` can re-introduce angle brackets
+			// past its `strip_tags`, so escape before it enters the raw box.
 			$data['html-output'] = Html::errorBox(
-				Message::get( [ 'smw-browse-invalid-subject', $error ], Message::TEXT, Message::USER_LANGUAGE ),
+				Message::get(
+					[ 'smw-browse-invalid-subject', htmlspecialchars( $error, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8' ) ],
+					Message::TEXT,
+					Message::USER_LANGUAGE
+				),
 				'',
 				'smw-error-browse'
 			);

--- a/tests/phpunit/Unit/MediaWiki/Specials/Ask/ErrorWidgetTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/Ask/ErrorWidgetTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Unit\MediaWiki\Specials\Ask;
 
 use MediaWiki\Html\Html;
 use PHPUnit\Framework\TestCase;
+use SMW\Localizer\Message;
 use SMW\MediaWiki\Specials\Ask\ErrorWidget;
 use SMW\Query\Query;
 
@@ -37,6 +38,24 @@ class ErrorWidgetTest extends TestCase {
 
 			ErrorWidget::noResult()
 		);
+	}
+
+	public function testQueryErrorEscapesReflectedMarkup() {
+		$query = $this->getMockBuilder( Query::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		// `Message::encode` un-swaps %3C/%3E into < > after strip_tags, so a
+		// crafted query chunk can smuggle live markup into the error stream.
+		$error = Message::encode( [ '%3Eimg src=x onerror=alert(1)%3C' ] );
+
+		$query->method( 'getErrors' )
+			->willReturn( [ $error ] );
+
+		$html = ErrorWidget::queryError( $query );
+
+		$this->assertStringNotContainsString( '<img src=x onerror=alert(1)>', $html );
+		$this->assertStringContainsString( '&lt;img src=x onerror=alert(1)&gt;', $html );
 	}
 
 	/**

--- a/tests/phpunit/Unit/MediaWiki/Specials/FacetedSearch/HtmlBuilderTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/FacetedSearch/HtmlBuilderTest.php
@@ -3,7 +3,9 @@
 namespace SMW\Tests\Unit\MediaWiki\Specials\FacetedSearch;
 
 use MediaWiki\Html\TemplateParser;
+use MediaWiki\Title\Title;
 use PHPUnit\Framework\TestCase;
+use SMW\Localizer\MessageLocalizer;
 use SMW\MediaWiki\Specials\FacetedSearch\ExploreListBuilder;
 use SMW\MediaWiki\Specials\FacetedSearch\ExtraFieldBuilder;
 use SMW\MediaWiki\Specials\FacetedSearch\FacetBuilder;
@@ -11,6 +13,7 @@ use SMW\MediaWiki\Specials\FacetedSearch\HtmlBuilder;
 use SMW\MediaWiki\Specials\FacetedSearch\OptionsBuilder;
 use SMW\MediaWiki\Specials\FacetedSearch\Profile;
 use SMW\MediaWiki\Specials\FacetedSearch\ResultFetcher;
+use SMW\Utils\UrlArgs;
 
 /**
  * @covers \SMW\MediaWiki\Specials\FacetedSearch\HtmlBuilder
@@ -24,12 +27,13 @@ use SMW\MediaWiki\Specials\FacetedSearch\ResultFetcher;
 class HtmlBuilderTest extends TestCase {
 
 	private $profile;
-	private $templateParser;
+	private TemplateParser $templateParser;
 	private $optionsBuilder;
 	private $extraFieldBuilder;
 	private $facetBuilder;
 	private $resultFetcher;
 	private $exploreListBuilder;
+	private $messageLocalizer;
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -38,9 +42,7 @@ class HtmlBuilderTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 
-		$this->templateParser = $this->getMockBuilder( TemplateParser::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$this->templateParser = new TemplateParser( __DIR__ . '/../../../../../../templates/FacetedSearch' );
 
 		$this->optionsBuilder = $this->getMockBuilder( OptionsBuilder::class )
 			->disableOriginalConstructor()
@@ -61,6 +63,12 @@ class HtmlBuilderTest extends TestCase {
 		$this->exploreListBuilder = $this->getMockBuilder( ExploreListBuilder::class )
 			->disableOriginalConstructor()
 			->getMock();
+
+		$this->messageLocalizer = $this->getMockBuilder( MessageLocalizer::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->messageLocalizer->method( 'msg' )->willReturn( '' );
 	}
 
 	public function testCanConstruct() {
@@ -68,6 +76,62 @@ class HtmlBuilderTest extends TestCase {
 			HtmlBuilder::class,
 			new HtmlBuilder( $this->profile, $this->templateParser, $this->optionsBuilder, $this->extraFieldBuilder, $this->facetBuilder, $this->resultFetcher, $this->exploreListBuilder )
 		);
+	}
+
+	public function testMaliciousCardStateValueIsEscapedInHiddenInput() {
+		$html = $this->buildHtmlForCardState( [ '0' => '"><script>alert(1)</script>' ] );
+
+		$this->assertStringNotContainsString( '<script>alert(1)</script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;alert(1)&lt;/script&gt;', $html );
+	}
+
+	public function testMaliciousCardStateKeyIsEscapedInHiddenInput() {
+		$html = $this->buildHtmlForCardState( [ '"><script>alert(2)</script>' => 'e' ] );
+
+		$this->assertStringNotContainsString( '<script>alert(2)</script>', $html );
+		$this->assertStringContainsString( '&lt;script&gt;alert(2)&lt;/script&gt;', $html );
+	}
+
+	public function testBenignCardStateIsPreservedInHiddenInput() {
+		$html = $this->buildHtmlForCardState( [ 'extra-fields' => 'c' ] );
+
+		$this->assertStringContainsString( 'name="cstate[extra-fields]"', $html );
+		$this->assertStringContainsString( 'value="c"', $html );
+	}
+
+	public function testNonScalarCardStateValueIsIgnored() {
+		$html = $this->buildHtmlForCardState( [ 'k' => [ 'b' => 'x' ] ] );
+
+		$this->assertStringNotContainsString( 'cstate[k]', $html );
+	}
+
+	/**
+	 * Renders the full search page for a given "cstate" (card state) request
+	 * value and returns the produced HTML.
+	 */
+	private function buildHtmlForCardState( array $cstate ): string {
+		$this->resultFetcher->method( 'getHtml' )->willReturn( '' );
+		$this->resultFetcher->method( 'getTotalCount' )->willReturn( 0 );
+		$this->resultFetcher->method( 'getOffset' )->willReturn( 0 );
+		$this->resultFetcher->method( 'getLimit' )->willReturn( 10 );
+		$this->resultFetcher->method( 'hasFurtherResults' )->willReturn( false );
+
+		$title = $this->createMock( Title::class );
+		$title->method( 'getLocalUrl' )->willReturn( '' );
+
+		$instance = new HtmlBuilder(
+			$this->profile,
+			$this->templateParser,
+			$this->optionsBuilder,
+			$this->extraFieldBuilder,
+			$this->facetBuilder,
+			$this->resultFetcher,
+			$this->exploreListBuilder
+		);
+
+		$instance->setMessageLocalizer( $this->messageLocalizer );
+
+		return $instance->buildHTML( $title, new UrlArgs( [ 'q' => 'Text', 'cstate' => $cstate ] ) );
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Specials/FacetedSearch/ResultFetcherTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/FacetedSearch/ResultFetcherTest.php
@@ -3,6 +3,8 @@
 namespace SMW\Tests\Unit\MediaWiki\Specials\FacetedSearch;
 
 use PHPUnit\Framework\TestCase;
+use ReflectionProperty;
+use SMW\Localizer\Message;
 use SMW\MediaWiki\Specials\FacetedSearch\ResultFetcher;
 use SMW\Store;
 
@@ -32,6 +34,26 @@ class ResultFetcherTest extends TestCase {
 			ResultFetcher::class,
 			new ResultFetcher( $this->store )
 		);
+	}
+
+	public function testGetHtmlEscapesReflectedQueryError() {
+		// `Message::encode` un-swaps %3C/%3E into < > after strip_tags, so a
+		// crafted query chunk can smuggle live markup into the error stream.
+		$error = Message::encode( [ '%3Eimg src=x onerror=alert(1)%3C' ] );
+
+		$instance = new ResultFetcher( $this->store );
+		$this->setErrors( $instance, [ $error ] );
+
+		$html = $instance->getHtml();
+
+		$this->assertStringNotContainsString( '<img src=x onerror=alert(1)>', $html );
+		$this->assertStringContainsString( '&lt;img src=x onerror=alert(1)&gt;', $html );
+	}
+
+	private function setErrors( ResultFetcher $instance, array $errors ): void {
+		$property = new ReflectionProperty( ResultFetcher::class, 'errors' );
+		$property->setAccessible( true );
+		$property->setValue( $instance, $errors );
 	}
 
 }

--- a/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
+++ b/tests/phpunit/Unit/MediaWiki/Specials/SpecialBrowseTest.php
@@ -78,6 +78,27 @@ class SpecialBrowseTest extends TestCase {
 		);
 	}
 
+	public function testInvalidSubjectErrorEscapesReflectedMarkup() {
+		$instance = new SpecialBrowse( $this->store, $this->settings, $this->serializerFactory );
+		$services = MediaWikiServices::getInstance();
+
+		$instance->getContext()->setTitle(
+			$services->getTitleFactory()->newFromText( 'SpecialBrowse' )
+		);
+		$instance->getContext()->setLanguage(
+			$services->getLanguageFactory()->getLanguage( 'en' )
+		);
+
+		// `Message::encode` un-swaps %3C/%3E into < > after strip_tags, so a
+		// crafted invalid subject can smuggle live markup into the error box.
+		$instance->execute( '{{%3Eimg src=x onerror=alert(1)%3C' );
+
+		$html = $instance->getOutput()->getHtml();
+
+		$this->assertStringNotContainsString( '<img src=x onerror=alert(1)>', $html );
+		$this->assertStringContainsString( '&lt;img src=x onerror=alert(1)&gt;', $html );
+	}
+
 	public function queryParameterProvider() {
 		# 0
 		$provider[] = [


### PR DESCRIPTION
Release 7.2.1, a security patch.

It fixes three reflected cross-site scripting (XSS) vulnerabilities, each reachable anonymously through a crafted request. In every case the fix escapes the reflected text before it reaches the raw error or output sink:

* `Special:FacetedSearch`: crafted card-state (`cstate`) parameters were reflected unescaped into the search form's hidden inputs ([GHSA-9rcc-pmj8-ffhr](https://github.com/SemanticMediaWiki/SemanticMediaWiki/security/advisories/GHSA-9rcc-pmj8-ffhr))
* `Special:FacetedSearch` and `Special:Ask`: a crafted query was reflected unescaped into query error messages
* `Special:Browse`: a crafted subject was reflected unescaped into the invalid-subject error message

Each fix ships with a regression test. Also bumps the version to 7.2.1 and adds the release notes.
