### PR TITLE
Share one query result cache per request

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.2.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.2.md
@@ -9,6 +9,8 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 
 ## Changes
 
+* Fixed wikis with the query result cache enabled (`$smwgQueryResultCacheType`) reading the object cache once per identical query on a page instead of once per page, and reporting no cache hits at all in the query cache statistics on `Special:SemanticMediaWiki` ([#7102](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7102))
+
 ## Upgrading
 
 No need to run "update.php" or any other migration scripts.

--- a/src/MediaWiki/Hooks/AfterQueryResultLookupComplete.php
+++ b/src/MediaWiki/Hooks/AfterQueryResultLookupComplete.php
@@ -34,10 +34,9 @@ class AfterQueryResultLookupComplete {
 
 		$queryDependencyLinksStore->updateDependencies( $result );
 
-		// `ResultCache` is resolved lazily rather than via the `services:`
-		// array because its query-result store is built from `smwgQueryResultCacheType`
-		// at construction and `MediaWikiServices` caches the resolved instance.
-		// See `BeforeQueryResultLookupComplete` for the full rationale.
+		// Records the statistics accumulated by the shared `SMW.ResultCache`
+		// during `BeforeQueryResultLookupComplete`. Resolved lazily rather than
+		// via the `services:` array; see that hook for the rationale.
 		ApplicationFactory::getInstance()->singleton( 'ResultCache' )->recordStats();
 
 		$store->getObjectIds()->warmUpCache( $result );

--- a/src/MediaWiki/Hooks/BeforeQueryResultLookupComplete.php
+++ b/src/MediaWiki/Hooks/BeforeQueryResultLookupComplete.php
@@ -19,14 +19,14 @@ class BeforeQueryResultLookupComplete {
 	 * @since 7.0.0
 	 */
 	public function onSMW__Store__BeforeQueryResultLookupComplete( $store, $query, &$result, $queryEngine ): bool {
-		// `ResultCache` cannot be injected through the declarative `services:`
-		// array because its query-result store is constructed from
-		// `smwgQueryResultCacheType` at instantiation, and `MediaWikiServices`
-		// caches the resolved instance for the container's lifetime. JSONScript
-		// tests vary that setting per test case, so the cached instance would
-		// hold a stale cache backend. Resolving it through
-		// `ServicesFactory::singleton()` rebuilds the instance per hook fire
-		// against current settings.
+		// Resolved per hook fire rather than injected through the declarative
+		// `services:` array, because `HookContainer` memoises the constructed
+		// handler and would pin one `ResultCache` for the container's lifetime.
+		// JSONScript data sets vary `smwgQueryResultCacheType`, and the
+		// `ServicesFactory::clear()` they run between data sets refreshes the
+		// service but not a handler already holding it. `SMW.ResultCache` is
+		// shared, so this hook and `AfterQueryResultLookupComplete` still see
+		// one instance, with one query-result store and one set of statistics.
 		$resultCache = ApplicationFactory::getInstance()->singleton( 'ResultCache' );
 
 		$resultCache->setQueryEngine(

--- a/src/Services/README.md
+++ b/src/Services/README.md
@@ -6,13 +6,13 @@ Services contain object definitions that handle the object build process and pro
 
 Object instances are generally accessed using the `ServicesFactory` locator and its public methods.
 
-`ServicesFactory` owns a private `Wikimedia\Services\ServiceContainer` populated from the `ServiceWiring.php` wiring file. That container holds the no-argument, stateless services (Bucket A). Services that take runtime arguments or are constructed fresh per use (Bucket B and C) are exposed as factory methods on `ServicesFactory` instead.
+`ServicesFactory` resolves services from MediaWiki's global `ServiceContainer`, populated from the `ServiceWiring.php` wiring file under `SMW.` keys. That container holds the no-argument services, including ones that carry request-scoped state such as `SMW.ResultCache`. Services that take runtime arguments or are constructed fresh per use are exposed as factory methods on `ServicesFactory` instead.
 
 ## Service files and containers
 
 ### Files
 
-* `ServiceWiring.php` wiring file for the private `ServiceContainer`; defines the Bucket-A services
+* `ServiceWiring.php` wiring file for MediaWiki's global `ServiceContainer`; defines the `SMW.` services
 * `importer.php` provides services for the [Importer](https://github.com/SemanticMediaWiki/SemanticMediaWiki/tree/master/src/Importer), consumed by `ImporterServiceFactory`
 * `datavalues.php` provides services for `DataValue` objects, consumed by `DataValueServiceFactory`
 

--- a/src/Services/ServiceWiring.php
+++ b/src/Services/ServiceWiring.php
@@ -51,6 +51,7 @@ use SMW\Property\AnnotatorFactory;
 use SMW\Property\SpecificationLookup;
 use SMW\PropertyLabelFinder;
 use SMW\Protection\ProtectionValidator;
+use SMW\Query\Cache\ResultCache;
 use SMW\Query\Processor\ParamListProcessor;
 use SMW\Query\Processor\QueryCreator;
 use SMW\Query\QuerySourceFactory;
@@ -614,6 +615,16 @@ return [
 			$lang->getCanonicalPropertyLabels(),
 			$lang->getCanonicalDatatypeLabels()
 		);
+	},
+
+	'SMW.ResultCache' => static function ( MediaWikiServices $services ): ResultCache {
+		$servicesFactory = ServicesFactory::getInstance();
+
+		if ( $servicesFactory->hasTestOverride( 'ResultCache' ) ) {
+			return $servicesFactory->getResultCache();
+		}
+
+		return $servicesFactory->newResultCache();
 	},
 
 	'SMW.InvalidateResultCacheEventListener' => static function ( MediaWikiServices $services ): InvalidateResultCacheEventListener {

--- a/src/Services/ServicesFactory.php
+++ b/src/Services/ServicesFactory.php
@@ -333,6 +333,7 @@ class ServicesFactory {
 			'ImporterServiceFactory' => fn () => $this->getImporterServiceFactory(),
 			'HierarchyLookup' => fn () => $this->newHierarchyLookup( ...$args ),
 			'DisplayTitleFinder' => fn () => $this->newDisplayTitleFinder( ...$args ),
+			'ResultCache' => fn () => $this->getResultCache( ...$args ),
 
 			// Bucket-B/C SMW services constructed fresh per call.
 			'IndicatorRegistry' => fn () => $this->newIndicatorRegistry( ...$args ),
@@ -351,7 +352,6 @@ class ServicesFactory {
 			'PostProcHandler' => fn () => $this->newPostProcHandler( ...$args ),
 			// @phan-suppress-next-line PhanParamTooFewUnpack
 			'QueryResultStore' => fn () => $this->newQueryResultStore( ...$args ),
-			'ResultCache' => fn () => $this->getResultCache( ...$args ),
 			// @phan-suppress-next-line PhanParamTooFewUnpack
 			'Stats' => fn () => $this->newStats( ...$args ),
 			// @phan-suppress-next-line PhanParamTooFewUnpack
@@ -1147,9 +1147,46 @@ class ServicesFactory {
 	}
 
 	/**
+	 * Returns the request-shared `ResultCache`; passing `$cacheType` builds a
+	 * separate, unshared instance against that cache back-end.
+	 *
+	 * The shared instance reads `smwgQueryResultCacheType` and the other cache
+	 * settings once, when it is first resolved. Code that changes those
+	 * settings for the rest of a process, such as
+	 * `MaintenanceHelper::setGlobalToValue()` in `rebuildData.php`, has to do so
+	 * before anything resolves the cache.
+	 *
 	 * @since 7.0.0
 	 */
 	public function getResultCache( $cacheType = null ): ResultCache {
+		if ( array_key_exists( 'ResultCache', $this->testOverrides ) ) {
+			return $this->testOverrides['ResultCache'];
+		}
+
+		// `SMW.ResultCache` on the global container is built from
+		// `smwgQueryResultCacheType`; when the caller asks for a different cache
+		// back-end, build the instance inline.
+		if ( $cacheType === null ) {
+			return MediaWikiServices::getInstance()->getService( 'SMW.ResultCache' );
+		}
+
+		return $this->newResultCache( $cacheType );
+	}
+
+	/**
+	 * Constructs a `ResultCache` and its query-result store. Use
+	 * `getResultCache()` instead: the request-scoped fast tier inside
+	 * `QueryResultStore` and the `CacheStats` counters that
+	 * `AfterQueryResultLookupComplete` flushes are only meaningful while one
+	 * instance serves the whole request (#7102). This method is public so
+	 * `ServiceWiring.php` can build the shared `SMW.ResultCache`.
+	 *
+	 * @since 7.2.2
+	 *
+	 * @param int|string|bool|null $cacheType Cache back-end to build against;
+	 *  `null` resolves `smwgQueryResultCacheType`.
+	 */
+	public function newResultCache( $cacheType = null ): ResultCache {
 		if ( array_key_exists( 'ResultCache', $this->testOverrides ) ) {
 			return $this->testOverrides['ResultCache'];
 		}

--- a/tests/phpunit/Integration/Query/QueryResultCacheStatsDBIntegrationTest.php
+++ b/tests/phpunit/Integration/Query/QueryResultCacheStatsDBIntegrationTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace SMW\Tests\Integration\Query;
+
+use SMW\DataItems\Property;
+use SMW\DataItems\WikiPage;
+use SMW\DataValueFactory;
+use SMW\Query\Language\SomeProperty;
+use SMW\Query\Language\ThingDescription;
+use SMW\Query\Query;
+use SMW\Services\ServicesFactory as ApplicationFactory;
+use SMW\Tests\SMWIntegrationTestCase;
+use SMW\Tests\TestEnvironment;
+use SMW\Tests\Utils\UtilityFactory;
+
+/**
+ * @group SMW
+ * @group SMWExtension
+ *
+ * @group semantic-mediawiki-integration
+ * @group semantic-mediawiki-query
+ *
+ * @group mediawiki-database
+ * @group Database
+ * @group medium
+ *
+ * @license GPL-2.0-or-later
+ * @since 7.2.2
+ */
+class QueryResultCacheStatsDBIntegrationTest extends SMWIntegrationTestCase {
+
+	/**
+	 * Qualifies the recorded hit so the assertion cannot be satisfied by a
+	 * statistic another test left in the shared back-end.
+	 */
+	private const PROC_CONTEXT = 'QueryResultCacheStatsDBIntegrationTest';
+
+	private ?WikiPage $subject = null;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->testEnvironment->addConfiguration( 'smwgQueryResultCacheType', 'hash' );
+
+		// The shared `SMW.ResultCache` reads the cache settings when it is first
+		// resolved, so drop it after changing them.
+		ApplicationFactory::clear();
+	}
+
+	protected function tearDown(): void {
+		if ( $this->subject !== null ) {
+			$this->getStore()->deleteSubject( $this->subject->getTitle() );
+		}
+
+		ApplicationFactory::clear();
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A query answered from the cache is counted as a hit by the `ResultCache`
+	 * that served it, and written out by `AfterQueryResultLookupComplete`. Both
+	 * hooks have to hold the same instance for the count to survive. While they
+	 * did not, the query cache statistics on `Special:SemanticMediaWiki`
+	 * reported no hits at all, however well the cache was working. See #7102.
+	 */
+	public function testQueryAnsweredFromCacheIsCountedAsAHit() {
+		$property = new Property( 'SomeQueryResultCacheStatsProperty' );
+		$property->setPropertyValueType( '_wpg' );
+
+		$semanticData = UtilityFactory::getInstance()->newSemanticDataFactory()->newEmptySemanticData( __METHOD__ );
+		$this->subject = $semanticData->getSubject();
+
+		$semanticData->addDataValue(
+			DataValueFactory::getInstance()->newDataValueByItem( $this->subject, $property )
+		);
+
+		$this->getStore()->updateData( $semanticData );
+
+		// Misses, and schedules the write to the cache back-end.
+		$this->getStore()->getQueryResult( $this->newQuery( $property ) );
+		TestEnvironment::executePendingDeferredUpdates();
+
+		// Stand in for a second request: a fresh `ResultCache` over the same
+		// cache back-end, so the next lookup is answered by the back-end rather
+		// than by the in-process result pool, which records no query context.
+		ApplicationFactory::clear();
+
+		$this->getStore()->getQueryResult( $this->newQuery( $property ) );
+		TestEnvironment::executePendingDeferredUpdates();
+
+		$stats = ApplicationFactory::getInstance()->getResultCache()->getStats();
+
+		$this->assertSame(
+			1,
+			$stats['hits']['embedded'][self::PROC_CONTEXT] ?? 0
+		);
+	}
+
+	private function newQuery( Property $property ): Query {
+		$query = new Query(
+			new SomeProperty( $property, new ThingDescription() )
+		);
+
+		$query->querymode = Query::MODE_INSTANCES;
+		$query->setLimit( 10 );
+		$query->setContextPage( $this->subject );
+		$query->setOption( Query::PROC_CONTEXT, self::PROC_CONTEXT );
+
+		return $query;
+	}
+
+}

--- a/tests/phpunit/Integration/SPARQLStore/QueryResultLookupWithoutBaseStoreIntegrationTest.php
+++ b/tests/phpunit/Integration/SPARQLStore/QueryResultLookupWithoutBaseStoreIntegrationTest.php
@@ -56,6 +56,16 @@ class QueryResultLookupWithoutBaseStoreIntegrationTest extends TestCase {
 		ApplicationFactory::getInstance()->singleton( 'ResultCache' )->disableCache();
 	}
 
+	protected function tearDown(): void {
+		// `disableCache()` above mutates the request-shared `SMW.ResultCache`,
+		// so drop it rather than leave the cache disabled for the rest of the
+		// process. Runs even when `setUp()` skipped before that line, where it
+		// is a no-op.
+		ApplicationFactory::clear();
+
+		parent::tearDown();
+	}
+
 	public function testQuerySubjects_afterUpdatingSemanticData() {
 		$semanticData = $this->semanticDataFactory->newEmptySemanticData( __METHOD__ );
 

--- a/tests/phpunit/Integration/Services/BehaviourSensitiveServiceCharacterizationTest.php
+++ b/tests/phpunit/Integration/Services/BehaviourSensitiveServiceCharacterizationTest.php
@@ -14,6 +14,7 @@ use SMW\NamespaceExaminer;
 use SMW\Parser\LinksProcessor;
 use SMW\Property\RestrictionExaminer;
 use SMW\Protection\ProtectionValidator;
+use SMW\Query\Cache\ResultCache;
 use SMW\Services\DataValueServiceFactory;
 use SMW\Services\ImporterServiceFactory;
 use SMW\Services\ServicesFactory;
@@ -255,6 +256,29 @@ class BehaviourSensitiveServiceCharacterizationTest extends MediaWikiIntegration
 		// service, so each call returns a fresh instance and the setUser() mutation
 		// is isolated per caller.
 		$this->assertNotSame( $first, $second, 'PropertyRestrictionExaminer: Bucket-C service constructed fresh per call' );
+	}
+
+	// -------------------------------------------------------------------------
+	// ResultCache: request-scoped state depends on a shared instance
+	// -------------------------------------------------------------------------
+
+	/**
+	 * ResultCache carries two pieces of request-scoped state that only work when
+	 * every call site in a request holds the same instance: the `MapCacheLRU`
+	 * fast tier inside its `QueryResultStore`, and the `CacheStats` counters that
+	 * `AfterQueryResultLookupComplete` flushes for the lookup performed by
+	 * `BeforeQueryResultLookupComplete`.
+	 *
+	 * When each call built its own instance, every lookup re-read the cache
+	 * back-end for a key the request had already fetched, and every cache hit was
+	 * counted on an instance nothing ever recorded. See #7102.
+	 */
+	public function testResultCacheIsSharedWithinARequest(): void {
+		$first = $this->factory->singleton( 'ResultCache' );
+		$second = $this->factory->singleton( 'ResultCache' );
+
+		$this->assertInstanceOf( ResultCache::class, $first );
+		$this->assertSame( $first, $second, 'ResultCache: shared instance resolved via the global ServiceContainer' );
 	}
 
 }

--- a/tests/phpunit/Integration/Services/ServiceWiringTest.php
+++ b/tests/phpunit/Integration/Services/ServiceWiringTest.php
@@ -78,6 +78,7 @@ use SMW\Property\AnnotatorFactory;
 use SMW\Property\SpecificationLookup;
 use SMW\PropertyLabelFinder;
 use SMW\Protection\ProtectionValidator;
+use SMW\Query\Cache\ResultCache;
 use SMW\Query\Processor\ParamListProcessor;
 use SMW\Query\Processor\QueryCreator;
 use SMW\Query\QuerySourceFactory;
@@ -160,6 +161,7 @@ class ServiceWiringTest extends MediaWikiIntegrationTestCase {
 			[ 'SMW.ImporterServiceFactory', ImporterServiceFactory::class ],
 			[ 'SMW.HierarchyLookup', HierarchyLookup::class ],
 			[ 'SMW.DisplayTitleFinder', DisplayTitleFinder::class ],
+			[ 'SMW.ResultCache', ResultCache::class ],
 		];
 	}
 


### PR DESCRIPTION
Fixes https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7102

`ServicesFactory::getResultCache()` built a new `ResultCache`, a new
`QueryResultStore` and a new `MapCacheLRU` on every call, and both query hooks
resolve the cache per query. A page holding the same `#ask` several times
therefore issued one `objectcache` read per occurrence for a key the request had
already fetched, which is what MediaWiki reports as a `Duplicate get()`.

The rebuild also lost the cache statistics. `ResultCache` counts a hit on the
instance that served the lookup and leaves `AfterQueryResultLookupComplete` to
flush it, but that hook received a different instance holding an empty
`CacheStats`, so the statistics on `Special:SemanticMediaWiki` never reported a
hit. Misses were unaffected, because the miss path registers its own
post-commit flush.

The cache was shared until the private callback container was removed in #6827.
The name was not carried over to the global `ServiceContainer`, so it fell
through to a factory method that constructs inline. Register `SMW.ResultCache`
and resolve it from `getResultCache()`, with the construction moved to
`newResultCache()`.

The hook comments claiming the cache cannot be a registered service were stale:
`JSONScriptServicesTestCaseRunner::prepareTest()` calls
`ApplicationFactory::clear()` after applying per case settings, which resets
every `SMW.*` service. They keep resolving lazily for a different reason, now
stated in the comment: `HookContainer` memoises handler objects, and `clear()`
does not reset those.

Because the shared instance reads the cache settings when it is first resolved,
`QueryResultLookupWithoutBaseStoreIntegrationTest`, which calls `disableCache()`
on it, now drops the instance again in `tearDown()` rather than leaving the
cache disabled for the rest of the process.

## Test plan

- New `BehaviourSensitiveServiceCharacterizationTest::testResultCacheIsSharedWithinARequest` and the
  `SMW.ResultCache` row in `ServiceWiringTest`, both seen failing before the change.
- New `QueryResultCacheStatsDBIntegrationTest`, which drives two real query lookups through the store
  and asserts the cache hit reaches the statistics. Without the change it fails on the reported
  symptom, asserting that 0 is identical to 1.
- Unit suite green, with the pre-existing skips unchanged.
- JSONScript cases that vary `smwgQueryResultCacheType` green: `p-0907`, `p-0908`, `p-0909`,
  `p-0911`, `p-0914`, `format-embedded-0001`, `format-embedded-0002`, `format-template-0004`,
  `q-0202`, `q-0205`.
- `composer analyze`, `phpcs -sp` on the changed files and `phan` clean.
- On a dev wiki with `$smwgQueryResultCacheType = CACHE_DB`, parsing a page holding twenty identical
  `{{#ask:}}`: `SELECT`s on `wiki:smw:query:store:<hash>` drop from twenty to one, the MediaWiki
  `Duplicate get()` warning disappears, and total logged SQL for the request drops from 120 to 62.
- Browser check of the query cache panel on `Special:SemanticMediaWiki`: after three `Special:Ask`
  requests for one query it reports one miss, two hits and a hit ratio of 0.6667, where it previously
  reported no hits at all. Pages with `#ask`, `Special:Ask` and the admin page also render with the
  cache left at its default, with no console errors.
