### PR TITLE
Stop JsonContentsFileReaderTest from rewriting the shipped language files

### DIFF
--- a/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
+++ b/tests/phpunit/Unit/Localizer/LocalLanguage/JsonContentsFileReaderTest.php
@@ -17,6 +17,27 @@ use Wikimedia\ObjectCache\BagOStuff;
  */
 class JsonContentsFileReaderTest extends TestCase {
 
+	private string $languageFileDir = '';
+
+	protected function setUp(): void {
+		$this->languageFileDir = sys_get_temp_dir() . '/' . uniqid( 'smw-lang-', true );
+
+		mkdir( $this->languageFileDir );
+
+		// `getLanguageFile` requires the file to exist before it can be written.
+		file_put_contents( $this->languageFileDir . '/zxx.json', '{}' );
+	}
+
+	protected function tearDown(): void {
+		foreach ( glob( $this->languageFileDir . '/*.json' ) as $file ) {
+			unlink( $file );
+		}
+
+		rmdir( $this->languageFileDir );
+
+		JsonContentsFileReader::clear();
+	}
+
 	public function testCanConstruct() {
 		$this->assertInstanceOf(
 			JsonContentsFileReader::class,
@@ -100,36 +121,21 @@ class JsonContentsFileReaderTest extends TestCase {
 		$instance->readByLanguageCode( 'foo', true );
 	}
 
-	/**
-	 * This method is just for convenience so that one can quickly add contents to files
-	 * without requiring an extra class when extending the language content. Normally the
-	 * test in active
-	 *
-	 * @dataProvider dataExtensionProvider
-	 */
-	public function testWriteToFile( $topic, $extension ) {
-		$instance = new JsonContentsFileReader();
-		$list = 'ar,arz,ca,de,es,fi,fr,he,hu,id,it,nb,nl,pl,pt,ru,sk,zh-cn,zh-tw';
+	public function testWriteByLanguageCodeRoundTripsContents() {
+		$instance = new JsonContentsFileReader( null, $this->languageFileDir );
 
-		$didWrite = false;
+		// A slash and a non-ASCII label: both survive a round trip regardless
+		// of how json_encode escapes them on disk.
+		$contents = [
+			'namespace' => [ 'SMW_NS_SCHEMA' => 'SMW/Schema' ],
+			'datatype' => [ 'labels' => [ '_ref_rec' => 'Verknüpfung' ] ],
+		];
 
-		foreach ( explode( ',', $list ) as $lang ) {
-			$contents = $instance->readByLanguageCode( $lang, true );
+		$instance->writeByLanguageCode( 'zxx', $contents );
 
-			if ( $contents === '' ) {
-				continue;
-			}
-
-			$contents[$topic] = ( $contents[$topic] ?? [] ) + $extension;
-
-			$instance->writeByLanguageCode( $lang, $contents );
-
-			$didWrite = true;
-		}
-
-		$this->assertTrue(
-			$didWrite,
-			'Expected at least one language file to be written'
+		$this->assertSame(
+			$contents,
+			$instance->readByLanguageCode( 'zxx', true )
 		);
 	}
 
@@ -148,17 +154,6 @@ class JsonContentsFileReaderTest extends TestCase {
 	public function languageCodeProvider() {
 		$provider[] = [
 			'en'
-		];
-
-		return $provider;
-	}
-
-	public function dataExtensionProvider() {
-		$provider[] = [
-			'dataTypeLabels',
-			[
-				"_ref_rec" => "Reference"
-			]
 		];
 
 		return $provider;


### PR DESCRIPTION
testWriteToFile was a dormant convenience scaffold for bulk-adding a key to
i18n/extra/*.json, not a test. It stayed dormant because its topic,
`dataTypeLabels`, is not a key in that file format (datatype labels live
under `datatype.labels`), so the `!isset( $contents[$topic] )` guard skipped
every language and nothing was ever written.

PHPUnit reported the resulting "This test did not perform any assertions",
and #6592 answered that by removing the guard and asserting instead that a
write had happened. Every unit run since then rewrites 19 tracked language
files: it adds a top-level `dataTypeLabels` block that no code reads,
carrying the English label into 19 non-English files, and reformats each
file because writeByLanguageCode() encodes without JSON_UNESCAPED_SLASHES
and writes no trailing newline. None of that has ever been committed, but it
leaves a dirty working tree that is easy to stage by accident.

Drop the scaffold and cover writeByLanguageCode() with a round trip against
a temporary directory, which is what the method needs and what nothing
tested before.