### PR TITLE
Better guard against invalid syntax / database errors when queries use Full-text Search (MySQL/MariaDB)

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.2.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.2.md
@@ -13,6 +13,9 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 * Fixed a failed data update or setup state write hiding its real cause when rolling the transaction back also failed ([#7107](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7107))
 * Fixed the tooltip of `{{#info:}}` and `{{#property_link:}}` not working on `Special:ExpandTemplates` when a context title is given ([#7109](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7109))
 * Fixed links and other markup in a property description not being rendered in the property tooltip ([#5494](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/5494))
+* Fixed full-text search queries failing with a database error when the search term left a boolean operator without a term, such as `[[Has text::~O'Se*]]`, where both parts of the term are too short to be indexed and only the wildcard remained ([#6129](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/6129))
+* Fixed full-text search queries failing with a database error when the search term contained an at sign, as in `[[Has text::~name@example.org]]`
+* Full-text search now keeps a term that carries a wildcard even when it is shorter than `$smwgFulltextSearchMinTokenSize` or is a stop word, matching how MySQL and MariaDB treat the truncation operator. A term such as `[[Has text::~to* be]]` previously searched only for "be" and now also searches for everything starting with "to", so such queries can return more results than before.
 
 ## Upgrading
 

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -134,8 +134,8 @@ class TextSanitizer {
 		// trailing operators ('*') and operators expected in
 		// both positions ('"')
 		$filteredText = str_replace(
-			[ ' *', '* ', ' "', '" ', '+ ', '- ', '@ ', '~ ', '*+', '*-', '*~' ],
-			[ '*', '*', '"', '"', '+', '-', '@', '~', '* +', '* -', '* ~' ],
+			[ ' *', ' "', '" ', '+ ', '- ', '@ ', '~ ', '*+', '*-', '*~' ],
+			[ '*', '"', '"', '+', '-', '@', '~', '* +', '* -', '* ~' ],
 			implode( ' ', $filtered )
 		);
 
@@ -314,7 +314,8 @@ class TextSanitizer {
 
 	/**
 	 * Filters out stopwords, tokens below the required
-	 * minimum length (1 for CJK), and adjacent duplicates.
+	 * minimum length (1 for CJK), and adjacent duplicates,
+	 * unless exceptions apply.
 	 * 
 	 * @param array $tokens
 	 * @param string|null $language
@@ -328,14 +329,12 @@ class TextSanitizer {
 		}
 
 		$whiteList = [];
-
 		if ( is_array( $exemptionList ) && $exemptionList !== [] ) {
 			$whiteList = array_fill_keys( $exemptionList, true );
 		}
 
 		// Determine if we should use word-based min length or character-based
 		$hasCjk = false;
-
 		foreach ( $tokens as $token ) {
 			if ( preg_match( '/[\x{4e00}-\x{9fa5}]/u', $token ) ) {
 				$hasCjk = true;
@@ -351,16 +350,26 @@ class TextSanitizer {
 		$pos = 0;
 
 		foreach ( $tokens as $word ) {
-			// If it is not an exemption and less than the required minimum length
-			// or identified as stop word it is removed
+			// Check if the next 'word' is a truncation operator.
+			// If so, it shouldn't be "stripped from a boolean query,
+			// even if it is too short or a stopword" (MySQL docs)
+			$hasTruncator = false;
+			if ( isset( $index[$pos + 1] ) && $index[$pos + 1] === "*" ) {
+				$hasTruncator = true;
+			}
+
+			// Remove token if it is not an exemption, shorter than 
+			// the required minimum length or identified as stop word,
+			// and has no truncation operator
 			if ( !isset( $whiteList[$word] ) && (
 				mb_strlen( $word ) < $minLength ||
 				( $stopwordReader !== null && $this->isStopWord( $stopwordReader, $word ) )
-			) ) {
+			) && !$hasTruncator ) {
 				continue;
 			}
 
-			// Simple proximity, check for same words appearing next to each other
+			// Simple proximity, check for same words or operators
+			// appearing next to each other
 			if ( isset( $index[$pos - 1] ) && $index[$pos - 1] === $word ) {
 				continue;
 			}

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -488,11 +488,21 @@ class TextSanitizer {
 		// Sequences such as "+*" are absent here because they are valid
 		// when bound to a term ("+*foo"); trimUnsupportedOperators() has
 		// already removed the unbound ones.
-		$cleaned = preg_replace( '/([+~-])\1+/', '$1', $text ) ?? $text;
-		$cleaned = preg_replace( '/\*{2,}/', '*', $cleaned ) ?? $cleaned;
-		$cleaned = str_replace(
-			[ "*+", "*-", "*~", "+-", "+~", "-+", "-~", "~+", "~-" ], "", $cleaned
-		);
+		//
+		// Removing a sequence can bring its neighbours together into
+		// another illegal one ("-+~-" leaves "--"), so repeat until the
+		// text stops changing. Each pass can only shorten it.
+		$cleaned = $text;
+
+		do {
+			$previous = $cleaned;
+
+			$cleaned = preg_replace( '/([+~-])\1+/', '$1', $cleaned ) ?? $cleaned;
+			$cleaned = preg_replace( '/\*{2,}/', '*', $cleaned ) ?? $cleaned;
+			$cleaned = str_replace(
+				[ "*+", "*-", "*~", "+-", "+~", "-+", "-~", "~+", "~-" ], "", $cleaned
+			);
+		} while ( $cleaned !== $previous );
 
 		// Remove operators that carry no term.
 		// May occur eg when trailing operators become detached or

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -466,7 +466,7 @@ class TextSanitizer {
 	private function sanitizeFilteredText( string $text ): string {
 		// Remove troublesome sequences
 		$cleaned = str_replace(
-			[ "+*", "-*", "~*", "+-", "-+" ], "", $text
+			[ "**", "*+", "*-", "*~", "+*", "++", "+-", "+~", "-*", "-+", "--", "-~", "~*", "~+", "~-", "~~" ], "", $text
 		);
 
 		// Remove isolated operators

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -120,7 +120,7 @@ class TextSanitizer {
 
 		$tokens = $this->tokenize( $text, $language, $exemptionList );
 
-		$filtered = $this->filterTokens( $tokens, $language, $exemptionList );
+		$filtered = $this->filterTokens( $tokens, $language, $exemptionList, $isSearchTerm );
 
 		// Remove possible spaces added by the tokenizer
 		// or originating from the input.
@@ -344,13 +344,11 @@ class TextSanitizer {
 	 * minimum length (1 for CJK), and adjacent duplicates,
 	 * unless exceptions apply.
 	 *
-	 * @param array $tokens
-	 * @param string|null $language
-	 * @param string|array $exemptionList
+	 * @param string[] $tokens
 	 *
-	 * @return array
+	 * @return string[]
 	 */
-	private function filterTokens( $tokens, int|string|null $language, array|string $exemptionList ): array {
+	private function filterTokens( $tokens, int|string|null $language, array|string $exemptionList, bool $isSearchTerm ): array {
 		if ( !$tokens || !is_array( $tokens ) ) {
 			return [];
 		}
@@ -379,11 +377,12 @@ class TextSanitizer {
 		foreach ( $tokens as $k => $word ) {
 			// Check if the next 'word' is a truncation operator.
 			// If so, it shouldn't be "stripped from a boolean query,
-			// even if it is too short or a stopword" (MySQL docs)
-			$hasTruncator = false;
-			if ( isset( $tokens[$k + 1] ) && $tokens[$k + 1] === "*" ) {
-				$hasTruncator = true;
-			}
+			// even if it is too short or a stopword" (MySQL docs).
+			// Only a search term has boolean operators; when indexing,
+			// an asterisk is just punctuation.
+			$hasTruncator = $isSearchTerm
+				&& isset( $tokens[$k + 1] )
+				&& $tokens[$k + 1] === "*";
 
 			// Remove token if it is not an exemption, shorter than
 			// the required minimum length or identified as stop word,

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -95,9 +95,11 @@ class TextSanitizer {
 		$exemptionList = '';
 
 		// Those have special meaning when running a match search against
-		// the fulltext index (wildcard, phrase matching markers etc.)
+		// the fulltext index (wildcard, phrase matching markers, etc.).
+		// Excludes '@', which InnoDB reserves for @distance queries 
+		// and which holds no special meaning in MyISAM.
 		if ( $isSearchTerm ) {
-			$exemptionList = [ '*', '"', '+', '-', '&', ',', '@', '~' ];
+			$exemptionList = [ '*', '"', '+', '-', '&', ',', '~' ];
 		}
 
 		$text = mb_strtolower( $text );
@@ -112,20 +114,34 @@ class TextSanitizer {
 			$text
 		);
 
+		if ( $isSearchTerm ) {
+			// Trim any leading asterisks and trailing +/-/~ signs
+			// now that we can still determine their position.
+			// @link https://dev.mysql.com/doc/refman/9.7/en/fulltext-boolean.html
+			$trimmed = [];
+			foreach( explode( " ", $text ) as $t ) {
+				$trimmed[] = rtrim( ltrim( $t, "*" ), "-+~" );
+			}
+			$text = implode( " ", $trimmed );
+		}
+
 		$tokens = $this->tokenize( $text, $language, $exemptionList );
 
 		$filtered = $this->filterTokens( $tokens, $language, $exemptionList );
 
-		$text = implode( ' ', $filtered );
-
-		// Remove possible spaces added by the tokenizer
-		$text = str_replace(
+		// Remove possible spaces added by the tokenizer.
+		// Reunites tokens with leading operators ('+', '-', etc.),
+		// trailing operators ('*') and operators expected in
+		// both positions ('"')
+		$filteredText = str_replace(
 			[ ' *', '* ', ' "', '" ', '+ ', '- ', '@ ', '~ ', '*+', '*-', '*~' ],
 			[ '*', '*', '"', '"', '+', '-', '@', '~', '* +', '* -', '* ~' ],
-			$text
+			implode( ' ', $filtered )
 		);
 
-		return $text;
+		return $isSearchTerm
+			? $this->sanitizeFilteredText( $filteredText )
+			: $filteredText;
 	}
 
 	/**
@@ -154,10 +170,8 @@ class TextSanitizer {
 	 *
 	 * @return array
 	 */
-	private function tokenize( string|array $text, int|string|null $language, array|string $exemptionList ): array {
-		$hasCjk = (bool)preg_match( '/[\x{4e00}-\x{9fa5}]/u', $text );
+	private function tokenize( string $text, int|string|null $language, array|string $exemptionList ): array {
 		$hasIcu = class_exists( IntlRuleBasedBreakIterator::class );
-
 		if ( $hasIcu ) {
 			$tokens = $this->tokenizeWithIcu( $text, $language );
 			$joined = implode( ' ', $tokens );
@@ -165,6 +179,7 @@ class TextSanitizer {
 			return $this->tokenizeWithGenericRegex( $joined, $exemptionList );
 		}
 
+		$hasCjk = (bool)preg_match( '/[\x{4e00}-\x{9fa5}]/u', $text );
 		if ( $hasCjk ) {
 			$hasJapanese = (bool)preg_match( '/[\x{3040}-\x{309F}\x{30A0}-\x{30FF}]/u', $text );
 
@@ -298,6 +313,9 @@ class TextSanitizer {
 	}
 
 	/**
+	 * Filters out stopwords, tokens below the required
+	 * minimum length (1 for CJK), and adjacent duplicates.
+	 * 
 	 * @param array $tokens
 	 * @param string|null $language
 	 * @param string|array $exemptionList
@@ -389,6 +407,37 @@ class TextSanitizer {
 	 */
 	private function isStopWord( Reader $reader, $word ): bool {
 		return $reader->get( $word ) !== false;
+	}
+
+	/**
+	 * Removes illegal sequences and isolated operators that may
+	 * have been left behind after tokenizer() and filterTokens()
+	 * and lead to malformed syntax that can cause database query
+	 * errors (compared to MyISAM, InnoDB is less forgiving).
+	 * 
+	 * @link https://dev.mysql.com/doc/refman/9.7/en/fulltext-boolean.html
+	 * 
+	 * @param string $text
+	 * @return string
+	 */
+	private function sanitizeFilteredText( string $text ): string {
+		// Remove troublesome sequences
+		$cleaned = str_replace(
+			[ "+*", "-*", "~*", "+-", "-+" ], "", $text
+		);
+
+		// Remove isolated operators
+		// May occur eg when trailing operators become detached or
+		// a stopword or other token is filtered out.
+		$tokens = [];
+		foreach( explode( " ", $cleaned ) as $token ) {
+			if ( in_array( $token, [ "*", "+", "-", "~" ] ) ) {
+				continue;
+			}
+			$tokens[] = $token;
+		}
+
+		return implode( " ", $tokens );
 	}
 
 	/**

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -250,7 +250,7 @@ class TextSanitizer {
 		$pattern = str_replace(
 			$exemptionList,
 			'',
-			'([\s\-_,:;?!%\'\|\/\(\)\[\]{}<>\r\n"]|(?<!\d)\.(?!\d)|(?<=\p{L})(?=\p{N}))'
+			'([\s\-_,:;?!%@\'\|\/\(\)\[\]{}<>\r\n"]|(?<!\d)\.(?!\d)|(?<=\p{L})(?=\p{N}))'
 		);
 
 		$result = preg_split( '/' . $pattern . '/u', $text, -1, PREG_SPLIT_NO_EMPTY );
@@ -349,12 +349,12 @@ class TextSanitizer {
 		$index = [];
 		$pos = 0;
 
-		foreach ( $tokens as $word ) {
+		foreach ( $tokens as $k => $word ) {
 			// Check if the next 'word' is a truncation operator.
 			// If so, it shouldn't be "stripped from a boolean query,
 			// even if it is too short or a stopword" (MySQL docs)
 			$hasTruncator = false;
-			if ( isset( $index[$pos + 1] ) && $index[$pos + 1] === "*" ) {
+			if ( isset( $tokens[$k + 1] ) && $tokens[$k + 1] === "*" ) {
 				$hasTruncator = true;
 			}
 

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -122,9 +122,9 @@ class TextSanitizer {
 			// @link https://dev.mysql.com/doc/refman/9.7/en/fulltext-boolean.html
 			$trimmed = [];
 			foreach ( explode( " ", $text ) as $t ) {
-				if ( !in_array( $t, [ "*", "-", "+", "~" ] ) ) {
-					$trimmed[] = rtrim( ltrim( $t, "*" ), "-+~" );
-				}
+				$trimmed[] = ( !in_array( $t, [ "*", "-", "+", "~" ] ) )
+					? rtrim( ltrim( $t, "*" ), "-+~" )
+					: $t;
 			}
 			$text = implode( " ", $trimmed );
 		}

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -115,18 +115,7 @@ class TextSanitizer {
 		);
 
 		if ( $isSearchTerm ) {
-			// Trim any leading asterisks and trailing +/-/~ signs
-			// now that we can still determine their position.
-			// Exempt free-standing operators, which may be
-			// joined to tokens later on.
-			// @link https://dev.mysql.com/doc/refman/9.7/en/fulltext-boolean.html
-			$trimmed = [];
-			foreach ( explode( " ", $text ) as $t ) {
-				$trimmed[] = ( !in_array( $t, [ "*", "-", "+", "~" ] ) )
-					? rtrim( ltrim( $t, "*" ), "-+~" )
-					: $t;
-			}
-			$text = implode( " ", $trimmed );
+			$text = $this->trimUnsupportedOperators( $text );
 		}
 
 		$tokens = $this->tokenize( $text, $language, $exemptionList );
@@ -147,6 +136,39 @@ class TextSanitizer {
 		return $isSearchTerm
 			? $this->sanitizeFilteredText( $filteredText )
 			: $filteredText;
+	}
+
+	/**
+	 * Removes an asterisk that no term precedes and a trailing +/-/~ sign,
+	 * which MySQL rejects in those positions, while their position in the
+	 * input is still known.
+	 *
+	 * A leading operator is retained: "+*foo" is a required "foo", not an
+	 * unbound wildcard. Free-standing operators are exempt because they may
+	 * be joined to a neighbouring token further down.
+	 *
+	 * @link https://dev.mysql.com/doc/refman/9.7/en/fulltext-boolean.html
+	 */
+	private function trimUnsupportedOperators( string $text ): string {
+		$trimmed = [];
+
+		foreach ( explode( " ", $text ) as $t ) {
+			if ( in_array( $t, [ "*", "-", "+", "~" ], true ) ) {
+				$trimmed[] = $t;
+				continue;
+			}
+
+			// An asterisk that a term precedes truncates it; one that a
+			// term only follows is a leading wildcard, which is not
+			// supported. One with a term on neither side is left alone:
+			// the delimiter between them is about to be removed, as in
+			// "apple.*".
+			$stripped = preg_replace( '/(?<![\p{L}\p{N}])\*+(?=[\p{L}\p{N}])/u', '', $t ) ?? $t;
+
+			$trimmed[] = rtrim( $stripped, "-+~" );
+		}
+
+		return implode( " ", $trimmed );
 	}
 
 	/**
@@ -459,24 +481,25 @@ class TextSanitizer {
 	 * errors (compared to MyISAM, InnoDB is less forgiving).
 	 *
 	 * @link https://dev.mysql.com/doc/refman/9.7/en/fulltext-boolean.html
-	 *
-	 * @param string $text
-	 * @return string
 	 */
 	private function sanitizeFilteredText( string $text ): string {
-		// Trim multiples like "++", "--", "~~", and
-		// fully remove troublesome sequences
+		// Trim multiples like "++", "--", "~~" and runs of asterisks, and
+		// fully remove sequences the parser rejects in any position.
+		// Sequences such as "+*" are absent here because they are valid
+		// when bound to a term ("+*foo"); trimUnsupportedOperators() has
+		// already removed the unbound ones.
 		$cleaned = preg_replace( '/([+~-])\1+/', '$1', $text ) ?? $text;
+		$cleaned = preg_replace( '/\*{2,}/', '*', $cleaned ) ?? $cleaned;
 		$cleaned = str_replace(
-			[ "**", "*+", "*-", "*~", "+*", "+-", "+~", "-*", "-+", "-~", "~*", "~+", "~-" ], "", $cleaned
+			[ "*+", "*-", "*~", "+-", "+~", "-+", "-~", "~+", "~-" ], "", $cleaned
 		);
 
-		// Remove isolated operators
+		// Remove operators that carry no term.
 		// May occur eg when trailing operators become detached or
 		// a stopword or other token is filtered out.
 		$tokens = [];
 		foreach ( explode( " ", $cleaned ) as $token ) {
-			if ( in_array( $token, [ "*", "+", "-", "~" ] ) ) {
+			if ( $token === '' || preg_match( '/^[*+~-]+$/', $token ) === 1 ) {
 				continue;
 			}
 			$tokens[] = $token;

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -498,6 +498,14 @@ class TextSanitizer {
 
 			$cleaned = preg_replace( '/([+~-])\1+/', '$1', $cleaned ) ?? $cleaned;
 			$cleaned = preg_replace( '/\*{2,}/', '*', $cleaned ) ?? $cleaned;
+			// A stray quote is harmless on its own, but not next to an
+			// operator, where it leaves the operator without a term.
+			// Only an unpaired quote can be stray, so a balanced phrase
+			// keeps the operator that introduces it.
+			if ( substr_count( $cleaned, '"' ) % 2 === 1 ) {
+				$cleaned = preg_replace( '/(?<=[*+~-])"+|"+(?=[*+~-])/', '', $cleaned ) ?? $cleaned;
+			}
+
 			$cleaned = str_replace(
 				[ "*+", "*-", "*~", "+-", "+~", "-+", "-~", "~+", "~-" ], "", $cleaned
 			);
@@ -514,7 +522,8 @@ class TextSanitizer {
 			$tokens[] = $token;
 		}
 
-		return implode( " ", $tokens );
+		// A trailing operator has nothing left to qualify.
+		return rtrim( implode( " ", $tokens ), "+-~" );
 	}
 
 }

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -130,12 +130,12 @@ class TextSanitizer {
 		$filtered = $this->filterTokens( $tokens, $language, $exemptionList );
 
 		// Remove possible spaces added by the tokenizer.
-		// Reunites tokens with leading operators ('+', '-', etc.),
+		// e.g. reunites tokens with leading operators ('+', '-', etc.),
 		// trailing operators ('*') and operators expected in
 		// both positions ('"')
 		$filteredText = str_replace(
-			[ ' *', ' "', '" ', '+ ', '- ', '@ ', '~ ', '*+', '*-', '*~' ],
-			[ '*', '"', '"', '+', '-', '@', '~', '* +', '* -', '* ~' ],
+			[ ' *', ' "', '" ', '+ ', '- ', '~ ', '*+', '*-', '*~' ],
+			[ '*', '"', '"', '+', '-', '~', '* +', '* -', '* ~' ],
 			implode( ' ', $filtered )
 		);
 
@@ -419,6 +419,35 @@ class TextSanitizer {
 	}
 
 	/**
+	 * @param string $text
+	 *
+	 * @return string|null
+	 */
+	private function predictLanguage( string $text ): null|int|string {
+		if ( $this->languageDetection === [] ) {
+			return null;
+		}
+
+		if ( !isset( $this->languageDetection['TextCatLanguageDetector'] ) ) {
+			return null;
+		}
+
+		$textCat = new TextCat();
+		$candidates = $this->languageDetection['TextCatLanguageDetector'];
+
+		$result = $textCat->classify(
+			Normalizer::reduceLengthTo( $text, 200 ),
+			$candidates
+		);
+
+		if ( is_array( $result ) && $result !== [] ) {
+			return key( $result );
+		}
+
+		return null;
+	}
+
+	/**
 	 * Removes illegal sequences and isolated operators that may
 	 * have been left behind after tokenizer() and filterTokens()
 	 * and lead to malformed syntax that can cause database query
@@ -447,35 +476,6 @@ class TextSanitizer {
 		}
 
 		return implode( " ", $tokens );
-	}
-
-	/**
-	 * @param string $text
-	 *
-	 * @return string|null
-	 */
-	private function predictLanguage( string $text ): null|int|string {
-		if ( $this->languageDetection === [] ) {
-			return null;
-		}
-
-		if ( !isset( $this->languageDetection['TextCatLanguageDetector'] ) ) {
-			return null;
-		}
-
-		$textCat = new TextCat();
-		$candidates = $this->languageDetection['TextCatLanguageDetector'];
-
-		$result = $textCat->classify(
-			Normalizer::reduceLengthTo( $text, 200 ),
-			$candidates
-		);
-
-		if ( is_array( $result ) && $result !== [] ) {
-			return key( $result );
-		}
-
-		return null;
 	}
 
 }

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -99,7 +99,7 @@ class TextSanitizer {
 		// Excludes '@', which InnoDB reserves for @distance queries
 		// and which holds no special meaning in MyISAM.
 		if ( $isSearchTerm ) {
-			$exemptionList = [ '*', '"', '+', '-', '&', ',', '~' ];
+			$exemptionList = [ '*', '"', '+', '-', '&', '~' ];
 		}
 
 		$text = mb_strtolower( $text );

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -464,9 +464,11 @@ class TextSanitizer {
 	 * @return string
 	 */
 	private function sanitizeFilteredText( string $text ): string {
-		// Remove troublesome sequences
+		// Trim multiples like "++", "--", "~~", and
+		// fully remove troublesome sequences
+		$cleaned = preg_replace( '/([+~-])\1+/', '$1', $text ) ?? $text;
 		$cleaned = str_replace(
-			[ "**", "*+", "*-", "*~", "+*", "++", "+-", "+~", "-*", "-+", "--", "-~", "~*", "~+", "~-", "~~" ], "", $text
+			[ "**", "*+", "*-", "*~", "+*", "+-", "+~", "-*", "-+", "-~", "~*", "~+", "~-" ], "", $cleaned
 		);
 
 		// Remove isolated operators

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -117,10 +117,14 @@ class TextSanitizer {
 		if ( $isSearchTerm ) {
 			// Trim any leading asterisks and trailing +/-/~ signs
 			// now that we can still determine their position.
+			// Exempt free-standing operators, which may be
+			// joined to tokens later on.
 			// @link https://dev.mysql.com/doc/refman/9.7/en/fulltext-boolean.html
 			$trimmed = [];
 			foreach ( explode( " ", $text ) as $t ) {
-				$trimmed[] = rtrim( ltrim( $t, "*" ), "-+~" );
+				if ( !in_array( $t, [ "*", "-", "+", "~" ] ) ) {
+					$trimmed[] = rtrim( ltrim( $t, "*" ), "-+~" );
+				}
 			}
 			$text = implode( " ", $trimmed );
 		}
@@ -129,8 +133,9 @@ class TextSanitizer {
 
 		$filtered = $this->filterTokens( $tokens, $language, $exemptionList );
 
-		// Remove possible spaces added by the tokenizer.
-		// e.g. reunites tokens with leading operators ('+', '-', etc.),
+		// Remove possible spaces added by the tokenizer
+		// or originating from the input.
+		// Reunites tokens with leading operators ('+', '-', etc.),
 		// trailing operators ('*') and operators expected in
 		// both positions ('"')
 		$filteredText = str_replace(

--- a/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
+++ b/src/SQLStore/QueryEngine/Fulltext/TextSanitizer.php
@@ -96,7 +96,7 @@ class TextSanitizer {
 
 		// Those have special meaning when running a match search against
 		// the fulltext index (wildcard, phrase matching markers, etc.).
-		// Excludes '@', which InnoDB reserves for @distance queries 
+		// Excludes '@', which InnoDB reserves for @distance queries
 		// and which holds no special meaning in MyISAM.
 		if ( $isSearchTerm ) {
 			$exemptionList = [ '*', '"', '+', '-', '&', ',', '~' ];
@@ -119,7 +119,7 @@ class TextSanitizer {
 			// now that we can still determine their position.
 			// @link https://dev.mysql.com/doc/refman/9.7/en/fulltext-boolean.html
 			$trimmed = [];
-			foreach( explode( " ", $text ) as $t ) {
+			foreach ( explode( " ", $text ) as $t ) {
 				$trimmed[] = rtrim( ltrim( $t, "*" ), "-+~" );
 			}
 			$text = implode( " ", $trimmed );
@@ -316,7 +316,7 @@ class TextSanitizer {
 	 * Filters out stopwords, tokens below the required
 	 * minimum length (1 for CJK), and adjacent duplicates,
 	 * unless exceptions apply.
-	 * 
+	 *
 	 * @param array $tokens
 	 * @param string|null $language
 	 * @param string|array $exemptionList
@@ -358,7 +358,7 @@ class TextSanitizer {
 				$hasTruncator = true;
 			}
 
-			// Remove token if it is not an exemption, shorter than 
+			// Remove token if it is not an exemption, shorter than
 			// the required minimum length or identified as stop word,
 			// and has no truncation operator
 			if ( !isset( $whiteList[$word] ) && (
@@ -452,9 +452,9 @@ class TextSanitizer {
 	 * have been left behind after tokenizer() and filterTokens()
 	 * and lead to malformed syntax that can cause database query
 	 * errors (compared to MyISAM, InnoDB is less forgiving).
-	 * 
+	 *
 	 * @link https://dev.mysql.com/doc/refman/9.7/en/fulltext-boolean.html
-	 * 
+	 *
 	 * @param string $text
 	 * @return string
 	 */
@@ -468,7 +468,7 @@ class TextSanitizer {
 		// May occur eg when trailing operators become detached or
 		// a stopword or other token is filtered out.
 		$tokens = [];
-		foreach( explode( " ", $cleaned ) as $token ) {
+		foreach ( explode( " ", $cleaned ) as $token ) {
 			if ( in_array( $token, [ "*", "+", "-", "~" ] ) ) {
 				continue;
 			}

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
@@ -122,6 +122,11 @@ class TextSanitizerTest extends TestCase {
 			'I am a test',
 			'test'
 		];
+
+		// The truncation operator only has meaning in a search term.
+		// When indexing, an asterisk is punctuation and must not keep
+		// a token that is below the minimum length.
+
 	}
 
 	public static function operatorSpacingProvider() {
@@ -187,13 +192,63 @@ class TextSanitizerTest extends TestCase {
 
 		yield 'illegal operator sequences' => [
 			'-+peach+* decidu*+-',
-			'peach  decidu*'
+			'peach decidu*'
 		];
 
 		yield 'at sign as delimiter' => [
 			'name@email',
 			'name email'
 		];
+
+		yield 'required term with leading wildcard' => [
+			'+*apple* banana',
+			'+apple* banana'
+		];
+
+		yield 'excluded term with leading wildcard' => [
+			'-*apple* pear',
+			'-apple* pear'
+		];
+
+		yield 'relevance operator with leading wildcard' => [
+			'~*apple* pear',
+			'~apple* pear'
+		];
+
+		yield 'doubled leading wildcard' => [
+			'**apple',
+			'apple'
+		];
+
+		yield 'doubled trailing wildcard' => [
+			'apple**',
+			'apple*'
+		];
+
+		yield 'comma directly before wildcard' => [
+			'foo,*bar',
+			'foo bar'
+		];
+
+
+
+
+
+
+
+
+
+		yield 'wildcard after a delimiter that is dropped' => [
+			'apple.*',
+			'apple*'
+		];
+
+		yield 'wildcard after a bracket that is dropped' => [
+			'(test)*',
+			'test*'
+		];
+
+
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
@@ -248,11 +248,35 @@ class TextSanitizerTest extends TestCase {
 			'apple ~pear'
 		];
 
+		yield 'trailing operator after a quoted phrase' => [
+			'"apple" -',
+			'"apple"'
+		];
 
+		yield 'trailing operator after an embedded quote' => [
+			'find "this" +',
+			'find"this"'
+		];
 
+		yield 'quote left behind by a filtered short token' => [
+			'+ab" +pear',
+			'+pear'
+		];
 
+		yield 'required phrase' => [
+			'+"apple pear"',
+			'+"apple pear"'
+		];
 
+		yield 'excluded phrase' => [
+			'-"apple pear"',
+			'-"apple pear"'
+		];
 
+		yield 'phrase followed by a required term' => [
+			'"apple pear" +kiwi',
+			'"apple pear"+kiwi'
+		];
 
 		yield 'wildcard after a delimiter that is dropped' => [
 			'apple.*',

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
@@ -288,7 +288,18 @@ class TextSanitizerTest extends TestCase {
 			'test*'
 		];
 
+		// The apostrophe splits the term into two parts that are both
+		// below the minimum length. Discarding them used to leave the
+		// truncation operator on its own. See issue 6129.
+		yield 'apostrophe with wildcard' => [
+			"O'Se*",
+			'se*'
+		];
 
+		yield 'apostrophe with wildcard after a longer term' => [
+			"+Col* +O'Se*",
+			'+col* +se*'
+		];
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
@@ -142,7 +142,7 @@ class TextSanitizerTest extends TestCase {
 
 		yield 'surrounding wildcards' => [
 			'* foo *',
-			'*foo*'
+			'foo*'
 		];
 
 		yield 'plus and wildcard combo' => [
@@ -157,13 +157,44 @@ class TextSanitizerTest extends TestCase {
 
 		yield 'adjacent wildcards' => [
 			'*foo* bar',
-			'*foo*bar'
+			'foo* bar'
 		];
 
 		yield 'plus wildcard combo' => [
 			'+foo*, *bar',
-			'+foo*,*bar'
+			'+foo* bar'
 		];
+
+		yield 'two letters with wildcard' => [
+			'be*',
+			'be*'
+		];
+
+		yield 'single asterisk wildcard' => [
+			'*',
+			''
+		];
+
+		yield 'duplicate operators' => [
+			'++appl* ~~doctor --away',
+			'+appl* ~doctor -away'
+		];
+
+		yield 'operators in wrong positions' => [
+			'*appl+ *doctor- *away~',
+			'appl doctor away'
+		];
+
+		yield 'illegal operator sequences' => [
+			'-+peach+* decidu*+-',
+			'peach decidu*'
+		];
+
+		yield 'at sign as delimiter' => [
+			'name@email',
+			'name email'
+		];
+
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
@@ -230,7 +230,15 @@ class TextSanitizerTest extends TestCase {
 			'foo bar'
 		];
 
+		yield 'operator run reducible only in several passes' => [
+			'-+~-apple',
+			'-apple'
+		];
 
+		yield 'operator run reducible only in several passes, trailing' => [
+			'apple ~+-~pear',
+			'apple ~pear'
+		];
 
 
 

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
@@ -187,14 +187,13 @@ class TextSanitizerTest extends TestCase {
 
 		yield 'illegal operator sequences' => [
 			'-+peach+* decidu*+-',
-			'peach decidu*'
+			'peach  decidu*'
 		];
 
 		yield 'at sign as delimiter' => [
 			'name@email',
 			'name email'
 		];
-
 	}
 
 }

--- a/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
+++ b/tests/phpunit/Unit/SQLStore/QueryEngine/Fulltext/TextSanitizerTest.php
@@ -126,7 +126,15 @@ class TextSanitizerTest extends TestCase {
 		// The truncation operator only has meaning in a search term.
 		// When indexing, an asterisk is punctuation and must not keep
 		// a token that is below the minimum length.
+		yield 'asterisk does not retain a short token when indexing' => [
+			'a * b',
+			''
+		];
 
+		yield 'multiplication signs do not retain digits when indexing' => [
+			'2 * pi * r',
+			''
+		];
 	}
 
 	public static function operatorSpacingProvider() {


### PR DESCRIPTION
This patch addresses database parsing issues with SMW queries using [Full-text Search](https://www.semantic-mediawiki.org/wiki/Help:Full-text_search) (FTS) in MySQL/MariaDB (SQLite is out of scope).

In some cases, the current `TextSanitizer` for FTS will fail to catch syntax errors in MATCH / AGAINST with the IN BOOLEAN MODE modifier. In others, it is even responsible for creating them, as reported for instance in #6129. If the database is not able to ignore or just misinterpet malformed syntax, it errors out - since SMW 7, the result is a hard database query error. This problem is particularly evident when the storage engine of the `*_smw_ft_search` table is InnoDB (MyISAM is more lenient).
* Incidentally, the default SQL engine set in`$smwgFulltextSearchTableOptions`is MyISAM, but oddly enough, I've noticed that InnoDB may end up being used instead.

### Syntax errors to watch out for and targeted by this update

* Most or many of those that potentially cause database errors are listed and described on https://dev.mysql.com/doc/refman/9.7/en/fulltext-boolean.html - including sequences like `+*` and `-+` 
* Add to the above standalone operators divorced from any token
* the at sign (see below)

One possible cause for these is a fragility inherent in the current implementation:

* array-based 'tokenization' into tokens and operators removes the distinction between leading and trailing operators as used in the original input.
* the removal of tokens in `filterTokens()` can have the side-effect of leaving behind a bit of debris, such as bare operators as well as infelicitous combinations of operators.

This patch provides a safety net (`sanitizeFilteredText()`) at the end of `sanitize()`, but also intervenes at earlier stages, for instance to remove unsupported leading/trailing ops.

### Related changes

* Removed `'* '` from the list of the replacements after `filterTokens()`, which may have been intended to reattach a leading asterisk, but (a) leading asterisks are unsupported as wildcards (and are now removed anyway) and (b) when combined with the first replacement, it can cause unintended contractions, e.g. _`*apple* pear*`_ would become `*apple*pear*`. The unit tests have been corrected accordingly.
* Removed the at sign (`@`) from the exemptions list (and list of replacements) since it can cause the DB to error out. It has no special meaning except in InnoDB's `@distance`, which is not supported by SMW. Added a case to the unit test ('at sign as delimiter').
* Removed the comma from the list of exemptions since it has no special meaning except as a delimiter. The regex-based tokenizer ensures the comma is always treated as such. The unit test case `'+foo*, *bar'` ('plus wildcard combo') has been adjusted.
* While MySQL's documentation says that "if a word is specified with the truncation operator \[i.e. \*\], it is not stripped from a boolean query, even if it is too short or a stopword", SMW discards these words/tokens nevertheless. A fix is provided to not discard them, which should also diminish the possibility of leaving behind solitary truncators. Note that it does not factor in that SMW provides a fallback to LIKE if the entire input string is too short to represent a token.
* Fixed a type declaration in `tokenize()`
* I tried to keep inline comments to a minimum but the complexity and fragility of the code called for at least some clarifications.

### Unit tests
Existing cases in `TextSanitizerTest` have been corrected where necessary and new ones were added ('two letters with wildcard', 'single asterisk wildcard', etc.).

### Variables to take into account when changing `TextSanitizer`

* `TextSanitizer::sanitize()` serves a double duty: it is called by `MySQLValueMatchConditionBuilder` (with `$isSearchTerm` = true) to answer queries; by `SearchTableRebuilder` (with `$isSearchTerm` = false) to populate the database. All of the care taken to ensure that operators are properly in place shouldn't affect the latter situation when `$isSearchTerm` is false.
* Fixes will target queries IN BOOLEAN MODE, the default mode, but although undocumented, SMW also supports IN NATURAL LANGUAGE MODE and WITH QUERY EXPANSION using shorthands. To my knowledge, special operators are not part of their syntax, but syntax errors such as a standalone asterisk can similarly cause database errors.
* InnoDB and MyISAM are the most common MySQL/MariaDB engines, but it would be good to know if anyone uses ARIA and has encountered related issues that are peculiar to ARIA.