### PR TITLE
Don't let a failed transaction rollback discard the original exception

### DIFF
--- a/docs/releasenotes/RELEASE-NOTES-7.2.2.md
+++ b/docs/releasenotes/RELEASE-NOTES-7.2.2.md
@@ -10,6 +10,7 @@ For more detailed information, see the [compatibility matrix](../COMPATIBILITY.m
 ## Changes
 
 * Fixed wikis with the query result cache enabled (`$smwgQueryResultCacheType`) reading the object cache once per identical query on a page instead of once per page, and reporting no cache hits at all in the query cache statistics on `Special:SemanticMediaWiki` ([#7102](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7102))
+* Fixed a failed data update or setup state write hiding its real cause when rolling the transaction back also failed ([#7107](https://github.com/SemanticMediaWiki/SemanticMediaWiki/issues/7107))
 
 ## Upgrading
 

--- a/src/DatabaseMetaRepo.php
+++ b/src/DatabaseMetaRepo.php
@@ -5,9 +5,11 @@ declare( strict_types = 1 );
 namespace SMW;
 
 use InvalidArgumentException;
+use MediaWiki\Logger\LoggerFactory;
 use SMW\SQLStore\SQLStore;
 use Throwable;
 use Wikimedia\Rdbms\DBQueryError;
+use Wikimedia\Rdbms\IDatabase;
 use Wikimedia\Rdbms\IExpression;
 use Wikimedia\Rdbms\ILoadBalancer;
 use Wikimedia\Rdbms\LikeValue;
@@ -180,8 +182,33 @@ class DatabaseMetaRepo implements SmwJsonRepo {
 
 			$db->endAtomic( __METHOD__ );
 		} catch ( Throwable $e ) {
-			$db->cancelAtomic( __METHOD__ );
+			$this->cancelAtomicSection( $db, __METHOD__, $e );
+
 			throw $e;
+		}
+	}
+
+	/**
+	 * The rollback can fail on its own, e.g. MariaDB 1305 when the savepoint is
+	 * already gone. Report that failure but let $saveError remain the exception
+	 * that propagates: it is the one that says why the save failed.
+	 *
+	 * `$fname` has to be the name the section was opened with: `cancelAtomic`
+	 * rejects a mismatch.
+	 */
+	private function cancelAtomicSection( IDatabase $db, string $fname, Throwable $saveError ): void {
+		try {
+			$db->cancelAtomic( $fname );
+		} catch ( Throwable $rollbackError ) {
+			LoggerFactory::getInstance( 'smw' )->error(
+				'Atomic section rollback in {fname} failed with "{rollback_error}" while handling "{save_error}"',
+				[
+					'fname' => $fname,
+					'rollback_error' => $rollbackError->getMessage(),
+					'save_error' => $saveError->getMessage(),
+					'exception' => $rollbackError
+				]
+			);
 		}
 	}
 

--- a/src/SQLStore/SQLStoreUpdater.php
+++ b/src/SQLStore/SQLStoreUpdater.php
@@ -10,6 +10,7 @@ use SMW\DataItems\Property;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
 use SMW\Enum;
+use SMW\MediaWiki\Connection\Database;
 use SMW\Parameters;
 use SMW\Services\ServicesFactory as ApplicationFactory;
 use SMW\SQLStore\EntityStore\CachingSemanticDataLookup;
@@ -168,6 +169,9 @@ class SQLStoreUpdater {
 	 * @since 1.8
 	 *
 	 * @param SemanticData $semanticData
+	 *
+	 * @throws Throwable Whatever the update threw; rethrown after the section
+	 *  transaction is rolled back.
 	 */
 	public function doDataUpdate( SemanticData $semanticData ): Status {
 		// Deprecated since 3.1, use SMW::SQLStore::BeforeDataUpdateComplete
@@ -274,13 +278,39 @@ class SQLStoreUpdater {
 			// shutdown with "Explicit transaction still active". Roll the
 			// section back and rethrow so callers (e.g. rebuildData
 			// --ignore-exceptions) can log and skip this entity and continue.
-			$connection->cancelSectionTransaction( SQLStore::UPDATE_TRANSACTION );
+			$this->cancelUpdateSectionTransaction( $connection, $subject, $e );
+
 			throw $e;
 		}
 
 		$propertyChangeListener->runChangeListeners();
 
 		return $status;
+	}
+
+	/**
+	 * The rollback can fail on its own, e.g. MariaDB 1305 when the savepoint is
+	 * already gone. Report that failure but let $updateError remain the
+	 * exception that propagates: it is the one that says why the update failed.
+	 */
+	private function cancelUpdateSectionTransaction(
+		Database $connection,
+		WikiPage $subject,
+		Throwable $updateError
+	): void {
+		try {
+			$connection->cancelSectionTransaction( SQLStore::UPDATE_TRANSACTION );
+		} catch ( Throwable $rollbackError ) {
+			$this->factory->getLogger()->error(
+				'Section rollback for {subject} failed with "{rollback_error}" while handling "{update_error}"',
+				[
+					'subject' => $subject->getHash(),
+					'rollback_error' => $rollbackError->getMessage(),
+					'update_error' => $updateError->getMessage(),
+					'exception' => $rollbackError
+				]
+			);
+		}
 	}
 
 	/**

--- a/tests/phpunit/Unit/DatabaseMetaRepoTest.php
+++ b/tests/phpunit/Unit/DatabaseMetaRepoTest.php
@@ -6,11 +6,13 @@ namespace SMW\Tests\Unit;
 
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
+use RuntimeException;
 use SMW\DatabaseMetaRepo;
 use SMW\Maintenance\AutoRecovery;
 use SMW\Site;
 use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
 use Wikimedia\Rdbms\DBQueryError;
+use Wikimedia\Rdbms\DBUnexpectedError;
 use Wikimedia\Rdbms\Expression;
 use Wikimedia\Rdbms\FakeResultWrapper;
 use Wikimedia\Rdbms\IDatabase;
@@ -132,6 +134,25 @@ class DatabaseMetaRepoTest extends TestCase {
 		$this->assertCount( 2, $capturedDeleteWheres );
 		$this->assertInstanceOf( IExpression::class, $capturedDeleteWheres[0] );
 		$this->assertInstanceOf( IExpression::class, $capturedDeleteWheres[1] );
+	}
+
+	public function testSaveSmwJsonPropagatesSaveErrorWhenAtomicRollbackAlsoFails(): void {
+		$db = $this->makeExprDatabase();
+
+		$saveError = new RuntimeException( 'write failure' );
+		$db->method( 'newDeleteQueryBuilder' )->willThrowException( $saveError );
+
+		// A rollback can fail on its own, e.g. MariaDB 1305 when the savepoint
+		// is already gone.
+		$db->method( 'cancelAtomic' )
+			->willThrowException( new DBUnexpectedError( null, 'rollback failure' ) );
+
+		$repo = new DatabaseMetaRepo( $this->makeLoadBalancer( $db ) );
+
+		// The save error says why the save failed, so it is the one the caller
+		// has to see; the rollback error must not take its place.
+		$this->expectExceptionObject( $saveError );
+		$repo->saveSmwJson( '/tmp', [ Site::id() => [ 'upgrade_key' => 'abc123' ] ] );
 	}
 
 	public function testSaveSmwJsonDeletesNullValues(): void {

--- a/tests/phpunit/Unit/SQLStore/SQLStoreUpdaterTest.php
+++ b/tests/phpunit/Unit/SQLStore/SQLStoreUpdaterTest.php
@@ -4,6 +4,7 @@ namespace SMW\Tests\Unit\SQLStore;
 
 use MediaWiki\MediaWikiServices;
 use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
 use RuntimeException;
 use SMW\DataItems\WikiPage;
 use SMW\DataModel\SemanticData;
@@ -26,6 +27,9 @@ use SMW\SQLStore\SQLStoreFactory;
 use SMW\SQLStore\SQLStoreUpdater;
 use SMW\Tests\Unit\MediaWiki\Connection\MockSelectQueryBuilderTrait;
 use SMW\Tests\Unit\MediaWiki\Connection\MockWriteQueryBuilderTrait;
+use SMW\Tests\Utils\SpyLogger;
+use Throwable;
+use Wikimedia\Rdbms\DBUnexpectedError;
 
 /**
  * @covers \SMW\SQLStore\SQLStoreUpdater
@@ -243,21 +247,11 @@ class SQLStoreUpdaterTest extends TestCase {
 	}
 
 	public function testDoDataUpdateCancelsSectionTransactionWhenUpdateThrows() {
-		$title = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( __METHOD__, NS_MAIN );
-
 		// A failing entity: the property lookup inside the section throws, mirroring
 		// e.g. a charset error while writing a 4-byte UTF-8 title to a non-utf8mb4 DB.
-		$semanticData = $this->getMockBuilder( SemanticData::class )
-			->setConstructorArgs( [ WikiPage::newFromTitle( $title ) ] )
-			->setMethods( [ 'getPropertyValues' ] )
-			->getMock();
+		$semanticData = $this->newSemanticDataFailingWith( __METHOD__, new RuntimeException( 'charset failure' ) );
 
-		$semanticData->method( 'getPropertyValues' )
-			->willThrowException( new RuntimeException( 'charset failure' ) );
-
-		$database = $this->getMockBuilder( Database::class )
-			->disableOriginalConstructor()
-			->getMock();
+		$database = $this->newConnection();
 
 		$database->expects( $this->once() )
 			->method( 'beginSectionTransaction' )
@@ -272,18 +266,95 @@ class SQLStoreUpdaterTest extends TestCase {
 		$database->expects( $this->never() )
 			->method( 'endSectionTransaction' );
 
-		$parentStore = $this->getMockBuilder( SQLStore::class )
-			->disableOriginalConstructor()
-			->getMock();
-
-		$parentStore->expects( $this->atLeastOnce() )
-			->method( 'getConnection' )
-			->willReturn( $database );
-
-		$instance = new SQLStoreUpdater( $parentStore, $this->factory );
+		$instance = new SQLStoreUpdater( $this->newStoreUsing( $database ), $this->factory );
 
 		$this->expectException( RuntimeException::class );
 		$instance->doDataUpdate( $semanticData );
+	}
+
+	public function testDoDataUpdatePropagatesUpdateErrorWhenSectionRollbackAlsoFails() {
+		$updateError = new RuntimeException( 'charset failure' );
+		$semanticData = $this->newSemanticDataFailingWith( __METHOD__, $updateError );
+
+		$database = $this->newConnection();
+		$database->method( 'cancelSectionTransaction' )
+			->willThrowException( $this->newRollbackFailure() );
+
+		$instance = new SQLStoreUpdater( $this->newStoreUsing( $database ), $this->factory );
+
+		// The update error says why the update failed, so it is the one the
+		// caller has to see; the rollback error must not take its place.
+		$this->expectExceptionObject( $updateError );
+		$instance->doDataUpdate( $semanticData );
+	}
+
+	public function testDoDataUpdateReportsSectionRollbackFailure() {
+		$semanticData = $this->newSemanticDataFailingWith( __METHOD__, new RuntimeException( 'charset failure' ) );
+
+		$database = $this->newConnection();
+		$database->method( 'cancelSectionTransaction' )
+			->willThrowException( $this->newRollbackFailure() );
+
+		$logger = new SpyLogger();
+
+		$this->factory->expects( $this->any() )
+			->method( 'getLogger' )
+			->willReturn( $logger );
+
+		$instance = new SQLStoreUpdater( $this->newStoreUsing( $database ), $this->factory );
+
+		try {
+			$instance->doDataUpdate( $semanticData );
+		} catch ( RuntimeException $updateError ) {
+			// Propagation is asserted by the sibling test.
+		}
+
+		$logs = $logger->getLogs();
+
+		$this->assertCount( 1, $logs );
+		$this->assertSame( LogLevel::ERROR, $logs[0][0] );
+		$this->assertSame( 'rollback failure', $logs[0][2]['rollback_error'] );
+		$this->assertSame( 'charset failure', $logs[0][2]['update_error'] );
+	}
+
+	private function newSemanticDataFailingWith( string $method, Throwable $updateError ): SemanticData {
+		$title = MediaWikiServices::getInstance()->getTitleFactory()->newFromText( $method, NS_MAIN );
+
+		$semanticData = $this->getMockBuilder( SemanticData::class )
+			->setConstructorArgs( [ WikiPage::newFromTitle( $title ) ] )
+			->onlyMethods( [ 'getPropertyValues' ] )
+			->getMock();
+
+		$semanticData->method( 'getPropertyValues' )
+			->willThrowException( $updateError );
+
+		return $semanticData;
+	}
+
+	private function newConnection(): Database {
+		return $this->getMockBuilder( Database::class )
+			->disableOriginalConstructor()
+			->getMock();
+	}
+
+	private function newStoreUsing( Database $connection ): SQLStore {
+		$store = $this->getMockBuilder( SQLStore::class )
+			->disableOriginalConstructor()
+			->getMock();
+
+		$store->expects( $this->atLeastOnce() )
+			->method( 'getConnection' )
+			->willReturn( $connection );
+
+		return $store;
+	}
+
+	/**
+	 * A rollback can fail on its own, e.g. MariaDB 1305 when the savepoint is
+	 * already gone.
+	 */
+	private function newRollbackFailure(): DBUnexpectedError {
+		return new DBUnexpectedError( null, 'rollback failure' );
 	}
 
 	public function testDoDataUpdateForConceptNamespaceWithoutSubobject() {


### PR DESCRIPTION
Two call sites roll a transaction back and rethrow the exception that
caused the failure:

  SQLStoreUpdater::doDataUpdate()  -> cancelSectionTransaction()
  DatabaseMetaRepo::saveSmwJson()  -> cancelAtomic()

Both are written as `$db->cancel...(); throw $e;`. If the rollback itself
throws, `throw $e` is never reached and the rollback error silently
replaces the real one.

Observed in production on MW 1.46 / MariaDB: an smw.update job reported

  Wikimedia\Rdbms\DBQueryError: Error 1305: SAVEPOINT wikimedia_rdbms_atomic1
  does not exist
  Function: sql/transaction/update
  Query: ROLLBACK TO SAVEPOINT `wikimedia_rdbms_atomic1`

with no trace of whatever actually failed the update. `Function:
sql/transaction/update` is SQLStore::UPDATE_TRANSACTION, so the 1305 is
this rollback, not the cause, but the cause is unrecoverable because it
was thrown away here. The savepoint only exists at that site since 7.1.0,
when #6988 added ATOMIC_CANCELABLE.

saveSmwJson() opens its section without ATOMIC_CANCELABLE, so its
cancelAtomic() raises "Uncancelable atomic section canceled" whenever the
section is not the outermost one, discarding the save error the same way.

Guard both rollbacks so a secondary failure is reported and the original
exception still propagates.